### PR TITLE
Bootstrap PowerShell ecosystem (#30) with PoshQC Pester tests and coverage conversion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		},
+		{
+			"name": "Debug: Agentic Sync",
+			"type": "python",
+			"request": "launch",
+			"program": "${workspaceFolder}/scripts/dev_tools/agentic_sync.py",
+			"console": "integratedTerminal",
+			"args": [
+				"${workspaceFolder}",
+				"${input:RightRepoPath}"
+			],
+			"justMyCode": true
+		},
+		{
+			"name": "Python: Current File",
+			"type": "python",
+			"request": "launch",
+			"program": "${file}",
+			"console": "integratedTerminal",
+			"justMyCode": true
+		}
+	],
+	"inputs": [
+		{
+			"id": "RightRepoPath",
+			"type": "promptString",
+			"description": "Enter the path to the right repository workspace",
+			"default": "${workspaceFolder}"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,875 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"$schema": "./schemas/tasks.schema.json",
+	"inputs": [
+		{
+		"default": "development",
+		"description": "Base branch for PR comparison (e.g., development, main)",
+		"id": "PRBaseBranch",
+		"type": "promptString"
+		},
+		{
+		"default": "notes-feature",
+		"description": "Short name (kebab-case, e.g., notes-feature)",
+		"id": "PotentialShortName",
+		"type": "promptString"
+		},
+		{
+		"default": "api-timeout-bug",
+		"description": "Short name (kebab-case, e.g., api-timeout-bug)",
+		"id": "PotentialBugShortName",
+		"type": "promptString"
+		},
+		{
+		"default": "feature",
+		"description": "Promotion type / label to apply",
+		"id": "PotentialPromotionType",
+		"options": [
+			"epic",
+			"feature",
+			"refactor",
+			"bug"
+		],
+		"type": "pickString"
+		},
+		{
+		"default": "new_feature",
+		"description": "Feature folder name (kebab/underscore-case, e.g., notes_feature)",
+		"id": "ActiveFeatureName",
+		"type": "promptString"
+		},
+		{
+		"default": "",
+		"description": "Feature folder under docs/features/active (leave blank to auto-detect)",
+		"id": "ExecutePlanFeatureFolder",
+		"type": "promptString"
+		},
+		{
+		"default": "feature",
+		"description": "Template type",
+		"id": "ActiveWorkType",
+		"options": [
+			"feature",
+			"refactor",
+			"epic",
+			"bug"
+		],
+		"type": "pickString"
+		},
+		{
+		"default": "auto",
+		"description": "Issue number (optional, e.g., 14)",
+		"id": "ActiveIssueNumber",
+		"type": "promptString"
+		},
+		{
+		"default": "",
+		"description": "Issue number to update (e.g., 14)",
+		"id": "LinkIssueNumber",
+		"type": "promptString"
+		},
+		{
+		"default": "new_feature",
+		"description": "Feature folder name (e.g., new_feature)",
+		"id": "LinkFeatureName",
+		"type": "promptString"
+		},
+		{
+		"default": "",
+		"description": "Child issue number to link (e.g., 15)",
+		"id": "ChildIssueNumber",
+		"type": "promptString"
+		},
+		{
+		"default": "10",
+		"description": "Parent tracking issue number (e.g., 10)",
+		"id": "ParentIssueNumber",
+		"type": "promptString"
+		},
+		{
+		"default": "Python Engineer (Strongly Typed, Testable, Pytest-First)",
+		"description": "Agent personality to inject into the template",
+		"id": "ExecutePlanAgent",
+		"options": [
+			"Python Engineer (Strongly Typed, Testable, Pytest-First)",
+			"Python Execution Only",
+			"atomic_executor"
+		],
+		"type": "pickString"
+		},
+		{
+		"default": "gpt-5.2",
+		"description": "Preferred model passed to --preferred-model",
+		"id": "AtomicPreferredModel",
+		"options": [
+			"Claude Sonnet 4.5",
+			"Claude Haiku 4.5",
+			"Claude Opus 4.5",
+			"Claude Sonnet 4",
+			"GPT-5.2-Codex",
+			"GPT-5.1-Codex-Max",
+			"GPT-5.1-Codex",
+			"GPT-5.2",
+			"GPT-5.1",
+			"GPT-5",
+			"GPT-5.1-Codex-Mini",
+			"GPT-5 mini",
+			"GPT-4.1",
+			"Gemini 3 Pro (Preview)"
+		],
+		"type": "pickString"
+		},
+		{
+		"default": "docs/features/active/",
+		"description": "Path to feature folder or plan file (relative or absolute)",
+		"id": "AtomicFeaturePath",
+		"type": "promptString"
+		}
+	],
+	"tasks": [
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/dev-tools/load-openai-key.ps1",
+				"-ItemName",
+				"Lexile OpenAI Key"
+			],
+			"command": "pwsh",
+			"label": "Load OpenAI Key",
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/dev-tools/publish-sideloaded-extension.ps1",
+				"-Force"
+			],
+			"command": "pwsh",
+			"label": "Publish (Side-load) VSIX",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+		"args": [
+			"run",
+			"black",
+			"."
+		],
+		"command": "poetry",
+		"group": {
+			"isDefault": false,
+			"kind": "build"
+		},
+		"label": "QC: 1 Black: format",
+		"presentation": {
+			"close": false,
+			"panel": "new",
+			"reveal": "always",
+			"showReuseMessage": false
+		},
+		"problemMatcher": [],
+		"type": "shell"
+		},
+		{
+		"args": [
+			"run",
+			"ruff",
+			"check"
+		],
+		"command": "poetry",
+		"group": {
+			"isDefault": false,
+			"kind": "test"
+		},
+		"label": "QC: 2 Ruff: lint",
+		"presentation": {
+			"close": false,
+			"panel": "new",
+			"reveal": "always",
+			"showReuseMessage": false
+		},
+		"problemMatcher": [],
+		"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"ruff",
+				"check",
+				"--fix"
+			],
+			"command": "poetry",
+			"group": {
+				"isDefault": false,
+				"kind": "build"
+		},
+		"label": "QC: 2 Ruff: fix",
+		"presentation": {
+			"close": false,
+			"panel": "new",
+			"reveal": "always",
+			"showReuseMessage": false
+		},
+		"problemMatcher": [],
+		"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"pyright"
+			],
+			"command": "poetry",
+			"group": {
+				"isDefault": false,
+				"kind": "test"
+			},
+			"label": "QC: 3 Pyright: type-check",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"pytest"
+			],
+			"command": "poetry",
+			"group": {
+				"isDefault": true,
+				"kind": "test"
+			},
+			"label": "QC: 4 Pytest: run tests",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"pytest",
+				"--cov=src/lexile_corpus_tuner",
+				"--cov=scripts/dev_tools",
+				"--cov-report=term-missing"
+			],
+			"command": "poetry",
+			"group": {
+				"isDefault": false,
+				"kind": "test"
+			},
+			"label": "QC: 4 Pytest: run tests with coverage",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-Command",
+				"& { Import-Module '${workspaceFolder}/scripts/powershell/PoshQC'; Invoke-PoshQCFormat -Root '${workspaceFolder}' }"
+			],
+			"command": "pwsh",
+			"detail": "Formats PowerShell files using Invoke-Formatter and repo PSScriptAnalyzer settings.",
+			"group": {
+				"isDefault": false,
+				"kind": "build"
+			},
+			"label": "PoshQC: 1 format",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-Command",
+				"& { Import-Module '${workspaceFolder}/scripts/powershell/PoshQC'; Invoke-PoshQCAnalyze -Root '${workspaceFolder}' }"
+			],
+			"command": "pwsh",
+			"detail": "Runs PSScriptAnalyzer with strict settings and fails on any findings.",
+			"group": {
+				"isDefault": false,
+				"kind": "build"
+			},
+			"label": "PoshQC: 2 analyze",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-Command",
+				"& { Import-Module '${workspaceFolder}/scripts/powershell/PoshQC'; $files = Get-ChildItem -Path '${workspaceFolder}' -Recurse -Include *.ps1, *.psm1 -File; if ($files) { foreach ($f in $files) { Invoke-ScriptAnalyzer -Path $f.FullName -Settings '${workspaceFolder}/scripts/powershell/PoshQC/settings/pssa.settings.psd1' -Severity Error,Warning,Information -Fix } } else { Write-Host 'No PowerShell files found under workspace.' } }"
+			],
+			"command": "pwsh",
+			"detail": "Runs PSScriptAnalyzer with -Fix to auto-apply supported fixes for PowerShell files.",
+			"group": {
+				"isDefault": false,
+				"kind": "build"
+			},
+			"label": "PoshQC: 2b autofix (PSSA -Fix)",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-Command",
+				"& { Import-Module '${workspaceFolder}/scripts/powershell/PoshQC'; Invoke-PoshQCTest -Root '${workspaceFolder}' }"
+			],
+			"command": "pwsh",
+			"detail": "Runs Pester with repo configuration and JUnit output.",
+			"group": {
+				"isDefault": false,
+				"kind": "test"
+			},
+			"label": "PoshQC: 4 test (Pester)",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},		
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.fix_all"
+			],
+			"command": "poetry",
+			"group": {
+				"isDefault": true,
+				"kind": "build"
+			},
+			"label": "QC: 0 Fix All",
+			"presentation": {
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.format_json"
+			],
+			"command": "poetry",
+			"detail": "Formats governed JSON files with jq --sort-keys.",
+			"group": {
+				"isDefault": false,
+				"kind": "build"
+			},
+			"label": "JSON: format",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.validate_json"
+			],
+			"command": "poetry",
+			"detail": "Validates governed JSON files against their $schema.",
+			"group": {
+				"isDefault": false,
+				"kind": "test"
+			},
+			"label": "JSON: validate",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.markdown_label_formatter",
+				"${relativeFile}",
+				"--output",
+				"${relativeFile}"
+			],
+			"command": "poetry",
+			"detail": "Formats the active markdown file with chat label normalization.",
+			"group": {
+				"isDefault": false,
+				"kind": "build"
+			},
+			"label": "Copilot MD: format current chat file",
+			"presentation": {
+				"panel": "dedicated",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.collect_commit_context",
+				"--output",
+				"${workspaceFolder}/artifacts/commit_context.txt"
+			],
+			"command": "poetry",
+			"detail": "Collects git diff and status information for commit message generation",
+			"label": "Git: Collect Commit Context",
+			"presentation": {
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.pr_context.collector",
+				"--base",
+				"${input:PRBaseBranch}"
+			],
+			"command": "poetry",
+			"detail": "Collects git PR context comparing current branch to specified base branch",
+			"label": "Git: Collect Pull Request Context",
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.copy_research_to_issue"
+			],
+			"command": "poetry",
+			"detail": "Interactively selects a research doc and an active issue file, then copies it into the issue folder as research.md.",
+			"label": "Dev: Copy Research to Active Folder",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},		
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.potential_to_issue",
+				"--potential-path",
+				"${relativeFile}",
+				"--promotion-type",
+				"${input:PotentialPromotionType}"
+			],
+			"command": "poetry",
+			"detail": "Creates a feature issue from the active editor file (workspace-relative) using gh issue create (non-interactive) via Python.",
+			"label": "Dev: 2 Promote Potential to GitHub Issue",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/dev-tools/link-feature-docs.ps1",
+				"-IssueNumber",
+				"${input:LinkIssueNumber}",
+				"-FeatureName",
+				"${input:LinkFeatureName}"
+			],
+			"command": "pwsh",
+			"detail": "Adds/updates a Feature Docs section in an issue with links to user-story/spec/plan.",
+			"label": "Dev: 5 Link Feature Docs to GitHub",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/dev-tools/link-parent-child.ps1",
+				"-ChildIssueNumber",
+				"${input:ChildIssueNumber}",
+				"-ParentIssueNumber",
+				"${input:ParentIssueNumber}"
+			],
+			"command": "pwsh",
+			"detail": "Adds child link to parent tracking issue and comments on the child with the parent link.",
+			"label": "Dev: 4 Link GitHub Parent/Child Issues",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.new_active_feature_folder",
+				"--feature-name",
+				"${input:ActiveFeatureName}",
+				"--type",
+				"${input:ActiveWorkType}",
+				"--issue-number",
+				"${input:ActiveIssueNumber}"
+			],
+			"command": "poetry",
+			"detail": "Creates docs/features/active/<name>/ from the selected template (feature/refactor/epic/bug) and opens the relevant files.",
+			"label": "Dev: 3 Create Active Folder",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},		
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-Command",
+				"& { Import-Module '${workspaceFolder}/scripts/powershell/PoshQC'; Install-PoshQCTools }"
+			],
+			"command": "pwsh",
+			"detail": "Installs PSScriptAnalyzer and Pester (CurrentUser scope) for repo tasks.",
+			"label": "Dev: Install PowerShell Tooling",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/powershell/BootstrapPC/bootstrap-host.ps1",
+				"-Apply"
+			],
+			"command": "pwsh",
+			"detail": "Installs host prerequisites from scripts/powershell/BootstrapPC/host-tools.manifest.json.",
+			"label": "Dev: Host Bootstrap (PowerShell)",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/powershell/BootstrapPC/verify-host.ps1"
+			],
+			"command": "pwsh",
+			"detail": "Verifies host prerequisites against scripts/powershell/BootstrapPC/host-tools.manifest.json.",
+			"label": "Dev: Host Verify (PowerShell)",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},		
+		{
+			"args": [
+				"run",
+				"python",
+				"${workspaceFolder}/scripts/dev_tools/resolve_execute_plan_prompt.py",
+				"--feature",
+				"${file}",
+				"--agent",
+				"${input:ExecutePlanAgent}"
+			],
+			"command": "poetry",
+			"detail": "Resolves the feature from the current file, fills execute-plan prompt, and copies it to the clipboard.",
+			"label": "Dev: Resolve Execute Plan Prompt",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"${workspaceFolder}/scripts/dev_tools/new_potential_bug_entry.py",
+				"--short-name",
+				"${input:PotentialBugShortName}"
+			],
+			"command": "poetry",
+			"detail": "Creates a dated potential bug file from the automation template for later promotion.",
+			"label": "Dev: 1A New Potential Bug",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/dev-tools/new-potential-entry.ps1",
+				"-ShortName",
+				"${input:PotentialShortName}"
+			],
+			"command": "pwsh",
+			"detail": "Creates a dated potential feature file from the template and opens it plus backlog.md for editing.",
+			"label": "Dev: 1 New Potential Entry",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"scripts/dev_tools/resolve_file_prompt.py",
+				"--template",
+				"${workspaceFolder}/.github/prompts/generate-atomic-plan.prompt.md",
+				"--target",
+				"${file}"
+			],
+			"command": "poetry",
+			"detail": "Resolves ${file} in the atomic plan prompt with the active file path and copies to clipboard.",
+			"label": "Dev: Resolve Atomic Plan Prompt",
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"scripts/dev_tools/resolve_hard_lock_prompt.py",
+				"--target",
+				"${file}",
+				"--workspace",
+				"${workspaceFolder}"
+			],
+			"command": "poetry",
+			"detail": "Resolves ${file} in the execute-hard-lock prompt with the active plan file path and copies to clipboard.",
+			"label": "Dev: Resolve Execute Hard-Lock Prompt",
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"python",
+				"-m",
+				"scripts.dev_tools.atomic_executor.cli",
+				"execute-all",
+				"${input:AtomicFeaturePath}",
+				"--workspace",
+				"${workspaceFolder}",
+				"--preferred-model",
+				"${input:AtomicPreferredModel}",
+				"--max-fix-attempts",
+				"10"
+			],
+			"command": "poetry",
+			"detail": "Starts the atomic executor with prompts for feature folder and preferred model.",
+			"label": "Atomic Executor: Execute (prompted)",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"-NoLogo",
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}/scripts/dev-tools/sync-agents-from-instructions.ps1"
+			],
+			"command": "pwsh",
+			"detail": "Synchronizes AGENTS.md from the canonical instruction files.",
+			"label": "Dev: Sync AGENTS.md from Instructions",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "new",
+				"reveal": "always"
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		}		
+	]
+}

--- a/docs/features/active/2026-02-17-bootstrap-powershell-ecosystem-30/issue.md
+++ b/docs/features/active/2026-02-17-bootstrap-powershell-ecosystem-30/issue.md
@@ -1,0 +1,65 @@
+# bootstrap-powershell-ecosystem (Issue #30)
+
+- Date captured: 2026-02-17
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/bootstrap-powershell-ecosystem/ (Issue #30)
+
+- Issue: #30
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/30
+- Last Updated: 2026-02-19
+
+## Problem / Why
+
+New workspaces do not consistently include a repeatable PowerShell quality toolchain for formatting, linting, testing, and coverage. That inconsistency causes local/CI drift, uneven script quality, and friction when contributors try to run the same checks. We need a deterministic bootstrap that establishes a PoshQC-compatible PowerShell ecosystem with explicit prerequisites and expected artifacts.
+
+## Proposed Behavior
+
+Provide a bootstrap flow that initializes PowerShell quality tooling from requirements (not ad-hoc manual setup).
+
+Required output behavior:
+- Ensure PowerShell runtime compatibility for the workspace (targeting 7.5+ for full parity with current tooling expectations).
+- Scaffold the PoshQC module bundle layout required for operation (`PoshQC.psm1`, `PoshQC.psd1`, and `settings/` files).
+- Install or validate required quality modules in CurrentUser scope via bootstrap helper flow:
+	- PSScriptAnalyzer (pinned major/minor compatibility with current baseline),
+	- Pester (pinned major/minor compatibility with current baseline).
+- Configure analyzer and test settings files so formatting, linting, and test/coverage behavior are deterministic for the target repo paths.
+- Provide bootstrap commands for the standard quality sequence:
+	- format (`Invoke-PoshQCFormat -Root .`),
+	- analyze (`Invoke-PoshQCAnalyze -Root .`),
+	- test (`Invoke-PoshQCTest -Root .`).
+- Ensure coverage artifacts include:
+	- JUnit XML output,
+	- CoverageGutters-compatible XML,
+	- optional relative-path `*.koverage.xml` output (with toggle/override support).
+- Validate presence of required files, module imports, and command availability; emit actionable diagnostics when missing.
+
+## Acceptance Criteria (early draft)
+
+- [ ] Bootstrap creates or validates the required PoshQC module structure and settings files in the target workspace.
+- [ ] Bootstrap verifies PowerShell runtime compatibility and reports a clear block when the minimum supported runtime is missing.
+- [ ] Bootstrap installs or validates required modules (PSScriptAnalyzer and Pester) using the documented helper workflow.
+- [ ] Running format/analyze/test commands after bootstrap succeeds in a correctly provisioned workspace.
+- [ ] Test execution emits JUnit XML and coverage outputs in expected artifact locations, including optional `.koverage.xml` output.
+- [ ] Bootstrap validation reports clear failures for missing module files, missing settings, missing modules, or command import failures.
+
+## Constraints & Risks
+
+- Do not overwrite user-authored analyzer/test settings without an explicit merge or overwrite policy.
+- Keep bootstrap behavior compatible with repository PowerShell policy expectations and CI artifact consumers.
+- Ensure module installation scope avoids requiring administrator elevation for normal developer setup.
+- Risk: module version drift can break deterministic lint/test behavior if bootstrap and CI pinning diverge.
+- Risk: path assumptions in settings files can break when workspaces use non-standard folder layouts.
+
+## Test Conditions to Consider
+
+- [ ] Unit coverage areas: module-file existence checks, version validation, and command availability detection.
+- [ ] Unit coverage areas: error messages for missing runtime, missing modules, and malformed settings files.
+- [ ] Integration scenarios: bootstrap a fresh workspace, then run format/analyze/test sequence end-to-end.
+- [ ] Integration scenarios: verify coverage/JUnit artifacts are written to expected paths and are readable by coverage consumers.
+- [ ] CLI/API examples: dry-run/bootstrap-plan output showing what will be installed, created, or validated.
+- [ ] CLI/API examples: bootstrap apply mode output summarizing completed steps and any blocked prerequisites.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (feature request template)
+- [ ] Create `docs/features/active/bootstrap-powershell-ecosystem/` folder from the template

--- a/docs/features/active/2026-02-17-bootstrap-powershell-ecosystem-30/issue.md
+++ b/docs/features/active/2026-02-17-bootstrap-powershell-ecosystem-30/issue.md
@@ -61,5 +61,5 @@ Required output behavior:
 
 ## Next Step
 
-- [ ] Promote to GitHub issue (feature request template)
-- [ ] Create `docs/features/active/bootstrap-powershell-ecosystem/` folder from the template
+- [x] Promote to GitHub issue (feature request template)
+- [x] Create `docs/features/active/bootstrap-powershell-ecosystem/` folder from the template

--- a/scripts/powershell/PoshQC/PoshQC.psd1
+++ b/scripts/powershell/PoshQC/PoshQC.psd1
@@ -1,0 +1,29 @@
+@{
+    RootModule           = 'PoshQC.psm1'
+    ModuleVersion        = '0.1.1'
+    GUID                 = '6a9b1a8b-1e8b-4c1f-9d6a-34b8e8c2f0e4'
+    Author               = 'Dan Moisan'
+    CompanyName          = 'Dan Moisan'
+    Copyright            = '(c) Dan Moisan. All rights reserved.'
+    Description          = 'Reusable PowerShell QC helpers (format, analyze, test) using Invoke-Formatter, PSScriptAnalyzer, and Pester.'
+    PowerShellVersion    = '5.1'
+    CompatiblePSEditions = @('Desktop', 'Core')
+    RequiredModules      = @(
+        @{ ModuleName = 'PSScriptAnalyzer'; ModuleVersion = '1.22.0' },
+        @{ ModuleName = 'Pester'; ModuleVersion = '5.6.1' }
+    )
+    FunctionsToExport    = @(
+        'Install-PoshQCTool',
+        'Invoke-PoshQCFormat',
+        'Invoke-PoshQCAnalyze',
+        'Invoke-PoshQCTest'
+    )
+    CmdletsToExport      = @()
+    VariablesToExport    = @()
+    AliasesToExport      = @('Install-PoshQCTools')
+    PrivateData          = @{}
+}
+
+
+
+

--- a/scripts/powershell/PoshQC/PoshQC.psm1
+++ b/scripts/powershell/PoshQC/PoshQC.psm1
@@ -1,0 +1,692 @@
+$script:ModuleRoot = Split-Path -Parent $PSCommandPath
+$script:PssaSettings = Join-Path $ModuleRoot 'settings/pssa.settings.psd1'
+$script:PesterSettings = Join-Path $ModuleRoot 'settings/pester.runsettings.psd1'
+
+$script:DefaultExcludedDirs = @(
+    '.git', '.venv', 'venv', 'node_modules', 'dist', 'build', '.pytest_cache',
+    '__pycache__', '.mypy_cache', '.ruff_cache', '.vscode', '.idea', 'artifacts',
+    '.vscode-test'
+)
+
+<#
+.SYNOPSIS
+Enumerates PowerShell files in a given root directory.
+.DESCRIPTION
+Returns all PowerShell (.ps1/.psm1/.psd1) files recursively, excluding specified directories.
+#>
+function Get-PoshQCFileList {
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Root,
+        [string[]] $ExcludeDirs = $script:DefaultExcludedDirs,
+        [scriptblock] $ResolvePath = { param([string] $Path) Resolve-Path -Path $Path -ErrorAction Stop },
+        [scriptblock] $EnumerateFiles = { param([string] $Path) Get-ChildItem -Path $Path -Recurse },
+        [scriptblock] $ShouldExclude = {
+            param($File, [string[]] $ExcludedDirs)
+            $parts = $File.FullName -split '[\\/]+' | Where-Object { $_ -ne '' }
+            foreach ($dir in $ExcludedDirs) {
+                if ($parts -contains $dir) { return $true }
+            }
+            return $false
+        },
+        [scriptblock] $IsAllowedExtension = {
+            param($File)
+            $File.Extension -in '.ps1', '.psm1', '.psd1'
+        }
+    )
+
+    try {
+        $resolvedRoot = & $ResolvePath $Root
+        if ($resolvedRoot -isnot [string]) {
+            $resolvedRoot = $resolvedRoot.Path
+        }
+    } catch {
+        throw "Failed to resolve root path '$Root': $($_.Exception.Message)"
+    }
+
+    $files = @(& $EnumerateFiles $resolvedRoot)
+    if (-not $files) { return @() }
+
+    $result = foreach ($file in $files) {
+        if (-not (& $IsAllowedExtension $file)) { continue }
+        if (& $ShouldExclude $file $ExcludeDirs) { continue }
+        $file
+    }
+
+    return @($result | Sort-Object -Property FullName -Stable)
+}
+
+<#
+.SYNOPSIS
+Installs PoshQC dependencies (PSScriptAnalyzer and Pester).
+.DESCRIPTION
+Ensures PSGallery is trusted and installs required module versions in the CurrentUser scope.
+#>
+function Install-PoshQCTool {
+    [CmdletBinding()]
+    param(
+        [scriptblock] $SetTls = { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 },
+        [scriptblock] $GetRepository = { param([string] $Name) Get-PSRepository -Name $Name -ErrorAction SilentlyContinue },
+        [scriptblock] $RegisterRepository = { Register-PSRepository -Default -InstallationPolicy Trusted },
+        [scriptblock] $SetRepository = { param([string] $Name, [string] $Policy) Set-PSRepository -Name $Name -InstallationPolicy $Policy -ErrorAction Stop },
+        [scriptblock] $FindModule = { param([string] $Name) Get-Module -ListAvailable -Name $Name },
+        [scriptblock] $InstallModule = { param([string] $Name, [string] $Version) Install-Module -Name $Name -RequiredVersion $Version -Scope CurrentUser -AllowClobber -Force },
+        [scriptblock] $Logger = {
+            param([string] $Message, [string] $Level = 'Information')
+            switch ($Level) {
+                'Warning' { Write-Warning $Message }
+                'Verbose' { Write-Verbose $Message }
+                default { Write-Information $Message -InformationAction Continue }
+            }
+        }
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    try {
+        & $SetTls
+    } catch {
+        & $Logger "Unable to enforce TLS 1.2 for module install: $($_.Exception.Message)" 'Verbose'
+    }
+    $gallery = & $GetRepository 'PSGallery'
+    if (-not $gallery) {
+        & $Logger 'PSGallery not found; registering.'
+        & $RegisterRepository
+    } elseif ($gallery.InstallationPolicy -ne 'Trusted') {
+        try {
+            & $SetRepository 'PSGallery' 'Trusted'
+        } catch {
+            & $Logger 'Could not set PSGallery as trusted automatically. You may be prompted during install.' 'Warning'
+        }
+    }
+
+    $requiredModules = @(
+        @{ Name = 'PSScriptAnalyzer'; Version = '1.22.0' },
+        @{ Name = 'Pester'; Version = '5.6.1' }
+    )
+
+    foreach ($module in $requiredModules) {
+        $installed = & $FindModule $module.Name | Where-Object { $_.Version -ge [version]$module.Version } | Select-Object -First 1
+        if ($installed) {
+            & $Logger "$($module.Name) $($installed.Version) already present."
+            continue
+        }
+
+        & $Logger "Installing $($module.Name) $($module.Version) (CurrentUser scope)..."
+        try {
+            & $InstallModule $module.Name $module.Version
+        } catch {
+            throw "Failed to install $($module.Name) $($module.Version): $($_.Exception.Message)"
+        }
+
+        $post = & $FindModule $module.Name | Where-Object { $_.Version -ge [version]$module.Version } | Select-Object -First 1
+        if (-not $post) {
+            throw "Failed to install $($module.Name) $($module.Version)."
+        }
+        & $Logger "$($module.Name) $($module.Version) installed."
+    }
+}
+
+<#
+.SYNOPSIS
+Formats PowerShell files using PSScriptAnalyzer.
+.DESCRIPTION
+Applies PSScriptAnalyzer formatting rules from repo settings to all PowerShell files under Root.
+.PARAMETER Root
+Root directory to search for PowerShell files. Defaults to current location.
+.PARAMETER SettingsPath
+Path to PSScriptAnalyzer settings file.
+.PARAMETER ExcludeDirs
+Directory names to exclude from processing.
+#>
+function Invoke-PoshQCFormat {
+    [CmdletBinding()]
+    param(
+        [string] $Root,
+        [string] $SettingsPath = $script:PssaSettings,
+        [string[]] $ExcludeDirs = $script:DefaultExcludedDirs,
+        [scriptblock] $EnsureModule = {
+            param([string] $Name, [string] $ErrorMessage)
+            if (-not (Get-Module -ListAvailable -Name $Name)) { throw $ErrorMessage }
+            Import-Module $Name -ErrorAction Stop
+        },
+        [scriptblock] $TestPathExists = { param([string] $Path) Test-Path $Path },
+        [scriptblock] $GetFileList = { param([string] $RootPath, [string[]] $Excluded) Get-PoshQCFileList -Root $RootPath -ExcludeDirs $Excluded },
+        [scriptblock] $ReadFile = { param([string] $Path) Get-Content -Raw -Path $Path },
+        [scriptblock] $WriteFile = { param([string] $Path, [string] $Content) Set-Content -Path $Path -Value $Content -Encoding UTF8 },
+        [scriptblock] $FormatContent = { param([string] $Content, [string] $Settings) Invoke-Formatter -ScriptDefinition $Content -Settings $Settings },
+        [scriptblock] $Logger = {
+            param([string] $Message)
+            Write-Information $Message -InformationAction Continue
+        }
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $Root) {
+        $Root = $PWD.ProviderPath
+    }
+
+    & $EnsureModule 'PSScriptAnalyzer' "PSScriptAnalyzer is not installed. Run Install-PoshQCTool (alias Install-PoshQCTools) first."
+
+    if (-not (& $TestPathExists $SettingsPath)) {
+        throw "Settings not found: $SettingsPath"
+    }
+
+    $files = @(& $GetFileList $Root $ExcludeDirs)
+    if (-not $files) {
+        & $Logger "No PowerShell files found under $Root"
+        return
+    }
+
+    foreach ($file in $files) {
+        $original = & $ReadFile $file.FullName
+        $normalized = $original -replace "`r?`n", "`n"
+        $formatted = & $FormatContent $normalized $SettingsPath
+        if ($formatted -ne $normalized) {
+            & $WriteFile $file.FullName $formatted
+            & $Logger "Formatted: $($file.FullName)"
+        } else {
+            & $Logger "Already formatted: $($file.FullName)"
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Runs PSScriptAnalyzer static analysis on PowerShell files.
+.DESCRIPTION
+Analyzes all PowerShell files under Root using repo PSScriptAnalyzer settings and reports issues.
+.PARAMETER Root
+Root directory to search for PowerShell files. Defaults to current location.
+.PARAMETER SettingsPath
+Path to PSScriptAnalyzer settings file.
+.PARAMETER ExcludeDirs
+Directory names to exclude from analysis.
+#>
+function Invoke-PoshQCAnalyze {
+    [CmdletBinding()]
+    param(
+        [string] $Root,
+        [string] $SettingsPath = $script:PssaSettings,
+        [string[]] $ExcludeDirs = $script:DefaultExcludedDirs,
+        [int] $NullReferenceRetryCount = 4,
+        [int] $NullReferenceInitialDelayMilliseconds = 200,
+        [scriptblock] $EnsureModule = {
+            param([string] $Name, [string] $ErrorMessage)
+            if (-not (Get-Module -ListAvailable -Name $Name)) { throw $ErrorMessage }
+            Import-Module $Name -ErrorAction Stop
+        },
+        [scriptblock] $TestPathExists = { param([string] $Path) Test-Path $Path },
+        [scriptblock] $GetFileList = { param([string] $RootPath, [string[]] $Excluded) Get-PoshQCFileList -Root $RootPath -ExcludeDirs $Excluded },
+        [scriptblock] $AnalyzeFile = {
+            param([string] $Path, [string] $Settings)
+            Invoke-ScriptAnalyzer -Path $Path -Settings $Settings -Severity Error, Warning, Information -ErrorAction Stop
+        },
+        [scriptblock] $ReloadAnalyzerModule = {
+            # Retry path: ScriptAnalyzer has intermittent engine-level NullReferenceExceptions.
+            # Re-importing the module can reset internal state without masking legitimate findings.
+            try {
+                Remove-Module -Name PSScriptAnalyzer -Force -ErrorAction SilentlyContinue
+            } catch {
+                # Best-effort reset; if removal fails we still attempt re-import.
+                Write-Verbose "Remove-Module PSScriptAnalyzer failed during retry reset: $($_.Exception.Message)"
+            }
+            Import-Module -Name PSScriptAnalyzer -Force -ErrorAction Stop
+        },
+        [scriptblock] $Logger = {
+            param([string] $Message)
+            Write-Information $Message -InformationAction Continue
+        }
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $Root) {
+        $Root = $PWD.ProviderPath
+    }
+
+    & $EnsureModule 'PSScriptAnalyzer' "PSScriptAnalyzer is not installed. Run Install-PoshQCTool (alias Install-PoshQCTools) first."
+
+    if (-not (& $TestPathExists $SettingsPath)) {
+        throw "Settings not found: $SettingsPath"
+    }
+
+    $files = @(& $GetFileList $Root $ExcludeDirs | Where-Object { $_.Extension -in '.ps1', '.psm1' })
+    if (-not $files) {
+        & $Logger "No PowerShell files found under $Root"
+        return
+    }
+
+    $results = @()
+    foreach ($file in $files) {
+        try {
+            $attempts = 0
+            $maxAttempts = 1 + [math]::Max(0, $NullReferenceRetryCount)
+            $delayMs = [math]::Max(0, $NullReferenceInitialDelayMilliseconds)
+
+            while ($attempts -lt $maxAttempts) {
+                $attempts++
+                try {
+                    $results += & $AnalyzeFile $file.FullName $SettingsPath
+                    break
+                } catch {
+                    $errorType = $_.Exception.GetType().FullName
+                    $errorMessage = $_.Exception.Message
+
+                    if ($errorType -ne 'System.NullReferenceException') {
+                        throw
+                    }
+
+                    if ($attempts -ge $maxAttempts) {
+                        throw
+                    }
+
+                    $pssaVersion = (Get-Module -Name PSScriptAnalyzer | Select-Object -First 1).Version
+                    & $Logger "Transient ScriptAnalyzer engine error (NullReferenceException) on $($file.FullName); retrying ($attempts/$maxAttempts). PSScriptAnalyzer=$pssaVersion PS=$($PSVersionTable.PSVersion)"
+
+                    if ($delayMs -gt 0) {
+                        Start-Sleep -Milliseconds $delayMs
+                        $delayMs = [math]::Min($delayMs * 2, 5000)
+                    }
+
+                    # Best-effort reset between retries.
+                    & $ReloadAnalyzerModule
+                }
+            }
+        } catch {
+            $errorType = $_.Exception.GetType().FullName
+            $errorMessage = $_.Exception.Message
+            throw "Invoke-ScriptAnalyzer failed for $($file.FullName) ($errorType): $errorMessage"
+        }
+    }
+
+    if ($results.Count -gt 0) {
+        $results | Format-Table -AutoSize
+        throw "PSScriptAnalyzer reported $($results.Count) issue(s)."
+    }
+    & $Logger "PSScriptAnalyzer passed: no findings under $Root"
+}
+
+<#
+.SYNOPSIS
+Converts coverage XML paths from absolute to relative.
+.DESCRIPTION
+Rewrites Pester coverage XML file paths to be relative to the repo root for Koverage compatibility.
+.PARAMETER InputPath
+Path to input coverage XML file.
+.PARAMETER OutputPath
+Path to write relative-path coverage XML.
+.PARAMETER RepoRoot
+Repository root directory for path relativization.
+.PARAMETER InputContent
+Alternative to InputPath - provide XML content directly.
+.PARAMETER PassThru
+Return the converted XML content as output.
+#>
+function Convert-PoshQCCoverageToRelative {
+    [CmdletBinding()]
+    param(
+        [Parameter()][string] $InputPath,
+        [Parameter()][string] $OutputPath,
+        [Parameter()][string] $RepoRoot,
+        [Parameter()][string] $InputContent,
+        [switch] $PassThru,
+        [scriptblock] $ResolvePath = { param([string] $Path) (Resolve-Path -Path $Path -ErrorAction Stop).Path },
+        [scriptblock] $JoinPath = { param([string] $Parent, [string] $Child) Join-Path -Path $Parent -ChildPath $Child },
+        [scriptblock] $TestPathExists = { param([string] $Path) Test-Path $Path },
+        [scriptblock] $ReadContent = { param([string] $Path) Get-Content -Path $Path -Raw },
+        [scriptblock] $WriteContent = { param([string] $Path, [string] $Content) Set-Content -Path $Path -Value $Content -Encoding UTF8 },
+        [scriptblock] $EnsureDirectory = {
+            param([string] $Path)
+            $dir = Split-Path -Parent $Path
+            if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        },
+        [scriptblock] $GetDefaultOutputPath = {
+            param([string] $ResolvedInputPath, [string] $ResolvedRoot)
+            $coverageDir = if ($ResolvedInputPath) { Split-Path -Parent $ResolvedInputPath } else { $ResolvedRoot }
+            $coverageBase = if ($ResolvedInputPath) { [IO.Path]::GetFileNameWithoutExtension($ResolvedInputPath) } else { 'powershell-coverage' }
+            Join-Path -Path $coverageDir -ChildPath "$coverageBase.koverage.xml"
+        },
+        [scriptblock] $Logger = {
+            param([string] $Message)
+            Write-Information $Message -InformationAction Continue
+        }
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $RepoRoot) {
+        $RepoRoot = $PWD.ProviderPath
+    }
+
+    if (-not $InputPath -and -not $InputContent) {
+        & $Logger 'No coverage input provided; skipping conversion.'
+        return
+    }
+
+    $resolvedRoot = $RepoRoot
+    try {
+        $maybeResolvedRoot = & $ResolvePath $RepoRoot
+        if ($maybeResolvedRoot) {
+            $resolvedRoot = if ($maybeResolvedRoot -is [string]) { $maybeResolvedRoot } else { $maybeResolvedRoot.Path }
+        }
+    }
+    catch {
+        $resolvedRoot = $RepoRoot
+    }
+
+    $resolvedInputPath = $null
+    if ($InputPath) {
+        $resolvedInputPath = if ([IO.Path]::IsPathRooted($InputPath)) { $InputPath } else { & $JoinPath $resolvedRoot $InputPath }
+        if (-not (& $TestPathExists $resolvedInputPath)) {
+            & $Logger "Coverage file not found; skipping Koverage output: $resolvedInputPath"
+            return
+        }
+
+        if (-not $InputContent) {
+            $InputContent = & $ReadContent $resolvedInputPath
+        }
+    }
+
+    $repoRootClean = [IO.Path]::TrimEndingDirectorySeparator($resolvedRoot)
+    # Normalize to forward slashes for consistent regex matching across platforms
+    $repoRootNormalized = $repoRootClean -replace '\\', '/'
+    $escapedRoot = [regex]::Escape($repoRootNormalized)
+    # Replace forward slashes with character class that matches both separators
+    $flexiblePattern = $escapedRoot -replace '/', '[\\/]'
+    # Match both forward and backslashes after the path
+    $escapedPrefixPattern = "$flexiblePattern[\\/]"
+    $fixedContent = $InputContent -replace $escapedPrefixPattern, ''
+
+    if ($PassThru) {
+        return $fixedContent
+    }
+
+    if (-not $OutputPath) {
+        $OutputPath = & $GetDefaultOutputPath $resolvedInputPath $resolvedRoot
+    }
+
+    $resolvedOutputPath = if ([IO.Path]::IsPathRooted($OutputPath)) { $OutputPath } else { & $JoinPath $resolvedRoot $OutputPath }
+    & $EnsureDirectory $resolvedOutputPath
+    & $WriteContent $resolvedOutputPath $fixedContent
+    & $Logger "Wrote Koverage coverage copy: $resolvedOutputPath"
+}
+
+<#
+.SYNOPSIS
+Runs Pester tests with coverage reporting.
+.DESCRIPTION
+Executes Pester tests using repo configuration, generates coverage reports in multiple formats.
+.PARAMETER Root
+Root directory for test discovery. Defaults to current location.
+.PARAMETER SettingsPath
+Path to Pester configuration file.
+.PARAMETER ExcludeDirs
+Directory names to exclude from test/coverage paths.
+.PARAMETER KoverageOutputPath
+Custom path for Koverage-compatible coverage XML output.
+.PARAMETER DisableKoverageCopy
+Skip creation of Koverage-friendly coverage copy.
+#>
+function Invoke-PoshQCTest {
+    [CmdletBinding()]
+    param(
+        [string] $Root,
+        [string] $SettingsPath = $script:PesterSettings,
+        [string[]] $ExcludeDirs = $script:DefaultExcludedDirs,
+        [string] $KoverageOutputPath,
+        [switch] $DisableKoverageCopy,
+        [scriptblock] $EnsureModule = {
+            param([string] $Name, [string] $ErrorMessage)
+            if (-not (Get-Module -ListAvailable -Name $Name)) { throw $ErrorMessage }
+            Import-Module $Name -ErrorAction Stop
+        },
+        [scriptblock] $TestPathExists = { param([string] $Path) Test-Path $Path },
+        [scriptblock] $LoadSettings = { param([string] $Path) Import-PowerShellDataFile -Path $Path },
+        [scriptblock] $BuildConfiguration = { param($Settings) New-PesterConfiguration -Hashtable $Settings },
+        [scriptblock] $ExpandRunPaths = {
+            param($Config, [string] $RootPath, [string[]] $Excluded)
+            $initialPaths = if ($Config.Run.Path -is [System.Array]) { @($Config.Run.Path) } elseif ($Config.Run.Path -and $Config.Run.Path.Value) { @($Config.Run.Path.Value) } else { @() }
+            if ($initialPaths) {
+                $resolvedPaths = @(
+                    $initialPaths |
+                        ForEach-Object { Join-Path $RootPath $_ } |
+                            Where-Object { $Excluded -notcontains (Split-Path -Path $_ -Leaf) }
+                )
+                $Config.Run.Path = $resolvedPaths
+            }
+
+            if ($Excluded) {
+                $excludedPaths = @($Excluded | ForEach-Object { Join-Path $RootPath $_ })
+                $existingExclude = if ($Config.Run.ExcludePath -is [System.Array]) { @($Config.Run.ExcludePath | ForEach-Object { Join-Path $RootPath $_ }) } elseif ($Config.Run.ExcludePath -and $Config.Run.ExcludePath.Value) { @($Config.Run.ExcludePath.Value | ForEach-Object { Join-Path $RootPath $_ }) } else { @() }
+                $Config.Run.ExcludePath = $existingExclude + $excludedPaths
+            }
+
+            $Config
+        },
+        [scriptblock] $EnsureResultPath = {
+            param($Config, [string] $RootPath)
+            if ($Config.TestResult.Enabled.Value -and $Config.TestResult.OutputPath.Value) {
+                $resultPath = $Config.TestResult.OutputPath.Value
+                $resultDir = Split-Path -Parent $resultPath
+                if (-not [string]::IsNullOrWhiteSpace($resultDir)) {
+                    $resolvedResultDir = if ([IO.Path]::IsPathRooted($resultDir)) { $resultDir } else { Join-Path $RootPath $resultDir }
+                    New-Item -ItemType Directory -Path $resolvedResultDir -Force | Out-Null
+                }
+                $Config.TestResult.OutputPath = if ([IO.Path]::IsPathRooted($resultPath)) {
+                    $resultPath
+                } else {
+                    Join-Path $RootPath $resultPath
+                }
+            }
+            $Config
+        },
+        [scriptblock] $ExpandCoveragePaths = {
+            param($Config, [string] $RootPath)
+            if (-not $Config.CodeCoverage) { return $Config }
+
+            if ($Config.CodeCoverage.Path.Value) {
+                $Config.CodeCoverage.Path = @(
+                    $Config.CodeCoverage.Path.Value | ForEach-Object { if ([IO.Path]::IsPathRooted($_)) { $_ } else { Join-Path $RootPath $_ } }
+                )
+            }
+
+            if ($Config.CodeCoverage.OutputPath.Value) {
+                $coveragePath = $Config.CodeCoverage.OutputPath.Value
+                $coverageDir = Split-Path -Parent $coveragePath
+                if (-not [string]::IsNullOrWhiteSpace($coverageDir)) {
+                    $resolvedCoverageDir = if ([IO.Path]::IsPathRooted($coverageDir)) { $coverageDir } else { Join-Path $RootPath $coverageDir }
+                    New-Item -ItemType Directory -Path $resolvedCoverageDir -Force | Out-Null
+                }
+                $Config.CodeCoverage.OutputPath = if ([IO.Path]::IsPathRooted($coveragePath)) {
+                    $coveragePath
+                } else {
+                    Join-Path $RootPath $coveragePath
+                }
+            }
+
+            $Config
+        },
+        [scriptblock] $EnumerateTests = {
+            param([string[]] $Paths, [string[]] $Excluded, [scriptblock] $TestPathFn)
+            $tests = @()
+            foreach ($path in $Paths) {
+                if (-not (& $TestPathFn $path)) { continue }
+                $tests += Get-ChildItem -Path $path -Recurse -Include *.Tests.ps1 | Where-Object {
+                    $parts = $_.FullName -split '[\\/]+' | Where-Object { $_ -ne '' }
+                    foreach ($dir in $Excluded) {
+                        if ($parts -contains $dir) { return $false }
+                    }
+                    return $true
+                }
+            }
+            @($tests | Sort-Object -Property FullName -Stable)
+        },
+        [scriptblock] $Logger = {
+            param([string] $Message)
+            # Use Write-Information so the replayed summary stays visible while respecting approved verbs.
+            Write-Information $Message -InformationAction Continue
+        },
+        [scriptblock] $InvokePester = { param($Config) Invoke-Pester -Configuration $Config },
+        [scriptblock] $CopyCoverage = {
+            param([string] $CoveragePath, [string] $RepoRoot, [string] $KoveragePath)
+            Convert-PoshQCCoverageToRelative -InputPath $CoveragePath -OutputPath $KoveragePath -RepoRoot $RepoRoot
+        }
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $Root) {
+        $Root = $PWD.ProviderPath
+    }
+
+    & $EnsureModule 'Pester' "Pester is not installed. Run Install-PoshQCTool (alias Install-PoshQCTools) first."
+
+    if (-not (& $TestPathExists $SettingsPath)) {
+        throw "Settings not found: $SettingsPath"
+    }
+
+    $settings = & $LoadSettings $SettingsPath
+    $config = & $BuildConfiguration $settings
+    $config = & $ExpandRunPaths $config $Root $ExcludeDirs
+    $config = & $EnsureResultPath $config $Root
+    $config = & $ExpandCoveragePaths $config $Root
+
+    # Reduce console noise from Pester while we replay a concise summary at the end.
+    if ($config.Output -and $config.Output.Verbosity) {
+        $config.Output.Verbosity = 'Normal'
+    }
+
+    if (-not $config.Run.PassThru) {
+        $config.Run.PassThru = $true
+    }
+
+    $coverageEnabled = $false
+    if ($config.CodeCoverage) {
+        if ($config.CodeCoverage.Enabled -is [bool]) {
+            $coverageEnabled = $config.CodeCoverage.Enabled
+        } elseif ($config.CodeCoverage.Enabled -and $config.CodeCoverage.Enabled.Value) {
+            $coverageEnabled = [bool]$config.CodeCoverage.Enabled.Value
+        }
+    }
+
+    if ($coverageEnabled -and $config.CodeCoverage) {
+        if ($config.CodeCoverage.Path.Value) {
+            $resolvedCoveragePaths = @(
+                $config.CodeCoverage.Path.Value |
+                    ForEach-Object {
+                        if ([IO.Path]::IsPathRooted($_)) { $_ } else { Join-Path $Root $_ }
+                    }
+            )
+            $config.CodeCoverage.Path = $resolvedCoveragePaths
+        }
+
+        if ($config.CodeCoverage.OutputPath.Value) {
+            $coveragePath = $config.CodeCoverage.OutputPath.Value
+            $coverageDir = Split-Path -Parent $coveragePath
+            if (-not [string]::IsNullOrWhiteSpace($coverageDir)) {
+                $resolvedCoverageDir = if ([IO.Path]::IsPathRooted($coverageDir)) { $coverageDir } else { Join-Path $Root $coverageDir }
+                New-Item -ItemType Directory -Path $resolvedCoverageDir -Force | Out-Null
+            }
+            $config.CodeCoverage.OutputPath = if ([IO.Path]::IsPathRooted($coveragePath)) {
+                $coveragePath
+            } else {
+                Join-Path $Root $coveragePath
+            }
+        }
+    }
+
+    $coverageOutputPath = $null
+    if ($config.CodeCoverage) {
+        if ($config.CodeCoverage.OutputPath -is [string]) {
+            $coverageOutputPath = $config.CodeCoverage.OutputPath
+        } elseif ($config.CodeCoverage.OutputPath -and $config.CodeCoverage.OutputPath.Value) {
+            $coverageOutputPath = $config.CodeCoverage.OutputPath.Value
+        }
+    }
+
+    $runPaths = if ($config.Run.Path -is [System.Array]) { [string[]]$config.Run.Path } elseif ($config.Run.Path -and $config.Run.Path.Value) { [string[]]$config.Run.Path.Value } else { @() }
+    $testFiles = & $EnumerateTests $runPaths $ExcludeDirs $TestPathExists
+    if (-not $testFiles) {
+        & $Logger "No Pester test files found under configured paths for root $Root"
+        return
+    }
+
+    $pesterResult = & $InvokePester $config
+
+    $shouldEmitKoverageCopy = -not $DisableKoverageCopy
+    if ($shouldEmitKoverageCopy -and $coverageEnabled -and $coverageOutputPath) {
+        $derivedKoveragePath = $null
+        if ($coverageOutputPath) {
+            $coverageBaseName = [IO.Path]::GetFileNameWithoutExtension($coverageOutputPath)
+            $coverageParent = Split-Path -Parent $coverageOutputPath
+            $derivedKoveragePath = Join-Path $coverageParent "$coverageBaseName.koverage.xml"
+        }
+
+        $effectiveKoveragePath = if ($PSBoundParameters.ContainsKey('KoverageOutputPath') -and -not [string]::IsNullOrWhiteSpace($KoverageOutputPath)) {
+            $KoverageOutputPath
+        } else {
+            $derivedKoveragePath
+        }
+
+        & $CopyCoverage $coverageOutputPath $Root $effectiveKoveragePath
+    }
+
+    if ($pesterResult) {
+        $durationSeconds = [math]::Round($pesterResult.Duration.TotalSeconds, 2)
+        $testsSummary = "Tests completed in {0:N2}s" -f $durationSeconds
+        $countsSummary = "Tests Passed: {0}, Failed: {1}, Skipped: {2}, Inconclusive: {3}, NotRun: {4}" -f `
+            $pesterResult.PassedCount, `
+            $pesterResult.FailedCount, `
+            $pesterResult.SkippedCount, `
+            $pesterResult.InconclusiveCount, `
+            $pesterResult.NotRunCount
+
+        $coverageLines = $null
+        if ($coverageEnabled -and $pesterResult.CodeCoverage) {
+            $coverageReport = $pesterResult.CodeCoverage.CoverageReport
+            if ($coverageReport -is [string] -and -not [string]::IsNullOrWhiteSpace($coverageReport)) {
+                $rawCoverageLines = @($coverageReport -split "`r?`n")
+                $trimmedCoverageLines = @()
+
+                foreach ($line in $rawCoverageLines) {
+                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+                    if ($line -match '^\s*Missed commands') { break }
+                    $trimmedCoverageLines += $line.TrimEnd()
+                }
+
+                if (-not $trimmedCoverageLines -and $rawCoverageLines) {
+                    $trimmedCoverageLines = @($rawCoverageLines[0])
+                }
+
+                if ($trimmedCoverageLines) {
+                    $coverageLines = $trimmedCoverageLines
+                }
+            }
+        }
+
+        & $Logger ''
+        & $Logger 'Pester summary (replayed for readability):'
+        & $Logger $testsSummary
+        & $Logger $countsSummary
+        if ($coverageLines) {
+            foreach ($line in $coverageLines) {
+                & $Logger $line
+            }
+        }
+    }
+}
+
+Set-Alias -Name Install-PoshQCTools -Value Install-PoshQCTool
+
+Export-ModuleMember -Function @(
+    'Get-PoshQCFileList',
+    'Install-PoshQCTool',
+    'Invoke-PoshQCFormat',
+    'Invoke-PoshQCAnalyze',
+    'Invoke-PoshQCTest',
+    'Convert-PoshQCCoverageToRelative'
+) -Alias @('Install-PoshQCTools')

--- a/scripts/powershell/PoshQC/README.md
+++ b/scripts/powershell/PoshQC/README.md
@@ -1,0 +1,69 @@
+# PoshQC
+
+PoshQC is a lightweight PowerShell quality gate that wraps Invoke-Formatter, PSScriptAnalyzer, and Pester with repo-safe defaults. It targets both Windows PowerShell 5.1 and PowerShell 7.5+.
+
+## What it does
+
+- Formats PowerShell code with consistent indentation and pipeline alignment.
+- Lints with PSScriptAnalyzer using a strict, dual-runtime ruleset.
+- Runs Pester tests with code coverage (CoverageGutters output), plus an optional Koverage-friendly copy.
+- Provides a one-time dependency installer for PSScriptAnalyzer and Pester.
+
+## Requirements
+
+- PowerShell 5.1 or 7.5+
+- Modules: PSScriptAnalyzer 1.22.0, Pester 5.6.1 (installed automatically via the helper if missing)
+
+## Getting started
+
+1) Install dependencies (CurrentUser scope):
+
+   ```powershell
+   Import-Module ./PoshQC.psm1
+   Install-PoshQCTool  # alias: Install-PoshQCTools
+   ```
+2) Format everything under the repo root:
+
+   ```powershell
+   Import-Module ./PoshQC.psm1
+   Invoke-PoshQCFormat -Root .
+   ```
+3) Lint with PSScriptAnalyzer:
+
+   ```powershell
+   Invoke-PoshQCAnalyze -Root .
+   ```
+4) Test with Pester + coverage:
+
+   ```powershell
+   Invoke-PoshQCTest -Root .
+   ```
+
+   - Writes JUnit XML to `artifacts/pester/pester-junit.xml`.
+   - Writes CoverageGutters XML to `artifacts/pester/powershell-coverage.xml`.
+   - Also emits `*.koverage.xml` (relative paths) for VS Code Coverage Gutters and Koverage. Disable with `-DisableKoverageCopy` or override the path with `-KoverageOutputPath`.
+
+## Functions
+
+- `Install-PoshQCTool` / `Install-PoshQCTools`: install required modules.
+- `Invoke-PoshQCFormat`: run Invoke-Formatter across the repo, honoring exclusions.
+- `Invoke-PoshQCAnalyze`: run PSScriptAnalyzer with the bundled settings.
+- `Invoke-PoshQCTest`: run Pester using the bundled runsettings, including coverage and optional Koverage copy.
+- `Convert-PoshQCCoverageToRelative`: utility to strip repo-root prefixes and write a `.koverage.xml` copy (used internally by `Invoke-PoshQCTest`).
+
+## Configuration
+
+- PSScriptAnalyzer settings: `./settings/pssa.settings.psd1`
+  - Enforces compatible syntax for 5.1 and 7.5, 4-space indentation, ShouldProcess for state-changing functions, and safety guards (no Invoke-Expression, no global vars, etc.).
+- Pester settings: `./settings/pester.runsettings.psd1`
+  - Runs tests under `scripts` and `tests/powershell`, outputs JUnit XML and CoverageGutters coverage, and enables coverage over `scripts/dev-tools/*.ps1`, `scripts/powershell/**/*.psm1`, and `src/**/*.ps1`.
+
+## Typical workflow
+
+- Day-to-day: run `Invoke-PoshQCFormat`, `Invoke-PoshQCAnalyze`, then `Invoke-PoshQCTest` before committing.
+- CI: call `Invoke-PoshQCTest` to get tests + coverage and consume JUnit/CoverageGutters artifacts.
+
+## Notes for standalone use
+
+- Place `PoshQC.psm1`, `PoshQC.psd1`, and the `settings/` folder together; import the module from that directory.
+- Adjust `settings/pester.runsettings.psd1` and `settings/pssa.settings.psd1` to match your repo paths and policies.

--- a/scripts/powershell/PoshQC/convert-poshqc-coverage.ps1
+++ b/scripts/powershell/PoshQC/convert-poshqc-coverage.ps1
@@ -1,0 +1,35 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$RepoRoot,
+    [string]$InputPath,
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$resolvedRepoRoot = if ($RepoRoot) {
+    (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
+} else {
+    $parentPath = Join-Path -Path $PSScriptRoot -ChildPath '..'
+    $grandParentPath = Join-Path -Path $parentPath -ChildPath '..'
+    $repoRootCandidate = Join-Path -Path $grandParentPath -ChildPath '..'
+    (Resolve-Path -Path $repoRootCandidate -ErrorAction Stop).Path
+}
+
+$resolvedInputPath = if ($InputPath) {
+    $InputPath
+} else {
+    Join-Path -Path $resolvedRepoRoot -ChildPath 'artifacts/pester/powershell-coverage.xml'
+}
+
+$resolvedOutputPath = if ($OutputPath) {
+    $OutputPath
+} else {
+    Join-Path -Path $resolvedRepoRoot -ChildPath 'artifacts/pester/powershell-coverage.koverage.xml'
+}
+
+Import-Module (Join-Path $PSScriptRoot 'PoshQC.psm1') -Force
+
+if ($PSCmdlet.ShouldProcess($resolvedOutputPath, 'Convert coverage paths to relative paths')) {
+    Convert-PoshQCCoverageToRelative -InputPath $resolvedInputPath -OutputPath $resolvedOutputPath -RepoRoot $resolvedRepoRoot
+}

--- a/scripts/powershell/PoshQC/settings/pester.runsettings.psd1
+++ b/scripts/powershell/PoshQC/settings/pester.runsettings.psd1
@@ -1,0 +1,41 @@
+@{
+    Run          = @{
+        Path = @('scripts', 'tests/powershell', 'tests/scripts')
+        Exit = $true
+    }
+    Should       = @{
+        ErrorAction = 'Stop'
+    }
+    Output       = @{
+        Verbosity = 'Detailed'
+    }
+    TestResult   = @{
+        Enabled      = $true
+        OutputFormat = 'JUnitXml'
+        OutputPath   = 'artifacts/pester/pester-junit.xml'
+    }
+    CodeCoverage = @{
+        Enabled               = $true
+        # Use Pester's CoverageGutters format so VS Code Coverage Gutters
+        # can map file paths correctly.
+        OutputFormat          = 'CoverageGutters'
+        OutputPath            = 'artifacts/pester/powershell-coverage.xml'
+        Path                  = @(
+            'scripts/dev-tools/*.ps1'
+            'scripts/powershell/**/*.psm1'
+            'src/**/*.ps1'
+        )
+        # Optional: don't fail the run on coverage percentage
+        CoveragePercentTarget = 0
+    }
+}
+
+
+
+
+
+
+
+
+
+

--- a/scripts/powershell/PoshQC/settings/pssa.settings.psd1
+++ b/scripts/powershell/PoshQC/settings/pssa.settings.psd1
@@ -1,0 +1,55 @@
+@{
+    # Analyze using all default rules and treat all severities as failures.
+    IncludeDefaultRules = $true
+    Severity            = @('Error', 'Warning', 'Information')
+
+    Rules               = @{
+        # Enforce compatibility with both Windows PowerShell 5.1 and PowerShell 7.4+
+        PSUseCompatibleSyntax                          = @{
+            Enable         = $true
+            TargetVersions = @('5.1', '7.5')
+            IgnoreUntested = $false
+        }
+
+        # Prefer 4-space indentation with pipeline indentation for clarity.
+        PSUseConsistentIndentation                     = @{
+            Enable              = $true
+            IndentationSize     = 4
+            PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+            Kind                = 'space'
+        }
+
+        # Harden against dangerous patterns.
+        PSAvoidUsingInvokeExpression                   = @{ Enable = $true }
+        PSAvoidGlobalVars                              = @{ Enable = $true }
+        PSAvoidUsingPlainTextForPassword               = @{ Enable = $true }
+        PSAvoidUsingWriteHost                          = @{ Enable = $true }
+        PSAvoidUsingConvertToSecureStringWithPlainText = @{ Enable = $true }
+
+        # Require ShouldProcess for state-changing functions.
+        PSUseShouldProcessForStateChangingFunctions    = @{
+            Enable = $true
+        }
+
+        # Enforce consistent naming and indentation of assignments/whitespace.
+        # PSAlignAssignmentStatement aligns equals signs by adding extra spaces.
+        # PSUseConsistentWhitespace must allow this by NOT checking assignment operators.
+        PSAlignAssignmentStatement                     = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+        PSUseConsistentWhitespace                      = @{
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $false  # Allow aligned assignments
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhitespace = $false
+            CheckSeparator                  = $true
+        }
+    }
+}
+
+
+

--- a/tests/scripts/powershell/PoshQC/Get-PoshQCFileList.Excludes.Tests.ps1
+++ b/tests/scripts/powershell/PoshQC/Get-PoshQCFileList.Excludes.Tests.ps1
@@ -1,0 +1,27 @@
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '../../../../scripts/powershell/PoshQC/PoshQC.psm1') -Force
+}
+
+Describe 'Get-PoshQCFileList (default excludes)' {
+    It 'excludes files under .vscode-test by default' {
+        $resolvePath = {
+            param([string] $Path)
+            $Path
+        }
+        $enumerateFiles = {
+            param([string] $Path)
+            [void] $Path
+            @(
+                [pscustomobject]@{ FullName = '/repo/.vscode-test/shellIntegration.ps1'; Extension = '.ps1' },
+                [pscustomobject]@{ FullName = '/repo/scripts/dev-tools/foo.ps1'; Extension = '.ps1' }
+            )
+        }
+
+        $result = Get-PoshQCFileList -Root '/repo' -ResolvePath $resolvePath -EnumerateFiles $enumerateFiles
+
+        $result | Should -HaveCount 1
+        $result[0].FullName | Should -Be '/repo/scripts/dev-tools/foo.ps1'
+    }
+}

--- a/tests/scripts/powershell/PoshQC/PoshQC.Comprehensive.Tests.ps1
+++ b/tests/scripts/powershell/PoshQC/PoshQC.Comprehensive.Tests.ps1
@@ -1,0 +1,757 @@
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAlignAssignmentStatement', '', Justification = 'Test mock data structures with nested hash tables are difficult to align uniformly')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Mock function parameters mirror real function signatures for testing')]
+param()
+
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '../../../../scripts/powershell/PoshQC/PoshQC.psm1'
+    Import-Module -Name $modulePath -Force
+    $moduleInfo = Get-Module PoshQC
+    $moduleRoot = Split-Path -Parent $moduleInfo.Path
+    $script:TestSettingsPath = Join-Path $moduleRoot 'settings/pssa.settings.psd1'
+}
+
+Describe 'Get-PoshQCFileList' {
+    Context 'When given a valid root path' {
+        It 'Should resolve the root path and return PowerShell files' {
+            InModuleScope PoshQC {
+                $testRoot = $PSScriptRoot
+                Mock -CommandName Resolve-Path -MockWith { [PSCustomObject]@{ Path = $testRoot } }
+                Mock -CommandName Get-ChildItem -MockWith {
+                    @(
+                        [PSCustomObject]@{ FullName = "$testRoot/test.ps1"; Extension = '.ps1' },
+                        [PSCustomObject]@{ FullName = "$testRoot/module.psm1"; Extension = '.psm1' }
+                    )
+                }
+
+                $result = Get-PoshQCFileList -Root $testRoot
+
+                $result.Count | Should -Be 2
+                Should -Invoke -CommandName Resolve-Path -Times 1 -Exactly
+                Should -Invoke -CommandName Get-ChildItem -Times 1 -Exactly
+            }
+        }
+
+        It 'Should exclude files in excluded directories' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                Mock -CommandName Resolve-Path -MockWith { [PSCustomObject]@{ Path = $testRoot } }
+                Mock -CommandName Get-ChildItem -MockWith {
+                    @(
+                        [PSCustomObject]@{ FullName = "$testRoot/scripts/test.ps1"; Extension = '.ps1' },
+                        [PSCustomObject]@{ FullName = "$testRoot/.git/hooks.ps1"; Extension = '.ps1' },
+                        [PSCustomObject]@{ FullName = "$testRoot/node_modules/lib.ps1"; Extension = '.ps1' }
+                    )
+                }
+
+                $result = Get-PoshQCFileList -Root $testRoot
+
+                $result.Count | Should -Be 1
+                $result[0].FullName | Should -Be "$testRoot/scripts/test.ps1"
+            }
+        }
+
+        It 'Should return empty array when no files found' {
+            InModuleScope PoshQC {
+                $testRoot = '/empty'
+                Mock -CommandName Resolve-Path -MockWith { [PSCustomObject]@{ Path = $testRoot } }
+                Mock -CommandName Get-ChildItem -MockWith { $null }
+
+                $result = Get-PoshQCFileList -Root $testRoot
+
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Should accept custom exclusion list' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                Mock -CommandName Resolve-Path -MockWith { [PSCustomObject]@{ Path = $testRoot } }
+                Mock -CommandName Get-ChildItem -MockWith {
+                    @(
+                        [PSCustomObject]@{ FullName = "$testRoot/scripts/test.ps1"; Extension = '.ps1' },
+                        [PSCustomObject]@{ FullName = "$testRoot/custom/excluded.ps1"; Extension = '.ps1' }
+                    )
+                }
+
+                $result = Get-PoshQCFileList -Root $testRoot -ExcludeDirs @('custom')
+
+                $result.Count | Should -Be 1
+                $result[0].FullName | Should -Be "$testRoot/scripts/test.ps1"
+            }
+        }
+    }
+
+    Context 'When given an invalid root path' {
+        It 'Should throw an error when path cannot be resolved' {
+            InModuleScope PoshQC {
+                Mock -CommandName Resolve-Path -MockWith { throw 'Path not found' }
+
+                { Get-PoshQCFileList -Root 'C:\nonexistent' } | Should -Throw
+            }
+        }
+    }
+}
+
+Describe 'Install-PoshQCTool' {
+    Context 'When PSGallery is not registered' {
+        It 'Should register PSGallery when not found' -Skip {
+            # Skip: Mocking Register-PSRepository is problematic due to dynamic parameters
+        }
+    }
+
+    Context 'When PSGallery is not trusted' {
+        It 'Should attempt to set PSGallery as trusted' -Skip {
+            # Skip: Mocking Set-PSRepository is problematic
+        }
+
+        It 'Should handle failure to set PSGallery as trusted gracefully' -Skip {
+            # Skip: Mocking Set-PSRepository is problematic
+        }
+    }
+
+    Context 'When modules need to be installed' {
+        It 'Should install missing modules' -Skip {
+            # Skip: Mocking Install-Module and complex Get-Module behavior is brittle
+        }
+
+        It 'Should verify module installation after install' -Skip {
+            # Skip: Mocking Install-Module and complex Get-Module behavior is brittle
+        }
+
+        It 'Should throw when module installation fails' -Skip {
+            # Skip: Mocking Install-Module and complex Get-Module behavior is brittle
+        }
+    }
+
+    Context 'When modules are already installed' {
+        It 'Should skip installation for already-present modules' -Skip {
+            # Skip: Covered by integration test in PoshQC.EntryPoints.Tests.ps1
+        }
+    }
+}
+
+Describe 'Invoke-PoshQCFormat' {
+    Context 'When PSScriptAnalyzer is not installed' {
+        It 'Should throw an error' {
+            InModuleScope PoshQC {
+                Mock -CommandName Get-Module -MockWith { $null }
+
+                { Invoke-PoshQCFormat -Root $PSScriptRoot } | Should -Throw '*PSScriptAnalyzer is not installed*'
+            }
+        }
+    }
+
+    Context 'When settings file does not exist' {
+        It 'Should throw an error' {
+            InModuleScope PoshQC {
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $false }
+
+                { Invoke-PoshQCFormat -Root $PSScriptRoot -SettingsPath 'C:\nonexistent.psd1' } | Should -Throw '*Settings not found*'
+            }
+        }
+    }
+
+    Context 'When formatting files' {
+        It 'Should handle files that do not need formatting' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Get-PoshQCFileList -MockWith {
+                    @([PSCustomObject]@{ FullName = "$testRoot/test.ps1" })
+                }
+                Mock -CommandName Get-Content -MockWith { "Write-Host 'test'" }
+                Mock -CommandName Invoke-Formatter -MockWith { "Write-Host 'test'" }
+                Mock -CommandName Set-Content -MockWith { }
+
+                { Invoke-PoshQCFormat -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName Set-Content -Times 0 -Exactly
+            }
+        }
+
+        It 'Should format files that need formatting' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Get-PoshQCFileList -MockWith {
+                    @([PSCustomObject]@{ FullName = "$testRoot/test.ps1" })
+                }
+                Mock -CommandName Get-Content -MockWith { "Write-Host  'test'" }
+                Mock -CommandName Invoke-Formatter -MockWith { "Write-Host 'test'" }
+                Mock -CommandName Set-Content -MockWith { }
+
+                { Invoke-PoshQCFormat -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName Set-Content -Times 1 -Exactly
+            }
+        }
+
+        It 'Should normalize line endings before formatting' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Get-PoshQCFileList -MockWith {
+                    @([PSCustomObject]@{ FullName = "$testRoot/test.ps1" })
+                }
+                Mock -CommandName Get-Content -MockWith { "Write-Host 'test'`r`n" }
+                Mock -CommandName Invoke-Formatter -MockWith {
+                    param($ScriptDefinition)
+                    $ScriptDefinition | Should -Not -Match "`r`n"
+                    return "Write-Host 'test'`n"
+                }
+                Mock -CommandName Set-Content -MockWith { }
+
+                { Invoke-PoshQCFormat -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+            }
+        }
+    }
+}
+
+Describe 'Invoke-PoshQCAnalyze' {
+    Context 'When PSScriptAnalyzer is not installed' {
+        It 'Should throw an error' {
+            InModuleScope PoshQC {
+                Mock -CommandName Get-Module -MockWith { $null }
+
+                { Invoke-PoshQCAnalyze -Root $PSScriptRoot } | Should -Throw '*PSScriptAnalyzer is not installed*'
+            }
+        }
+    }
+
+    Context 'When settings file does not exist' {
+        It 'Should throw an error' {
+            InModuleScope PoshQC {
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $false }
+
+                { Invoke-PoshQCAnalyze -Root $PSScriptRoot -SettingsPath 'C:\nonexistent.psd1' } | Should -Throw '*Settings not found*'
+            }
+        }
+    }
+
+    Context 'When analyzing files' {
+        It 'Should pass when no issues are found' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Get-PoshQCFileList -MockWith {
+                    @([PSCustomObject]@{ FullName = "$testRoot/test.ps1"; Extension = '.ps1' })
+                }
+                Mock -CommandName Invoke-ScriptAnalyzer -MockWith { @() }
+
+                { Invoke-PoshQCAnalyze -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+            }
+        }
+
+        It 'Should throw when issues are found' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Get-PoshQCFileList -MockWith {
+                    @([PSCustomObject]@{ FullName = "$testRoot/test.ps1"; Extension = '.ps1' })
+                }
+                Mock -CommandName Invoke-ScriptAnalyzer -MockWith {
+                    @([PSCustomObject]@{ Message = 'Test issue'; Severity = 'Warning' })
+                }
+                Mock -CommandName Format-Table -MockWith { }
+
+                { Invoke-PoshQCAnalyze -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Throw '*reported 1 issue*'
+            }
+        }
+
+        It 'Should filter files by extension (.ps1, .psm1)' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Get-PoshQCFileList -MockWith {
+                    @(
+                        [PSCustomObject]@{ FullName = "$testRoot/test.ps1"; Extension = '.ps1' },
+                        [PSCustomObject]@{ FullName = "$testRoot/module.psm1"; Extension = '.psm1' },
+                        [PSCustomObject]@{ FullName = "$testRoot/data.psd1"; Extension = '.psd1' }
+                    )
+                }
+                Mock -CommandName Invoke-ScriptAnalyzer -MockWith { @() }
+
+                { Invoke-PoshQCAnalyze -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-ScriptAnalyzer -Times 2 -Exactly
+            }
+        }
+
+        It 'Should handle Invoke-ScriptAnalyzer failures with detailed error' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'PSScriptAnalyzer' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Get-PoshQCFileList -MockWith {
+                    @([PSCustomObject]@{ FullName = "$testRoot/test.ps1"; Extension = '.ps1' })
+                }
+                Mock -CommandName Invoke-ScriptAnalyzer -MockWith {
+                    throw [System.InvalidOperationException]::new('Parse error')
+                }
+
+                { Invoke-PoshQCAnalyze -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Throw '*Invoke-ScriptAnalyzer failed*'
+            }
+        }
+    }
+}
+
+Describe 'Invoke-PoshQCTest' {
+    Context 'When Pester is not installed' {
+        It 'Should throw an error' {
+            InModuleScope PoshQC {
+                Mock -CommandName Get-Module -MockWith { $null }
+
+                { Invoke-PoshQCTest -Root $PSScriptRoot } | Should -Throw '*Pester is not installed*'
+            }
+        }
+    }
+
+    Context 'When settings file does not exist' {
+        It 'Should throw an error' {
+            InModuleScope PoshQC {
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $false }
+
+                { Invoke-PoshQCTest -Root $PSScriptRoot -SettingsPath 'C:\nonexistent.psd1' } | Should -Throw '*Settings not found*'
+            }
+        }
+    }
+
+    Context 'When running tests' {
+        It 'Should handle no test files gracefully' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{ Enabled = $false }
+                        CodeCoverage = @{ Enabled = $false }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = @("$testRoot/tests") }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $false }
+                            OutputPath = @{ Value = $null }
+                        }
+                        CodeCoverage = $null
+                    }
+                    return $config
+                }
+                Mock -CommandName Test-Path -MockWith {
+                    param($Path)
+                    # Settings path check
+                    if ($Path -eq $testSettings) {
+                        return $true
+                    }
+                    # Run path check
+                    if ($Path -eq "$testRoot/tests") {
+                        return $true
+                    }
+                    return $false
+                }
+                Mock -CommandName Get-ChildItem -MockWith { @() }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+            }
+        }
+
+        It 'Should resolve paths relative to root' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests', 'scripts') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{ Enabled = $false }
+                        CodeCoverage = @{ Enabled = $false }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = $Hashtable.Run.Path }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $false }
+                            OutputPath = @{ Value = $null }
+                        }
+                        CodeCoverage = $null
+                    }
+                    return $config
+                }
+                Mock -CommandName Get-ChildItem -MockWith { @() }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+            }
+        }
+
+        It 'Should apply ExcludeDirs to paths' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests', '.venv', 'scripts') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{ Enabled = $false }
+                        CodeCoverage = @{ Enabled = $false }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = $Hashtable.Run.Path }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $false }
+                            OutputPath = @{ Value = $null }
+                        }
+                        CodeCoverage = $null
+                    }
+                    return $config
+                }
+                Mock -CommandName Get-ChildItem -MockWith { @() }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -ExcludeDirs @('.venv') -InformationAction SilentlyContinue } | Should -Not -Throw
+            }
+        }
+
+        It 'Should create result directory when needed' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{
+                            Enabled = $true
+                            OutputPath = 'artifacts/results.xml'
+                            OutputFormat = 'JUnitXml'
+                        }
+                        CodeCoverage = @{ Enabled = $false }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = $Hashtable.Run.Path }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $true }
+                            OutputPath = @{ Value = $Hashtable.TestResult.OutputPath }
+                        }
+                        CodeCoverage = $null
+                    }
+                    return $config
+                }
+                Mock -CommandName New-Item -MockWith { }
+                Mock -CommandName Get-ChildItem -MockWith { @() }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName New-Item -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'When coverage is enabled' {
+        It 'Should resolve coverage paths' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{ Enabled = $false }
+                        CodeCoverage = @{
+                            Enabled = $true
+                            Path = @('src/**/*.ps1')
+                            OutputPath = 'artifacts/coverage.xml'
+                            OutputFormat = 'CoverageGutters'
+                        }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = $Hashtable.Run.Path }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $false }
+                            OutputPath = @{ Value = $null }
+                        }
+                        CodeCoverage = @{
+                            Enabled = @{ Value = $true }
+                            Path = @{ Value = $Hashtable.CodeCoverage.Path }
+                            OutputPath = @{ Value = $Hashtable.CodeCoverage.OutputPath }
+                        }
+                    }
+                    return $config
+                }
+                Mock -CommandName New-Item -MockWith { }
+                Mock -CommandName Get-ChildItem -MockWith { @() }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName New-Item -Times 1 -Exactly
+            }
+        }
+
+        It 'Should generate Koverage copy by default when coverage is enabled' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{ Enabled = $false }
+                        CodeCoverage = @{
+                            Enabled = $true
+                            Path = @('src/**/*.ps1')
+                            OutputPath = 'artifacts/coverage.xml'
+                            OutputFormat = 'CoverageGutters'
+                        }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = @("$testRoot/tests") }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $false }
+                            OutputPath = @{ Value = $null }
+                        }
+                        CodeCoverage = @{
+                            Enabled = @{ Value = $true }
+                            Path = @{ Value = $Hashtable.CodeCoverage.Path }
+                            OutputPath = @{ Value = "$testRoot/artifacts/coverage.xml" }
+                        }
+                    }
+                    return $config
+                }
+                Mock -CommandName New-Item -MockWith { }
+                Mock -CommandName Test-Path -MockWith {
+                    param($Path)
+                    # Settings path check
+                    if ($Path -eq $testSettings) {
+                        return $true
+                    }
+                    # Run path check
+                    if ($Path -eq "$testRoot/tests") {
+                        return $true
+                    }
+                    return $false
+                }
+                Mock -CommandName Invoke-Pester -MockWith { }
+                Mock -CommandName Convert-PoshQCCoverageToRelative -MockWith { }
+
+                $enumerateTestsStub = {
+                    param([string[]] $Paths, [string[]] $Excluded, [scriptblock] $TestPathFn)
+                    @([PSCustomObject]@{ FullName = "$testRoot/tests/test.Tests.ps1" })
+                }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -EnumerateTests $enumerateTestsStub -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-Pester -Times 1 -Exactly
+                Should -Invoke -CommandName Convert-PoshQCCoverageToRelative -Times 1 -Exactly
+            }
+        }
+
+        It 'Should skip Koverage copy when DisableKoverageCopy is set' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Test-Path -MockWith { $true }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{ Enabled = $false }
+                        CodeCoverage = @{
+                            Enabled = $true
+                            Path = @('src/**/*.ps1')
+                            OutputPath = 'artifacts/coverage.xml'
+                            OutputFormat = 'CoverageGutters'
+                        }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = $Hashtable.Run.Path }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $false }
+                            OutputPath = @{ Value = $null }
+                        }
+                        CodeCoverage = @{
+                            Enabled = @{ Value = $true }
+                            Path = @{ Value = $Hashtable.CodeCoverage.Path }
+                            OutputPath = @{ Value = 'artifacts/coverage.xml' }
+                        }
+                    }
+                    return $config
+                }
+                Mock -CommandName New-Item -MockWith { }
+                Mock -CommandName Invoke-Pester -MockWith { }
+                Mock -CommandName Convert-PoshQCCoverageToRelative -MockWith { }
+
+                $enumerateTestsStub = {
+                    param([string[]] $Paths, [string[]] $Excluded, [scriptblock] $TestPathFn)
+                    @([PSCustomObject]@{ FullName = "$testRoot/tests/test.Tests.ps1" })
+                }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -EnumerateTests $enumerateTestsStub -DisableKoverageCopy -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-Pester -Times 1 -Exactly
+                Should -Invoke -CommandName Convert-PoshQCCoverageToRelative -Times 0 -Exactly
+            }
+        }
+
+        It 'Should use custom KoverageOutputPath when provided' {
+            InModuleScope PoshQC {
+                $testRoot = '/repo'
+                $testSettings = '/settings.psd1'
+                $customKoveragePath = '/custom/koverage.xml'
+                Mock -CommandName Get-Module -MockWith { [PSCustomObject]@{ Name = 'Pester' } }
+                Mock -CommandName Import-Module -MockWith { }
+                Mock -CommandName Import-PowerShellDataFile -MockWith {
+                    @{
+                        Run = @{ Path = @('tests') }
+                        Should = @{ ErrorAction = 'Stop' }
+                        Output = @{ Verbosity = 'Detailed' }
+                        TestResult = @{ Enabled = $false }
+                        CodeCoverage = @{
+                            Enabled = $true
+                            Path = @('src/**/*.ps1')
+                            OutputPath = 'artifacts/coverage.xml'
+                            OutputFormat = 'CoverageGutters'
+                        }
+                    }
+                }
+                Mock -CommandName New-PesterConfiguration -MockWith {
+                    param($Hashtable)
+                    $config = [PSCustomObject]@{
+                        Run = @{
+                            Path = @{ Value = @("$testRoot/tests") }
+                            ExcludePath = @{ Value = @() }
+                        }
+                        TestResult = @{
+                            Enabled = @{ Value = $false }
+                            OutputPath = @{ Value = $null }
+                        }
+                        CodeCoverage = @{
+                            Enabled = @{ Value = $true }
+                            Path = @{ Value = $Hashtable.CodeCoverage.Path }
+                            OutputPath = @{ Value = "$testRoot/artifacts/coverage.xml" }
+                        }
+                    }
+                    return $config
+                }
+                Mock -CommandName New-Item -MockWith { }
+                Mock -CommandName Test-Path -MockWith {
+                    param($Path)
+                    # Settings path check
+                    if ($Path -eq $testSettings) {
+                        return $true
+                    }
+                    # Run path check
+                    if ($Path -eq "$testRoot/tests") {
+                        return $true
+                    }
+                    return $false
+                }
+                Mock -CommandName Invoke-Pester -MockWith { }
+                Mock -CommandName Convert-PoshQCCoverageToRelative -MockWith { }
+
+                $enumerateTestsStub = {
+                    param([string[]] $Paths, [string[]] $Excluded, [scriptblock] $TestPathFn)
+                    @([PSCustomObject]@{ FullName = "$testRoot/tests/test.Tests.ps1" })
+                }
+
+                { Invoke-PoshQCTest -Root $testRoot -SettingsPath $testSettings -EnumerateTests $enumerateTestsStub -KoverageOutputPath $customKoveragePath -InformationAction SilentlyContinue } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-Pester -Times 1 -Exactly
+                Should -Invoke -CommandName Convert-PoshQCCoverageToRelative -ParameterFilter { $OutputPath -eq $customKoveragePath } -Times 1 -Exactly
+            }
+        }
+    }
+}
+

--- a/tests/scripts/powershell/PoshQC/PoshQC.EntryPoints.Tests.ps1
+++ b/tests/scripts/powershell/PoshQC/PoshQC.EntryPoints.Tests.ps1
@@ -1,0 +1,58 @@
+Set-StrictMode -Version Latest
+# PSScriptAnalyzerSuppressRule PSUseConsistentWhitespace
+# PSScriptAnalyzerSuppressRule PSAlignAssignmentStatement
+
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '../../../../scripts/powershell/PoshQC/PoshQC.psm1'
+    Import-Module -Name $modulePath -Force
+    $moduleInfo = Get-Module PoshQC
+    $moduleRoot = Split-Path -Parent $moduleInfo.Path
+    $script:TestSettingsPath = Join-Path $moduleRoot 'settings/pssa.settings.psd1'
+    if (-not (Test-Path -Path $script:TestSettingsPath)) {
+        throw "Test settings file missing at $script:TestSettingsPath"
+    }
+}
+
+# Note: These tests focus on behavioral integration rather than full isolation
+# due to the tight coupling with PSScriptAnalyzer and Pester modules.
+# Mocking core PowerShell cmdlets (Get-Module, Import-Module, etc.) is
+# problematic and leads to brittle tests.
+
+Describe 'Install-PoshQCTool' {
+    It 'reports already-installed modules without error' {
+        # This test verifies the function runs successfully when dependencies are present
+        # It won't reinstall if PSScriptAnalyzer and Pester are already available
+        { Install-PoshQCTool -InformationAction SilentlyContinue } | Should -Not -Throw
+    }
+}
+
+Describe 'Invoke-PoshQCFormat' {
+    It 'handles empty file list without error' {
+        # Mock the internal Get-PoshQCFileList function within the module scope
+        $testRoot = $PSScriptRoot
+        $testSettings = $TestSettingsPath
+        InModuleScope PoshQC -Parameters @{ testRoot = $testRoot; testSettings = $testSettings } {
+            param($testRoot, $testSettings)
+            # Suppress warnings about unused parameters (they ARE used in the Should assertion below)
+            $null = $testRoot
+            $null = $testSettings
+            Mock -CommandName Get-PoshQCFileList -MockWith { @() }
+            { Invoke-PoshQCFormat -Root $testRoot -SettingsPath $testSettings -InformationAction SilentlyContinue } | Should -Not -Throw
+        }
+    }
+}
+
+Describe 'Invoke-PoshQCAnalyze' {
+    It 'validates settings path exists' {
+        { Invoke-PoshQCAnalyze -Root $PSScriptRoot -SettingsPath 'C:\nonexistent\settings.psd1' } | Should -Throw '*Settings not found*'
+    }
+}
+
+Describe 'Invoke-PoshQCTest' {
+    It 'validates Pester module availability' {
+        $pesterInstalled = Get-Module -ListAvailable -Name Pester
+        $pesterInstalled | Should -Not -BeNullOrEmpty -Because 'Pester should be installed for these tests to run'
+    }
+}
+
+

--- a/tests/scripts/powershell/PoshQC/PoshQC.Tests.ps1
+++ b/tests/scripts/powershell/PoshQC/PoshQC.Tests.ps1
@@ -1,0 +1,528 @@
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '../../../../scripts/powershell/PoshQC/PoshQC.psm1') -Force
+}
+
+Describe 'Get-PoshQCFileList' {
+    It 'returns empty when no PowerShell files are enumerated' {
+        $resolvePath = {
+            param($Path)
+            'resolvePath-called' | Out-Null
+            $Path
+        }
+        $enumerateFiles = {
+            param($Path)
+            'enumerateFiles-called' | Out-Null
+            [void] $Path
+            @()
+        }
+
+        $result = Get-PoshQCFileList -Root '/repo' -ResolvePath $resolvePath -EnumerateFiles $enumerateFiles
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'excludes files matched by the injected predicate' {
+        $resolvePath = { param($Path) $Path }
+        $enumerateFiles = {
+            param($Path)
+            [void] $Path
+            @([pscustomobject]@{ FullName = '/repo/skip/file.ps1'; Extension = '.ps1' })
+        }
+        $shouldExclude = {
+            param($File, [string[]] $ExcludedDirs)
+            [void] $ExcludedDirs
+            $File.FullName -match '/skip/'
+        }
+
+        $result = Get-PoshQCFileList -Root '/repo' -ExcludeDirs @('skip') -ResolvePath $resolvePath -EnumerateFiles $enumerateFiles -ShouldExclude $shouldExclude
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'throws when the injected resolver fails' {
+        { Get-PoshQCFileList -Root '/missing' -ResolvePath { throw 'not found' } } |
+            Should -Throw "Failed to resolve root path '/missing': not found"
+    }
+
+    It 'filters out non-PowerShell extensions with the injected predicate' {
+        $result = Get-PoshQCFileList -Root '/repo' -ResolvePath { param([string] $Path) $Path } -EnumerateFiles {
+            param([string] $Path)
+            [void] $Path
+            @(
+                [pscustomobject]@{ FullName = '/repo/a.ps1'; Extension = '.ps1' },
+                [pscustomobject]@{ FullName = '/repo/b.txt'; Extension = '.txt' }
+            )
+        } -IsAllowedExtension {
+            param($File)
+            $File.Extension -eq '.ps1'
+        }
+
+        $result | Should -HaveCount 1
+        $result[0].FullName | Should -Be '/repo/a.ps1'
+    }
+
+    It 'resolves relative roots using the injected resolver' {
+        $received = $null
+        $resolvePath = { param([string] $Path) [void] $Path; '/abs/scripts' }
+        $enumerateFiles = {
+            param([string] $Path)
+            Set-Variable -Scope 1 -Name 'received' -Value $Path
+            @([pscustomobject]@{ FullName = (Join-Path $Path 'tool.psm1'); Extension = '.psm1' })
+        }
+
+        $result = Get-PoshQCFileList -Root 'scripts' -ResolvePath $resolvePath -EnumerateFiles $enumerateFiles
+
+        ($received -replace '\\', '/') | Should -Be '/abs/scripts'
+        $result | Should -HaveCount 1
+        ($result[0].FullName -replace '\\', '/') | Should -Be '/abs/scripts/tool.psm1'
+    }
+}
+
+Describe 'Install-PoshQCTool' {
+    It 'registers PSGallery when absent and installs required modules' {
+        $registered = $false
+        $installed = @{}
+        $logger = New-Object System.Collections.Generic.List[string]
+
+        Install-PoshQCTool -GetRepository { $null } -RegisterRepository { Set-Variable -Scope 1 -Name 'registered' -Value $true } `
+            -FindModule {
+            param([string] $Name)
+            [void] $Name
+            if ($installed.ContainsKey($Name)) {
+                [pscustomobject]@{ Name = $Name; Version = $installed[$Name] }
+            }
+        } -InstallModule {
+            param([string] $Name, [string] $Version)
+            [void] $Name
+            [void] $Version
+            $installed[$Name] = [version] $Version
+        } -Logger {
+            param([string] $Message, [string] $Level)
+            [void] $Message
+            [void] $Level
+            $logger.Add("$($Level):$($Message)") | Out-Null
+        } -SetTls { } -SetRepository { } | Out-Null
+
+        $registered | Should -BeTrue
+        ($installed.Keys | Sort-Object) | Should -Be @('Pester', 'PSScriptAnalyzer')
+    }
+
+    It 'logs a warning when PSGallery trust cannot be set' {
+        $logs = New-Object System.Collections.Generic.List[string]
+
+        Install-PoshQCTool -GetRepository { [pscustomobject]@{ InstallationPolicy = 'Untrusted' } } `
+            -SetRepository { throw 'cannot set' } -FindModule {
+            param([string] $Name)
+            [pscustomobject]@{ Name = $Name; Version = [version]'9.9.9' }
+        } `
+            -InstallModule { param([string] $Name, [string] $Version) [void] $Name; [void] $Version } -RegisterRepository { } -SetTls { } -Logger {
+            param([string] $Message, [string] $Level)
+            [void] $Message
+            [void] $Level
+            $logs.Add("$($Level):$($Message)") | Out-Null
+        } | Out-Null
+
+        ($logs | Where-Object { $_ -like 'Warning:*PSGallery*' }).Count | Should -Be 1
+    }
+
+    It 'skips installation when required modules are already present' {
+        $installCalls = 0
+
+        Install-PoshQCTool -FindModule {
+            param([string] $Name)
+            [pscustomobject]@{ Name = $Name; Version = [version]'9.9.9' }
+        } -InstallModule {
+            param([string] $Name, [string] $Version)
+            [void] $Name
+            [void] $Version
+            $script:installCalls++
+        } -SetTls { } -GetRepository { [pscustomobject]@{ InstallationPolicy = 'Trusted' } } `
+            -SetRepository { } -RegisterRepository { } -Logger {
+            param([string] $Message, [string] $Level)
+            [void] $Message
+            [void] $Level
+        } | Out-Null
+
+        $installCalls | Should -Be 0
+    }
+
+    It 'throws when an injected install operation fails' {
+        { Install-PoshQCTool -FindModule { param([string] $Name) [void] $Name } -InstallModule { param([string] $Name, [string] $Version) [void] $Name; [void] $Version; throw 'boom' } -SetTls { } -GetRepository { $null } -RegisterRepository { } -SetRepository { } -Logger { param([string] $Message, [string] $Level) [void] $Message; [void] $Level } } |
+            Should -Throw '*Failed to install PSScriptAnalyzer 1.22.0: boom*'
+    }
+}
+
+Describe 'Invoke-PoshQCFormat' {
+    It 'throws when PSScriptAnalyzer is missing' {
+        { Invoke-PoshQCFormat -EnsureModule { param([string] $Name, [string] $ErrorMessage) [void] $Name; throw $ErrorMessage } } |
+            Should -Throw '*PSScriptAnalyzer is not installed*'
+    }
+
+    It 'throws when the settings file is missing' {
+        { Invoke-PoshQCFormat -Root '/repo' -SettingsPath '/missing.psd1' -EnsureModule { } -TestPathExists { $false } } |
+            Should -Throw 'Settings not found: /missing.psd1'
+    }
+
+    It 'logs and returns when no files are found' {
+        $logs = New-Object System.Collections.Generic.List[string]
+
+        Invoke-PoshQCFormat -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } `
+            -GetFileList { @() } -Logger { param([string] $Message) $logs.Add($Message) | Out-Null } | Out-Null
+
+        $logs | Should -Contain 'No PowerShell files found under /repo'
+    }
+
+    It 'writes formatted content when the formatter changes text' {
+        $writes = @()
+
+        Invoke-PoshQCFormat -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } `
+            -GetFileList { param([string] $RootPath, [string[]] $Excluded) [void] $RootPath; [void] $Excluded; @([pscustomobject]@{ FullName = '/repo/file.ps1' }) } -ReadFile { param([string] $Path) [void] $Path; "Write-Host  `"test`"`r`n" } `
+            -FormatContent {
+            param([string] $Content, [string] $Settings)
+            [void] $Settings
+            $Content | Should -Not -Match "`r`n"
+            "Write-Host 'test'`n"
+        } -WriteFile {
+            param([string] $Path, [string] $Content)
+            Set-Variable -Scope 1 -Name 'writes' -Value ($writes + @(@{ Path = $Path; Content = $Content }))
+        } -Logger { param([string] $Message) [void] $Message } | Out-Null
+
+        $writes | Should -HaveCount 1
+        $writes[0].Path | Should -Be '/repo/file.ps1'
+        $writes[0].Content | Should -Be "Write-Host 'test'`n"
+    }
+
+    It 'performs no writes when content is unchanged' {
+        $writes = 0
+
+        Invoke-PoshQCFormat -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } `
+            -GetFileList { @([pscustomobject]@{ FullName = '/repo/file.ps1' }) } -ReadFile { param([string] $Path) [void] $Path; "Write-Host 'same'`n" } `
+            -FormatContent { param([string] $Content, [string] $Settings) [void] $Settings; $Content } -WriteFile {
+            param([string] $Path, [string] $Content)
+            [void] $Path
+            [void] $Content
+            $script:writes++
+        } -Logger { param([string] $Message) [void] $Message } | Out-Null
+
+        $writes | Should -Be 0
+    }
+}
+
+Describe 'Invoke-PoshQCAnalyze' {
+    It 'throws when PSScriptAnalyzer is missing' {
+        { Invoke-PoshQCAnalyze -EnsureModule { param([string] $Name, [string] $ErrorMessage) [void] $Name; throw $ErrorMessage } } |
+            Should -Throw '*PSScriptAnalyzer is not installed*'
+    }
+
+    It 'throws when the settings file is missing' {
+        { Invoke-PoshQCAnalyze -Root '/repo' -SettingsPath '/missing.psd1' -EnsureModule { } -TestPathExists { $false } } |
+            Should -Throw 'Settings not found: /missing.psd1'
+    }
+
+    It 'logs and returns when no files are found' {
+        $logs = New-Object System.Collections.Generic.List[string]
+
+        Invoke-PoshQCAnalyze -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } `
+            -GetFileList { @() } -Logger { param([string] $Message) $logs.Add($Message) | Out-Null } -AnalyzeFile { param([string] $Path) [void] $Path; throw 'should not run' } | Out-Null
+
+        $logs | Should -Contain 'No PowerShell files found under /repo'
+    }
+
+    It 'throws when analyzer returns findings' {
+        { Invoke-PoshQCAnalyze -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } `
+                -GetFileList { @([pscustomobject]@{ FullName = '/repo/file.ps1'; Extension = '.ps1' }) } `
+                -AnalyzeFile { param([string] $Path) [void] $Path; @([pscustomobject]@{ Message = 'warn' }) } `
+                -Logger { param([string] $Message) [void] $Message } } |
+            Should -Throw 'PSScriptAnalyzer reported 1 issue(s).'
+    }
+
+    It 'retries transient NullReferenceExceptions and succeeds' {
+        $script:poshqcAnalyzeCalls = 0
+
+        {
+            Invoke-PoshQCAnalyze -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } `
+                -GetFileList { @([pscustomobject]@{ FullName = '/repo/file.ps1'; Extension = '.ps1' }) } `
+                -AnalyzeFile {
+                param([string] $Path, [string] $Settings)
+                [void] $Path
+                [void] $Settings
+                $script:poshqcAnalyzeCalls++
+                if ($script:poshqcAnalyzeCalls -le 2) {
+                    throw [System.NullReferenceException]::new('boom')
+                }
+                @()
+            } `
+                -ReloadAnalyzerModule { } -Logger { param([string] $Message) [void] $Message } `
+                -NullReferenceRetryCount 4 -NullReferenceInitialDelayMilliseconds 0
+        } | Should -Not -Throw
+
+        $script:poshqcAnalyzeCalls | Should -Be 3
+    }
+
+    It 'fails after exhausting NullReferenceException retries' {
+        $script:poshqcAnalyzeCalls = 0
+
+        {
+            Invoke-PoshQCAnalyze -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } `
+                -GetFileList { @([pscustomobject]@{ FullName = '/repo/file.ps1'; Extension = '.ps1' }) } `
+                -AnalyzeFile {
+                param([string] $Path, [string] $Settings)
+                [void] $Path
+                [void] $Settings
+                $script:poshqcAnalyzeCalls++
+                throw [System.NullReferenceException]::new('boom')
+            } `
+                -ReloadAnalyzerModule { } -Logger { param([string] $Message) [void] $Message } `
+                -NullReferenceRetryCount 2 -NullReferenceInitialDelayMilliseconds 0
+        } | Should -Throw '*Invoke-ScriptAnalyzer failed for /repo/file.ps1*NullReferenceException*boom*'
+
+        $script:poshqcAnalyzeCalls | Should -Be 3
+    }
+}
+
+Describe 'Convert-PoshQCCoverageToRelative' {
+    Context 'When converting coverage paths with repo root' {
+        It 'Should convert forward-slash paths in XML to relative paths' {
+            $mockXmlContent = @'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="Pester">
+  <package name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools">
+  <class name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools/collect-commit-context" sourcefilename="collect-commit-context.ps1">
+  </class>
+  </package>
+  <package name="/tmp/repos/lexile-corpus-tuner/scripts/powershell/PoshQC">
+  <sourcefile name="PoshQC.psm1">
+  </sourcefile>
+  </package>
+</report>
+'@
+
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/tmp/repos/lexile-corpus-tuner' -PassThru
+
+            $result | Should -Not -Match '/tmp/repos/lexile-corpus-tuner/'
+            $result | Should -Match '<package name="scripts/dev-tools">'
+            $result | Should -Match '<class name="scripts/dev-tools/collect-commit-context"'
+            $result | Should -Match '<package name="scripts/powershell/PoshQC">'
+        }
+
+        It 'Should convert backslash paths in XML to relative paths (Windows-style)' {
+            $mockXmlContent = @'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="Pester">
+  <package name="C:\repos\lexile-corpus-tuner\scripts\dev-tools">
+  <class name="C:\repos\lexile-corpus-tuner\scripts\dev-tools\collect-commit-context" sourcefilename="collect-commit-context.ps1">
+  </class>
+  </package>
+</report>
+'@
+
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot 'C:\repos\lexile-corpus-tuner' -PassThru
+
+            $result | Should -Not -Match 'C:/repos/lexile-corpus-tuner/'
+            $result | Should -Not -Match 'C:\\repos\\lexile-corpus-tuner\\'
+            $result | Should -Match 'scripts'
+        }
+
+        It 'Should handle mixed forward and backslash paths' {
+            $mockXmlContent = @'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="Pester">
+  <package name="C:/repos/lexile-corpus-tuner/scripts/dev-tools">
+  <class name="C:\repos\lexile-corpus-tuner\scripts\powershell\PoshQC" sourcefilename="PoshQC.psm1">
+  </class>
+  </package>
+</report>
+'@
+
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot 'C:\repos\lexile-corpus-tuner' -PassThru
+
+            $result | Should -Not -Match 'C:/repos/lexile-corpus-tuner/'
+            $result | Should -Not -Match 'C:\\repos\\lexile-corpus-tuner\\'
+            $result | Should -Match 'scripts'
+        }
+    }
+
+    Context 'When RepoRoot has trailing separator' {
+        It 'Should still convert paths correctly' {
+            $mockXmlContent = @'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="Pester">
+  <package name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools">
+  </package>
+</report>
+'@
+
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/tmp/repos/lexile-corpus-tuner/' -PassThru
+
+            $result | Should -Not -Match '/tmp/repos/lexile-corpus-tuner/'
+            $result | Should -Match '<package name="scripts/dev-tools">'
+        }
+    }
+
+    Context 'When inputs or outputs are injected' {
+        It 'skips conversion when neither InputPath nor InputContent is provided' {
+            $logs = New-Object System.Collections.Generic.List[string]
+
+            Convert-PoshQCCoverageToRelative -Logger { param([string] $Message) $logs.Add($Message) | Out-Null } | Out-Null
+
+            $logs | Should -Contain 'No coverage input provided; skipping conversion.'
+        }
+
+        It 'derives default output path when only InputPath is supplied' {
+            $writtenPath = $null
+            $writtenContent = $null
+
+            Convert-PoshQCCoverageToRelative -RepoRoot '/repo' -InputPath 'artifacts/pester/coverage.xml' -ResolvePath { param([string] $Path) if ($Path.StartsWith('/repo')) { $Path } else { "/repo/$Path" } } `
+                -JoinPath { param([string] $Parent, [string] $Child) "$Parent/$Child" } -TestPathExists { param([string] $Path) [void] $Path; $true } -ReadContent { '<report></report>' } `
+                -WriteContent {
+                param([string] $Path, [string] $Content)
+                Set-Variable -Scope 1 -Name 'writtenPath' -Value $Path
+                Set-Variable -Scope 1 -Name 'writtenContent' -Value $Content
+            } -EnsureDirectory { param([string] $Path) [void] $Path } -GetDefaultOutputPath {
+                param([string] $ResolvedInputPath, [string] $ResolvedRoot)
+                [void] $ResolvedInputPath
+                "$ResolvedRoot/artifacts/pester/coverage.koverage.xml"
+            } -Logger { param([string] $Message) [void] $Message } | Out-Null
+
+            $writtenPath | Should -Be '/repo/artifacts/pester/coverage.koverage.xml'
+            $writtenContent | Should -Be '<report></report>'
+        }
+
+        It 'returns converted content when PassThru is set with trailing RepoRoot separator' {
+            $mockXmlContent = @'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="Pester">
+  <package name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools">
+  </package>
+</report>
+'@
+
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/tmp/repos/lexile-corpus-tuner/' -PassThru
+
+            $result | Should -Not -Match '/tmp/repos/lexile-corpus-tuner/'
+            $result | Should -Match 'scripts/dev-tools'
+        }
+    }
+}
+
+Describe 'Invoke-PoshQCTest' {
+    It 'throws when Pester is missing' {
+        { Invoke-PoshQCTest -EnsureModule { param([string] $Name, [string] $ErrorMessage) [void] $Name; throw $ErrorMessage } } |
+            Should -Throw '*Pester is not installed*'
+    }
+
+    It 'throws when settings file is missing' {
+        { Invoke-PoshQCTest -Root '/repo' -SettingsPath '/missing.psd1' -EnsureModule { } -TestPathExists { $false } } |
+            Should -Throw 'Settings not found: /missing.psd1'
+    }
+
+    It 'expands Run.Path and merges ExcludeDirs into ExcludePath' {
+        $config = $null
+        $script:capturedRunPaths = $null
+        $script:capturedExcludes = $null
+        $settings = @{
+            Run          = @{ Path = @('tests') }
+            Should       = @{ ErrorAction = 'Stop' }
+            Output       = @{ Verbosity = 'Detailed' }
+            TestResult   = @{ Enabled = $false }
+            CodeCoverage = $null
+        }
+
+        Invoke-PoshQCTest -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } -LoadSettings { $settings } `
+            -BuildConfiguration {
+            param($Table)
+            $config = [pscustomobject]@{
+                Run          = @{
+                    Path        = @{ Value = $Table.Run.Path }
+                    ExcludePath = @{ Value = @() }
+                }
+                TestResult   = @{ Enabled = @{ Value = $false }; OutputPath = @{ Value = $null } }
+                CodeCoverage = $null
+                Output       = @{ Verbosity = 'Normal' }
+            }
+            return $config
+        } -EnsureResultPath { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } -ExpandCoveragePaths { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } `
+            -ExpandRunPaths {
+            param($cfg, [string] $RootPath, [string[]] $Excluded)
+            $cfg.Run.Path = @($cfg.Run.Path.Value | ForEach-Object { Join-Path $RootPath $_ })
+            $cfg.Run.ExcludePath = @($Excluded | ForEach-Object { Join-Path $RootPath $_ })
+            $cfg
+        } `
+            -EnumerateTests {
+            param([string[]] $Paths, [string[]] $Excluded, [scriptblock] $TestPathFn)
+            [void] $TestPathFn
+            Set-Variable -Scope Script -Name capturedRunPaths -Value $Paths -Force
+            Set-Variable -Scope Script -Name capturedExcludes -Value $Excluded -Force
+            @([pscustomobject]@{ FullName = '/repo/tests/sample.Tests.ps1' })
+        } -InvokePester {
+            [pscustomobject]@{ Duration = [timespan]::Zero; PassedCount = 1; FailedCount = 0; SkippedCount = 0; InconclusiveCount = 0; NotRunCount = 0 }
+        } -Logger { param([string] $Message) [void] $Message } -ExcludeDirs @('skip') | Out-Null
+
+        ($script:capturedRunPaths | ForEach-Object { $_ -replace '\\', '/' }) | Should -Be @('/repo/tests')
+        ($script:capturedExcludes | ForEach-Object { $_ -replace '\\', '/' }) | Should -Contain 'skip'
+    }
+
+    It 'logs and returns when no test files are found' {
+        $logs = New-Object System.Collections.Generic.List[string]
+
+        Invoke-PoshQCTest -Root '/repo' -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } -LoadSettings {
+            @{ Run = @{ Path = @('tests') }; Should = @{ ErrorAction = 'Stop' }; Output = @{ Verbosity = 'Detailed' }; TestResult = @{ Enabled = $false }; CodeCoverage = $null }
+        } -BuildConfiguration {
+            param($Table)
+            [pscustomobject]@{
+                Run          = @{ Path = @{ Value = $Table.Run.Path }; ExcludePath = @{ Value = @() } }
+                TestResult   = @{ Enabled = @{ Value = $false }; OutputPath = @{ Value = $null } }
+                CodeCoverage = $null
+                Output       = @{ Verbosity = 'Normal' }
+            }
+        } -EnsureResultPath { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } -ExpandCoveragePaths { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } `
+            -EnumerateTests { @() } -Logger { param([string] $Message) $logs.Add($Message) | Out-Null } | Out-Null
+
+        $logs | Should -Contain 'No Pester test files found under configured paths for root /repo'
+    }
+
+    It 'invokes coverage copy when coverage is enabled and not disabled' {
+        $copyArgs = $null
+        $repoRoot = Join-Path ([IO.Path]::GetTempPath()) 'repo'
+        $coveragePath = Join-Path $repoRoot 'coverage.xml'
+        $coverageSrcPath = Join-Path $repoRoot 'src'
+        $expectedCoveragePath = $coveragePath
+        $expectedRepoRoot = $repoRoot
+        $expectedKoveragePath = Join-Path $repoRoot 'coverage.koverage.xml'
+
+        Invoke-PoshQCTest -Root $repoRoot -SettingsPath '/settings.psd1' -EnsureModule { } -TestPathExists { $true } -LoadSettings {
+            @{ Run = @{ Path = @('tests') }; Should = @{ ErrorAction = 'Stop' }; Output = @{ Verbosity = 'Detailed' }; TestResult = @{ Enabled = $false }; CodeCoverage = @{ Enabled = $true; Path = @($coverageSrcPath); OutputPath = $coveragePath } }
+        } -BuildConfiguration {
+            param($Table)
+            [pscustomobject]@{
+                Run          = @{ Path = @{ Value = $Table.Run.Path }; ExcludePath = @{ Value = @() } }
+                TestResult   = @{ Enabled = @{ Value = $false }; OutputPath = @{ Value = $null } }
+                CodeCoverage = @{ Enabled = $true; Path = @{ Value = $Table.CodeCoverage.Path }; OutputPath = @{ Value = $Table.CodeCoverage.OutputPath } }
+                Output       = @{ Verbosity = 'Normal' }
+            }
+        } -EnsureResultPath { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } -ExpandCoveragePaths { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } `
+            -EnumerateTests { @([pscustomobject]@{ FullName = '/repo/tests/sample.Tests.ps1' }) } -InvokePester {
+            [pscustomobject]@{
+                Duration          = [timespan]::Zero
+                PassedCount       = 1
+                FailedCount       = 0
+                SkippedCount      = 0
+                InconclusiveCount = 0
+                NotRunCount       = 0
+                CodeCoverage      = [pscustomobject]@{ CoverageReport = 'Coverage: 100%' }
+            }
+        } -CopyCoverage {
+            param([string] $CoveragePath, [string] $RepoRoot, [string] $KoveragePath)
+            Set-Variable -Scope 1 -Name 'copyArgs' -Value @($CoveragePath, $RepoRoot, $KoveragePath)
+        } -Logger { param([string] $Message) [void] $Message } | Out-Null
+
+        ($copyArgs[0] -replace '\\', '/') | Should -Be ($expectedCoveragePath -replace '\\', '/')
+        ($copyArgs[1] -replace '\\', '/') | Should -Be ($expectedRepoRoot -replace '\\', '/')
+        ($copyArgs[2] -replace '\\', '/') | Should -Be ($expectedKoveragePath -replace '\\', '/')
+    }
+}
+
+
+

--- a/tests/scripts/powershell/Support/TestHelpers.ps1
+++ b/tests/scripts/powershell/Support/TestHelpers.ps1
@@ -1,0 +1,35 @@
+function global:Import-ScriptFunction {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    $resolved = (Resolve-Path -Path $Path).Path
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($resolved, [ref]$null, [ref]$errors)
+    if ($errors -and $errors.Count -gt 0) {
+        throw "Failed to parse ${resolved}: $($errors[0].Message)"
+    }
+
+    $funcAst = $ast.Find(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $Name
+        },
+        $true
+    )
+
+    if (-not $funcAst) {
+        throw "Function $Name not found in $resolved"
+    }
+
+    $functionText = $funcAst.Extent.Text
+    $parseErrors = $null
+    $parsed = [System.Management.Automation.Language.Parser]::ParseInput($functionText, $resolved, [ref]$null, [ref]$parseErrors)
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        throw "Failed to parse function body for ${resolved}: $($parseErrors[0].Message)"
+    }
+
+    return $parsed.GetScriptBlock()
+}


### PR DESCRIPTION
Bootstrap PowerShell ecosystem (#30) with PoshQC Pester tests and coverage conversion

## Summary

- Add a Pester test suite for the `PoshQC` PowerShell tooling to support the bootstrap-powershell-ecosystem acceptance criteria (#30).
- Add a PowerShell coverage conversion helper at `scripts/powershell/PoshQC/convert-poshqc-coverage.ps1`.
- Add shared PowerShell test helpers under `tests/scripts/powershell/Support/TestHelpers.ps1`.
- Introduce Python dev tooling under `scripts/dev_tools/` (including PR/commit context collection and QC helpers) to support repo workflows.
- Tighten evidence requirements by clarifying the “Command exactness” rule in `.github/skills/evidence-and-timestamp-conventions/SKILL.md`.
- Add the active feature issue document at `docs/features/active/2026-02-17-bootstrap-powershell-ecosystem-30/issue.md`.

## Why

Issue #30 defines a “bootstrap-powershell-ecosystem” capability with acceptance criteria that require:

- Creating or validating the required `PoshQC` module structure and settings files in a target workspace.
- Verifying PowerShell runtime compatibility and reporting a clear block when the minimum supported runtime is missing.
- Installing or validating required modules (PSScriptAnalyzer and Pester) using the documented helper workflow.
- Ensuring running format/analyze/test commands after bootstrap succeeds in a correctly provisioned workspace.
- Ensuring test execution emits JUnit XML and coverage outputs in expected artifact locations, including optional `.koverage.xml` output.
- Reporting clear validation failures for missing module files, missing settings, missing modules, or command import failures.

This PR focuses on delivering test coverage and supporting tooling around `PoshQC` so the bootstrap workflow can be validated and quality-gated consistently.

## What Changed

- Core behavior / architecture
  - Add coverage conversion utility: `scripts/powershell/PoshQC/convert-poshqc-coverage.ps1`.

- Tooling / automation / CI / DevEx
  - Add developer tooling scripts under `scripts/dev_tools/` (e.g., PR context collection and QC helpers).
  - Update evidence guidance in `.github/skills/evidence-and-timestamp-conventions/SKILL.md` to require that `Command:` lines be exact, verbatim command lines.

- Tests
  - Add Pester test coverage for `PoshQC`:
    - `tests/scripts/powershell/PoshQC/PoshQC.Comprehensive.Tests.ps1`
    - `tests/scripts/powershell/PoshQC/PoshQC.Tests.ps1`
    - `tests/scripts/powershell/PoshQC/PoshQC.EntryPoints.Tests.ps1`
    - `tests/scripts/powershell/PoshQC/Get-PoshQCFileList.Excludes.Tests.ps1`
  - Add shared test helpers: `tests/scripts/powershell/Support/TestHelpers.ps1`.

- Docs / templates / agents
  - Add active feature issue doc: `docs/features/active/2026-02-17-bootstrap-powershell-ecosystem-30/issue.md`.

## Architecture / How It Fits Together

- PowerShell quality checks and related behavior are validated via Pester tests under `tests/scripts/powershell/PoshQC/`.
- Shared test utilities live under `tests/scripts/powershell/Support/` to reduce duplication across test files.
- Coverage output handling is supported by `scripts/powershell/PoshQC/convert-poshqc-coverage.ps1`, intended to transform/normalize coverage artifacts to match expected downstream formats (including the optional `.koverage.xml` output called out in #30).
- Repo workflow support scripts live under `scripts/dev_tools/` to collect PR/commit context and support consistent QC execution/documentation.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in pr_context.summary.txt).

### Recommended

- Run the Pester suite for `PoshQC` (from repo root), capturing test results:
  - `pwsh -NoProfile -Command "Invoke-Pester -Path 'tests/scripts/powershell/PoshQC' -CI"`
- Validate that coverage conversion behaves as expected for your coverage input format:
  - `pwsh -NoProfile -File "scripts/powershell/PoshQC/convert-poshqc-coverage.ps1" <args-as-needed>`
- Confirm the bootstrap expectations in #30 by exercising the `PoshQC` module import and entry points in a provisioned workspace (and verifying failures are clear in an unprovisioned workspace).

## Backward Compatibility / Migration Notes

- No removals or renames are indicated in the PR context; changes are additive (new tests, new helper scripts, and documentation updates).

## Risks and Mitigations

- Risk: New comprehensive Pester tests may increase test runtime or be sensitive to environment assumptions.
  - Mitigation: Keep tests scoped to deterministic entry points and use shared helpers (`tests/scripts/powershell/Support/TestHelpers.ps1`) to centralize environment setup/guards.
- Risk: Coverage conversion script may not match all upstream coverage formats.
  - Mitigation: Validate against the expected coverage producers for this repo and extend conversion logic only when concrete formats are confirmed.

## Review Guide

- Start with issue intent and acceptance criteria:
  - `docs/features/active/2026-02-17-bootstrap-powershell-ecosystem-30/issue.md`
- Review the new Pester tests (highest signal for expected behavior):
  - `tests/scripts/powershell/PoshQC/PoshQC.Tests.ps1`
  - `tests/scripts/powershell/PoshQC/PoshQC.EntryPoints.Tests.ps1`
  - `tests/scripts/powershell/PoshQC/PoshQC.Comprehensive.Tests.ps1`
  - `tests/scripts/powershell/PoshQC/Get-PoshQCFileList.Excludes.Tests.ps1`
- Review shared test scaffolding:
  - `tests/scripts/powershell/Support/TestHelpers.ps1`
- Review coverage conversion behavior:
  - `scripts/powershell/PoshQC/convert-poshqc-coverage.ps1`
- Review workflow/tooling additions (broad but secondary to #30’s behavior):
  - `scripts/dev_tools/` (new dev workflow helpers)
- Review evidence policy clarification:
  - `.github/skills/evidence-and-timestamp-conventions/SKILL.md`

## Follow-ups

- Fill in PR Intent fields (Primary outcome / Impact / Risks) in the PR context workflow to strengthen reviewer framing.
- Add or excerpt spec/plan/user-story content for feature `2026-02-17-bootstrap-powershell-ecosystem-30` so the PR “Why” can cite a stable design narrative (none was found in the current feature-doc excerpt section).
- Wire the Pester/JUnit/coverage artifact expectations from #30 into CI once the artifact paths and formats are finalized.

## GitHub Auto-close

- Closes #30

## Related issues / PRs

- None