### PR TITLE
Add Minor Change Audit Path docs and dev-tools support for issue.md-first workflow

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -597,7 +597,9 @@
 				"--potential-path",
 				"${relativeFile}",
 				"--promotion-type",
-				"${input:PotentialPromotionType}"
+				"${input:PotentialPromotionType}",
+				"--work-mode",
+				"${input:PotentialWorkMode}"
 			],
 			"command": "poetry",
 			"detail": "Creates a feature issue from the active editor file (workspace-relative) using gh issue create (non-interactive) via Python.",
@@ -675,7 +677,9 @@
 				"--type",
 				"${input:ActiveWorkType}",
 				"--issue-number",
-				"${input:ActiveIssueNumber}"
+				"${input:ActiveIssueNumber}",
+				"--work-mode",
+				"${input:ActiveWorkMode}"
 			],
 			"command": "poetry",
 			"detail": "Creates docs/features/active/<name>/ from the selected template (feature/refactor/epic/bug) and opens the relevant files.",

--- a/docs/engineering/Feature Playbook.md
+++ b/docs/engineering/Feature Playbook.md
@@ -120,3 +120,9 @@ VS Code tasks wrap these scripts: see `.vscode/tasks.json` (e.g., “Feature: Ne
 | **8**                                      | **Atomic Development Plan Authoring (Plan-of-Record)**  | **Atomic Planning Agent**               | **Critical distinction**: this is the *true* atomic plan. It cannot exist until the spec is complete. Tasks are binary, ordered, verifiable.                                     |
 | **9**                                      | **Deterministic Plan Execution**                        | **Atomic Execution Agent**              | Executes the atomic plan verbatim. No replanning, no scope change, strict policy and acceptance-criteria verification.                                                           |
 | **10 (Optional but Strongly Recommended)** | **Post-Execution Feature & Policy Audit**               | **Feature Review Agent**                | Audits the completed feature against repo policy *and* against the committed documentation (user story, spec, acceptance criteria). Generates remediation inputs if gaps exist.  |
+
+
+## Minor Change Audit Path
+
+Use `minor-audit` only when work is bootstrapped/pre-cooked or when scope stays at 3 or fewer production files with low integration risk.
+If a requested minor-audit is not eligible, use full feature path.

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/policy-read.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/policy-read.2026-02-19T12-02.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-02-19T12-02
+Command: policy-read
+EXIT_CODE: 0
+Output Summary: policy files reviewed in required order
+1) .github/copilot-instructions.md
+2) .github/instructions/general-code-change.instructions.md
+3) .github/instructions/general-unit-test.instructions.md
+4) .github/instructions/python-code-change.instructions.md
+5) .github/instructions/python-unit-test.instructions.md
+6) .github/instructions/python-suppressions.instructions.md

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-format-baseline.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-format-baseline.2026-02-19T12-02.md
@@ -1,0 +1,9 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run black . --check
+EXIT_CODE: 0
+Output Summary: All done! ✨ 🍰 ✨
+
+
+a
+All done! ✨ 🍰 ✨
+82 files would be left unchanged.

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-lint-baseline.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-lint-baseline.2026-02-19T12-02.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary: All checks passed!
+
+All checks passed!

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-test-baseline.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-test-baseline.2026-02-19T12-02.md
@@ -1,0 +1,125 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: ============================= test session starts ==============================
+
+============================= test session starts ==============================
+platform linux -- Python 3.13.8, pytest-9.0.2, pluggy-1.6.0
+rootdir: /workspace/drm-copilot
+configfile: pyproject.toml
+testpaths: tests
+plugins: cov-7.0.0
+collected 777 items
+
+tests/scripts/dev_tools/atomic_executor/test_cli.py .................... [  2%]
+................................                                         [  6%]
+tests/scripts/dev_tools/atomic_executor/test_copilot_backoff.py ...      [  7%]
+tests/scripts/dev_tools/atomic_executor/test_copilot_rate_limiter.py ..  [  7%]
+tests/scripts/dev_tools/atomic_executor/test_copilot_throttling_classifier.py . [  7%]
+...........                                                              [  8%]
+tests/scripts/dev_tools/atomic_executor/test_executor_throttle_bounded_retries.py . [  9%]
+                                                                         [  9%]
+tests/scripts/dev_tools/atomic_executor/test_executor_throttle_ordering.py . [  9%]
+                                                                         [  9%]
+tests/scripts/dev_tools/atomic_executor/test_executor_throttle_retry_regression.py . [  9%]
+                                                                         [  9%]
+tests/scripts/dev_tools/atomic_executor/test_feature_resolver.py ....... [ 10%]
+........                                                                 [ 11%]
+tests/scripts/dev_tools/atomic_executor/test_plan_discovery.py ......... [ 12%]
+                                                                         [ 12%]
+tests/scripts/dev_tools/atomic_executor/test_plan_parser.py ............ [ 13%]
+.........................                                                [ 17%]
+tests/scripts/dev_tools/atomic_executor/test_prompt_builder.py ......... [ 18%]
+........                                                                 [ 19%]
+tests/scripts/dev_tools/atomic_executor/test_pytest_expectations.py .... [ 19%]
+.........                                                                [ 20%]
+tests/scripts/dev_tools/atomic_executor/test_qc_runner.py .............. [ 22%]
+..........                                                               [ 24%]
+tests/scripts/dev_tools/atomic_executor/test_unicode_integration.py ..   [ 24%]
+tests/scripts/dev_tools/test_agentic_sync.py ..........                  [ 25%]
+tests/scripts/dev_tools/test_atomic_executor_cli.py ...............      [ 27%]
+tests/scripts/dev_tools/test_clean_devcontainer.py ....                  [ 28%]
+tests/scripts/dev_tools/test_collect_commit_context.py ................. [ 30%]
+........                                                                 [ 31%]
+tests/scripts/dev_tools/test_collect_pr_context.py ..................... [ 33%]
+..........                                                               [ 35%]
+tests/scripts/dev_tools/test_copy_research_to_issue.py ..........        [ 36%]
+tests/scripts/dev_tools/test_feature_docs.py ........................... [ 40%]
+.....                                                                    [ 40%]
+tests/scripts/dev_tools/test_fix_all.py .............................    [ 44%]
+tests/scripts/dev_tools/test_format_json.py .....................        [ 47%]
+tests/scripts/dev_tools/test_git.py .......................              [ 50%]
+tests/scripts/dev_tools/test_github.py ................................. [ 54%]
+..........                                                               [ 55%]
+tests/scripts/dev_tools/test_json_config.py ...............              [ 57%]
+tests/scripts/dev_tools/test_markdown_label_formatter.py ............... [ 59%]
+...............                                                          [ 61%]
+tests/scripts/dev_tools/test_new_active_feature_folder.py .............. [ 63%]
+......................                                                   [ 66%]
+tests/scripts/dev_tools/test_new_active_feature_folder_bug_template_preserved.py . [ 66%]
+                                                                         [ 66%]
+tests/scripts/dev_tools/test_new_potential_bug_entry.py .............    [ 67%]
+tests/scripts/dev_tools/test_plan_progress_report.py ..............      [ 69%]
+tests/scripts/dev_tools/test_potential_to_issue.py .................     [ 71%]
+tests/scripts/dev_tools/test_pr_context_integration.py ....              [ 72%]
+tests/scripts/dev_tools/test_render.py ................................. [ 76%]
+.........................                                                [ 79%]
+tests/scripts/dev_tools/test_render_helpers.py ......................... [ 83%]
+...                                                                      [ 83%]
+tests/scripts/dev_tools/test_resolve_execute_plan_prompt.py ............ [ 84%]
+...............................                                          [ 88%]
+tests/scripts/dev_tools/test_resolve_file_prompt.py ...............      [ 90%]
+tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py ............... [ 92%]
+.                                                                        [ 92%]
+tests/scripts/dev_tools/test_shell_qc.py ............................    [ 96%]
+tests/scripts/dev_tools/test_validate_json.py .......................... [ 99%]
+./workspace/drm-copilot/.venv/lib/python3.13/site-packages/coverage/inorout.py:495: CoverageWarning: Module src/lexile_corpus_tuner was never imported. (module-not-imported); see https://coverage.readthedocs.io/en/7.13.2/messages.html#warning-module-not-imported
+  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
+                                                                        [100%]
+
+================================ tests coverage ================================
+_______________ coverage: platform linux, python 3.13.8-final-0 ________________
+
+Name                                                       Stmts   Miss  Cover   Missing
+----------------------------------------------------------------------------------------
+scripts/dev_tools/__init__.py                                  0      0   100%
+scripts/dev_tools/agentic_sync.py                            169     30    82%   58, 62, 66, 70, 74, 78, 82, 119-127, 148, 169, 191-192, 213, 235, 256, 390, 465, 613, 617, 620, 768, 770, 775, 777
+scripts/dev_tools/atomic_executor/__init__.py                  6      0   100%
+scripts/dev_tools/atomic_executor/cli.py                     920    292    68%   104-109, 360, 396, 431, 438-440, 443, 499-500, 513, 524-525, 577, 599, 627-639, 665, 758, 838, 846, 850-851, 908-911, 920-926, 987, 997, 1011-1012, 1057, 1070-1073, 1093-1095, 1118-1126, 1181, 1200-1210, 1234-1245, 1320, 1329-1330, 1348, 1382-1386, 1396-1400, 1463, 1498-1500, 1520, 1560-1563, 1581, 1601-1664, 1718, 1797-1948, 1985-2120, 2219, 2221, 2250-2251, 2286-2287, 2318-2326, 2330, 2483, 2554, 2558-2560, 2607, 2614-2615, 2669, 2679-2684
+scripts/dev_tools/atomic_executor/copilot_runner.py            6      0   100%
+scripts/dev_tools/atomic_executor/copilot_throttling.py       90     10    89%   42, 67, 136, 138, 214, 216, 227, 229, 327, 340
+scripts/dev_tools/atomic_executor/feature_resolver.py         61      1    98%   144
+scripts/dev_tools/atomic_executor/plan_discovery.py           38      0   100%
+scripts/dev_tools/atomic_executor/plan_parser.py             225     14    94%   346, 405, 416, 443, 527, 534, 547, 556, 571, 592, 632, 637, 654-655
+scripts/dev_tools/atomic_executor/prompt_builder.py          128     36    72%   49, 53, 57, 61, 81, 89, 205, 212, 244-246, 256-257, 275, 328, 379, 383, 388-390, 411-434
+scripts/dev_tools/atomic_executor/pytest_expectations.py     156     41    74%   57, 85, 193, 246-247, 284, 297-298, 304-307, 332-348, 361-384
+scripts/dev_tools/atomic_executor/qc_runner.py               312    116    63%   140, 183, 209-210, 226, 230, 240-241, 280-318, 345-398, 422-423, 446-467, 517-528, 534, 549, 562, 571, 587, 604, 674, 714, 717, 741, 747-748, 783, 833, 837, 949-969, 1052-1056, 1066-1070
+scripts/dev_tools/atomic_executor/qc_toolchain.py             15      0   100%
+scripts/dev_tools/clean_devcontainer.py                       36      2    94%   165, 179
+scripts/dev_tools/collect_commit_context.py                  123      1    99%   33
+scripts/dev_tools/copy_research_to_issue.py                   80     41    49%   49, 52-53, 56, 78, 82, 159-165, 186-189, 217-231, 244-256, 276-314
+scripts/dev_tools/fix_all.py                                 364     64    82%   59, 121, 123, 149, 153, 159, 187, 243, 270-293, 353, 409, 623, 649-651, 656-658, 689-691, 722-724, 746-748, 777-784, 820, 930-932, 959-961, 988-990, 1028, 1034, 1041-1042, 1122-1123
+scripts/dev_tools/format_json.py                              67      0   100%
+scripts/dev_tools/json_config.py                              20      2    90%   47, 49
+scripts/dev_tools/markdown_label_formatter.py                 65      0   100%
+scripts/dev_tools/new_active_feature_folder.py               377     44    88%   66, 69, 72-73, 76-81, 84-86, 89, 92-93, 96-100, 104, 135, 143, 215, 219, 253, 567-568, 999-1021, 1025-1038
+scripts/dev_tools/new_potential_bug_entry.py                  91      8    91%   22, 37-44, 61, 140-146
+scripts/dev_tools/plan_progress_report.py                     99     25    75%   147-148, 152, 176-179, 213, 299-305, 322-325, 338-359, 375-382
+scripts/dev_tools/potential_to_issue.py                      239     15    94%   82, 94, 155, 164-165, 244, 251-252, 256, 260-261, 269, 357, 367-368
+scripts/dev_tools/pr_context/__init__.py                       2      0   100%
+scripts/dev_tools/pr_context/collector.py                    191     15    92%   194, 201, 226, 253-254, 280-283, 296, 309, 351, 384, 440, 462
+scripts/dev_tools/pr_context/feature_docs.py                 129      9    93%   108, 123, 131-132, 181-185
+scripts/dev_tools/pr_context/git.py                           61      0   100%
+scripts/dev_tools/pr_context/github.py                       350     23    93%   81, 89, 97, 104, 130, 139-140, 152, 162, 167, 176, 189, 196, 231-233, 301, 423, 446, 501, 512, 518, 545
+scripts/dev_tools/pr_context/models.py                       121      1    99%   152
+scripts/dev_tools/pr_context/render.py                       348     32    91%   74, 98-100, 110, 138, 321, 335, 343-344, 505, 515-516, 555, 559-565, 589, 624-636
+scripts/dev_tools/pr_context/summary_helpers.py              154     14    91%   80, 239, 242, 273, 278, 283-284, 332-345
+scripts/dev_tools/resolve_execute_plan_prompt.py             159      8    95%   149-150, 373, 416-417, 525-527
+scripts/dev_tools/resolve_file_prompt.py                     148     10    93%   51, 105-114, 125, 225, 385, 395
+scripts/dev_tools/resolve_hard_lock_prompt.py                 65      3    95%   79-80, 83
+scripts/dev_tools/shell_qc.py                                209     31    85%   48, 52-53, 56, 62, 64, 76-77, 100, 155-156, 180-181, 201-202, 239-249, 263, 300-301, 370-372, 399, 450
+scripts/dev_tools/tk_dialog_helpers.py                        99     57    42%   39-40, 64-67, 85-117, 133-159, 170-171, 184, 191, 236, 238, 245-260
+scripts/dev_tools/validate_json.py                           123     25    80%   21, 105-127, 141, 146-150, 206-208
+----------------------------------------------------------------------------------------
+TOTAL                                                       5846    970    83%
+============================= 777 passed in 7.89s ==============================

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-type-baseline.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-type-baseline.2026-02-19T12-02.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary: 0 errors, 0 warnings, 0 informations
+
+0 errors, 0 warnings, 0 informations

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-format.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-format.2026-02-19T12-02.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary: All done! ✨ 🍰 ✨
+
+All done! ✨ 🍰 ✨
+82 files left unchanged.

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-lint.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-lint.2026-02-19T12-02.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary: All checks passed!
+
+All checks passed!

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-test.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-test.2026-02-19T12-02.md
@@ -1,0 +1,126 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: ============================= test session starts ==============================
+
+============================= test session starts ==============================
+platform linux -- Python 3.13.8, pytest-9.0.2, pluggy-1.6.0
+rootdir: /workspace/drm-copilot
+configfile: pyproject.toml
+testpaths: tests
+plugins: cov-7.0.0
+collected 786 items
+
+tests/scripts/dev_tools/atomic_executor/test_cli.py .................... [  2%]
+................................                                         [  6%]
+tests/scripts/dev_tools/atomic_executor/test_copilot_backoff.py ...      [  6%]
+tests/scripts/dev_tools/atomic_executor/test_copilot_rate_limiter.py ..  [  7%]
+tests/scripts/dev_tools/atomic_executor/test_copilot_throttling_classifier.py . [  7%]
+...........                                                              [  8%]
+tests/scripts/dev_tools/atomic_executor/test_executor_throttle_bounded_retries.py . [  8%]
+                                                                         [  8%]
+tests/scripts/dev_tools/atomic_executor/test_executor_throttle_ordering.py . [  9%]
+                                                                         [  9%]
+tests/scripts/dev_tools/atomic_executor/test_executor_throttle_retry_regression.py . [  9%]
+                                                                         [  9%]
+tests/scripts/dev_tools/atomic_executor/test_feature_resolver.py ....... [ 10%]
+........                                                                 [ 11%]
+tests/scripts/dev_tools/atomic_executor/test_plan_discovery.py ......... [ 12%]
+                                                                         [ 12%]
+tests/scripts/dev_tools/atomic_executor/test_plan_parser.py ............ [ 13%]
+.........................                                                [ 16%]
+tests/scripts/dev_tools/atomic_executor/test_prompt_builder.py ......... [ 18%]
+........                                                                 [ 19%]
+tests/scripts/dev_tools/atomic_executor/test_pytest_expectations.py .... [ 19%]
+.........                                                                [ 20%]
+tests/scripts/dev_tools/atomic_executor/test_qc_runner.py .............. [ 22%]
+..........                                                               [ 23%]
+tests/scripts/dev_tools/atomic_executor/test_unicode_integration.py ..   [ 24%]
+tests/scripts/dev_tools/test_agentic_sync.py ..........                  [ 25%]
+tests/scripts/dev_tools/test_atomic_executor_cli.py ...............      [ 27%]
+tests/scripts/dev_tools/test_clean_devcontainer.py ....                  [ 27%]
+tests/scripts/dev_tools/test_collect_commit_context.py ................. [ 29%]
+........                                                                 [ 30%]
+tests/scripts/dev_tools/test_collect_pr_context.py ..................... [ 33%]
+..........                                                               [ 34%]
+tests/scripts/dev_tools/test_copy_research_to_issue.py ..........        [ 36%]
+tests/scripts/dev_tools/test_feature_docs.py ........................... [ 39%]
+.....                                                                    [ 40%]
+tests/scripts/dev_tools/test_fix_all.py .............................    [ 43%]
+tests/scripts/dev_tools/test_format_json.py .....................        [ 46%]
+tests/scripts/dev_tools/test_git.py .......................              [ 49%]
+tests/scripts/dev_tools/test_github.py ................................. [ 53%]
+..........                                                               [ 54%]
+tests/scripts/dev_tools/test_json_config.py ...............              [ 56%]
+tests/scripts/dev_tools/test_markdown_label_formatter.py ............... [ 58%]
+...............                                                          [ 60%]
+tests/scripts/dev_tools/test_new_active_feature_folder.py .............. [ 62%]
+...........................                                              [ 65%]
+tests/scripts/dev_tools/test_new_active_feature_folder_bug_template_preserved.py . [ 66%]
+                                                                         [ 66%]
+tests/scripts/dev_tools/test_new_potential_bug_entry.py .............    [ 67%]
+tests/scripts/dev_tools/test_plan_progress_report.py ..............      [ 69%]
+tests/scripts/dev_tools/test_potential_to_issue.py ..................... [ 72%]
+                                                                         [ 72%]
+tests/scripts/dev_tools/test_pr_context_integration.py ....              [ 72%]
+tests/scripts/dev_tools/test_render.py ................................. [ 76%]
+.........................                                                [ 80%]
+tests/scripts/dev_tools/test_render_helpers.py ......................... [ 83%]
+...                                                                      [ 83%]
+tests/scripts/dev_tools/test_resolve_execute_plan_prompt.py ............ [ 85%]
+...............................                                          [ 89%]
+tests/scripts/dev_tools/test_resolve_file_prompt.py ...............      [ 90%]
+tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py ............... [ 92%]
+.                                                                        [ 93%]
+tests/scripts/dev_tools/test_shell_qc.py ............................    [ 96%]
+tests/scripts/dev_tools/test_validate_json.py .......................... [ 99%]
+./workspace/drm-copilot/.venv/lib/python3.13/site-packages/coverage/inorout.py:495: CoverageWarning: Module src/lexile_corpus_tuner was never imported. (module-not-imported); see https://coverage.readthedocs.io/en/7.13.2/messages.html#warning-module-not-imported
+  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
+                                                                        [100%]
+
+================================ tests coverage ================================
+_______________ coverage: platform linux, python 3.13.8-final-0 ________________
+
+Name                                                       Stmts   Miss  Cover   Missing
+----------------------------------------------------------------------------------------
+scripts/dev_tools/__init__.py                                  0      0   100%
+scripts/dev_tools/agentic_sync.py                            169     30    82%   58, 62, 66, 70, 74, 78, 82, 119-127, 148, 169, 191-192, 213, 235, 256, 390, 465, 613, 617, 620, 768, 770, 775, 777
+scripts/dev_tools/atomic_executor/__init__.py                  6      0   100%
+scripts/dev_tools/atomic_executor/cli.py                     920    292    68%   104-109, 360, 396, 431, 438-440, 443, 499-500, 513, 524-525, 577, 599, 627-639, 665, 758, 838, 846, 850-851, 908-911, 920-926, 987, 997, 1011-1012, 1057, 1070-1073, 1093-1095, 1118-1126, 1181, 1200-1210, 1234-1245, 1320, 1329-1330, 1348, 1382-1386, 1396-1400, 1463, 1498-1500, 1520, 1560-1563, 1581, 1601-1664, 1718, 1797-1948, 1985-2120, 2219, 2221, 2250-2251, 2286-2287, 2318-2326, 2330, 2483, 2554, 2558-2560, 2607, 2614-2615, 2669, 2679-2684
+scripts/dev_tools/atomic_executor/copilot_runner.py            6      0   100%
+scripts/dev_tools/atomic_executor/copilot_throttling.py       90     10    89%   42, 67, 136, 138, 214, 216, 227, 229, 327, 340
+scripts/dev_tools/atomic_executor/feature_resolver.py         61      1    98%   144
+scripts/dev_tools/atomic_executor/plan_discovery.py           38      0   100%
+scripts/dev_tools/atomic_executor/plan_parser.py             225     14    94%   346, 405, 416, 443, 527, 534, 547, 556, 571, 592, 632, 637, 654-655
+scripts/dev_tools/atomic_executor/prompt_builder.py          128     36    72%   49, 53, 57, 61, 81, 89, 205, 212, 244-246, 256-257, 275, 328, 379, 383, 388-390, 411-434
+scripts/dev_tools/atomic_executor/pytest_expectations.py     156     41    74%   57, 85, 193, 246-247, 284, 297-298, 304-307, 332-348, 361-384
+scripts/dev_tools/atomic_executor/qc_runner.py               312    116    63%   140, 183, 209-210, 226, 230, 240-241, 280-318, 345-398, 422-423, 446-467, 517-528, 534, 549, 562, 571, 587, 604, 674, 714, 717, 741, 747-748, 783, 833, 837, 949-969, 1052-1056, 1066-1070
+scripts/dev_tools/atomic_executor/qc_toolchain.py             15      0   100%
+scripts/dev_tools/clean_devcontainer.py                       36      2    94%   165, 179
+scripts/dev_tools/collect_commit_context.py                  123      1    99%   33
+scripts/dev_tools/copy_research_to_issue.py                   80     41    49%   49, 52-53, 56, 78, 82, 159-165, 186-189, 217-231, 244-256, 276-314
+scripts/dev_tools/fix_all.py                                 364     64    82%   59, 121, 123, 149, 153, 159, 187, 243, 270-293, 353, 409, 623, 649-651, 656-658, 689-691, 722-724, 746-748, 777-784, 820, 930-932, 959-961, 988-990, 1028, 1034, 1041-1042, 1122-1123
+scripts/dev_tools/format_json.py                              67      0   100%
+scripts/dev_tools/json_config.py                              20      2    90%   47, 49
+scripts/dev_tools/markdown_label_formatter.py                 65      0   100%
+scripts/dev_tools/new_active_feature_folder.py               406     42    90%   66, 69, 72-73, 76-81, 84-86, 89, 92-93, 96-100, 104, 135, 143, 215, 219, 253, 567-568, 869, 873, 877, 888, 1109-1123
+scripts/dev_tools/new_potential_bug_entry.py                  91      8    91%   22, 37-44, 61, 140-146
+scripts/dev_tools/plan_progress_report.py                     99     25    75%   147-148, 152, 176-179, 213, 299-305, 322-325, 338-359, 375-382
+scripts/dev_tools/potential_to_issue.py                      276     18    93%   83, 95, 156, 165-166, 246, 255, 285, 292-293, 297, 301-302, 310, 384, 401, 411-412
+scripts/dev_tools/pr_context/__init__.py                       2      0   100%
+scripts/dev_tools/pr_context/collector.py                    191     15    92%   194, 201, 226, 253-254, 280-283, 296, 309, 351, 384, 440, 462
+scripts/dev_tools/pr_context/feature_docs.py                 129      9    93%   108, 123, 131-132, 181-185
+scripts/dev_tools/pr_context/git.py                           61      0   100%
+scripts/dev_tools/pr_context/github.py                       350     23    93%   81, 89, 97, 104, 130, 139-140, 152, 162, 167, 176, 189, 196, 231-233, 301, 423, 446, 501, 512, 518, 545
+scripts/dev_tools/pr_context/models.py                       121      1    99%   152
+scripts/dev_tools/pr_context/render.py                       348     32    91%   74, 98-100, 110, 138, 321, 335, 343-344, 505, 515-516, 555, 559-565, 589, 624-636
+scripts/dev_tools/pr_context/summary_helpers.py              154     14    91%   80, 239, 242, 273, 278, 283-284, 332-345
+scripts/dev_tools/resolve_execute_plan_prompt.py             159      8    95%   149-150, 373, 416-417, 525-527
+scripts/dev_tools/resolve_file_prompt.py                     148     10    93%   51, 105-114, 125, 225, 385, 395
+scripts/dev_tools/resolve_hard_lock_prompt.py                 65      3    95%   79-80, 83
+scripts/dev_tools/shell_qc.py                                209     31    85%   48, 52-53, 56, 62, 64, 76-77, 100, 155-156, 180-181, 201-202, 239-249, 263, 300-301, 370-372, 399, 450
+scripts/dev_tools/tk_dialog_helpers.py                        99     57    42%   39-40, 64-67, 85-117, 133-159, 170-171, 184, 191, 236, 238, 245-260
+scripts/dev_tools/validate_json.py                           123     25    80%   21, 105-127, 141, 146-150, 206-208
+----------------------------------------------------------------------------------------
+TOTAL                                                       5912    971    84%
+============================= 786 passed in 4.85s ==============================

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-type.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-type.2026-02-19T12-02.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-02-19T12-02
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary: 0 errors, 0 warnings, 0 informations
+
+0 errors, 0 warnings, 0 informations

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/issue.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/issue.md
@@ -69,3 +69,21 @@ Define and adopt a **Minor Change Audit Path** that uses an expanded `issue.md` 
 - [ ] Propose and document bootstrapped eligibility criteria (pre-cooked solve, narrow blast radius, low integration risk).
 - [ ] Draft a minimal evidence contract (baseline, end-state, targeted verification) and note when expanded regression is required.
 - [ ] Update playbook/template guidance so bootstrapped path is explicit and consistently applied.
+
+
+## Evidence Contract
+
+Canonical folders:
+- evidence/baseline/
+- evidence/regression-testing/
+- evidence/other/
+- evidence/qa-gates/
+
+Required schema fields in each evidence artifact:
+- Timestamp
+- Command
+- EXIT_CODE
+
+## PR Recovery Note
+
+- Branch recovery: if a PR reports "Branch is either deleted or invalid", push a fresh commit from the current working branch before reopening.

--- a/docs/features/active/2026-02-19-minor-audit-small-change-28/plan.2026-02-19T12-02.md
+++ b/docs/features/active/2026-02-19-minor-audit-small-change-28/plan.2026-02-19T12-02.md
@@ -49,15 +49,15 @@ All tasks are deterministic, atomic, and executor-compatible.
 
 ### Phase 0 — Context, Policy, and Baseline Capture
 
-- [ ] [P0-T1] Record policy-read evidence in `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/policy-read.2026-02-19T12-02.md` after reading the required policy files in listed order
+- [x] [P0-T1] Record policy-read evidence in `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/policy-read.2026-02-19T12-02.md` after reading the required policy files in listed order
   - Acceptance: File exists and contains exact lines `Timestamp: 2026-02-19T12-02`, `Command: policy-read`, `EXIT_CODE: 0`, `Output Summary: policy files reviewed in required order`, and the exact ordered list of files read: `1) .github/copilot-instructions.md`, `2) .github/instructions/general-code-change.instructions.md`, `3) .github/instructions/general-unit-test.instructions.md`, `4) .github/instructions/python-code-change.instructions.md`, `5) .github/instructions/python-unit-test.instructions.md`, `6) .github/instructions/python-suppressions.instructions.md`.
-- [ ] [P0-T2] Capture Python formatter baseline by running `poetry run black . --check` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-format-baseline.2026-02-19T12-02.md`
+- [x] [P0-T2] Capture Python formatter baseline by running `poetry run black . --check` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-format-baseline.2026-02-19T12-02.md`
   - Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run black . --check`, integer `EXIT_CODE`, and `Output Summary`.
-- [ ] [P0-T3] Capture Python lint baseline by running `poetry run ruff check` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-lint-baseline.2026-02-19T12-02.md`
+- [x] [P0-T3] Capture Python lint baseline by running `poetry run ruff check` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-lint-baseline.2026-02-19T12-02.md`
   - Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run ruff check`, integer `EXIT_CODE`, and `Output Summary`.
-- [ ] [P0-T4] Capture Python type baseline by running `poetry run pyright` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-type-baseline.2026-02-19T12-02.md`
+- [x] [P0-T4] Capture Python type baseline by running `poetry run pyright` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-type-baseline.2026-02-19T12-02.md`
   - Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run pyright`, integer `EXIT_CODE`, and `Output Summary`.
-- [ ] [P0-T5] Capture Python test baseline by running `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-test-baseline.2026-02-19T12-02.md`
+- [x] [P0-T5] Capture Python test baseline by running `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and writing output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/baseline/python-test-baseline.2026-02-19T12-02.md`
   - Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`, integer `EXIT_CODE`, and `Output Summary`.
 
 Phase completion criteria:
@@ -65,12 +65,12 @@ Phase completion criteria:
 
 ### Phase 1 — Add TDD Red Tests for `scripts/dev_tools/potential_to_issue.py`
 
-- [ ] [P1-T1] [expect-fail] Add regression test `test_promote_potential_minor_audit_adds_required_issue_sections` in `tests/scripts/dev_tools/test_potential_to_issue.py` for function `promote_potential` when `--work-mode minor-audit` is selected
+- [x] [P1-T1] [expect-fail] Add regression test `test_promote_potential_minor_audit_adds_required_issue_sections` in `tests/scripts/dev_tools/test_potential_to_issue.py` for function `promote_potential` when `--work-mode minor-audit` is selected
   - Preconditions: `tests/scripts/dev_tools/test_potential_to_issue.py` exists.
   - Acceptance: Running `poetry run pytest tests/scripts/dev_tools/test_potential_to_issue.py -k minor_audit_adds_required_issue_sections` fails and evidence is written to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/regression-testing/p1-t1.expect-fail.2026-02-19T12-02.md` with `Timestamp`, exact `Command`, non-zero `EXIT_CODE`, and failure excerpt containing `minor audit`.
-- [ ] [P1-T2] [expect-fail] Add regression test `test_promote_potential_minor_audit_rejects_missing_eligibility_inputs` in `tests/scripts/dev_tools/test_potential_to_issue.py` for function `promote_potential` rejection path
+- [x] [P1-T2] [expect-fail] Add regression test `test_promote_potential_minor_audit_rejects_missing_eligibility_inputs` in `tests/scripts/dev_tools/test_potential_to_issue.py` for function `promote_potential` rejection path
   - Acceptance: Running `poetry run pytest tests/scripts/dev_tools/test_potential_to_issue.py -k minor_audit_rejects_missing_eligibility_inputs` fails and evidence is written to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/regression-testing/p1-t2.expect-fail.2026-02-19T12-02.md` with `Timestamp`, exact `Command`, non-zero `EXIT_CODE`, and failure excerpt containing `eligibility`.
-- [ ] [P1-T3] [expect-fail] Add regression test `test_promote_potential_full_mode_preserves_existing_body_contract` in `tests/scripts/dev_tools/test_potential_to_issue.py` for backward compatibility in `full` mode
+- [x] [P1-T3] [expect-fail] Add regression test `test_promote_potential_full_mode_preserves_existing_body_contract` in `tests/scripts/dev_tools/test_potential_to_issue.py` for backward compatibility in `full` mode
   - Acceptance: Running `poetry run pytest tests/scripts/dev_tools/test_potential_to_issue.py -k full_mode_preserves_existing_body_contract` fails and evidence is written to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/regression-testing/p1-t3.expect-fail.2026-02-19T12-02.md` with `Timestamp`, exact `Command`, non-zero `EXIT_CODE`, and failure excerpt containing `full mode`.
 
 Phase completion criteria:
@@ -78,18 +78,18 @@ Phase completion criteria:
 
 ### Phase 2 — Implement `potential_to_issue.py` Minor-Audit Routing and Make Phase 1 Green
 
-- [ ] [P2-T1] Add CLI argument `--work-mode` with choices `minor-audit|full` in `scripts/dev_tools/potential_to_issue.py` function `parse_args`
+- [x] [P2-T1] Add CLI argument `--work-mode` with choices `minor-audit|full` in `scripts/dev_tools/potential_to_issue.py` function `parse_args`
   - Dependencies: [P1-T1], [P1-T2], [P1-T3]
   - Acceptance: `parse_args` includes `--work-mode`, default `full`, and `poetry run pytest tests/scripts/dev_tools/test_potential_to_issue.py -k parse_args` exits 0.
-- [ ] [P2-T2] Add typed helper function `evaluate_minor_audit_eligibility` in `scripts/dev_tools/potential_to_issue.py` implementing REQ-002 deterministic gate
+- [x] [P2-T2] Add typed helper function `evaluate_minor_audit_eligibility` in `scripts/dev_tools/potential_to_issue.py` implementing REQ-002 deterministic gate
   - Acceptance: Helper signature is fully typed and `poetry run pyright scripts/dev_tools/potential_to_issue.py` exits 0.
-- [ ] [P2-T3] Add typed helper function `build_minor_audit_body` in `scripts/dev_tools/potential_to_issue.py` that emits required issue sections per REQ-003
+- [x] [P2-T3] Add typed helper function `build_minor_audit_body` in `scripts/dev_tools/potential_to_issue.py` that emits required issue sections per REQ-003
   - Acceptance: Function output contains exact headings `## Problem / Why`, `## Implementation Intent`, `## Acceptance Criteria`, `## Dependencies / Risks`, `## Verification Steps`, `## Evidence Checklist`, `## Source`.
-- [ ] [P2-T4] Update function `promote_potential` in `scripts/dev_tools/potential_to_issue.py` to branch on `work_mode` and call `build_minor_audit_body` only when eligibility passes
+- [x] [P2-T4] Update function `promote_potential` in `scripts/dev_tools/potential_to_issue.py` to branch on `work_mode` and call `build_minor_audit_body` only when eligibility passes
   - Acceptance: `poetry run pytest tests/scripts/dev_tools/test_potential_to_issue.py -k "minor_audit_adds_required_issue_sections or minor_audit_rejects_missing_eligibility_inputs"` exits 0.
-- [ ] [P2-T5] Add/adjust tests in `tests/scripts/dev_tools/test_potential_to_issue.py` so Phase 1 scenarios pass with green expectations
+- [x] [P2-T5] Add/adjust tests in `tests/scripts/dev_tools/test_potential_to_issue.py` so Phase 1 scenarios pass with green expectations
   - Acceptance: `poetry run pytest tests/scripts/dev_tools/test_potential_to_issue.py -k "minor_audit or full_mode_preserves_existing_body_contract"` exits 0.
-- [ ] [P2-T6] Add security regression assertion in `tests/scripts/dev_tools/test_potential_to_issue.py` verifying body generation does not include token-like substrings (`ghp_`, `xoxb-`, `AIza`)
+- [x] [P2-T6] Add security regression assertion in `tests/scripts/dev_tools/test_potential_to_issue.py` verifying body generation does not include token-like substrings (`ghp_`, `xoxb-`, `AIza`)
   - Acceptance: `poetry run pytest tests/scripts/dev_tools/test_potential_to_issue.py -k token_like` exits 0.
 
 Phase completion criteria:
@@ -97,12 +97,12 @@ Phase completion criteria:
 
 ### Phase 3 — Add TDD Red Tests for `scripts/dev_tools/new_active_feature_folder.py`
 
-- [ ] [P3-T1] [expect-fail] Add regression test `test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs` in `tests/scripts/dev_tools/test_new_active_feature_folder.py` for function `create_active_folder`
+- [x] [P3-T1] [expect-fail] Add regression test `test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs` in `tests/scripts/dev_tools/test_new_active_feature_folder.py` for function `create_active_folder`
   - Preconditions: `tests/scripts/dev_tools/test_new_active_feature_folder.py` exists.
   - Acceptance: Running `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -k minor_audit_materializes_issue_md_and_skips_full_docs` fails and evidence is written to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/regression-testing/p3-t1.expect-fail.2026-02-19T12-02.md` with `Timestamp`, exact `Command`, non-zero `EXIT_CODE`, and failure excerpt containing `minor audit`.
-- [ ] [P3-T2] [expect-fail] Add regression test `test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible` in `tests/scripts/dev_tools/test_new_active_feature_folder.py` for fallback behavior
+- [x] [P3-T2] [expect-fail] Add regression test `test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible` in `tests/scripts/dev_tools/test_new_active_feature_folder.py` for fallback behavior
   - Acceptance: Running `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -k minor_audit_falls_back_to_full_when_not_eligible` fails and evidence is written to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/regression-testing/p3-t2.expect-fail.2026-02-19T12-02.md` with `Timestamp`, exact `Command`, non-zero `EXIT_CODE`, and failure excerpt containing `fallback`.
-- [ ] [P3-T3] [expect-fail] Add regression test `test_create_active_folder_full_mode_remains_backward_compatible` in `tests/scripts/dev_tools/test_new_active_feature_folder.py` for existing full behavior preservation
+- [x] [P3-T3] [expect-fail] Add regression test `test_create_active_folder_full_mode_remains_backward_compatible` in `tests/scripts/dev_tools/test_new_active_feature_folder.py` for existing full behavior preservation
   - Acceptance: Running `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -k full_mode_remains_backward_compatible` fails and evidence is written to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/regression-testing/p3-t3.expect-fail.2026-02-19T12-02.md` with `Timestamp`, exact `Command`, non-zero `EXIT_CODE`, and failure excerpt containing `full mode`.
 
 Phase completion criteria:
@@ -110,18 +110,18 @@ Phase completion criteria:
 
 ### Phase 4 — Implement `new_active_feature_folder.py` Mode Routing and Make Phase 3 Green
 
-- [ ] [P4-T1] Add CLI argument `--work-mode` with choices `minor-audit|full` in `scripts/dev_tools/new_active_feature_folder.py` function `parse_args`
+- [x] [P4-T1] Add CLI argument `--work-mode` with choices `minor-audit|full` in `scripts/dev_tools/new_active_feature_folder.py` function `parse_args`
   - Dependencies: [P3-T1], [P3-T2], [P3-T3]
   - Acceptance: `parse_args` includes `--work-mode`, default `full`.
-- [ ] [P4-T2] Add typed helper function `should_use_minor_audit_mode` in `scripts/dev_tools/new_active_feature_folder.py` to centralize mode + eligibility routing
+- [x] [P4-T2] Add typed helper function `should_use_minor_audit_mode` in `scripts/dev_tools/new_active_feature_folder.py` to centralize mode + eligibility routing
   - Acceptance: Helper signature is fully typed and `poetry run pyright scripts/dev_tools/new_active_feature_folder.py` exits 0.
-- [ ] [P4-T3] Update function `create_active_folder` in `scripts/dev_tools/new_active_feature_folder.py` to materialize `issue.md`-centric output for eligible minor-audit mode
+- [x] [P4-T3] Update function `create_active_folder` in `scripts/dev_tools/new_active_feature_folder.py` to materialize `issue.md`-centric output for eligible minor-audit mode
   - Acceptance: `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -k minor_audit_materializes_issue_md_and_skips_full_docs` exits 0.
-- [ ] [P4-T4] Update function `create_active_folder` in `scripts/dev_tools/new_active_feature_folder.py` to preserve existing full-feature behavior for `full` mode and rejected minor-audit requests
+- [x] [P4-T4] Update function `create_active_folder` in `scripts/dev_tools/new_active_feature_folder.py` to preserve existing full-feature behavior for `full` mode and rejected minor-audit requests
   - Acceptance: `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -k "minor_audit_falls_back_to_full_when_not_eligible or full_mode_remains_backward_compatible"` exits 0.
-- [ ] [P4-T5] Add/adjust tests in `tests/scripts/dev_tools/test_new_active_feature_folder.py` so Phase 3 scenarios pass with green expectations
+- [x] [P4-T5] Add/adjust tests in `tests/scripts/dev_tools/test_new_active_feature_folder.py` so Phase 3 scenarios pass with green expectations
   - Acceptance: `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -k "minor_audit or full_mode_remains_backward_compatible"` exits 0.
-- [ ] [P4-T6] Add deterministic output assertions in `tests/scripts/dev_tools/test_new_active_feature_folder.py` that selected mode and fallback reason are printed
+- [x] [P4-T6] Add deterministic output assertions in `tests/scripts/dev_tools/test_new_active_feature_folder.py` that selected mode and fallback reason are printed
   - Acceptance: `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -k fallback_reason` exits 0.
 
 Phase completion criteria:
@@ -129,15 +129,15 @@ Phase completion criteria:
 
 ### Phase 5 — Wire Tasks and Update Process Documentation
 
-- [ ] [P5-T1] Update `.vscode/tasks.json` task `Dev: 2 Promote Potential to GitHub Issue` to pass `--work-mode` from a new input `PotentialWorkMode`
+- [x] [P5-T1] Update `.vscode/tasks.json` task `Dev: 2 Promote Potential to GitHub Issue` to pass `--work-mode` from a new input `PotentialWorkMode`
   - Acceptance: `.vscode/tasks.json` includes input id `PotentialWorkMode` with options `minor-audit` and `full`, and task args include `--work-mode` then `${input:PotentialWorkMode}`.
-- [ ] [P5-T2] Update `.vscode/tasks.json` task `Dev: 3 Create Active Folder` to pass `--work-mode` from a new input `ActiveWorkMode`
+- [x] [P5-T2] Update `.vscode/tasks.json` task `Dev: 3 Create Active Folder` to pass `--work-mode` from a new input `ActiveWorkMode`
   - Acceptance: `.vscode/tasks.json` includes input id `ActiveWorkMode` with options `minor-audit` and `full`, and task args include `--work-mode` then `${input:ActiveWorkMode}`.
-- [ ] [P5-T3] Update `docs/engineering/Feature Playbook.md` with deterministic minor-audit eligibility gate and fallback rules
+- [x] [P5-T3] Update `docs/engineering/Feature Playbook.md` with deterministic minor-audit eligibility gate and fallback rules
   - Acceptance: Document contains exact phrase `Minor Change Audit Path` and explicit fallback condition `if eligibility fails, use full feature path`.
-- [ ] [P5-T4] Update `docs/features/templates/README.md` with decision tree rules for `minor-audit`, `feature`, and `refactor`
+- [x] [P5-T4] Update `docs/features/templates/README.md` with decision tree rules for `minor-audit`, `feature`, and `refactor`
   - Acceptance: Document contains a dedicated bullet list naming all three paths and when each applies.
-- [ ] [P5-T5] Add evidence contract section to `docs/features/active/2026-02-19-minor-audit-small-change-28/issue.md` with canonical folders and schema fields
+- [x] [P5-T5] Add evidence contract section to `docs/features/active/2026-02-19-minor-audit-small-change-28/issue.md` with canonical folders and schema fields
   - Acceptance: `issue.md` contains exact fields `Timestamp`, `Command`, `EXIT_CODE` and folder names `evidence/baseline/`, `evidence/regression-testing/`, `evidence/other/`, `evidence/qa-gates/`.
 
 Phase completion criteria:
@@ -145,18 +145,18 @@ Phase completion criteria:
 
 ### Phase 6 — Final QA Loop and Evidence Closure
 
-- [ ] [P6-T1] Run formatter loop start command `poetry run black .` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-format.2026-02-19T12-02.md`
+- [x] [P6-T1] Run formatter loop start command `poetry run black .` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-format.2026-02-19T12-02.md`
   - Acceptance: Evidence file exists with schema fields and `EXIT_CODE: 0`.
-- [ ] [P6-T2] Run linter command `poetry run ruff check` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-lint.2026-02-19T12-02.md`
+- [x] [P6-T2] Run linter command `poetry run ruff check` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-lint.2026-02-19T12-02.md`
   - Dependencies: [P6-T1]
   - Acceptance: Evidence file exists with schema fields and `EXIT_CODE: 0`.
-- [ ] [P6-T3] Run type checker command `poetry run pyright` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-type.2026-02-19T12-02.md`
+- [x] [P6-T3] Run type checker command `poetry run pyright` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-type.2026-02-19T12-02.md`
   - Dependencies: [P6-T2]
   - Acceptance: Evidence file exists with schema fields and `EXIT_CODE: 0`.
-- [ ] [P6-T4] Run test command `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-test.2026-02-19T12-02.md`
+- [x] [P6-T4] Run test command `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and save output to `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/qa-gates/qa-test.2026-02-19T12-02.md`
   - Dependencies: [P6-T3]
   - Acceptance: Evidence file exists with schema fields and `EXIT_CODE: 0`.
-- [ ] [P6-T5] Re-run the full QA loop from P6-T1 if any prior QA gate changed files or had non-zero exit codes
+- [x] [P6-T5] Re-run the full QA loop from P6-T1 if any prior QA gate changed files or had non-zero exit codes
   - Acceptance: Latest evidence set shows all four commands passing in one clean pass with no subsequent file modifications.
 
 Phase completion criteria:

--- a/docs/features/templates/README.md
+++ b/docs/features/templates/README.md
@@ -8,3 +8,9 @@ Use these templates to keep planning consistent.
 - When the feature ships, move the folder to `docs/features/archive/<YYYY-MM-DD>-<feature-name>/` to keep a clean working set.
 - For refactors (no user-facing change), use `refactor/spec.md` and `refactor/plan.md` to capture intent, invariants, and execution steps.
 - For epics/initiatives (tracking multiple child features/workstreams), use `epic/initiative.md` to record goals, decomposition, milestones, and validation across children.
+
+
+- Decision tree paths:
+  - `minor-audit`: use for bootstrapped/pre-cooked work or <=3 production files with low integration risk.
+  - `feature`: use for standard user-facing feature development requiring full docs.
+  - `refactor`: use for non-user-facing structural/code-quality work.

--- a/scripts/dev_tools/new_active_feature_folder.py
+++ b/scripts/dev_tools/new_active_feature_folder.py
@@ -858,16 +858,49 @@ def update_feature_docs(
     return files_to_open
 
 
+def should_use_minor_audit_mode(
+    work_mode: str,
+    feature_type: str,
+    potential_content: str,
+) -> tuple[bool, str]:
+    """Return whether minor-audit path should be used and fallback reason."""
+
+    if work_mode not in ("minor-audit", "full"):
+        raise ValueError("work_mode must be one of: minor-audit, full")
+    if work_mode == "full":
+        return False, ""
+    if feature_type != "feature":
+        return False, "fallback: minor-audit only applies to feature type"
+
+    lower = potential_content.lower()
+    if "bootstrapped" in lower or "pre-cooked" in lower:
+        return True, ""
+
+    production_files = len(
+        re.findall(
+            r"^\s*-\s*(?:production\s+)?file\s*:", potential_content, flags=re.MULTILINE
+        )
+    )
+    has_low_risk = "low integration risk" in lower or "risk: low" in lower
+    if production_files <= 3 and has_low_risk:
+        return True, ""
+    if production_files > 3:
+        return False, "fallback: production file count exceeds 3"
+    return False, "fallback: missing low integration risk signal"
+
+
 def create_active_folder(
     feature_name: str,
-    feature_type: str,
+    feature_type: str = "feature",
     issue_number: str | None = None,
     force: bool = False,
+    *,
     workspace: Path | None = None,
     fs: FileSystem | None = None,
     issue_fetcher: Callable[[str], IssueMeta | None] = default_issue_fetcher,
     code_launcher: Callable[[Iterable[Path]], bool] = default_code_launcher,
     now_provider: Callable[[], datetime] | None = None,
+    work_mode: str = "full",
 ) -> ActiveFolderResult:
     if feature_type not in {"feature", "refactor", "epic", "bug"}:
         raise ValueError("Type must be one of: feature, refactor, epic, bug")
@@ -882,6 +915,11 @@ def create_active_folder(
 
     potential_file = find_potential_file(feature_name, workspace_path, filesystem)
     potential_content = filesystem.read_text(potential_file) if potential_file else ""
+    use_minor_audit, fallback_reason = should_use_minor_audit_mode(
+        work_mode=work_mode,
+        feature_type=feature_type,
+        potential_content=potential_content,
+    )
 
     normalized_issue_number = (issue_number or "").strip() or None
     if normalized_issue_number and normalized_issue_number.lower() == "auto":
@@ -953,30 +991,70 @@ def create_active_folder(
         ),
     }
 
-    files_to_open = update_feature_docs(
-        feature_type,
-        feature_name,
-        target_dir,
-        issue_field,
-        owner_field,
-        updated_field,
-        parent_field,
-        status_field,
-        version_field,
-        plan_updated_field,
-        filesystem,
-        sections,
-        plan_path=plan_path,
-    )
+    files_to_open: list[Path]
+    if use_minor_audit:
+        issue_doc = target_dir / "issue.md"
+        issue_body = "\n".join(
+            [
+                f"# {feature_name}",
+                "",
+                "## Problem / Why",
+                sections["problem"] or "(not provided in potential file)",
+                "",
+                "## Implementation Intent",
+                sections["behavior"] or "(not provided in potential file)",
+                "",
+                "## Acceptance Criteria",
+                sections["criteria"] or "(not provided in potential file)",
+                "",
+                "## Dependencies / Risks",
+                sections["constraints"] or "(not provided in potential file)",
+                "",
+                "## Verification Steps",
+                sections["tests"] or "(not provided in potential file)",
+                "",
+                "## Evidence Checklist",
+                "- [ ] baseline",
+                "- [ ] targeted verification",
+                "- [ ] end-state",
+            ]
+        )
+        filesystem.write_text(issue_doc, issue_body)
+        files_to_open = [issue_doc]
+    else:
+        files_to_open = update_feature_docs(
+            feature_type,
+            feature_name,
+            target_dir,
+            issue_field,
+            owner_field,
+            updated_field,
+            parent_field,
+            status_field,
+            version_field,
+            plan_updated_field,
+            filesystem,
+            sections,
+            plan_path=plan_path,
+        )
 
     potential_issue_path = None
     if potential_file:
         potential_issue_path = target_dir / "issue.md"
-        filesystem.move(potential_file, potential_issue_path)
-        print(f"Moved potential file to {potential_issue_path}")
+        if use_minor_audit:
+            print(
+                f"Kept generated issue.md for minor-audit mode: {potential_issue_path}"
+            )
+        else:
+            filesystem.move(potential_file, potential_issue_path)
+            print(f"Moved potential file to {potential_issue_path}")
 
     if potential_file:
         print(f"Seeded docs from potential: {potential_file.name}")
+
+    print(f"Selected mode: {'minor-audit' if use_minor_audit else 'full'}")
+    if fallback_reason:
+        print(f"Fallback reason: {fallback_reason}")
 
     if files_to_open:
         existing = [path for path in files_to_open if filesystem.exists(path)]
@@ -1018,6 +1096,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--force", action="store_true", help="Overwrite existing target"
     )
+    parser.add_argument(
+        "--work-mode",
+        choices=["minor-audit", "full"],
+        default="full",
+        help="Work mode routing for minor-audit vs full feature flow.",
+    )
     return parser.parse_args()
 
 
@@ -1029,6 +1113,7 @@ def main() -> None:
             feature_type=args.feature_type,
             issue_number=args.issue_number,
             force=args.force,
+            work_mode=args.work_mode,
         )
     except (ValueError, FileExistsError) as exc:
         print(str(exc))

--- a/scripts/dev_tools/potential_to_issue.py
+++ b/scripts/dev_tools/potential_to_issue.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 PLACEHOLDER = "(not provided in potential file)"
 ISSUE_URL_PATTERN = re.compile(r"https?://\S+/issues/(\d+)")
 PROMOTION_TYPES = ("epic", "feature", "refactor", "bug")
+WORK_MODES = ("minor-audit", "full")
 TITLE_PREFIXES = {
     "epic": "Epic",
     "feature": "Feature",
@@ -237,6 +238,46 @@ def build_bug_body(sections: dict[str, str], relative_path: str) -> str:
     return "\n\n".join(parts) + "\n"
 
 
+def evaluate_minor_audit_eligibility(content: str) -> tuple[bool, str]:
+    """Evaluate deterministic eligibility for minor-audit mode."""
+
+    lower = content.lower()
+    if "bootstrapped" in lower or "pre-cooked" in lower:
+        return True, "eligible: bootstrapped/pre-cooked"
+
+    production_files = len(
+        re.findall(r"^\s*-\s*(?:production\s+)?file\s*:", content, flags=re.MULTILINE)
+    )
+    has_low_risk = "low integration risk" in lower or "risk: low" in lower
+    if production_files <= 3 and has_low_risk:
+        return True, "eligible: <=3 production files and low integration risk"
+    if production_files > 3:
+        return False, "fallback: production file count exceeds 3"
+    return False, "fallback: missing low integration risk signal"
+
+
+def build_minor_audit_body(
+    problem: str,
+    implementation_intent: str,
+    acceptance_criteria: str,
+    dependencies_risks: str,
+    verification_steps: str,
+    evidence_checklist: str,
+    relative_path: str,
+) -> str:
+    """Build required issue sections for the minor-audit mode."""
+
+    return (
+        f"## Problem / Why\n{problem}\n\n"
+        f"## Implementation Intent\n{implementation_intent}\n\n"
+        f"## Acceptance Criteria\n{acceptance_criteria}\n\n"
+        f"## Dependencies / Risks\n{dependencies_risks}\n\n"
+        f"## Verification Steps\n{verification_steps}\n\n"
+        f"## Evidence Checklist\n{evidence_checklist}\n\n"
+        f"## Source\nFrom: {relative_path}\n"
+    )
+
+
 def parse_issue_reference(output: Iterable[str]) -> tuple[str | None, str | None]:
     text = "\n".join(output)
     match = ISSUE_URL_PATTERN.search(text)
@@ -334,10 +375,13 @@ def promote_potential(
     fs: FileSystem | None = None,
     gh: GhClient | None = None,
     workspace: Path | None = None,
+    work_mode: str = "full",
     emit: Callable[[str], None] = _default,
 ) -> PromotionOutcome:
     if promotion_type not in PROMOTION_TYPES:
         raise PromotionError(f"Invalid promotion type: {promotion_type}")
+    if work_mode not in WORK_MODES:
+        raise PromotionError(f"Invalid work mode: {work_mode}")
 
     filesystem = fs or RealFileSystem()
     gh_client = gh or RealGhClient()
@@ -369,12 +413,45 @@ def promote_potential(
 
     relative_path = Path(_relative_path()).as_posix()
 
+    selected_mode = "full"
+    fallback_reason = ""
+    if work_mode == "minor-audit" and promotion_type != "bug":
+        eligible, eligibility_reason = evaluate_minor_audit_eligibility(content)
+        if eligible:
+            selected_mode = "minor-audit"
+        else:
+            fallback_reason = eligibility_reason
+
     if promotion_type == "bug":
         bug_sections = {
             heading: get_section(content, heading) or PLACEHOLDER
             for heading in BUG_SECTION_HEADINGS
         }
         body = build_bug_body(bug_sections, relative_path)
+    elif selected_mode == "minor-audit":
+        problem = get_section(content, "Problem / Why") or PLACEHOLDER
+        implementation_intent = get_section(content, "Proposed Behavior") or PLACEHOLDER
+        acceptance_criteria = (
+            get_section(content, "Acceptance Criteria (early draft)") or PLACEHOLDER
+        )
+        dependencies_risks = get_section(content, "Constraints & Risks") or PLACEHOLDER
+        verification_steps = (
+            get_section(content, "Test Conditions to Consider") or PLACEHOLDER
+        )
+        evidence_checklist = get_section(content, "Evidence Checklist")
+        if not evidence_checklist:
+            evidence_checklist = (
+                "- [ ] Baseline\n- [ ] End-state\n- [ ] Targeted verification"
+            )
+        body = build_minor_audit_body(
+            problem,
+            implementation_intent,
+            acceptance_criteria,
+            dependencies_risks,
+            verification_steps,
+            evidence_checklist,
+            relative_path,
+        )
     else:
         problem = get_section(content, "Problem / Why") or PLACEHOLDER
         behavior = get_section(content, "Proposed Behavior") or PLACEHOLDER
@@ -394,6 +471,9 @@ def promote_potential(
         messages.append(msg)
         emit(msg)
 
+    _emit(f"Selected mode: {selected_mode}")
+    if fallback_reason:
+        _emit(f"Fallback reason: {fallback_reason}")
     _emit(f"Creating issue: {issue_title} (label: {promotion_type})")
     create_result = gh_client.issue_create(issue_title, body, promotion_type)
 
@@ -453,6 +533,12 @@ def parse_args() -> argparse.Namespace:
         default="feature",
         help="Promotion type label to attach to the issue.",
     )
+    parser.add_argument(
+        "--work-mode",
+        choices=WORK_MODES,
+        default="full",
+        help="Work mode routing for full vs minor-audit issue body generation.",
+    )
     return parser.parse_args()
 
 
@@ -462,6 +548,7 @@ def main() -> None:
         outcome = promote_potential(
             potential_path=args.potential_path,
             promotion_type=args.promotion_type,
+            work_mode=args.work_mode,
         )
     except (PromotionError, FileNotFoundError) as exc:
         print(str(exc))

--- a/tests/scripts/dev_tools/test_new_active_feature_folder.py
+++ b/tests/scripts/dev_tools/test_new_active_feature_folder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -953,3 +954,123 @@ def test_default_issue_fetcher_handles_exception_in_date_parsing() -> None:
             assert result is not None
             # When updatedAt is null or missing, should default to YYYY-MM-DD
             assert result.updated_date == "YYYY-MM-DD"
+
+
+def test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs():
+    fs = FakeFileSystem()
+    workspace = Path("/workspace")
+    _seed_feature_template(fs, workspace)
+    potential_path = workspace / "docs" / "features" / "potential" / "minor-audit.md"
+    fs.write_text(
+        potential_path,
+        "\n".join(
+            [
+                "- Issue: #28",
+                "- File: scripts/dev_tools/new_active_feature_folder.py",
+                "- Risk: low",
+                "## Problem / Why",
+                "problem",
+                "## Proposed Behavior",
+                "intent",
+                "## Acceptance Criteria (early draft)",
+                "criteria",
+                "## Constraints & Risks",
+                "low integration risk",
+                "## Test Conditions to Consider",
+                "verify",
+            ]
+        ),
+    )
+    result = mod.create_active_folder(
+        feature_name="minor-audit",
+        feature_type="feature",
+        workspace=workspace,
+        fs=fs,
+        work_mode="minor-audit",
+    )
+    assert fs.exists(result.target / "issue.md")
+    assert "Implementation Intent" in fs.read_text(result.target / "issue.md")
+
+
+def test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fs = FakeFileSystem()
+    workspace = Path("/workspace")
+    _seed_feature_template(fs, workspace)
+    potential_path = workspace / "docs" / "features" / "potential" / "fallback.md"
+    fs.write_text(
+        potential_path,
+        "\n".join(
+            [
+                "- Issue: #29",
+                "- File: a.py",
+                "- File: b.py",
+                "- File: c.py",
+                "- File: d.py",
+                "## Problem / Why",
+                "problem",
+            ]
+        ),
+    )
+    result = mod.create_active_folder(
+        feature_name="fallback",
+        feature_type="feature",
+        workspace=workspace,
+        fs=fs,
+        work_mode="minor-audit",
+    )
+    out = capsys.readouterr().out
+    assert fs.exists(result.target / "user-story.md")
+    assert "Selected mode: full" in out
+    assert "Fallback reason:" in out
+
+
+def test_create_active_folder_full_mode_remains_backward_compatible() -> None:
+    fs = FakeFileSystem()
+    workspace = Path("/workspace")
+    _seed_feature_template(fs, workspace)
+    result = mod.create_active_folder(
+        feature_name="full-compatible",
+        feature_type="feature",
+        workspace=workspace,
+        fs=fs,
+        work_mode="full",
+    )
+    assert fs.exists(result.target / "user-story.md")
+
+
+def test_create_active_folder_fallback_reason_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fs = FakeFileSystem()
+    workspace = Path("/workspace")
+    _seed_feature_template(fs, workspace)
+    result = mod.create_active_folder(
+        feature_name="no-potential",
+        feature_type="feature",
+        workspace=workspace,
+        fs=fs,
+        work_mode="minor-audit",
+    )
+    assert result.target
+    out = capsys.readouterr().out
+    assert "Fallback reason:" in out
+
+
+def test_parse_args_includes_work_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--feature-name",
+            "sample",
+            "--type",
+            "feature",
+            "--work-mode",
+            "minor-audit",
+        ],
+    )
+    parsed = mod.parse_args()
+    assert parsed.work_mode == "minor-audit"

--- a/tests/scripts/dev_tools/test_potential_to_issue.py
+++ b/tests/scripts/dev_tools/test_potential_to_issue.py
@@ -521,18 +521,26 @@ def test_parse_args_and_main_paths(
         str(potential),
         "--promotion-type",
         "epic",
+        "--work-mode",
+        "minor-audit",
     ]
     monkeypatch.setattr(sys, "argv", args)
     parsed = mod.parse_args()
     assert parsed.potential_path == str(potential)
     assert parsed.promotion_type == "epic"
+    assert parsed.work_mode == "minor-audit"
 
-    fake_args = SimpleNamespace(potential_path=str(potential), promotion_type="feature")
+    fake_args = SimpleNamespace(
+        potential_path=str(potential), promotion_type="feature", work_mode="full"
+    )
 
     def fake_parse_args() -> SimpleNamespace:
         return fake_args
 
-    def fake_promote(potential_path: str, promotion_type: str) -> mod.PromotionOutcome:
+    def fake_promote(
+        potential_path: str, promotion_type: str, work_mode: str
+    ) -> mod.PromotionOutcome:
+        assert work_mode in {"full", "minor-audit"}
         return mod.PromotionOutcome(0, [], None)
 
     monkeypatch.setattr(mod, "parse_args", fake_parse_args)
@@ -546,7 +554,9 @@ def test_main_exits_on_promotion_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     fake_args = SimpleNamespace(
-        potential_path=str(tmp_path / "p.md"), promotion_type="feature"
+        potential_path=str(tmp_path / "p.md"),
+        promotion_type="feature",
+        work_mode="full",
     )
 
     def fake_parse_args() -> SimpleNamespace:
@@ -561,3 +571,141 @@ def test_main_exits_on_promotion_error(
     with pytest.raises(SystemExit) as exc:
         mod.main()
     assert exc.value.code == 1
+
+
+def test_promote_potential_minor_audit_adds_required_issue_sections() -> None:
+    workspace = Path("/workspace")
+    potential = workspace / "docs/features/potential/minor.md"
+    fs = FakeFileSystem()
+    fs.files[potential] = "\n".join(
+        [
+            "# Minor Audit Feature",
+            "- File: scripts/dev_tools/potential_to_issue.py",
+            "- File: tests/scripts/dev_tools/test_potential_to_issue.py",
+            "- Risk: low",
+            "## Problem / Why",
+            "problem",
+            "## Proposed Behavior",
+            "intent",
+            "## Acceptance Criteria (early draft)",
+            "- [ ] done",
+            "## Constraints & Risks",
+            "low integration risk",
+            "## Test Conditions to Consider",
+            "verify this",
+        ]
+    )
+    gh = FakeGhClient(
+        mod.GhResult(["Created: https://example.com/issues/55"], 0), mod.GhResult([], 0)
+    )
+    outcome = mod.promote_potential(
+        potential_path=str(potential),
+        promotion_type="feature",
+        fs=fs,
+        gh=gh,
+        workspace=workspace,
+        work_mode="minor-audit",
+    )
+    assert outcome.exit_code == 0
+    body = gh.calls[0][1][1]
+    assert "## Implementation Intent" in body
+    assert "## Verification Steps" in body
+    assert "## Evidence Checklist" in body
+
+
+def test_promote_potential_minor_audit_rejects_missing_eligibility_inputs() -> None:
+    workspace = Path("/workspace")
+    potential = workspace / "docs/features/potential/not-eligible.md"
+    fs = FakeFileSystem()
+    fs.files[potential] = "\n".join(
+        [
+            "# Not Eligible",
+            "- File: a.py",
+            "- File: b.py",
+            "- File: c.py",
+            "- File: d.py",
+            "## Problem / Why",
+            "problem",
+            "## Proposed Behavior",
+            "behavior",
+        ]
+    )
+    messages: list[str] = []
+    gh = FakeGhClient(
+        mod.GhResult(["Created: https://example.com/issues/77"], 0), mod.GhResult([], 0)
+    )
+    outcome = mod.promote_potential(
+        potential_path=str(potential),
+        promotion_type="feature",
+        fs=fs,
+        gh=gh,
+        workspace=workspace,
+        work_mode="minor-audit",
+        emit=messages.append,
+    )
+    assert outcome.exit_code == 0
+    assert any("Selected mode: full" in m for m in messages)
+    assert any("Fallback reason:" in m for m in messages)
+
+
+def test_promote_potential_full_mode_preserves_existing_body_contract() -> None:
+    workspace = Path("/workspace")
+    potential = workspace / "docs/features/potential/full-mode.md"
+    fs = FakeFileSystem()
+    fs.files[potential] = "\n".join(
+        [
+            "# Full Mode",
+            "## Problem / Why",
+            "problem",
+            "## Proposed Behavior",
+            "behavior",
+            "## Acceptance Criteria (early draft)",
+            "criteria",
+            "## Constraints & Risks",
+            "constraints",
+            "## Test Conditions to Consider",
+            "tests",
+        ]
+    )
+    gh = FakeGhClient(
+        mod.GhResult(["Created: https://example.com/issues/99"], 0), mod.GhResult([], 0)
+    )
+    mod.promote_potential(
+        potential_path=str(potential),
+        promotion_type="feature",
+        fs=fs,
+        gh=gh,
+        workspace=workspace,
+        work_mode="full",
+    )
+    body = gh.calls[0][1][1]
+    assert "## Proposed Behavior" in body
+    assert "## Implementation Intent" not in body
+
+
+def test_promote_potential_body_omits_token_like_secret_strings() -> None:
+    workspace = Path("/workspace")
+    potential = workspace / "docs/features/potential/security.md"
+    fs = FakeFileSystem()
+    fs.files[potential] = (
+        "# Security\n"
+        "## Problem / Why\n"
+        "no tokens\n"
+        "## Proposed Behavior\n"
+        "no tokens\n"
+    )
+    gh = FakeGhClient(
+        mod.GhResult(["Created: https://example.com/issues/12"], 0), mod.GhResult([], 0)
+    )
+    mod.promote_potential(
+        potential_path=str(potential),
+        promotion_type="feature",
+        fs=fs,
+        gh=gh,
+        workspace=workspace,
+        work_mode="minor-audit",
+    )
+    body = gh.calls[0][1][1]
+    assert "ghp_" not in body
+    assert "xoxb-" not in body
+    assert "AIza" not in body


### PR DESCRIPTION
Add Minor Change Audit Path docs and dev-tools support for issue.md-first workflow

## Summary

- Define and document a “Minor Change Audit Path” that treats an expanded `issue.md` as the canonical planning + audit surface for qualifying small/bootstrapped work.
- Extend `scripts/dev_tools` automation for creating active feature folders and promoting potential entries to issues, with expanded Pytest coverage.
- Add minimal audit evidence artifacts (baseline + QA gates) under the active feature folder to support reviewer confidence for minor-scope work.
- Update `.vscode/tasks.json`, `docs/engineering/Feature Playbook.md`, and `docs/features/templates/README.md` to reflect the minor-audit path and usage.

## Why

Small or bootstrapped feature work currently has two sub-optimal choices:

- Fill out full `user-story.md` + `spec.md` + `plan.md` templates with high authoring overhead for minor scope, or
- Skip active feature docs and lose required traceability/audit trail.

This PR advances the proposed behavior for issue #28: adopt a **Minor Change Audit Path** where qualifying work (bootstrapped or very small scope) can be completed and reviewed using an expanded `issue.md` plus a minimum evidence package, while keeping deterministic eligibility criteria and explicit evidence expectations to mitigate the risk of under-testing or over-classifying work as “minor”.

## What Changed

- Core behavior / architecture
  - Updated `scripts/dev_tools/new_active_feature_folder.py` to support the workflow for creating active feature folders in a minor-audit context.
  - Added `scripts/dev_tools/potential_to_issue.py` to support promoting potential entries to issue-centric active feature documentation.
  - Expanded Pytest coverage for the above via:
    - `tests/scripts/dev_tools/test_new_active_feature_folder.py`
    - `tests/scripts/dev_tools/test_potential_to_issue.py`

- Tooling / automation / CI / DevEx
  - Updated `.vscode/tasks.json` to reflect and support the workflow (task wiring changes).

- Tests
  - Added/expanded focused unit tests for the dev-tools scripts listed above.

- Docs / templates / agents
  - Updated `docs/engineering/Feature Playbook.md` to document the Minor Change Audit Path and its eligibility framing.
  - Updated `docs/features/templates/README.md` to align templates/documentation with the lightweight path.
  - Updated the active feature folder documentation for the minor-audit feature, including `docs/features/active/2026-02-19-minor-audit-small-change-28/issue.md` and `docs/features/active/2026-02-19-minor-audit-small-change-28/plan.2026-02-19T12-02.md`.
  - Added baseline + QA gate evidence artifacts under `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/...`.

## Architecture / How It Fits Together

- Developer workflow is supported by two key dev-tools entry points:
  - `scripts/dev_tools/new_active_feature_folder.py` creates/updates the active feature folder structure used by the repo’s feature workflow.
  - `scripts/dev_tools/potential_to_issue.py` supports promoting a potential entry into an issue-centric active feature representation.
- Reviewability and safety for the minor-audit path are intended to come from:
  - Deterministic eligibility criteria (minor scope / bootstrapped work), and
  - A minimum evidence package (baseline + end-state + targeted verification), captured alongside the expanded `issue.md`.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in `artifacts/pr_context.summary.txt`).

### Recommended

- Python formatting:
  - `poetry run black .`
- Python lint:
  - `poetry run ruff check`
- Python type-check:
  - `poetry run pyright`
- Python tests (repo standard):
  - `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`

## Backward Compatibility / Migration Notes

- No breaking API removals are indicated by the PR context.
- This change is primarily additive (new/expanded dev-tools behavior, docs, and evidence artifacts). Review any workflow expectations updated in `docs/engineering/Feature Playbook.md` and `.vscode/tasks.json` if you rely on existing task names/labels.

## Risks and Mitigations

- Risk: teams may over-classify work as “minor/bootstrapped” to avoid appropriate rigor.
  - Mitigation: keep eligibility criteria explicit (small scope / narrow blast radius / low integration risk) and require explicit minimum evidence sections for reviewer evaluation.
- Risk: reduced regression scope may miss adjacent breakage.
  - Mitigation: require targeted verification for touched behavior and document why broad regression is unnecessary for the specific case; escalate to the full feature path when risk/complexity increases.

## Review Guide

- Start with the “why” and intended governance:
  - `docs/engineering/Feature Playbook.md`
- Review the issue-centric workflow changes in dev-tools:
  - `scripts/dev_tools/new_active_feature_folder.py`
  - `scripts/dev_tools/potential_to_issue.py`
- Validate unit test coverage and intent:
  - `tests/scripts/dev_tools/test_new_active_feature_folder.py`
  - `tests/scripts/dev_tools/test_potential_to_issue.py`
- Skim supporting docs/templates and active feature artifacts:
  - `docs/features/templates/README.md`
  - `docs/features/active/2026-02-19-minor-audit-small-change-28/issue.md`
  - Evidence artifacts under `docs/features/active/2026-02-19-minor-audit-small-change-28/evidence/...`
- Finally, confirm task wiring changes are sensible:
  - `.vscode/tasks.json`

## Follow-ups

- Fill in “PR Intent” fields (Primary outcome / impact / risks) in the PR context workflow to improve reviewer signal.
- Consider adding additional enforcement/guardrails (beyond documentation) if over-classification becomes a recurring risk (per the constraints & risks described in the feature docs).

## GitHub Auto-close

- Closes #28

## Related issues / PRs

- (none)