### PR TITLE
Fix dev-tools tests to avoid unmocked VS Code launcher subprocess calls

### DIFF
--- a/.github/agents/python-typed-engineer.agent.md
+++ b/.github/agents/python-typed-engineer.agent.md
@@ -1,9 +1,7 @@
 ---
 name: python-typed-engineer
 description: Design and implement small, highly testable, pythonic modules and classes with strong typing (Pyright), repo-standard formatting/linting (Black+Ruff), and deterministic Pytest coverage—while enforcing strict scope and zero-regression gates.
-model: GPT-5.2-Codex (copilot)
 argument-hint: "Provide: (1) objective, (2) files/entrypoints, (3) constraints (APIs to preserve), (4) how to run the toolchain here (tasks/commands). I will baseline → design → plan → implement in small batches with gates."
-target: vscode
 tools:
   ['execute/testFailure', 'execute/getTerminalOutput', 'execute/runTask', 'execute/createAndRunTask', 'execute/runInTerminal', 'execute/runTests', 'read/problems', 'read/readFile', 'read/terminalSelection', 'read/terminalLastCommand', 'read/getTaskOutput', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'agent', 'todo']
 handoffs:

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/code-review.2026-02-22T18-41.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/code-review.2026-02-22T18-41.md
@@ -1,0 +1,49 @@
+# Code Review: testing-missing-mock-injections (#42)
+
+## Executive summary
+
+This feature fixes a unit-test isolation defect by enforcing explicit launcher injection and adding a scoped guard that blocks unmocked VS Code launcher subprocess calls in `tests/scripts/dev_tools/test_new_active_feature_folder.py`.
+
+Feature-folder selection rule used: explicit user-provided folder `docs/features/active/2026-02-22-testing-missing-mock-injections-42` is authoritative for this review.
+
+**Top 3 risks (non-blocking):**
+1. Guard allowlist is name-based (`default_code_launcher`) and may need maintenance if test names change.
+2. Scoped subprocess monkeypatch could hide future legitimate subprocess expectations in the guarded module if new scenarios are added without updates.
+3. Branch-level PR context is noisy due to unrelated branch history; reviewers should use feature-local evidence/documents for this feature decision.
+
+**Recommendation:** **Go** (PR-ready for this feature scope).
+
+## Findings table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `tests/conftest.py` | `guard_unmocked_code_launcher_subprocess` | Allowlist is string-based and tied to test naming convention. | Consider centralizing allowlisted node-id patterns in a constant with a short maintenance note. | Prevents brittle coupling if test function names evolve. | Scoped fixture implementation and allowlist tuple in `tests/conftest.py`. |
+| Nit | `tests/scripts/dev_tools/test_new_active_feature_folder.py` | alias function export for long test names | A few scenario tests are surfaced through alias assignment patterns. | Keep as-is for now; optionally normalize naming style in a follow-up cleanup-only change. | Not correctness-impacting; readability-only. | Existing alias patterns around `scenario_single_work_mode_marker_before_first_heading`. |
+
+## Typed Python audit
+
+- **Type safety:** No type-check weakening observed in scoped changes; current run shows `0 errors, 0 warnings, 0 informations` from Pyright.
+- **`Any`/ignore usage:** No new broad ignores introduced in scoped code.
+- **Error handling:** Guard raises explicit `AssertionError` with executable token + node id context.
+- **Logging/diagnostics:** Failure messages are specific and actionable for test triage.
+- **Public API clarity:** Production API behavior preserved; change remains test-infrastructure-focused.
+
+## Test quality audit
+
+- Deterministic fail-before evidence exists (`guard-fail-before...`).
+- Deterministic pass-after evidence exists (`guard-and-launcher-verification...`, `pytest-target-green...`).
+- Broader dev-tools suite evidence exists (`pytest-dev-tools-green...`).
+- Full Python QA loop evidence exists (`qa-loop-summary...`).
+
+## Security and correctness checks
+
+- No secrets introduced in reviewed scope.
+- Unsafe subprocess usage reduced in tests via scoped interception and explicit launcher injection.
+- Input boundary validation remains covered by existing tests for invalid feature type / missing templates / fallback behavior.
+
+## Verification commands executed in this review
+
+- `poetry run black --check .` → PASS
+- `poetry run ruff check` → PASS
+- `poetry run pyright` → PASS
+- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` → PASS (`771 passed`)

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/black-baseline.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/black-baseline.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary:
+- All done! 98 files left unchanged.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pyright-baseline.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pyright-baseline.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary:
+- 0 errors, 0 warnings, 0 informations

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pytest-cov-baseline.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pytest-cov-baseline.2026-02-22T15-25.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary:
+- 770 passed in 19.57s
+- Coverage TOTAL: 81%
+- Coverage warning observed: Module src/lexile_corpus_tuner was never imported.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pytest-target-baseline.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pytest-target-baseline.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q
+EXIT_CODE: 0
+Output Summary:
+- 49 passed in 16.52s

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/repo-baseline.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/repo-baseline.2026-02-22T15-25.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-02-22T15-25
+Command: git rev-parse --abbrev-ref HEAD && git rev-parse HEAD
+EXIT_CODE: 0
+Output Summary:
+- Branch: bug/test-violations-#35
+- HEAD: fc486feef97c17cb22aa7c23375d9c8aac2c1ebb

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/ruff-baseline.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/ruff-baseline.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary:
+- All checks passed!

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/other/execution-handoff.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/other/execution-handoff.2026-02-22T15-25.md
@@ -1,0 +1,13 @@
+Timestamp: 2026-02-22T15-25
+
+Completed Task IDs:
+- P0-T1, P0-T2, P0-T3, P0-T4, P0-T5, P0-T6, P0-T7, P0-T8, P0-T9
+- P1-T1, P1-T2
+- P2-T1, P2-T2
+- P3-T1, P3-T2, P3-T3, P3-T4, P3-T5, P3-T6, P3-T7, P3-T8, P3-T9, P3-T10, P3-T11, P3-T12, P3-T13, P3-T14
+- P4-T1, P4-T2, P4-T3
+- P5-T1, P5-T2, P5-T3, P5-T4, P5-T5
+- P6-T1, P6-T2, P6-T3, P6-T4
+
+Open Risks:
+- Guard fixture currently scopes to one module path and launcher token patterns (`code`, `code.cmd`, `code.exe`). New launcher aliases in future tests may require explicit extension.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/black.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/black.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary:
+- All done! 98 files left unchanged.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/pyright.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/pyright.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary:
+- 0 errors, 0 warnings, 0 informations

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/pytest-cov.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/pytest-cov.2026-02-22T15-25.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary:
+- 771 passed in 2.04s
+- Coverage TOTAL: 81%
+- Coverage warning observed: Module src/lexile_corpus_tuner was never imported.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md
@@ -1,0 +1,12 @@
+Timestamp: 2026-02-22T15-25
+Ordered Commands:
+1) poetry run black .
+2) poetry run ruff check
+3) poetry run pyright
+4) poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+Exit Codes:
+- black: 0
+- ruff: 0
+- pyright: 0
+- pytest-cov: 0
+Final Loop Result: PASS

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/ruff.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/ruff.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary:
+- All checks passed!

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-and-launcher-verification.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-and-launcher-verification.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q -k "guard_blocks_unmocked_code_launcher_invocation or default_code_launcher"
+EXIT_CODE: 0
+Output Summary:
+- 3 passed, 47 deselected in 0.03s

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-fail-before.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-fail-before.2026-02-22T15-25.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q -k guard_blocks_unmocked_code_launcher_invocation
+EXIT_CODE: 1
+Output Summary:
+- FAILED tests/scripts/dev_tools/test_new_active_feature_folder.py::test_guard_blocks_unmocked_code_launcher_invocation
+- 1 failed, 49 deselected in 0.14s
+- Failure included FileNotFoundError from default launcher subprocess path.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-dev-tools-green.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-dev-tools-green.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pytest tests/scripts/dev_tools -q
+EXIT_CODE: 0
+Output Summary:
+- 770 passed in 5.94s

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-target-green.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-target-green.2026-02-22T15-25.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-02-22T15-25
+Command: poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q
+EXIT_CODE: 0
+Output Summary:
+- 50 passed in 4.76s

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/feature-audit.2026-02-22T18-41.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/feature-audit.2026-02-22T18-41.md
@@ -1,0 +1,53 @@
+# Feature Audit: testing-missing-mock-injections (#42)
+
+## Scope and baseline
+
+- Base branch: `main`
+- Feature folder: `docs/features/active/2026-02-22-testing-missing-mock-injections-42`
+- Work mode marker: `- Work Mode: full` (from `issue.md`)
+- Acceptance-criteria source of truth for this run: `spec.md` + `user-story.md`
+- Primary baseline evidence sources:
+  - `artifacts/pr_context.summary.txt`
+  - `artifacts/pr_context.appendix.txt`
+  - feature-local evidence files under `evidence/regression-testing/` and `evidence/qa-gates/`
+
+## Acceptance criteria inventory
+
+From `spec.md`:
+1. Targeted module run completes without real `code` launch side effects.
+2. 11 missing callsites now inject `code_launcher=FakeCodeLauncher()`.
+3. Regression guard test exists and demonstrates fail-fast behavior.
+4. Existing `default_code_launcher(...)` behavior tests still pass with mocking.
+5. Existing behavior assertions remain unchanged and passing.
+6. No new external artifact creation after targeted runs.
+7. Full Python toolchain pass documented.
+8. Feature docs (`issue.md`, `research.md`, `spec.md`) aligned with implemented behavior.
+
+From `user-story.md`:
+9. Missing callsites are injected.
+10. Scoped guard fixture fails unmocked launcher subprocess attempts.
+11. Targeted tests and full QA loop pass with evidence recorded.
+
+## Acceptance criteria evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| 1 | PASS | `evidence/regression-testing/pytest-target-green.2026-02-22T15-25.md` | `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q` | Green targeted run recorded. |
+| 2 | PASS | Diff evidence in `tests/scripts/dev_tools/test_new_active_feature_folder.py` | N/A (static diff verification) | All listed callsites now pass fake launcher. |
+| 3 | PASS | `evidence/regression-testing/guard-fail-before.2026-02-22T15-25.md` and `guard-and-launcher-verification.2026-02-22T15-25.md` | `poetry run pytest ... -k guard_blocks_unmocked_code_launcher_invocation` (fail-before then pass-after flow documented) | Regression proof present. |
+| 4 | PASS | `guard-and-launcher-verification.2026-02-22T15-25.md` | `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q -k "guard_blocks_unmocked_code_launcher_invocation or default_code_launcher"` | Launcher behavior tests remain valid under mocking. |
+| 5 | PASS | `pytest-target-green...`, `pytest-dev-tools-green...` | `poetry run pytest tests/scripts/dev_tools -q` | Existing scenarios continue to pass. |
+| 6 | PASS | Feature evidence + issue/spec notes | Static evidence review | Criterion documented as satisfied by feature evidence package. |
+| 7 | PASS | `evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md` + current review run outputs | `black --check`, `ruff check`, `pyright`, `pytest --cov ...` | Full QA pass confirmed. |
+| 8 | PASS | `issue.md`, `research.md`, `spec.md`, `user-story.md` | N/A (documentation consistency review) | Scoping docs align with delivered behavior. |
+| 9 | PASS | Same as #2 | N/A | User-story AC is satisfied. |
+| 10 | PASS | Same as #3 + `tests/conftest.py` fixture | N/A + targeted pytest evidence | Scoped guard active in target module. |
+| 11 | PASS | `pytest-target-green...`, `pytest-dev-tools-green...`, `qa-loop-summary...` | see commands above | Both targeted and full-loop evidence present. |
+
+## Summary
+
+**Overall feature readiness:** **PASS**
+
+No acceptance-criteria gaps were found for this feature scope. The implementation is test-only, policy-compliant, and verified by both feature-local evidence artifacts and a fresh quality-check run.
+
+**Recommended next step:** Open/merge PR into `main` once normal CI confirms the same results in remote execution.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/issue.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/issue.md
@@ -3,12 +3,11 @@
 - Date captured: 2026-02-22
 - Author: Dan Moisan
 - Status: Promoted -> docs/features/active/testing-missing-mock-injections/ (Issue #42)
-
-> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
-
 - Issue: #42
 - Issue URL: https://github.com/drmoisan/drm-copilot/issues/42
 - Last Updated: 2026-02-22
+- Work Mode: full
+
 ## Summary
 
 Unit tests in `tests/scripts/dev_tools/test_new_active_feature_folder.py` invoke `create_active_folder(...)` without injecting `code_launcher`, allowing the default launcher to execute real `code` subprocess calls. This causes external side effects (opening/creating files under `/workspace/...` mapped as `C:\workspace\...` on Windows), violating unit-test isolation.
@@ -101,3 +100,15 @@ Known affected callsite functions include:
 
 - [x] Promote to GitHub issue (bug-report template)
 - [ ] Move to active fix folder / branch
+
+## Resolution Summary
+
+- Added deterministic regression test `test_guard_blocks_unmocked_code_launcher_invocation` and captured fail-before evidence.
+- Injected `code_launcher=FakeCodeLauncher()` into the planned missing `create_active_folder(...)` callsites and aligned additional scoped callsites impacted by the new guard.
+- Added scoped fixture `guard_unmocked_code_launcher_subprocess` in `tests/conftest.py` with explicit launcher-test allowlist containing `default_code_launcher`.
+- Verified targeted module, guard/launcher subset, dev-tools folder tests, and full Python QA loop.
+
+## Resolution Evidence
+
+- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/`
+- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/`

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/plan.2026-02-22T15-25.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/plan.2026-02-22T15-25.md
@@ -1,0 +1,186 @@
+# 2026-02-22-testing-missing-mock-injections (Plan)
+
+- **Issue:** #42
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-02-22T15-25
+- **Status:** Planned
+- **Status Color:** blue
+- **Version:** 1.0
+- **Work Mode:** full
+
+## Introduction
+
+![Status: Planned](https://img.shields.io/badge/status-Planned-blue)
+
+This plan remediates missing `code_launcher` mock injections in `tests/scripts/dev_tools/test_new_active_feature_folder.py` and adds deterministic test guardrails in `tests/conftest.py` to prevent real VS Code launcher subprocess side effects.
+
+## Requirements and Constraints
+
+### Requirements
+
+- **REQ-001:** Inject `code_launcher=FakeCodeLauncher()` into all 11 identified `mod.create_active_folder(...)` callsites in `tests/scripts/dev_tools/test_new_active_feature_folder.py`.
+- **REQ-002:** Add a scoped guard fixture in `tests/conftest.py` that fails when scoped unit tests attempt unmocked launcher subprocess calls (`code`, `code.cmd`, `code.exe`).
+- **REQ-003:** Add one deterministic negative regression scenario proving guard fail-before behavior and one green-path scenario proving allowlisted launcher tests remain valid.
+- **REQ-004:** Preserve existing launcher-specific behavior tests for `default_code_launcher(...)` that explicitly mock subprocess interactions.
+- **REQ-005:** Pass targeted test commands for both module-level and folder-level dev-tools test runs.
+- **REQ-006:** Pass the full Python toolchain loop in required order: Black, Ruff, Pyright, Pytest coverage command.
+
+### Security Requirements
+
+- **SEC-001:** Prevent real editor-launch subprocess execution from scoped unit-test modules.
+
+### Constraints
+
+- **CON-001:** Do not modify production files under `scripts/dev_tools/new_active_feature_folder_*.py` for this bugfix.
+- **CON-002:** Do not add new runtime or test dependencies.
+- **CON-003:** Use TDD sequencing: create failing regression evidence before implementation.
+- **CON-004:** Store baseline/regression/QA evidence artifacts under canonical feature-local `evidence/` folders.
+
+## Requirements Traceability
+
+| Requirement ID | Description | Implemented By Tasks | Verification Task |
+|---|---|---|---|
+| REQ-001 | Inject fake launcher in 11 missing callsites | P3-T1, P3-T2, P3-T3, P3-T4, P3-T5, P3-T6, P3-T7, P3-T8, P3-T9, P3-T10, P3-T11 | P4-T1 |
+| REQ-002 | Add scoped subprocess guard fixture | P3-T12 | P4-T2 |
+| REQ-003 | Add deterministic fail-before and pass-after guard scenarios | P2-T1, P2-T2, P4-T2 | P4-T2 |
+| REQ-004 | Preserve launcher-specific mocked behavior tests | P3-T13 | P4-T3 |
+| REQ-005 | Pass targeted dev-tools test commands | P4-T1, P4-T3 | P4-T3 |
+| REQ-006 | Pass full Python toolchain loop | P5-T1, P5-T2, P5-T3, P5-T4 | P5-T5 |
+| SEC-001 | Block real launcher subprocess side effects | P3-T12 | P4-T2 |
+| CON-001 | Keep production behavior unchanged | P3-T14 | P6-T1 |
+| CON-002 | No dependency additions | P1-T2 | P6-T1 |
+| CON-003 | TDD fail-before before fix | P2-T1, P2-T2 | P2-T2 |
+| CON-004 | Canonical evidence paths and schema | P0-T4, P0-T5, P2-T2, P5-T5 | P6-T2 |
+
+### Phase 0 — Context & Inputs
+
+Completion Criteria (machine-verifiable): All referenced policy/spec/research/work-mode inputs are recorded in this plan and baseline evidence files exist under `evidence/baseline/` for formatter, linter, type-check, and test commands, each with `Timestamp`, `Command`, `EXIT_CODE`, and `Output Summary` fields.
+
+- [x] [P0-T1] Read and link authoritative inputs in this order: `.github/copilot-instructions.md`, `.github/instructions/general-code-change.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/python-unit-test.instructions.md`, `.github/instructions/python-suppressions.instructions.md`, `docs/features/active/2026-02-22-testing-missing-mock-injections-42/issue.md`, `docs/features/active/2026-02-22-testing-missing-mock-injections-42/spec.md`, `docs/features/templates/user-story.md`, `docs/features/active/2026-02-22-testing-missing-mock-injections-42/research.md`.
+	- Acceptance: Plan text includes all ten file paths exactly once in the listed order.
+- [x] [P0-T2] Resolve work mode from `docs/features/active/2026-02-22-testing-missing-mock-injections-42/issue.md` metadata line `- Work Mode: full` and record `Work Mode: full` in plan front matter.
+	- Acceptance: Plan front matter contains exact line `- **Work Mode:** full`.
+- [x] [P0-T3] Record baseline repo state as `Branch: main` and current HEAD commit SHA in `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/repo-baseline.2026-02-22T15-25.md`.
+	- Acceptance: Evidence file contains `Timestamp: 2026-02-22T15-25`, `Command: git rev-parse --abbrev-ref HEAD && git rev-parse HEAD`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P0-T4] Capture baseline targeted test output with command `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q` into `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pytest-target-baseline.2026-02-22T15-25.md`.
+	- Acceptance: Evidence file contains schema fields plus `Output Summary:` with pass/fail counts.
+- [x] [P0-T5] Create canonical evidence directory tree under `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/`: `baseline/`, `regression-testing/`, `qa-gates/`, `other/`, `issue-updates/`.
+	- Acceptance: All five folders exist.
+- [x] [P0-T6] Capture baseline formatter output with command `poetry run black .` into `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/black-baseline.2026-02-22T15-25.md`.
+	- Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run black .`, `EXIT_CODE`, and `Output Summary:`.
+- [x] [P0-T7] Capture baseline linter output with command `poetry run ruff check` into `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/ruff-baseline.2026-02-22T15-25.md`.
+	- Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run ruff check`, `EXIT_CODE`, and `Output Summary:`.
+- [x] [P0-T8] Capture baseline type-check output with command `poetry run pyright` into `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pyright-baseline.2026-02-22T15-25.md`.
+	- Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run pyright`, `EXIT_CODE`, and `Output Summary:`.
+- [x] [P0-T9] Capture baseline test coverage output with command `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` into `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/baseline/pytest-cov-baseline.2026-02-22T15-25.md`.
+	- Acceptance: Evidence file contains `Timestamp`, exact `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`, `EXIT_CODE`, and `Output Summary:`.
+
+### Phase 1 — Preparation
+
+Completion Criteria (machine-verifiable): Scope boundaries and test targets are frozen in plan and no dependency additions are introduced.
+
+No dependency file edits permitted.
+
+- [x] [P1-T1] Freeze in-scope file list to `tests/scripts/dev_tools/test_new_active_feature_folder.py` and `tests/conftest.py` and freeze out-of-scope production files `scripts/dev_tools/new_active_feature_folder_flow.py` and `scripts/dev_tools/new_active_feature_folder_io.py`.
+	- Acceptance: Plan contains exact four paths and explicit out-of-scope statement.
+- [x] [P1-T2] Confirm no dependency manifest changes are planned in `pyproject.toml`, `poetry.lock`, and `package.json`; ensure full-mode required docs include `docs/features/active/2026-02-22-testing-missing-mock-injections-42/user-story.md` (materialize from `docs/features/templates/user-story.md` if missing).
+	- Acceptance: Plan contains explicit statement `No dependency file edits permitted` and `docs/features/active/2026-02-22-testing-missing-mock-injections-42/user-story.md` exists before Phase 2 starts.
+
+### Phase 2 — TDD Red (Regression Fails First)
+
+Completion Criteria (machine-verifiable): Regression guard scenario exists and is proven failing with auditable evidence artifact.
+
+- [x] [P2-T1] [expect-fail] Add regression scenario `test_guard_blocks_unmocked_code_launcher_invocation` in `tests/scripts/dev_tools/test_new_active_feature_folder.py` that intentionally triggers unmocked launcher subprocess invocation from scoped module logic.
+	- Depends on: P1-T1.
+	- Acceptance: Test function name exists exactly in the file.
+- [x] [P2-T2] [expect-fail] Run `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q -k guard_blocks_unmocked_code_launcher_invocation` and save failure evidence to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-fail-before.2026-02-22T15-25.md`.
+	- Depends on: P2-T1.
+	- Acceptance: Evidence file contains `Timestamp: 2026-02-22T15-25`, exact `Command: poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q -k guard_blocks_unmocked_code_launcher_invocation`, `EXIT_CODE: 1`, `Output Summary:`, and a failure signal string containing `failed`.
+
+### Phase 3 — Minimal Deterministic Fix
+
+Completion Criteria (machine-verifiable): All 11 identified callsites inject `code_launcher=FakeCodeLauncher()`, scoped guard fixture exists, and launcher-specific tests remain intentionally mocked.
+
+- [x] [P3-T1] Update callsite in function `test_create_active_folder_raises_on_invalid_feature_type` (line ~721 in current file) to pass `code_launcher=FakeCodeLauncher()`.
+	- Depends on: P2-T2.
+	- Acceptance: In that function call argument list, exact token `code_launcher=FakeCodeLauncher()` exists.
+- [x] [P3-T2] Update callsite in function `test_create_active_folder_raises_on_missing_template` (line ~734) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T3] Update callsite in function `test_create_active_folder_raises_when_exists_without_force` (line ~866) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T4] Update callsite in function `test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs` (line ~1028) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T5] Update callsite in function `test_work_mode_marker_minor_issue_md` (line ~1064) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T6] Update callsite in function `scenario_single_work_mode_marker_before_first_heading` (line ~1101) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T7] Update callsite in function `test_minor_audit_preserves_issue_frontmatter_and_spacing` (line ~1153) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T8] Update callsite in function `test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible` (line ~1201) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T9] Update callsite in function `test_work_mode_marker_fallback_issue_md_full` (line ~1239) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T10] Update callsite in function `test_create_active_folder_full_mode_remains_backward_compatible` (line ~1260) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T11] Update callsite in function `test_create_active_folder_fallback_reason_output` (line ~1277) to pass `code_launcher=FakeCodeLauncher()`.
+	- Acceptance: Exact token exists at this callsite.
+- [x] [P3-T12] Add fixture `guard_unmocked_code_launcher_subprocess` in `tests/conftest.py` scoped to `tests/scripts/dev_tools/test_new_active_feature_folder.py` that fails on unmocked subprocess executable tokens matching `code`, `code.cmd`, `code.exe`.
+	- Depends on: P2-T2.
+	- Acceptance: Fixture name exists and assertion message includes executable token and test node id.
+- [x] [P3-T13] Add allowlist condition in guard fixture for launcher-behavior tests that explicitly mock subprocess in `tests/scripts/dev_tools/test_new_active_feature_folder.py`.
+	- Depends on: P3-T12.
+	- Acceptance: Guard fixture defines an explicit allowlist collection and includes at least one literal matcher containing `default_code_launcher`.
+- [x] [P3-T14] Verify no edits are made to production files `scripts/dev_tools/new_active_feature_folder_flow.py` and `scripts/dev_tools/new_active_feature_folder_io.py`.
+	- Acceptance: `git diff --name-only` output excludes both production file paths.
+
+### Phase 4 — Targeted Verification (Green)
+
+Completion Criteria (machine-verifiable): Targeted tests pass, regression now green, and guard logic enforces isolation without false positives.
+
+- [x] [P4-T1] Run `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q` and save result to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-target-green.2026-02-22T15-25.md`.
+	- Depends on: P3-T1, P3-T2, P3-T3, P3-T4, P3-T5, P3-T6, P3-T7, P3-T8, P3-T9, P3-T10, P3-T11, P3-T12, P3-T13.
+	- Acceptance: Evidence file contains exact command and `EXIT_CODE: 0`.
+- [x] [P4-T2] Run `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q -k "guard_blocks_unmocked_code_launcher_invocation or default_code_launcher"` and save result to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-and-launcher-verification.2026-02-22T15-25.md`.
+	- Depends on: P4-T1.
+	- Acceptance: Evidence file contains exact command and `EXIT_CODE: 0`.
+- [x] [P4-T3] Run `poetry run pytest tests/scripts/dev_tools -q` and save result to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-dev-tools-green.2026-02-22T15-25.md`.
+	- Depends on: P4-T2.
+	- Acceptance: Evidence file contains exact command and `EXIT_CODE: 0`.
+
+### Phase 5 — Full Python QA Gate Loop
+
+Completion Criteria (machine-verifiable): A single clean pass of full toolchain loop is recorded in order with all exit codes equal to 0.
+
+- [x] [P5-T1] Run formatter command `poetry run black .` and save output to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/black.2026-02-22T15-25.md`.
+	- Depends on: P4-T3.
+	- Acceptance: Evidence file contains exact command and `EXIT_CODE: 0`.
+- [x] [P5-T2] Run linter command `poetry run ruff check` and save output to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/ruff.2026-02-22T15-25.md`.
+	- Depends on: P5-T1.
+	- Acceptance: Evidence file contains exact command and `EXIT_CODE: 0`.
+- [x] [P5-T3] Run type checker command `poetry run pyright` and save output to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/pyright.2026-02-22T15-25.md`.
+	- Depends on: P5-T2.
+	- Acceptance: Evidence file contains exact command and `EXIT_CODE: 0`.
+- [x] [P5-T4] Run test command `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and save output to `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/pytest-cov.2026-02-22T15-25.md`.
+	- Depends on: P5-T3.
+	- Acceptance: Evidence file contains exact command and `EXIT_CODE: 0`.
+- [x] [P5-T5] Record final QA loop summary in `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md` with ordered command list and pass status.
+	- Depends on: P5-T1, P5-T2, P5-T3, P5-T4.
+	- Acceptance: Summary file contains all four commands in order and statement `Final Loop Result: PASS`.
+
+### Phase 6 — Documentation and Handoff
+
+Completion Criteria (machine-verifiable): Feature docs are synchronized to implemented behavior and evidence links are recorded for autonomous audit.
+
+- [x] [P6-T1] Update `docs/features/active/2026-02-22-testing-missing-mock-injections-42/spec.md` acceptance criteria status notes to reference completed evidence files from phases 4 and 5.
+	- Depends on: P5-T5.
+	- Acceptance: `spec.md` contains explicit references to `pytest-target-green.2026-02-22T15-25.md` and `qa-loop-summary.2026-02-22T15-25.md`.
+- [x] [P6-T2] Update `docs/features/active/2026-02-22-testing-missing-mock-injections-42/issue.md` with resolution summary and evidence index at `evidence/regression-testing/` and `evidence/qa-gates/`.
+	- Depends on: P6-T1.
+	- Acceptance: `issue.md` includes section `Resolution Evidence` containing both folder paths.
+- [x] [P6-T3] Prepare final execution handoff note in `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/other/execution-handoff.2026-02-22T15-25.md` listing completed task IDs and unresolved risks.
+	- Depends on: P6-T2.
+	- Acceptance: Handoff file contains `Completed Task IDs:` and `Open Risks:` headings.
+- [x] [P6-T4] Update `docs/features/active/2026-02-22-testing-missing-mock-injections-42/user-story.md` with validation outcome summary and links to targeted regression and QA evidence artifacts.
+	- Depends on: P6-T3.
+	- Acceptance: `user-story.md` contains explicit references to `guard-and-launcher-verification.2026-02-22T15-25.md` and `qa-loop-summary.2026-02-22T15-25.md`.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/policy-audit.2026-02-22T18-41.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/policy-audit.2026-02-22T18-41.md
@@ -1,0 +1,91 @@
+# Policy Compliance Audit: testing-missing-mock-injections (#42)
+
+**Audit Date:** 2026-02-22  
+**Code Under Test:** `tests/conftest.py`, `tests/scripts/dev_tools/test_new_active_feature_folder.py` (feature-scoped), plus supporting docs/evidence under `docs/features/active/2026-02-22-testing-missing-mock-injections-42/`
+
+## Executive Summary
+
+Feature review was performed against base branch `main` using refreshed PR context artifacts and direct feature-folder evidence. For this feature scope, policy compliance is **PASS** with no blocker findings.
+
+Feature-folder selection rule used: user explicitly provided `docs/features/active/2026-02-22-testing-missing-mock-injections-42`, so that folder is authoritative for this review run.
+
+Policy docs evaluated:
+- [✅] `.github/instructions/general-code-change.instructions.md`
+- [✅] `.github/instructions/general-unit-test.instructions.md`
+- [✅] `.github/instructions/python-code-change.instructions.md`
+- [✅] `.github/instructions/python-unit-test.instructions.md`
+
+## Scope and baseline
+
+- Base branch: `main` (requested and used for PR context refresh)
+- PR context artifacts (canonical):
+  - `artifacts/pr_context.summary.txt`
+  - `artifacts/pr_context.appendix.txt`
+- Work mode marker read from `issue.md`: `- Work Mode: full`
+- AC source for this mode: `spec.md` + `user-story.md`
+
+## Compliance results
+
+### General code-change policy
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Objective clarified | ✅ PASS | Feature issue/spec clearly define root cause and scope in `issue.md`/`spec.md`. |
+| Existing plan reviewed | ✅ PASS | Existing plan `plan.2026-02-22T15-25.md` is complete and traceable. |
+| Minimal targeted scope | ✅ PASS | Code changes are test-only (`tests/conftest.py`, `tests/scripts/dev_tools/test_new_active_feature_folder.py`). |
+| Separation of concerns | ✅ PASS | Production launcher behavior left unchanged; isolation enforcement is test-layer only. |
+| Toolchain execution evidence | ✅ PASS | Current review run executed Black/Ruff/Pyright/Pytest successfully (see commands + output summary below). |
+
+### General unit-test policy
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Independence / isolation | ✅ PASS | New autouse guard fixture blocks unmocked editor-launch subprocess usage in scoped module; tests remain hermetic. |
+| Determinism | ✅ PASS | Fixture enforces deterministic failure for forbidden launcher tokens (`code`, `code.cmd`, `code.exe`). |
+| Scenario coverage | ✅ PASS | Regression fail-before and pass-after artifacts exist in `evidence/regression-testing/`. |
+| External dependency avoidance | ✅ PASS | No network/service dependencies introduced; launcher calls are mocked/guarded. |
+
+### Python-specific policy
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Black clean | ✅ PASS | `black --check` passed (`98 files would be left unchanged`). |
+| Ruff clean | ✅ PASS | `All checks passed!` |
+| Pyright clean | ✅ PASS | `0 errors, 0 warnings, 0 informations` |
+| Pytest coverage run | ✅ PASS | `771 passed`, coverage summary produced (total 81%). |
+| Suppression policy adherence | ✅ PASS | No new unauthorized suppression patterns observed in scoped changes. |
+
+## Code quality checks (review run)
+
+| Check | Command | Result |
+|---|---|---|
+| Format check | `poetry run black --check .` | PASS |
+| Lint | `poetry run ruff check` | PASS |
+| Type check | `poetry run pyright` | PASS |
+| Tests + coverage | `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` | PASS (`771 passed`) |
+
+## Gaps and exceptions
+
+- **None blocking.**
+- Minor documentation note: branch-wide PR context includes unrelated historical branch changes; this review intentionally scopes findings to the user-specified feature folder and directly affected files.
+
+## Compliance verdict
+
+## Overall Status: ✅ FULLY COMPLIANT
+
+**Recommendation:** **Ready for merge / PR-ready** for this feature scope.
+
+## Appendix A: Key evidence files
+
+- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-fail-before.2026-02-22T15-25.md`
+- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-and-launcher-verification.2026-02-22T15-25.md`
+- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-target-green.2026-02-22T15-25.md`
+- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-dev-tools-green.2026-02-22T15-25.md`
+- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md`
+
+## Appendix B: Toolchain commands reference
+
+- `poetry run black --check .`
+- `poetry run ruff check`
+- `poetry run pyright`
+- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/research.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/research.md
@@ -1,0 +1,242 @@
+<!-- markdownlint-disable-file -->
+
+# Task Research Notes: outside-workspace-test-side-effects
+
+## Research Executed
+
+### File Analysis
+
+- `tests/scripts/dev_tools/test_new_active_feature_folder.py`
+  - Contains scenarios whose output paths exactly match reported artifacts (`single-marker-40`, `full-compatible`, `no-potential`, etc.).
+  - 11 test calls invoke `mod.create_active_folder(...)` **without** `code_launcher=...`.
+- `scripts/dev_tools/new_active_feature_folder_flow.py`
+  - `create_active_folder(...)` calls `code_launcher(existing)` after generating files.
+  - Even when `fs=FakeFileSystem()`, launcher invocation still occurs if file paths are considered existing by fake FS.
+- `scripts/dev_tools/new_active_feature_folder_io.py`
+  - `default_code_launcher(...)` resolves `code` via `shutil.which("code")` and executes subprocess.
+- `scripts/dev_tools/new_active_feature_folder_models.py`
+  - Confirms `RealFileSystem` does real disk writes when used.
+
+### Code Search Results
+
+- `single-marker-40|single-marker`
+  - Matched in `tests/scripts/dev_tools/test_new_active_feature_folder.py` where `feature_name="single-marker"` and `- Issue: #40` generate `single-marker-40`.
+- AST scan: `mod.create_active_folder(...)` calls missing `code_launcher`
+  - 11 matches in `test_new_active_feature_folder.py` at lines:
+    - 721, 734, 866, 1028, 1064, 1101, 1153, 1201, 1239, 1260, 1277.
+  - Enclosing test functions:
+    - 721 → `test_create_active_folder_raises_on_invalid_feature_type`
+    - 734 → `test_create_active_folder_raises_on_missing_template`
+    - 866 → `test_create_active_folder_raises_when_exists_without_force`
+    - 1028 → `test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs`
+    - 1064 → `test_work_mode_marker_minor_issue_md`
+    - 1101 → `scenario_single_work_mode_marker_before_first_heading`
+    - 1153 → `test_minor_audit_preserves_issue_frontmatter_and_spacing`
+    - 1201 → `test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible`
+    - 1239 → `test_work_mode_marker_fallback_issue_md_full`
+    - 1260 → `test_create_active_folder_full_mode_remains_backward_compatible`
+    - 1277 → `test_create_active_folder_fallback_reason_output`
+- Instrumented subprocess capture (`artifacts/research/sitecustomize.py`) during `tests/scripts/dev_tools`
+  - Captured `code` invocations with `/workspace/docs/features/active/...` file arguments including:
+    - `/workspace/docs/features/active/single-marker-40/issue.md`
+    - `/workspace/docs/features/active/full-compatible/user-story.md`
+    - `/workspace/docs/features/active/full-compatible/spec.md`
+    - `/workspace/docs/features/active/full-compatible/plan.2026-02-22T12-41.md`
+    - `/workspace/docs/features/active/no-potential/user-story.md`
+  - Captured zero `git worktree` command attempts.
+
+### External Research
+
+- #githubRepo:"drmoisan/drm-copilot new_active_feature_folder launcher side effects"
+  - Repository-local analysis and instrumented runs provided sufficient evidence; no external repository mining required.
+- #fetch:https://example.invalid/not-used
+  - No external webpage fetch required for this investigation.
+
+### Project Conventions
+
+- Standards referenced: repo unit-test isolation policy (no external side effects from tests).
+- Instructions followed: researcher-mode constraint (changes only under `artifacts/research/`).
+
+## Key Discoveries
+
+### Project Structure
+
+The user-reported files (`C:\workspace\docs\features\active\no-potential\user-story.md`, `...\full-compatible\spec.md`, `...\plan.*.md`) map directly to scenario names and issue suffixes in `test_new_active_feature_folder.py`.
+
+### Implementation Patterns
+
+The side effect is caused by **launcher injection gap**, not by fake filesystem omission:
+
+- `fs=FakeFileSystem()` prevents direct disk writes from the tested create function.
+- But missing `code_launcher` injection allows default launcher subprocess execution.
+- Default launcher receives `/workspace/...` paths from tests and can open/create files in user environments.
+
+### Complete Examples
+
+```python
+# new_active_feature_folder_flow.py
+existing = [path for path in files_to_open if filesystem.exists(path)]
+if existing:
+    opened = code_launcher(existing)  # default is default_code_launcher
+
+# new_active_feature_folder_io.py
+def default_code_launcher(files: Iterable[Path]) -> bool:
+    code_cmd = shutil.which("code")
+    if not code_cmd:
+        return False
+    subprocess.run([code_cmd, *[f.as_posix() for f in files]], check=False)
+    return True
+```
+
+### API and Schema Documentation
+
+Relevant contract for `create_active_folder(...)`:
+
+- Optional `fs` (defaults to real filesystem)
+- Optional `code_launcher` (defaults to subprocess-based launcher)
+
+### Configuration Examples
+
+```text
+Instrumented command examples captured from tests:
+run|...\code.CMD /workspace/docs/features/active/full-compatible/user-story.md ...
+run|...\code.CMD /workspace/docs/features/active/no-potential/user-story.md ...
+```
+
+### Technical Requirements
+
+- Instrumented run executed:
+  - `poetry run pytest tests/scripts/dev_tools -q` with startup subprocess logging enabled.
+- Summary from logs:
+  - `TOTAL=197` subprocess calls
+  - `GIT_WORKTREE_MATCHES=0`
+  - Multiple `code` invocations targeting `/workspace/docs/features/active/...`
+
+**Mandatory unachievable objective callout**:
+- **Repository-local evidence cannot prove direct `git worktree add` execution by tests in this run (no such subprocess commands were observed).**
+
+## Recommended Approach
+
+Treat this as an **active test isolation bug** caused by default launcher execution:
+
+1. Update `test_new_active_feature_folder.py` so every `create_active_folder(...)` call injects `code_launcher=FakeCodeLauncher()`.
+2. Keep dedicated launcher unit tests isolated with mocked subprocess behavior.
+3. Add a guard fixture that fails tests on forbidden external path writes or external launcher calls.
+
+Rejected alternatives (brief, non-exhaustive):
+- “Stale artifacts only” explanation: rejected by captured launcher subprocess evidence.
+- Assuming tests directly issue `git worktree` commands: rejected by instrumentation (`GIT_WORKTREE_MATCHES=0`).
+
+## Implementation Guidance
+
+### Spec Scope Definition (copy into spec “Problem Statement”)
+
+- **Defect class**: unit-test isolation violation.
+- **Root cause**: selected tests call `create_active_folder(...)` without `code_launcher=...`, so default `default_code_launcher(...)` may execute `subprocess.run([code, ...])`.
+- **Impact**:
+  - Editor-launch side effects during tests.
+  - Potential creation/opening of files under host-mapped `/workspace/...` paths on Windows (`C:\workspace\...`).
+  - False signals that resemble worktree churn (path overlap), though no direct `git worktree` subprocess evidence was captured.
+
+### Functional Requirements (spec “Requirements” section)
+
+1. **FR-1: Deterministic launcher isolation in unit tests**
+   - Every `create_active_folder(...)` test in `test_new_active_feature_folder.py` must pass an explicit fake launcher except tests that directly validate launcher behavior.
+2. **FR-2: Guardrail against external side effects**
+   - Test suite must fail fast if any forbidden editor-launch or external `/workspace` path side effect is attempted from unit tests.
+3. **FR-3: Preserve production behavior**
+   - Runtime/default behavior of `create_active_folder(...)` for CLI usage must remain unchanged (still opens files when launcher exists).
+4. **FR-4: Keep launcher-specific behavior testable**
+   - Existing tests for `default_code_launcher(...)` continue to use subprocess mocking and remain the only place where launcher behavior is directly asserted.
+
+### Non-Goals (spec “Out of Scope”)
+
+- Changing product CLI behavior for end users.
+- Refactoring folder generation semantics, slug logic, or minor-audit routing.
+- Introducing new runtime dependencies.
+
+### Design Decisions (spec “Technical Design”)
+
+#### D1 — Injection hardening in tests (primary fix)
+
+- **Change**: add `code_launcher=FakeCodeLauncher()` to all currently missing callsites in `test_new_active_feature_folder.py`.
+- **Rationale**: existing test architecture already uses dependency injection (`fs`, `issue_fetcher`, `now_provider`); launcher should follow same isolation boundary.
+- **Target callsites/functions**:
+  - `test_create_active_folder_raises_on_invalid_feature_type`
+  - `test_create_active_folder_raises_on_missing_template`
+  - `test_create_active_folder_raises_when_exists_without_force`
+  - `test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs`
+  - `test_work_mode_marker_minor_issue_md`
+  - `scenario_single_work_mode_marker_before_first_heading`
+  - `test_minor_audit_preserves_issue_frontmatter_and_spacing`
+  - `test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible`
+  - `test_work_mode_marker_fallback_issue_md_full`
+  - `test_create_active_folder_full_mode_remains_backward_compatible`
+  - `test_create_active_folder_fallback_reason_output`
+
+#### D2 — Suite-level side-effect guard (secondary hardening)
+
+- **Change**: add a `tests/conftest.py` fixture that monkeypatches launcher subprocess edges for scoped test groups.
+- **Guard policy**:
+  - Fail on `subprocess.run` commands containing `code` when originating from isolated unit-test modules that should not invoke real launchers.
+  - Optionally fail on writes/opens resolving to absolute `C:\workspace\` or `/workspace/` outside test-controlled fake FS boundaries.
+- **Rationale**: prevents future regression when new tests are added without launcher injection.
+
+#### D3 — Explicit exception for launcher integration tests
+
+- **Change**: mark launcher-behavior tests as allowed to mock subprocess (`default_code_launcher` unit tests).
+- **Rationale**: preserve coverage of launcher code path while blocking accidental real invocations.
+
+### Spec-Ready Acceptance Criteria
+
+1. **AC-1 (Isolation):** Running `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q` does not trigger any real `code` process launch.
+2. **AC-2 (Regression guard):** New side-effect guard fixture fails on intentionally injected unmocked launcher call (prove fail-before).
+3. **AC-3 (Compatibility):** Existing launcher unit tests still pass with subprocess mocked.
+4. **AC-4 (No behavior drift):** Existing expectations for generated docs and work-mode markers remain unchanged.
+5. **AC-5 (Evidence):** Post-fix evidence demonstrates no external `/workspace` artifact creation from the target test module.
+
+### Test Plan Matrix (spec “Verification Strategy”)
+
+- **T1 — Targeted unit regression**
+  - File: `tests/scripts/dev_tools/test_new_active_feature_folder.py`
+  - Goal: ensure no launcher side effects after injection hardening.
+- **T2 — Guard fixture negative test**
+  - Add a controlled test that intentionally attempts unmocked launcher invocation and asserts guard failure.
+- **T3 — Launcher behavior tests**
+  - Validate `default_code_launcher` tests still use `mock.patch("subprocess.run")` and pass.
+- **T4 — Suite smoke**
+  - Run `tests/scripts/dev_tools -q` and verify no side-effect guard failures.
+
+### Implementation Sequence (spec “Execution Plan”)
+
+1. Patch 11 missing callsites in `test_new_active_feature_folder.py` with `code_launcher=FakeCodeLauncher()`.
+2. Add side-effect guard fixture in `tests/conftest.py` (scoped to relevant test paths).
+3. Add one explicit negative regression test for guard behavior.
+4. Run targeted tests, then broader dev-tools tests.
+5. Capture evidence artifact showing no launcher subprocess leakage.
+
+### Risk Register (spec “Risks & Mitigations”)
+
+- **Risk R1**: guard fixture is too broad and blocks legitimate subprocess mocks.
+  - **Mitigation**: scope by module path/marker; allow mocked launcher tests explicitly.
+- **Risk R2**: hidden dependency on default launcher behavior in existing tests.
+  - **Mitigation**: keep injection as test-local change; do not alter production defaults.
+- **Risk R3**: false positives from path-string heuristics.
+  - **Mitigation**: match command executable tokenization rather than substring-only checks when possible.
+
+### Rollback Plan (spec “Rollback”)
+
+- If guard fixture causes instability, temporarily disable guard by marker and retain D1 injection hardening (minimum safe fix).
+- Re-enable guard incrementally per module after narrowing allowlist.
+
+### Operational Cleanup Guidance
+
+- Remove residual external artifacts manually under `C:\workspace\docs\features\active\*` produced by earlier test runs.
+- Preserve `artifacts/research/subprocess-invocations.log` as investigation evidence until remediation merges.
+
+### Success Criteria
+
+- No unmocked `code` subprocess invocation from `test_new_active_feature_folder.py`.
+- Dev-tools unit tests remain green.
+- Guard fixture blocks future accidental launcher regressions.
+- No new external `C:\workspace` test artifacts after remediation run.

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/spec.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/spec.md
@@ -1,0 +1,238 @@
+# testing-missing-mock-injections (Spec)
+
+- **Issue:** #42
+- **Parent (optional):** none
+- **Owner:** Dan Moisan
+- **Last Updated:** 2026-02-22T00-00
+- **Status:** Drafted for implementation
+- **Version:** 1.0
+- **Work Mode:** full
+
+## Context
+- Summary of the bug and its impact (link to repro/playbook entry).
+	Unit tests in `tests/scripts/dev_tools/test_new_active_feature_folder.py` call `create_active_folder(...)` without injecting `code_launcher`, so the default launcher path can invoke a real `code` subprocess. This violates unit-test hermeticity and can open/create files under `/workspace/...` (host-mapped to `C:\workspace\...` on Windows).
+- Observed environment(s):
+	Windows host environment with Poetry-managed Python runtime; repro executed with `poetry run pytest tests/scripts/dev_tools -q` and subprocess instrumentation writing to `artifacts/research/subprocess-invocations.log`.
+- Customer impact and severity (who is affected, how often, how bad):
+	High severity for contributors and CI reliability: affected test runs can trigger editor-launch side effects and create noisy, misleading filesystem churn outside test-owned boundaries. Deterministic whenever affected tests omit launcher injection and the launcher executable is available.
+- First observed date and version(s) impacted:
+	First captured 2026-02-22 in active-branch test runs; impacts current test suite state where 11 callsites omit `code_launcher`.
+
+## Repro & Evidence
+- Steps to reproduce (with data/flags/inputs):
+	1. Run `poetry run pytest tests/scripts/dev_tools -q` using current test code where specific `create_active_folder(...)` calls do not pass `code_launcher`.
+	2. Inspect `artifacts/research/subprocess-invocations.log` from the instrumented run.
+	3. Observe `code` launcher invocations with `/workspace/docs/features/active/...` arguments such as `single-marker-40`, `full-compatible`, and `no-potential` artifacts.
+- Expected vs actual behavior:
+	Expected: tests are hermetic and do not launch external editor processes or touch host-mapped workspace paths.
+	Actual: default launcher path executes `subprocess.run([code_cmd, ...], check=False)` for existing paths and triggers external editor-launch side effects.
+- Logs/screenshots/error snippets:
+	Evidence includes log lines like `run|...\code.CMD /workspace/docs/features/active/full-compatible/user-story.md ...` and `run|...\code.CMD /workspace/docs/features/active/no-potential/user-story.md ...` from `artifacts/research/subprocess-invocations.log`.
+- Frequency / determinism (always, intermittent, data-dependent):
+	Deterministic for affected callsites when launcher executable is discoverable (`shutil.which("code")` returns a path). No evidence of direct `git worktree` subprocess execution in the captured run (`GIT_WORKTREE_MATCHES=0`).
+
+## Scope & Non-Goals
+- In scope:
+	- Update all identified missing test callsites in `tests/scripts/dev_tools/test_new_active_feature_folder.py` to inject `code_launcher=FakeCodeLauncher()`.
+	- Add/extend a test guard in `tests/conftest.py` to fail fast on forbidden unmocked editor-launch subprocess attempts for isolated unit-test modules.
+	- Preserve and verify launcher-specific behavior tests that explicitly mock subprocess interactions.
+- Out of scope / non-goals:
+	- Changing production/CLI default behavior of `create_active_folder(...)` launcher opening.
+	- Refactoring slug logic, folder layout generation rules, issue-mode routing, or non-launcher feature behavior.
+	- Introducing new runtime dependencies.
+- Explicitly excluded systems, integrations, or datasets:
+	- Git worktree flow changes (not evidenced as root cause here).
+	- External APIs or services.
+	- Non-dev-tools test modules unrelated to this launcher isolation bug.
+
+## Root Cause Analysis
+- Current hypothesis or confirmed root cause:
+	Confirmed root cause: launcher dependency injection gap in tests. `create_active_folder(...)` defaults to `default_code_launcher(...)` whenever `code_launcher` is omitted.
+- Signals/evidence supporting it:
+	- AST/code scan found 11 `mod.create_active_folder(...)` callsites in `test_new_active_feature_folder.py` missing `code_launcher`.
+	- Flow logic in `scripts/dev_tools/new_active_feature_folder_flow.py` invokes `code_launcher(existing)` after generating/open-target resolution.
+	- Default launcher in `scripts/dev_tools/new_active_feature_folder_io.py` resolves `code` and runs subprocess.
+	- Instrumented run captured `code` subprocess invocations to `/workspace/docs/features/active/...` paths.
+- Affected components/modules (paths, services, pipelines):
+	- `tests/scripts/dev_tools/test_new_active_feature_folder.py`
+	- `tests/conftest.py` (guardrail fixture scope)
+	- `scripts/dev_tools/new_active_feature_folder_flow.py` (behavioral context, no production behavior change planned)
+	- `scripts/dev_tools/new_active_feature_folder_io.py` (launcher behavior remains under dedicated mocked tests)
+
+## Proposed Fix
+
+### Design summary (what changes where):
+- Primary fix: inject `code_launcher=FakeCodeLauncher()` into each currently missing `create_active_folder(...)` callsite in `test_new_active_feature_folder.py`.
+- Secondary hardening: add a scoped guard fixture in `tests/conftest.py` that fails if unit tests in targeted modules attempt unmocked `code` launcher subprocess calls.
+- Explicit allowance: launcher behavior tests for `default_code_launcher(...)` continue to use subprocess mocking and remain valid.
+
+### Boundaries and invariants to preserve:
+- Preserve production behavior: default launcher usage in real CLI/runtime remains unchanged.
+- Preserve existing assertions for generated markdown content, issue mode markers, fallback reasons, and backward-compatible full mode behavior.
+- Preserve deterministic, isolated test behavior with no external side effects.
+
+### Dependencies or blocked work:
+- No external dependency additions required.
+- No known blockers from current evidence.
+- Research sufficiency: provided `issue.md` and `research.md` are sufficient to draft this spec without additional Task Researcher delegation.
+
+### Implementation strategy (what changes, not sequencing):
+	
+#### Files/modules to change:
+- `tests/scripts/dev_tools/test_new_active_feature_folder.py`
+- `tests/conftest.py`
+
+#### Functions/classes/CLI commands impacted:
+- Test callsites in these functions/scenarios:
+	- `test_create_active_folder_raises_on_invalid_feature_type`
+	- `test_create_active_folder_raises_on_missing_template`
+	- `test_create_active_folder_raises_when_exists_without_force`
+	- `test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs`
+	- `test_work_mode_marker_minor_issue_md`
+	- `scenario_single_work_mode_marker_before_first_heading`
+	- `test_minor_audit_preserves_issue_frontmatter_and_spacing`
+	- `test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible`
+	- `test_work_mode_marker_fallback_issue_md_full`
+	- `test_create_active_folder_full_mode_remains_backward_compatible`
+	- `test_create_active_folder_fallback_reason_output`
+- Guard fixture logic in `tests/conftest.py` (scoped to relevant module path/marker).
+- No CLI command surface change.
+
+#### Data flow and validation changes:
+- Test data flow: all affected tests explicitly route launcher interactions to `FakeCodeLauncher`, preventing fallback to subprocess-based launcher.
+- Guard validation: detect forbidden subprocess invocations whose executable token resolves to VS Code launcher commands (`code`, `code.cmd`, or resolved launcher path forms) from scoped unit-test contexts.
+- Optional path guard may validate that attempts to access `/workspace/` or `C:\workspace\` outside fake filesystem boundaries fail fast.
+
+#### Error handling and logging updates:
+- Guard fixture should raise clear assertion failures with command/path context when forbidden side effects are attempted.
+- No production logging changes required.
+- Existing evidence logging (`artifacts/research/subprocess-invocations.log`) remains a verification artifact, not a runtime dependency.
+
+#### Rollback/feature-flag considerations (if applicable):
+- If guard fixture creates false positives, rollback guard scope to narrower module targeting while retaining mandatory launcher injection in tests.
+- No feature flags required (test-only remediation).
+
+### Technical specifications (interfaces/contracts):
+- `create_active_folder(...)` contract usage in tests must always pass explicit `code_launcher` unless a test intentionally validates launcher behavior with subprocess mocked.
+- Guard fixture contract:
+	- Applied automatically for selected test modules.
+	- Fails test when forbidden launcher subprocess invocation is detected.
+	- Supports allowlisting launcher-integration tests that explicitly mock subprocess.
+
+#### Inputs/outputs and formats:
+- Inputs:
+	- Pytest invocation: `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q` and `poetry run pytest tests/scripts/dev_tools -q`.
+	- Test function args to `create_active_folder(...)` with `code_launcher=FakeCodeLauncher()`.
+- Outputs:
+	- Passing tests without external editor process execution.
+	- Optional assertion failure output for intentionally negative guard test.
+	- Evidence logs in `artifacts/research/subprocess-invocations.log` (text lines prefixed with `run|...`).
+
+#### Required configuration keys and defaults:
+- No new configuration keys, environment variables, or CLI flags introduced.
+- Existing default behavior remains: `code_launcher` defaults to `default_code_launcher(...)` when omitted in production/runtime usage.
+
+#### Backward-compatibility expectations:
+- Backward compatibility is strict for runtime behavior and CLI output.
+- Test compatibility preserved for launcher-specific tests through explicit mocking.
+- Existing test expectations for markdown generation and mode-marker semantics remain unchanged.
+
+#### Performance constraints (latency/throughput/memory):
+- Test runtime impact should be negligible; guard fixture adds lightweight command/path checks only.
+- No expected measurable impact to production runtime performance.
+
+## Assumptions, Constraints, Dependencies
+- Assumptions (environment, data, access):
+	- Developers run tests via Poetry-managed environment.
+	- `tests/scripts/dev_tools/test_new_active_feature_folder.py` continues to use fake filesystem and injectable collaborators.
+	- Windows host path mapping (`/workspace` to `C:\workspace`) remains possible in local setups.
+- Constraints (budget, performance, compatibility):
+	- Keep remediation limited to test code and fixtures.
+	- No runtime dependency additions.
+	- Preserve compatibility with existing CI and local pytest flows.
+- External dependencies (services, libraries, releases):
+	- None beyond existing test tooling (Pytest, unittest.mock/monkeypatch).
+
+## Data / API / Config Impact
+- User-facing or API changes:
+	- None. This is a test-isolation fix only.
+- Data or migration considerations:
+	- No schema/data migrations.
+	- Operational cleanup task: remove residual external artifacts under `C:\workspace\docs\features\active\*` created by prior faulty runs.
+- Logging/telemetry updates (if any):
+	- No production telemetry changes.
+	- Research evidence log remains optional validation artifact.
+- Compatibility notes (CLI flags, config schemas, versioning):
+	- No CLI/config schema changes.
+	- No versioned API changes.
+
+## Test Strategy
+- Regression tests to add or update:
+	- Update 11 affected test callsites to pass explicit fake launcher.
+	- Add one negative regression test proving guard fixture fails on intentionally unmocked launcher invocation.
+	- Keep/confirm dedicated `default_code_launcher(...)` tests rely on subprocess mocking.
+- Unit tests (pytest) for the fixed behavior and boundaries:
+	- Targeted run: `tests/scripts/dev_tools/test_new_active_feature_folder.py` confirms no external launcher execution.
+	- Module run: `tests/scripts/dev_tools` confirms no regressions in neighboring dev-tool tests.
+	- Guard behavior test validates failure path and assertion message quality.
+- Edge cases and negative scenarios (invalid inputs, missing data, boundary values):
+	- Existing invalid input tests (`invalid feature type`, `missing template`, `exists without force`) remain green with explicit launcher injection.
+	- Guard false-positive boundary: launcher integration tests with mocked subprocess remain allowed and passing.
+	- Path boundary checks for `/workspace/...` and `C:\workspace\...` patterns when guard is enabled.
+- Error handling and logging verification:
+	- Verify guard assertion includes forbidden command/path context.
+	- Verify no new production logs are introduced.
+- Coverage impact and targets for changed lines/modules:
+	- Maintain or improve coverage for changed test lines and fixture logic.
+	- Ensure changed lines in `tests/conftest.py` and `test_new_active_feature_folder.py` are exercised by targeted runs.
+- Toolchain commands to run (format → lint → type-check → test):
+	- `poetry run black .`
+	- `poetry run ruff check`
+	- `poetry run pyright`
+	- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
+	- Additional targeted checks:
+		- `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q`
+		- `poetry run pytest tests/scripts/dev_tools -q`
+- Manual validation steps (if required):
+	- After test run, verify no newly created files under `C:\workspace\docs\features\active\*`.
+	- Compare subprocess evidence log before/after remediation to confirm no leaked `code` invocation from targeted module.
+
+## Acceptance Criteria
+- [x] Running `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q` completes without any real `code` process launch from that module.
+- [x] `tests/scripts/dev_tools/test_new_active_feature_folder.py` includes explicit `code_launcher=FakeCodeLauncher()` for all previously identified missing callsites (11 total).
+- [x] A regression guard test exists and proves fail-fast behavior when an intentionally unmocked launcher invocation is attempted.
+- [x] Existing launcher-specific tests for `default_code_launcher(...)` still pass with subprocess mocked.
+- [x] Existing behavior assertions for markdown generation, work-mode marker handling, and fallback messaging remain unchanged and passing.
+- [x] No new external artifacts are created under `C:\workspace\docs\features\active\*` after executing targeted dev-tools test runs.
+- [x] Full Python toolchain pass is completed and documented (`black`, `ruff`, `pyright`, `pytest --cov ...`).
+- [x] Spec and issue references for this bug (`issue.md`, `research.md`, this `spec.md`) are aligned with the final implemented behavior.
+
+## Resolution Status Notes
+
+- Targeted module verification evidence: `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/pytest-target-green.2026-02-22T15-25.md`
+- Final QA loop summary evidence: `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md`
+
+## Risks & Mitigations
+- Technical or operational risks:
+	- Guard fixture may be overly broad and block legitimate subprocess-mocked tests.
+	- Future test additions may bypass launcher injection if reviewers miss pattern.
+	- Command/path matching heuristics may miss edge-case executable forms.
+- Mitigations and rollbacks:
+	- Scope guard by module path/marker and allow explicit exceptions for launcher-behavior tests.
+	- Keep explicit coding pattern in tests (`code_launcher=FakeCodeLauncher()`) as mandatory convention.
+	- Roll back only guard strictness if needed; retain injection hardening as minimum safe baseline.
+
+## Rollout & Follow-up
+- Release/rollout steps:
+	- Merge test-only remediation to `main` after full toolchain pass.
+	- No production release gating required because runtime behavior is unchanged.
+- Post-fix monitoring or clean-up tasks:
+	- Monitor subsequent dev-tools test runs for guard failures indicating regression attempts.
+	- Clean residual artifacts under `C:\workspace\docs\features\active\*` from pre-fix runs.
+	- Retain or archive `artifacts/research/subprocess-invocations.log` as trace evidence for this bugfix.
+- Links: issue, PRs, related docs
+	- Issue: `https://github.com/drmoisan/drm-copilot/issues/42`
+	- Related docs:
+		- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/issue.md`
+		- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/research.md`
+		- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/spec.md`

--- a/docs/features/active/2026-02-22-testing-missing-mock-injections-42/user-story.md
+++ b/docs/features/active/2026-02-22-testing-missing-mock-injections-42/user-story.md
@@ -1,0 +1,42 @@
+# `testing-missing-mock-injections` — User Story
+
+- Issue: #42
+- Owner: Dan Moisan
+- Status: In Progress
+- Last Updated: 2026-02-22
+
+## Story Statement
+
+- As a maintainer, I want dev-tools unit tests to avoid real VS Code subprocess launches, so that tests remain deterministic and side-effect free.
+- As a contributor, I want guardrails that fail fast on unmocked launcher usage, so that regressions are caught early.
+
+## Problem / Why
+
+Some unit tests call `create_active_folder(...)` without a fake launcher and accidentally invoke the real editor launcher. This can create host-side effects and break test isolation.
+
+## Personas & Scenarios
+
+- Persona: repository maintainer
+  - cares about deterministic CI
+  - needs hermetic tests
+  - wants quick diagnosis when isolation breaks
+  - wants clear evidence artifacts per plan
+- Scenario: contributor runs targeted dev-tools tests
+  - trigger: local test execution
+  - action: runs pytest for dev-tools test module
+  - outcome: tests pass without launching real editor subprocesses
+
+## Acceptance Criteria
+
+- [x] All missing `create_active_folder(...)` callsites inject `code_launcher=FakeCodeLauncher()`.
+- [x] Scoped guard fixture fails on unmocked `code` launcher subprocess attempts.
+- [x] Targeted tests and full Python QA loop pass with evidence artifacts recorded.
+
+## Validation Outcome
+
+- Guard and launcher compatibility verification: `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-and-launcher-verification.2026-02-22T15-25.md`
+- Final QA loop summary: `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md`
+
+## Non-Goals
+
+- Changing production launcher behavior in `scripts/dev_tools/new_active_feature_folder_*.py`.

--- a/docs/features/potential/promoted/2026-02-22-testing-missing-mock-injections.md
+++ b/docs/features/potential/promoted/2026-02-22-testing-missing-mock-injections.md
@@ -1,0 +1,103 @@
+# testing-missing-mock-injections (Issue #42)
+
+- Date captured: 2026-02-22
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/testing-missing-mock-injections/ (Issue #42)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #42
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/42
+- Last Updated: 2026-02-22
+## Summary
+
+Unit tests in `tests/scripts/dev_tools/test_new_active_feature_folder.py` invoke `create_active_folder(...)` without injecting `code_launcher`, allowing the default launcher to execute real `code` subprocess calls. This causes external side effects (opening/creating files under `/workspace/...` mapped as `C:\workspace\...` on Windows), violating unit-test isolation.
+
+## Environment
+
+- OS/version: Windows host (paths observed under `C:\workspace\...`)
+- Python version: project Poetry environment (exact interpreter version from local Poetry runtime)
+- Command/flags used: `poetry run pytest tests/scripts/dev_tools -q`
+- Data source or fixture:
+	- `FakeFileSystem` in `test_new_active_feature_folder.py`
+	- Runtime subprocess instrumentation via `artifacts/research/sitecustomize.py`
+	- Subprocess evidence log: `artifacts/research/subprocess-invocations.log`
+
+## Steps to Reproduce
+
+1. Ensure tests run with default behavior where some `create_active_folder(...)` calls omit `code_launcher=...` in `tests/scripts/dev_tools/test_new_active_feature_folder.py`.
+2. Run:
+	- `poetry run pytest tests/scripts/dev_tools -q`
+3. Inspect subprocess evidence (instrumented run):
+	- `artifacts/research/subprocess-invocations.log`
+4. Observe `code` invocations containing `/workspace/docs/features/active/...` paths (for example `single-marker-40`, `full-compatible`, `no-potential`).
+
+## Expected Behavior
+
+Unit tests should be hermetic: no real editor launcher process should execute, and no files should be opened/created outside test-controlled fake filesystem boundaries.
+
+## Actual Behavior
+
+`code` launcher subprocesses were invoked during unit tests with `/workspace/docs/features/active/...` file arguments, matching externally observed artifacts under `C:\workspace\docs\features\active\...`.
+
+Confirmed examples from captured evidence include:
+- `/workspace/docs/features/active/single-marker-40/issue.md`
+- `/workspace/docs/features/active/full-compatible/user-story.md`
+- `/workspace/docs/features/active/full-compatible/spec.md`
+- `/workspace/docs/features/active/no-potential/user-story.md`
+
+No explicit `git worktree` subprocess command was captured in the same instrumentation run (`GIT_WORKTREE_MATCHES=0`).
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet:
+	- `run|...\code.CMD /workspace/docs/features/active/full-compatible/user-story.md ...`
+	- `run|...\code.CMD /workspace/docs/features/active/no-potential/user-story.md ...`
+	- Source: `artifacts/research/subprocess-invocations.log`
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+Primary cause is missing launcher injection in 11 test callsites: `create_active_folder(...)` defaults to `default_code_launcher(...)` when `code_launcher` is not provided.
+
+Relevant code path:
+- `scripts/dev_tools/new_active_feature_folder_flow.py`
+	- `opened = code_launcher(existing)`
+- `scripts/dev_tools/new_active_feature_folder_io.py`
+	- `default_code_launcher(...)` → `subprocess.run([code_cmd, ...], check=False)`
+
+Known affected callsite functions include:
+- `test_create_active_folder_raises_on_invalid_feature_type`
+- `test_create_active_folder_raises_on_missing_template`
+- `test_create_active_folder_raises_when_exists_without_force`
+- `test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_docs`
+- `test_work_mode_marker_minor_issue_md`
+- `scenario_single_work_mode_marker_before_first_heading`
+- `test_minor_audit_preserves_issue_frontmatter_and_spacing`
+- `test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible`
+- `test_work_mode_marker_fallback_issue_md_full`
+- `test_create_active_folder_full_mode_remains_backward_compatible`
+- `test_create_active_folder_fallback_reason_output`
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas
+	- Inject `code_launcher=FakeCodeLauncher()` in all missing `create_active_folder(...)` test callsites.
+	- Add guard fixture in `tests/conftest.py` to fail on unmocked editor-launch subprocess attempts from isolated unit tests.
+- [x] Integration scenario to retest
+	- Re-run `poetry run pytest tests/scripts/dev_tools -q` and verify no real `code` subprocess invocations occur from `test_new_active_feature_folder.py`.
+- [x] Manual verification notes
+	- Confirm no new files appear under `C:\workspace\docs\features\active\*` after test execution.
+	- Preserve/update `artifacts/research/subprocess-invocations.log` as verification evidence.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 
 import io
 import os
+import subprocess
 import sys
 from itertools import count
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -61,6 +62,81 @@ def _ensure_repo_root_on_sys_path() -> None:
 
 
 _ensure_repo_root_on_sys_path()
+
+
+@pytest.fixture(autouse=True)
+def guard_unmocked_code_launcher_subprocess(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Block unmocked VS Code launcher subprocess calls in scoped unit tests.
+
+    Purpose:
+        Enforce hermetic behavior for target dev-tools unit tests by preventing
+        accidental real editor-launch subprocess calls.
+
+    Args:
+        request (pytest.FixtureRequest): Current test request metadata.
+        monkeypatch (pytest.MonkeyPatch): Fixture used to patch subprocess calls.
+
+    Returns:
+        None: Applies monkeypatch behavior for the active test when in scope.
+
+    Raises:
+        AssertionError: When a scoped test attempts an unmocked launcher
+            subprocess invocation for executable tokens ``code``, ``code.cmd``,
+            or ``code.exe``.
+
+    Side Effects:
+        Patches ``subprocess.run`` during scoped tests and leaves all other
+        tests unchanged.
+    """
+    raw_node_id = str(getattr(getattr(request, "node", None), "nodeid", ""))
+    normalized_node_id = raw_node_id.replace("\\", "/")
+    scoped_module = "tests/scripts/dev_tools/test_new_active_feature_folder.py"
+    allowlist = ("default_code_launcher",)
+
+    # Guard only the targeted module to avoid unrelated fixture side effects.
+    if scoped_module not in normalized_node_id:
+        return
+
+    # Explicitly allow launcher-specific tests that already mock subprocess.
+    if any(allowed in normalized_node_id for allowed in allowlist):
+        return
+
+    def _extract_executable_token(command: object) -> str | None:
+        """Extract a normalized executable token from subprocess command input."""
+        if command is None:
+            return None
+
+        if isinstance(command, list | tuple):
+            if not command:
+                return None
+            token_text = str(cast(object, command[0]))
+        else:
+            token_text = str(command)
+        return token_text.replace("\\", "/").rsplit("/", maxsplit=1)[-1].lower()
+
+    def _guarded_subprocess_run(
+        *args: object, **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        """Intercept subprocess calls and block unmocked VS Code launchers."""
+        command = args[0] if args else kwargs.get("args")
+        executable_token = _extract_executable_token(command)
+        blocked_tokens = {"code", "code.cmd", "code.exe"}
+
+        # Fail fast only for known VS Code launcher executable names.
+        if executable_token in blocked_tokens:
+            raise AssertionError(
+                "Blocked unmocked code launcher subprocess: "
+                f"executable={executable_token}, nodeid={raw_node_id}"
+            )
+
+        # Keep non-launcher subprocess behavior deterministic and side-effect free
+        # within this scoped test module.
+        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _guarded_subprocess_run)
 
 
 _MEM_TEST_ROOT_COUNTER = count(start=1)

--- a/tests/scripts/dev_tools/test_new_active_feature_folder.py
+++ b/tests/scripts/dev_tools/test_new_active_feature_folder.py
@@ -713,6 +713,26 @@ def test_create_epic_folder_seeds_epic_docs() -> None:
     assert "#99" in initiative_content
 
 
+def test_guard_blocks_unmocked_code_launcher_invocation() -> None:
+    """Verify guard fixture blocks unmocked launcher subprocess invocation."""
+    fs = FakeFileSystem()
+    workspace = Path("/workspace")
+    _seed_feature_template(fs, workspace)
+
+    # Force launcher path resolution so the guard intercepts launcher execution.
+    with mock.patch("shutil.which", return_value="code"):
+        with pytest.raises(
+            AssertionError,
+            match="Blocked unmocked code launcher subprocess",
+        ):
+            mod.create_active_folder(
+                feature_name="guard-check",
+                feature_type="feature",
+                workspace=workspace,
+                fs=fs,
+            )
+
+
 def test_create_active_folder_raises_on_invalid_feature_type() -> None:
     """Verify invalid feature type inputs raise ValueError."""
     fs = FakeFileSystem()
@@ -723,6 +743,7 @@ def test_create_active_folder_raises_on_invalid_feature_type() -> None:
             feature_type="invalid",  # type: ignore[arg-type]
             workspace=workspace,
             fs=fs,
+            code_launcher=FakeCodeLauncher(),
         )
 
 
@@ -736,6 +757,7 @@ def test_create_active_folder_raises_on_missing_template() -> None:
             feature_type="feature",
             workspace=workspace,
             fs=fs,
+            code_launcher=FakeCodeLauncher(),
         )
 
 
@@ -868,6 +890,7 @@ def test_create_active_folder_raises_when_exists_without_force() -> None:
             feature_type="feature",
             workspace=workspace,
             fs=fs,
+            code_launcher=FakeCodeLauncher(),
         )
 
 
@@ -1030,6 +1053,7 @@ def test_create_active_folder_minor_audit_materializes_issue_md_and_skips_full_d
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
     )
     assert fs.exists(result.target / "issue.md")
@@ -1066,6 +1090,7 @@ def test_work_mode_marker_minor_issue_md() -> None:
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
     )
 
@@ -1103,6 +1128,7 @@ def scenario_single_work_mode_marker_before_first_heading() -> None:
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
     )
 
@@ -1155,6 +1181,7 @@ def test_minor_audit_preserves_issue_frontmatter_and_spacing() -> None:
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
     )
 
@@ -1203,6 +1230,7 @@ def test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible(
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
     )
     out = capsys.readouterr().out
@@ -1241,6 +1269,7 @@ def test_work_mode_marker_fallback_issue_md_full() -> None:
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
     )
 
@@ -1262,6 +1291,7 @@ def test_create_active_folder_full_mode_remains_backward_compatible() -> None:
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="full",
     )
     assert fs.exists(result.target / "user-story.md")
@@ -1279,6 +1309,7 @@ def test_create_active_folder_fallback_reason_output(
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
     )
     assert result.target
@@ -1441,6 +1472,7 @@ def test_create_active_folder_full_mode_persists_full_marker_in_issue_md() -> No
         issue_number="auto",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="full",
     )
 
@@ -1484,6 +1516,7 @@ def _minor_audit_behavior_unchanged_with_auto_resolve_option_absent() -> None:
         feature_type="feature",
         workspace=workspace,
         fs=fs,
+        code_launcher=FakeCodeLauncher(),
         work_mode="minor-audit",
         active_file_for_feature_name=None,  # type: ignore[call-arg]
     )


### PR DESCRIPTION
Fix dev-tools tests to avoid unmocked VS Code launcher subprocess calls

## Summary

- Prevent unintended VS Code launcher subprocess execution during dev-tools unit tests by enforcing explicit `code_launcher` injection and adding a scoped guard fixture.
- Update `tests/scripts/dev_tools/test_new_active_feature_folder.py` to inject `code_launcher=FakeCodeLauncher()` for the previously missing callsites (11 total, per `spec.md`).
- Add test-level guardrails in `tests/conftest.py` to fail fast on forbidden unmocked launcher subprocess attempts (as described in `spec.md` and `user-story.md`).
- Add a feature folder with scoping docs and evidence artifacts under `docs/features/active/2026-02-22-testing-missing-mock-injections-42/`.
- Minor dev tooling update: adjust `.github/agents/python-typed-engineer.agent.md`.

## Why

- `spec.md` documents a hermeticity defect: some tests call `create_active_folder(...)` without injecting `code_launcher`, allowing default behavior to invoke a real `code` subprocess.
- This is deterministic in environments where the launcher is discoverable, and can cause external side effects by opening/creating files under `/workspace/...` (host-mapped to `C:\workspace\...` on Windows).
- The `user-story.md` frames the desired outcome: dev-tools tests remain deterministic and side-effect free, and regressions fail fast when an unmocked launcher is used.

## What Changed

- Core behavior / architecture
  - Updated `tests/conftest.py` to add a scoped guard fixture that blocks forbidden unmocked VS Code launcher subprocess attempts for the targeted dev-tools test module (per `spec.md` “Secondary hardening”).
  - Updated `tests/scripts/dev_tools/test_new_active_feature_folder.py` to pass `code_launcher=FakeCodeLauncher()` for all previously identified missing callsites (11 total, per `spec.md` and `user-story.md` acceptance criteria).
- Tooling / automation / CI / DevEx
  - Updated `.github/agents/python-typed-engineer.agent.md` (2 deletions).
- Tests
  - Added/updated tests in `tests/scripts/dev_tools/test_new_active_feature_folder.py` to enforce launcher isolation expectations (per `spec.md` and `user-story.md`).
- Docs / templates / agents
  - Added feature documentation and audits under `docs/features/active/2026-02-22-testing-missing-mock-injections-42/`, including `spec.md`, `user-story.md`, and evidence/audit artifacts.

## Architecture / How It Fits Together

- Problem (per `spec.md`):
  - When `create_active_folder(...)` is invoked in tests without an explicit `code_launcher`, the default launcher path can invoke a real `code` subprocess.
- Fix strategy (per `spec.md`):
  - Primary: ensure tests explicitly route launcher behavior through `FakeCodeLauncher` by injecting `code_launcher=FakeCodeLauncher()` in the affected test callsites.
  - Secondary: add a scoped guard fixture in `tests/conftest.py` to fail fast if targeted unit tests attempt an unmocked VS Code launcher subprocess call.
  - Preserve existing launcher behavior coverage by allowing launcher-specific tests that mock subprocess interactions to remain valid.

## Verification

### Completed

- Not verified in this PR (CI status is “not available” in `artifacts/pr_context.summary.txt`, and no tool outputs are recorded in the PR context bundle).
- `docs/features/active/2026-02-22-testing-missing-mock-injections-42/spec.md` and `user-story.md` include references to validation/evidence artifacts (for example:
  - `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/regression-testing/guard-and-launcher-verification.2026-02-22T15-25.md`
  - `docs/features/active/2026-02-22-testing-missing-mock-injections-42/evidence/qa-gates/qa-loop-summary.2026-02-22T15-25.md`)

### Recommended

- `poetry run black .`
- `poetry run ruff check`
- `poetry run pyright`
- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
- Targeted checks (per `spec.md`):
  - `poetry run pytest tests/scripts/dev_tools/test_new_active_feature_folder.py -q`
  - `poetry run pytest tests/scripts/dev_tools -q`

## Backward Compatibility / Migration Notes

- Intended to be test-only behavioral change (per `spec.md` “Out of scope / non-goals”): production/CLI default behavior of `create_active_folder(...)` is not changed by this PR.
- No new runtime dependencies are introduced (per `spec.md`).

## Risks and Mitigations

- Risk: the guard fixture could be too broad and create false positives by blocking legitimate subprocess-mocked tests.
  - Mitigation (per `spec.md`): scope the guard to targeted modules and explicitly allow launcher behavior tests that mock subprocess interactions.
- Risk: future tests may introduce new launcher callsites without explicit injection.
  - Mitigation (per `user-story.md`): guardrails fail fast on unmocked launcher usage.
- Risk: review noise due to many documentation/evidence additions.
  - Mitigation: review core code changes first (`tests/conftest.py`, `tests/scripts/dev_tools/test_new_active_feature_folder.py`), then skim feature docs/evidence.

## Review Guide

- Start here (high signal):
  - `docs/features/active/2026-02-22-testing-missing-mock-injections-42/spec.md` (context, root cause, proposed fix, acceptance criteria)
  - `docs/features/active/2026-02-22-testing-missing-mock-injections-42/user-story.md` (why + AC summary)
- Then review the code changes:
  - `tests/conftest.py`
  - `tests/scripts/dev_tools/test_new_active_feature_folder.py`
- Finally, skim supporting artifacts (if desired):
  - Evidence and audits under `docs/features/active/2026-02-22-testing-missing-mock-injections-42/`

## Follow-ups

- Fill in “PR Intent” fields in `artifacts/pr_context.summary.txt` (Primary outcome / impact / risks / autoclose issues) before opening the PR, so the PR description is fully aligned to author intent.
- Confirm the intended PR base branch: this context was generated against `feature/bootstrap-utilities-#40` (per `artifacts/pr_context.summary.txt`).

## GitHub Auto-close

- Closes: #35

