### PR TITLE
Fix pr_context to emit approved auto-close issues for PASS audited features

### DIFF
--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/code-review.2026-02-22T22-59.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/code-review.2026-02-22T22-59.md
@@ -1,0 +1,63 @@
+# Code Review: pr-does-not-autoclose-with-valid-issue-audit-48
+
+**Date:** 2026-02-22  
+**Base:** `feature/bootstrap-utilities-#40`  
+**Head:** `bug/pr-does-not-autoclose-with-valid-issue-audit-48`  
+**Feature Folder Selection Rule:** Used explicit user-provided active folder `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48`.
+
+## Executive Summary
+
+This feature introduces deterministic autoclose derivation for PR context generation by:
+- extracting primary issue only from explicit metadata (`Issue: #NN`),
+- gating pending autoclose emission on `Readiness: PASS`, and
+- emitting approved summary section `Issues to autoclose (verified or pending)`.
+
+**Top 3 risks**
+1. PR context base/head are currently identical in canonical summary (range empty), so reviewers must use appendix working-tree diff to assess code deltas.
+2. Readiness derivation depends on strict `Readiness:` line parsing in latest `feature-audit.*.md`; malformed metadata causes conservative fallback.
+3. Touched modules are central prompt-context plumbing, so regressions could affect downstream PR generation quality.
+
+**PR readiness recommendation:** **GO** (no blocker findings; quality gates and targeted regressions pass).
+
+## Findings
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `artifacts/pr_context.summary.txt` | Base/Head section | Base/head SHA equality yields empty commit-range diff in summary. | Commit/stage current delta before final PR context generation for final PR body. | Ensures changed-files sections reflect real implementation delta in summary. | Canonical summary + appendix (`Status (short)` + unstaged diff). |
+| Minor | `scripts/dev_tools/pr_context/feature_docs.py` | readiness parsing helpers | Readiness parsing is intentionally strict (`PASS`, `NEEDS REVISION`, `BLOCKED`) and ignores other values. | Keep strictness; document in feature docs that readiness metadata must be canonical. | Strict parser prevents accidental false-positive autoclose behavior. | `_parse_readiness_value` + targeted fallback tests passing. |
+| Nit | `scripts/dev_tools/pr_context/models.py` | `FeatureDocExcerpt` extension | Data model grew by two optional fields. | No change required; continue maintaining backwards-safe defaults (`None`). | Optional defaults preserve compatibility for call sites/tests. | `primary_issue_ref: str | None = None`, `readiness_signal: str | None = None`. |
+
+## Typed Python Audit
+
+- **No new `Any` / no weakening:** PASS. No new broad typing suppressions or config relaxations.
+- **Type precision:** PASS. Uses `Sequence` and concrete container typing (`list[str]`, `set[str]`) appropriately.
+- **Error handling:** PASS. No naked broad catch in changed logic path; fallback behavior is explicit and conservative.
+- **Public API clarity:** PASS. Added fields in `FeatureDocExcerpt` are typed and defaulted; helper docstrings are robust.
+- **Logging/performance:** PASS. No heavy hot-path logging added; ordering remains deterministic and linear.
+
+## Test Quality Audit
+
+- Deterministic targeted regressions pass:
+  - `primary_issue_and_pass_readiness`
+  - `pass_readiness_autoclose_section`
+  - `narrative_mentions_excluded_from_autoclose_section`
+  - `non_pass_readiness_fallback`
+- Full suite health: `780 passed`.
+- Coverage quality signal (changed production modules):
+  - `collector.py 92%`
+  - `feature_docs.py 93%`
+  - `models.py 99%`
+  - `render_pr_helpers.py 94%`
+
+## Security & Correctness Checks
+
+- No embedded secrets observed in touched files.
+- No unsafe subprocess usage introduced in touched scope.
+- Input validation approach is conservative by design (metadata-only primary issue source, explicit readiness gating).
+
+## Final Review Verdict
+
+**No-Go blockers:** None  
+**Go/No-Go:** **GO**
+
+Proceed to PR once the working-tree changes are committed and PR context is regenerated for the commit range intended for merge.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/black-baseline.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/black-baseline.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary: All done. 114 files left unchanged.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/collector-baseline.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/collector-baseline.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40
+EXIT_CODE: 0
+Output Summary: Collector completed and wrote artifacts/pr_context.summary.txt and artifacts/pr_context.appendix.txt. Runtime warning from runpy about module already in sys.modules was emitted; command still succeeded.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/full-mode-preconditions.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/full-mode-preconditions.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+ModeSource: issue.md
+ResolvedMode: full
+RequiredDocs: spec.md,user-story.md

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/policy-and-input-read.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/policy-and-input-read.2026-02-22T23-15.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-02-22T23-15
+Work Mode: full
+
+Inputs Read:
+- C:\Users\DanMoisan\repos\drm-copilot.worktrees\copilot-worktree-2026-02-18T01-26-49\docs\features\active\2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48\issue.md
+- C:\Users\DanMoisan\repos\drm-copilot.worktrees\copilot-worktree-2026-02-18T01-26-49\docs\features\active\2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48\spec.md
+- C:\Users\DanMoisan\repos\drm-copilot.worktrees\copilot-worktree-2026-02-18T01-26-49\docs\features\active\2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48\user-story.md
+- C:\Users\DanMoisan\repos\drm-copilot.worktrees\copilot-worktree-2026-02-18T01-26-49\docs\features\active\2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48\research.md
+- C:\Users\DanMoisan\repos\drm-copilot.worktrees\copilot-worktree-2026-02-18T01-26-49\artifacts\pr_context.summary.txt
+- C:\Users\DanMoisan\repos\drm-copilot.worktrees\copilot-worktree-2026-02-18T01-26-49\artifacts\pr_context.appendix.txt

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/pyright-baseline.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/pyright-baseline.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary: 0 errors, 0 warnings, 0 informations.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/pytest-cov-baseline.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/pytest-cov-baseline.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: 776 passed in 2.50s. Coverage TOTAL 81%. Coverage warning noted: module src/lexile_corpus_tuner was never imported.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/ruff-baseline.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/ruff-baseline.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary: All checks passed.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40
+EXIT_CODE: 0
+Output Assertions:
+- New section header present: ===== Issues to autoclose (verified or pending) =====
+- PASS readiness path validated in targeted test evidence: pass-pass-readiness-autoclose-section.2026-02-22T23-15.md includes #46 in approved section.
+- Narrative mention exclusion validated in targeted test evidence: pass-narrative-mention-exclusion.2026-02-22T23-15.md confirms #40/#42/#43 are absent from approved section.
+- Non-PASS conservative fallback observed in collector output: None (no verified closing issues and readiness not PASS).

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/black-final.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/black-final.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary: All done. 114 files left unchanged.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/final-pass-summary.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/final-pass-summary.2026-02-22T23-15.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-02-22T23-15
+FinalPass: formatting, linting, type checking, and testing all passed in one final clean pass.
+Artifacts:
+- black-final.2026-02-22T23-15.md
+- ruff-final.2026-02-22T23-15.md
+- pyright-final.2026-02-22T23-15.md
+- pytest-final.2026-02-22T23-15.md

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/pyright-final.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/pyright-final.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary: 0 errors, 0 warnings, 0 informations.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/pytest-final.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/pytest-final.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: 780 passed in 2.71s; TOTAL coverage 81%.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/ruff-final.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/ruff-final.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary: All checks passed.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-narrative-mention-exclusion.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-narrative-mention-exclusion.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q -k narrative_mentions_excluded_from_autoclose_section
+EXIT_CODE: 1
+Failure: NameError: name 'collect_and_write' is not defined

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-non-pass-fallback.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-non-pass-fallback.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k non_pass_readiness_fallback
+EXIT_CODE: 1
+Failure: TypeError: FeatureDocExcerpt.__init__() got an unexpected keyword argument 'primary_issue_ref'

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-pass-readiness-autoclose-section.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-pass-readiness-autoclose-section.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k pass_readiness_autoclose_section
+EXIT_CODE: 1
+Failure: TypeError: FeatureDocExcerpt.__init__() got an unexpected keyword argument 'primary_issue_ref'

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-primary-issue-and-pass-readiness.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-primary-issue-and-pass-readiness.2026-02-22T23-15.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q -k primary_issue_and_pass_readiness
+EXIT_CODE: 1
+Failure: AttributeError: 'FeatureDocExcerpt' object has no attribute 'primary_issue_ref'

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-narrative-mention-exclusion.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-narrative-mention-exclusion.2026-02-22T23-15.md
@@ -1,0 +1,3 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q -k narrative_mentions_excluded_from_autoclose_section
+EXIT_CODE: 0

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-non-pass-fallback.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-non-pass-fallback.2026-02-22T23-15.md
@@ -1,0 +1,3 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k non_pass_readiness_fallback
+EXIT_CODE: 0

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-pass-readiness-autoclose-section.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-pass-readiness-autoclose-section.2026-02-22T23-15.md
@@ -1,0 +1,3 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k pass_readiness_autoclose_section
+EXIT_CODE: 0

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-primary-issue-and-pass-readiness.2026-02-22T23-15.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-primary-issue-and-pass-readiness.2026-02-22T23-15.md
@@ -1,0 +1,3 @@
+Timestamp: 2026-02-22T23-15
+Command: poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q -k primary_issue_and_pass_readiness
+EXIT_CODE: 0

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/feature-audit.2026-02-22T22-59.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/feature-audit.2026-02-22T22-59.md
@@ -1,0 +1,39 @@
+# Feature Audit: pr-does-not-autoclose-with-valid-issue-audit-48
+
+Readiness: PASS
+
+## Scope and Baseline
+
+- **Base branch:** `feature/bootstrap-utilities-#40`
+- **Head branch:** `bug/pr-does-not-autoclose-with-valid-issue-audit-48`
+- **Primary evidence source:** `artifacts/pr_context.summary.txt`
+- **Baseline diff source:** `artifacts/pr_context.appendix.txt`
+- **Feature folder used:** `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48`
+- **Work mode source of truth:** `issue.md` indicates `- Work Mode: full`; acceptance criteria evaluated from `spec.md` and `user-story.md`.
+
+## Acceptance Criteria Inventory (Authoritative)
+
+Extracted from `spec.md` and `user-story.md`:
+1. Collector output includes `===== Issues to autoclose (verified or pending) =====`.
+2. With `Issue: #46` and readiness `PASS`, approved section includes `#46` and supports PR auto-close emission.
+3. Mention-only refs (`#40/#42/#43`) are excluded from approved autoclose source.
+4. Conservative fallback is emitted when deterministic inputs are incomplete/non-PASS.
+5. Regression coverage includes positive path, readiness gating, mention exclusion, and fallback paths.
+6. Full Python toolchain passes.
+
+## Acceptance Criteria Evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| 1) Approved section header exists | PASS | `evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md` asserts new header present. | `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40` | Command succeeds in-session; summary includes section (currently conservative fallback due empty commit-range feature-doc extraction). |
+| 2) PASS readiness + Issue metadata yields `#46` | PASS | Targeted regression evidence + in-session rerun of test for PASS path. | `poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q -k primary_issue_and_pass_readiness`; `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k pass_readiness_autoclose_section` | Both commands passed in-session (`T1_EXIT:0`, `T2_EXIT:0`). |
+| 3) Mention-only refs excluded from approved source | PASS | Regression evidence file + in-session targeted test confirms `#40/#42/#43` absent from approved section. | `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q -k narrative_mentions_excluded_from_autoclose_section` | Passed in-session (`T3_EXIT:0`). |
+| 4) Non-PASS fallback is conservative | PASS | Dedicated regression test and evidence assert exact fallback message. | `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k non_pass_readiness_fallback` | Passed in-session (`T4_EXIT:0`). |
+| 5) Regression coverage breadth present | PASS | New tests exist in `test_feature_docs.py`, `test_collect_pr_context.py`, `test_collect_pr_context_part4.py`; full suite passes. | `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` | Full suite passed in-session (`780 passed`, `PYTEST_EXIT:0`). |
+| 6) Python toolchain fully passing | PASS | Black, Ruff, Pyright, Pytest all green in this review session. | `poetry run black --check .`; `poetry run ruff check .`; `poetry run pyright`; `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` | Final gate: all commands exit code 0. |
+
+## Summary
+
+**Overall feature readiness:** **PASS**
+
+The implemented behavior matches the acceptance criteria in full mode, with deterministic primary-issue sourcing, readiness gating, conservative fallback behavior, and explicit regression coverage. No criterion is PARTIAL/FAIL/UNVERIFIED.

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/issue.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/issue.md
@@ -1,0 +1,115 @@
+# pr-does-not-autoclose-with-valid-issue-audit (Issue #48)
+
+- Date captured: 2026-02-22
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/pr-does-not-autoclose-with-valid-issue-audit/ (Issue #48)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #48
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/48
+- Last Updated: 2026-02-23
+- Work Mode: full
+
+## Summary
+
+PR generation misses auto-close for issue #46 even when the active feature audit readiness is PASS and the feature docs declare `Issue: #46`. `pr_context` currently places `#46` under `Close candidates`, but the PR prompt only permits auto-close numbers from `Issues to autoclose (verified or pending)` or `PR Intent -> Author-asserted autoclose issues`.
+
+## Environment
+
+- OS/version: Windows host workspace
+- Python version: Poetry-managed interpreter
+- Command/flags used: `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
+- Data source or fixture: `artifacts/pr_context.summary.txt`, `artifacts/pr_context.appendix.txt`, `.github/prompts/generate-pr.prompt.md`, and active feature docs (`spec.md`/`user-story.md`) that declare `Issue: #46`
+
+## Steps to Reproduce
+
+1. Run `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`.
+2. Open `artifacts/pr_context.summary.txt` and confirm `Close candidates` contains `Auto-close issues (author asserted): #40, #42, #43, #46` while `PR Intent` shows `Author-asserted autoclose issues:` with no value.
+3. Confirm there is no `Issues to autoclose (verified or pending)` section in the summary output.
+4. Generate PR content using `.github/prompts/generate-pr.prompt.md` and observe the `GitHub Auto-close` output does not emit `Closes #46`.
+
+## Expected Behavior
+
+When the active feature has a deterministic issue ID (`Issue: #46` in `spec.md`/`user-story.md`) and feature-audit readiness is PASS, `pr_context` should emit an approved auto-close source so the PR author can produce `Closes #46` under existing prompt rules.
+
+## Actual Behavior
+
+`#46` appears only under `Close candidates`, which the PR prompt does not allow as an auto-close source. Because `PR Intent -> Author-asserted autoclose issues` is blank and no `Issues to autoclose (verified or pending)` section exists, generated PRs omit `Closes #46`.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet:
+	- `artifacts/pr_context.summary.txt`:
+		- `Author-asserted autoclose issues:` (blank in `PR Intent`)
+		- `Auto-close issues (author asserted): #40 #42 #43 #46` (under `Close candidates`)
+	- `.github/prompts/generate-pr.prompt.md` allows auto-close from only:
+		1) `Issues to autoclose (verified or pending)`
+		2) `PR Intent -> Author-asserted autoclose issues`
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+Contract mismatch between `pr_context` rendering and PR prompt consumption:
+- `scripts/dev_tools/pr_context/collector.py` computes issue references and surfaces them in `Close candidates`, but does not populate the `PR Intent` author-asserted field.
+- The summary schema does not emit `Issues to autoclose (verified or pending)` for pending deterministic close targets.
+- Candidate issue derivation appears mention-based (includes `#40/#42/#43`) instead of using the active feature’s primary issue metadata (`Issue: #46`).
+
+Files to inspect:
+- `scripts/dev_tools/pr_context/collector.py`
+- `scripts/dev_tools/pr_context/feature_docs.py`
+- `tests/scripts/dev_tools/test_collect_pr_context.py`
+- `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+- `tests/scripts/dev_tools/test_pr_context_integration.py`
+- `.github/prompts/generate-pr.prompt.md`
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas
+	- Add/extend tests so `pr_context` emits an approved auto-close source when feature docs provide a deterministic `Issue: #NN` and readiness is PASS.
+	- Add regression assertions that narrative mentions (`#40/#42/#43`) are not promoted to close targets.
+- [x] Integration scenario to retest
+	- Re-run `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40` and regenerate PR content.
+	- Verify generated `GitHub Auto-close` includes `Closes #46` and excludes `Closes #40/#42/#43` unless explicitly author-asserted in PR Intent.
+- [x] Manual verification notes
+	- Confirm summary includes either populated `PR Intent -> Author-asserted autoclose issues` or `Issues to autoclose (verified or pending)` with `#46`.
+	- Confirm behavior remains conservative when deterministic primary issue cannot be resolved.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch
+
+## Final Execution Summary (2026-02-22)
+
+- Implemented deterministic autoclose derivation in `pr_context`:
+	- Added `primary_issue_ref` and `readiness_signal` to `FeatureDocExcerpt`.
+	- Parsed primary issue from explicit metadata line `Issue: #NN` only.
+	- Resolved readiness from latest `feature-audit.*.md` with normalized values (`PASS`, `NEEDS REVISION`, `BLOCKED`).
+	- Added summary section `===== Issues to autoclose (verified or pending) =====` ahead of `Close candidates`.
+	- Applied precedence: verified closing issues first, then pending deterministic primary issue only when readiness is `PASS`, else conservative `None` fallback.
+- Confirmed narrative mentions (`#40/#42/#43`) are not promoted into approved autoclose section.
+
+Verification commands run:
+- `poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q -k primary_issue_and_pass_readiness`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k pass_readiness_autoclose_section`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q -k narrative_mentions_excluded_from_autoclose_section`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k non_pass_readiness_fallback`
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
+- `poetry run black .`
+- `poetry run ruff check`
+- `poetry run pyright`
+- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
+
+Evidence artifacts:
+- Baseline: `evidence/baseline/*.2026-02-22T23-15.md`
+- Regression expect-fail/pass: `evidence/regression-testing/*.2026-02-22T23-15.md`
+- End-state collector contract: `evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md`
+- Final QA gates: `evidence/qa-gates/*.2026-02-22T23-15.md`

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/plan.2026-02-22T22-33.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/plan.2026-02-22T22-33.md
@@ -1,0 +1,152 @@
+# 2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48 (Python Atomic Plan)
+
+DIRECTIVE: FULL EXECUTION
+
+- Issue: #48
+- Owner: drmoisan
+- Work Mode: full
+- Last Updated: 2026-02-22T23-15
+- Plan Path: docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/plan.2026-02-22T22-33.md
+
+## Execution Scope (bounded)
+
+Production files allowed in this plan:
+- `scripts/dev_tools/pr_context/models.py`
+- `scripts/dev_tools/pr_context/feature_docs.py`
+- `scripts/dev_tools/pr_context/collector.py`
+- `scripts/dev_tools/pr_context/render_pr_helpers.py`
+
+Test files allowed in this plan:
+- `tests/scripts/dev_tools/test_feature_docs.py`
+- `tests/scripts/dev_tools/test_collect_pr_context.py`
+- `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+- `tests/scripts/dev_tools/test_pr_context_integration.py`
+
+Evidence roots used in this plan:
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/other/`
+
+### Phase 0 — Context, Policy, and Baseline Capture
+
+- [x] [P0-T1] Read policy inputs and feature inputs, then record a single baseline manifest at `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/policy-and-input-read.2026-02-22T23-15.md`.
+	- Preconditions: `issue.md`, `spec.md`, `user-story.md`, `research.md`, `artifacts/pr_context.summary.txt`, and `artifacts/pr_context.appendix.txt` are present.
+	- Acceptance: Manifest file exists and contains exact lines for `Timestamp: 2026-02-22T23-15`, `Work Mode: full`, and absolute paths for each required input.
+
+- [x] [P0-T2] Verify full-mode source marker from `issue.md` and document full-document expectations in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/full-mode-preconditions.2026-02-22T23-15.md`.
+	- Preconditions: `issue.md` metadata block includes `- Work Mode: full`.
+	- Acceptance: Evidence file exists and contains exact lines `ModeSource: issue.md`, `ResolvedMode: full`, `RequiredDocs: spec.md,user-story.md`.
+
+- [x] [P0-T3] Run baseline collector repro command and save command output summary to `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/collector-baseline.2026-02-22T23-15.md`.
+	- Preconditions: Working tree is clean.
+	- Acceptance: Evidence file contains `Timestamp:`, `Command: poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T4] Run baseline formatter check and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/black-baseline.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run black .`, integer `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T5] Run baseline lint check and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/ruff-baseline.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run ruff check`, integer `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T6] Run baseline type check and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/pyright-baseline.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run pyright`, integer `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T7] Run baseline pytest coverage command and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/pytest-cov-baseline.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`, integer `EXIT_CODE:`, and `Output Summary:`.
+
+### Phase 1 — TDD Red Regression Tests
+
+- [x] [P1-T1] Add a regression test in `tests/scripts/dev_tools/test_feature_docs.py` that asserts explicit metadata `Issue: #46` is parsed as deterministic primary issue and readiness `PASS` is resolved from latest `feature-audit.*.md`.
+	- Preconditions: Existing feature-doc test fixtures remain deterministic and file-system isolated.
+	- Acceptance: New test function exists and references only fixture-controlled inputs.
+
+- [x] [P1-T2] [expect-fail] Run the new `test_feature_docs.py` nodeid before implementation and store failure evidence at `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-primary-issue-and-pass-readiness.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Timestamp:`, exact `Command: poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q -k primary_issue_and_pass_readiness`, integer `EXIT_CODE:` with non-zero value, and a `Failure:` excerpt.
+
+- [x] [P1-T3] Add a regression test in `tests/scripts/dev_tools/test_collect_pr_context_part4.py` that asserts summary includes header `===== Issues to autoclose (verified or pending) =====` and includes `#46` when readiness is `PASS`.
+	- Preconditions: Test uses deterministic fixture context and does not depend on network or external services.
+	- Acceptance: New test function exists and asserts exact header text plus `#46` presence.
+
+- [x] [P1-T4] [expect-fail] Run the new PASS-readiness summary nodeid before implementation and store failure evidence at `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-pass-readiness-autoclose-section.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Timestamp:`, exact `Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k pass_readiness_autoclose_section`, integer `EXIT_CODE:` with non-zero value, and a `Failure:` excerpt.
+
+- [x] [P1-T5] Add a regression test in `tests/scripts/dev_tools/test_collect_pr_context.py` that asserts narrative mentions `#40/#42/#43` remain excluded from `Issues to autoclose (verified or pending)`.
+	- Preconditions: Fixture data includes mention-only issue references.
+	- Acceptance: New test function exists and asserts mention refs are absent from approved autoclose section.
+
+- [x] [P1-T6] [expect-fail] Run the narrative-exclusion nodeid before implementation and store failure evidence at `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-narrative-mention-exclusion.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Timestamp:`, exact `Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q -k narrative_mentions_excluded_from_autoclose_section`, integer `EXIT_CODE:` with non-zero value, and a `Failure:` excerpt.
+
+- [x] [P1-T7] Add a regression test in `tests/scripts/dev_tools/test_collect_pr_context_part4.py` that asserts conservative `None` text is emitted when readiness is missing or not `PASS`.
+	- Preconditions: Test fixtures can produce non-PASS readiness state without external files.
+	- Acceptance: New test function exists and asserts exact `None` fallback wording in approved autoclose section.
+
+- [x] [P1-T8] [expect-fail] Run the non-PASS fallback nodeid before implementation and store failure evidence at `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/expect-fail-non-pass-fallback.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Timestamp:`, exact `Command: poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k non_pass_readiness_fallback`, integer `EXIT_CODE:` with non-zero value, and a `Failure:` excerpt.
+
+### Phase 2 — Minimal Production Fix
+
+- [x] [P2-T1] Extend `FeatureDocExcerpt` in `scripts/dev_tools/pr_context/models.py` with typed fields required for deterministic autoclose derivation (`primary_issue_ref` and readiness signal).
+	- Preconditions: Existing constructor call sites are identified.
+	- Acceptance: Model type-checks and all call sites compile with explicit values or `None` defaults.
+
+- [x] [P2-T2] Implement explicit primary-issue metadata parsing in `scripts/dev_tools/pr_context/feature_docs.py` using only `Issue: #NN` metadata lines, not narrative references.
+	- Acceptance: Parser returns deterministic `primary_issue_ref` when metadata is valid and returns `None` for malformed/missing metadata.
+
+- [x] [P2-T3] Implement readiness resolver in `scripts/dev_tools/pr_context/feature_docs.py` that reads the latest `feature-audit.*.md` and returns normalized readiness status.
+	- Acceptance: Resolver returns `PASS`, `NEEDS REVISION`, `BLOCKED`, or `None` deterministically for fixture-driven inputs.
+
+- [x] [P2-T4] Thread primary issue and readiness metadata through collector inputs in `scripts/dev_tools/pr_context/collector.py`.
+	- Acceptance: Collector runtime model exposes both values at summary-render decision points.
+
+- [x] [P2-T5] Implement `issues_to_autoclose` precedence in `scripts/dev_tools/pr_context/collector.py`: verified PR closing issues first; pending deterministic primary issue only when readiness is `PASS`; otherwise conservative none.
+	- Acceptance: Logic path is deterministic, deduplicated, and preserves stable order.
+
+- [x] [P2-T6] Add rendering helper in `scripts/dev_tools/pr_context/render_pr_helpers.py` for `===== Issues to autoclose (verified or pending) =====` section with explicit `None` reason text when empty.
+	- Acceptance: Helper returns section text with exact header and deterministic formatting.
+
+- [x] [P2-T7] Insert the new autoclose section into `scripts/dev_tools/pr_context/collector.py` before `Close candidates` without changing unrelated summary sections.
+	- Acceptance: Summary output order contains new section immediately before `===== Close candidates =====`.
+
+### Phase 3 — Targeted Verification (Pass After Fix)
+
+- [x] [P3-T1] Re-run `test_feature_docs.py` primary-issue/readiness nodeid and save pass evidence to `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-primary-issue-and-pass-readiness.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains exact command from P1-T2 and `EXIT_CODE: 0`.
+
+- [x] [P3-T2] Re-run PASS-readiness autoclose-section nodeid and save pass evidence to `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-pass-readiness-autoclose-section.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains exact command from P1-T4 and `EXIT_CODE: 0`.
+
+- [x] [P3-T3] Re-run narrative-mention exclusion nodeid and save pass evidence to `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-narrative-mention-exclusion.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains exact command from P1-T6 and `EXIT_CODE: 0`.
+
+- [x] [P3-T4] Re-run non-PASS fallback nodeid and save pass evidence to `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-non-pass-fallback.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains exact command from P1-T8 and `EXIT_CODE: 0`.
+
+- [x] [P3-T5] Run collector repro command and save end-state contract evidence to `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`, `EXIT_CODE: 0`, and output assertions for: new section header present, `#46` present only for readiness `PASS`, and `#40/#42/#43` absent from approved section.
+
+### Phase 4 — Final QA Toolchain Loop
+
+- [x] [P4-T1] Run formatter step for final pass and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/black-final.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run black .` and `EXIT_CODE: 0` from the final clean pass.
+
+- [x] [P4-T2] Run lint step for final pass and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/ruff-final.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run ruff check` and `EXIT_CODE: 0` from the final clean pass.
+
+- [x] [P4-T3] Run type-check step for final pass and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/pyright-final.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run pyright` and `EXIT_CODE: 0` from the final clean pass.
+
+- [x] [P4-T4] Run test step for final pass and record result in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/pytest-final.2026-02-22T23-15.md`.
+	- Acceptance: Evidence file contains `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and `EXIT_CODE: 0` from the final clean pass.
+
+- [x] [P4-T5] Record single-pass toolchain completion summary in `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/final-pass-summary.2026-02-22T23-15.md`.
+	- Acceptance: Summary file states that formatting, linting, type checking, and testing all passed in one final pass and lists artifact file names from P4-T1 through P4-T4.
+
+### Phase 5 — Documentation and Handoff
+
+- [x] [P5-T1] Update `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/spec.md` acceptance checklist and test strategy sections to reflect implemented deterministic autoclose behavior and evidence files.
+	- Acceptance: `spec.md` explicitly references `Issues to autoclose (verified or pending)` and includes evidence paths for regressions and final QA.
+
+- [x] [P5-T2] Update `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/issue.md` with final behavior summary and verification commands used.
+	- Acceptance: `issue.md` contains exact command list and confirms narrative mentions are not promoted to autoclose targets.
+

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/policy-audit.2026-02-22T22-59.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/policy-audit.2026-02-22T22-59.md
@@ -1,0 +1,104 @@
+# Policy Compliance Audit: pr-does-not-autoclose-with-valid-issue-audit-48
+
+**Audit Date:** 2026-02-22  
+**Base Branch:** `feature/bootstrap-utilities-#40`  
+**Head Branch:** `bug/pr-does-not-autoclose-with-valid-issue-audit-48`  
+**Feature Folder Selection Rule:** Explicit user-provided active feature folder path was used directly (`docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48`).
+
+**Code Under Test:**
+- `scripts/dev_tools/pr_context/collector.py`
+- `scripts/dev_tools/pr_context/feature_docs.py`
+- `scripts/dev_tools/pr_context/models.py`
+- `scripts/dev_tools/pr_context/render_pr_helpers.py`
+- `tests/scripts/dev_tools/test_collect_pr_context.py`
+- `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+- `tests/scripts/dev_tools/test_feature_docs.py`
+
+## Coverage Metrics by Language
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------:|------:|-------------|-------------------|----------------------|-------------------|
+| Python | 7 | 780 | [✅] 780 pass, 0 fail | 81% total (`pytest-cov-baseline.2026-02-22T23-15.md`) | 81% total (current run) | PASS proxy: changed production modules all >=92% module coverage |
+
+## Executive Summary
+
+- [✅] `general-code-change.instructions.md` evaluated
+- [✅] `general-unit-test.instructions.md` evaluated
+- [✅] `python-code-change.instructions.md` + `python-unit-test.instructions.md` evaluated
+- [N/A] PowerShell/Bash/JSON language sections (no files changed in this feature diff)
+
+Result: **Policy compliance PASS** for this feature review.
+
+Notes:
+- Canonical PR context artifacts were regenerated for this audit.
+- PR context comparison range resolves to identical base/head commit, so changed-scope evidence is derived from the canonical appendix working-tree diff plus direct file inspection.
+- Full Python toolchain passed in one clean pass in this session.
+
+## 1. General Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] PASS | Pytest suite (`780` tests) passed without order dependencies in this run. |
+| Isolation | [✅] PASS | New tests target deterministic behaviors (`primary_issue`, PASS readiness gating, mention exclusion, non-PASS fallback). |
+| Fast Execution | [✅] PASS | Full run: `780 passed in 2.81s`; targeted regressions each ~`0.02-0.03s`. |
+| Determinism | [✅] PASS | Tests use in-memory stubs/fixtures and no external network dependency for asserted behavior. |
+| Readability & Maintainability | [✅] PASS | Descriptive test names and AAA-style structure in touched test files. |
+| No Coverage Regression | [✅] PASS | Baseline and current total coverage both `81%` (no regression). |
+| New/Changed Logic Coverage | [✅] PASS | Changed production modules show module coverage: `collector.py 92%`, `feature_docs.py 93%`, `models.py 99%`, `render_pr_helpers.py 94%`. |
+| Positive/Negative/Edge/Error Scenarios | [✅] PASS | Positive (PASS readiness), negative (non-PASS fallback), edge (narrative mention exclusion) all explicitly tested. |
+| External Dependencies Avoided | [✅] PASS | Feature tests rely on stubs/mocks and local fixtures only. |
+
+## 2. General Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Objective clarified | [✅] PASS | `issue.md`, `spec.md`, and `user-story.md` define defect and target behavior. |
+| Existing plan read/documented | [✅] PASS | `plan.2026-02-22T22-33.md` present and aligned with implemented behavior. |
+| Simplicity / separation of concerns | [✅] PASS | Deterministic issue/readiness parsing isolated in `feature_docs.py`; rendering isolated in `render_pr_helpers.py`; orchestration in `collector.py`. |
+| Reusability / extensibility | [✅] PASS | New helper functions are composable and data contract extended via `FeatureDocExcerpt` fields. |
+| Naming/docs/comments | [✅] PASS | Added functions include robust docstrings and intent comments for decision paths. |
+| Toolchain order compliance | [✅] PASS | Formatting -> lint -> type-check -> test executed; all passed in one final pass. |
+
+## 3. Python-Specific Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Black | [✅] PASS | `poetry run black --check .` -> no changes needed. |
+| Ruff | [✅] PASS | `poetry run ruff check .` -> all checks passed. |
+| Pyright | [✅] PASS | `poetry run pyright` -> `0 errors, 0 warnings, 0 informations`. |
+| Pytest (+coverage) | [✅] PASS | `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` -> `780 passed`, total coverage `81%`. |
+| Strong typing / no type weakening | [✅] PASS | No new broad `type: ignore`; typed dataclasses and typed helper signatures retained. |
+| Exception handling clarity | [✅] PASS | Narrow exception usage at availability boundary and explicit fallback text for uncertain readiness paths. |
+
+## 4. Temporary Artifacts Cleanup
+
+- [✅] PASS — No temporary throwaway scripts were added as part of this reviewed change set.
+
+## 5. Compliance Verdict
+
+**Overall Status: ✅ FULLY COMPLIANT**
+
+**Recommendation:** **Ready for merge** (policy perspective), pending normal PR creation/commit of current working-tree changes.
+
+## Appendix A: Commands Executed
+
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
+- `poetry run black --check .`
+- `poetry run ruff check .`
+- `poetry run pyright`
+- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
+- `poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q -k primary_issue_and_pass_readiness`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k pass_readiness_autoclose_section`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q -k narrative_mentions_excluded_from_autoclose_section`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k non_pass_readiness_fallback`
+
+## Appendix B: Evidence Sources
+
+- `artifacts/pr_context.summary.txt`
+- `artifacts/pr_context.appendix.txt`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/baseline/pytest-cov-baseline.2026-02-22T23-15.md`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-primary-issue-and-pass-readiness.2026-02-22T23-15.md`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-pass-readiness-autoclose-section.2026-02-22T23-15.md`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/regression-testing/pass-narrative-mention-exclusion.2026-02-22T23-15.md`
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/final-pass-summary.2026-02-22T23-15.md`

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/research.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/research.md
@@ -1,0 +1,187 @@
+<!-- markdownlint-disable-file -->
+
+# Task Research Notes: PR auto-close emission for audited issue when readiness is PASS
+
+## Research Executed
+
+### File Analysis
+
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/issue.md`
+  - Defines target behavior: when active feature has deterministic `Issue: #46` and readiness is PASS, `pr_context` must emit an auto-close source recognized by `.github/prompts/generate-pr.prompt.md`.
+- `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/spec.md`
+  - Confirms root-cause hypothesis: `#46` appears only in `Close candidates`; PR prompt only consumes `Issues to autoclose (verified or pending)` or `PR Intent -> Author-asserted autoclose issues`.
+- `artifacts/pr_context.summary.txt`
+  - Current sample output shows `Auto-close issues (author asserted): #40 #42 #43 #46` under `Close candidates`, while `PR Intent` author-asserted field is blank and no `Issues to autoclose (verified or pending)` section exists.
+- `scripts/dev_tools/pr_context/collector.py`
+  - `author_asserted` is currently derived from all `referenced_issues`, then rendered only in `Close candidates`; PR Intent remains template-only (not populated).
+  - Summary rendering pipeline is the canonical place to add a prompt-recognized auto-close section.
+- `scripts/dev_tools/pr_context/feature_docs.py`
+  - `gather_feature_excerpts()` currently extracts issue refs from full doc text (`extract_issue_references`) rather than explicit primary metadata (`- Issue: #NN`).
+- `scripts/dev_tools/pr_context/models.py`
+  - `FeatureDocExcerpt` currently carries `issue_refs` and `context_files`; no explicit field for primary issue or readiness signal.
+- `scripts/dev_tools/pr_context/render_pr_helpers.py`
+  - `build_close_candidates_section()` emits only `===== Close candidates =====`; no helper exists for `Issues to autoclose (verified or pending)`.
+- `tests/scripts/dev_tools/test_collect_pr_context.py`
+  - Existing tests assert current `Close candidates` behavior and include a regression that promotes referenced issues into author-asserted close candidates.
+- `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+  - End-to-end summary rendering tests are already present and are the right seam for validating new summary section semantics.
+- `tests/scripts/dev_tools/test_pr_context_integration.py`
+  - Contains prompt-contract assertions and should be extended to enforce auto-close source compatibility.
+- `tests/scripts/dev_tools/test_feature_docs.py`
+  - Existing parsing tests provide the correct seam for adding deterministic primary-issue extraction + readiness gating behavior.
+- `.github/prompts/generate-pr.prompt.md`
+  - Explicitly allows auto-close only from: (1) `Issues to autoclose (verified or pending)`, else (2) `PR Intent -> Author-asserted autoclose issues`.
+
+### Code Search Results
+
+- `Author-asserted autoclose issues`
+  - Found in `scripts/dev_tools/pr_context/collector.py` and `scripts/dev_tools/pr_context/render.py`; both are label-only intent templates today.
+- `Close candidates`
+  - Found in `scripts/dev_tools/pr_context/render_pr_helpers.py`; section is rendered but not consumed by PR-author prompt for `Closes #NNN`.
+- `Issues to autoclose (verified or pending)`
+  - Found as a required source in `.github/prompts/generate-pr.prompt.md`; not emitted by current collector summary output.
+- `feature-audit` / readiness conventions
+  - Feature review/orchestrator docs standardize `feature-audit.<timestamp>.md` with readiness values `PASS / NEEDS REVISION / BLOCKED`; this can be used as deterministic readiness source.
+
+### External Research
+
+- #githubRepo:"github/docs linking-a-pull-request-to-an-issue closing-keyword behavior"
+  - Canonical docs source (`github/docs` content file) confirms close keywords only trigger issue closure when PR targets default branch and uses supported keywords like `Closes`, `Fixes`, `Resolves`.
+- #fetch:https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
+  - Confirms keyword list, default-branch requirement, and distinction between linked references vs auto-close behavior.
+- #fetch:https://github.com/github/docs/blob/main/content/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue.md
+  - Confirms same semantics in source markdown used by GitHub Docs; strengthens correctness for prompt/summary contract decisions.
+- #fetch:https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch
+  - Confirms default branch is PR base branch for canonical close-keyword behavior, reinforcing why deterministic source emission matters before PR authoring.
+
+### Project Conventions
+
+- Standards referenced: prompt-contract strictness, deterministic evidence-first output, conservative fallback behavior when verification sources are missing.
+- Instructions followed: `.github/prompts/research-issue.prompt.md` framework, `.github/prompts/generate-pr.prompt.md` auto-close source constraints, Python test seams under `tests/scripts/dev_tools/*`.
+
+## Key Discoveries
+
+### Project Structure
+
+`scripts/dev_tools/pr_context/collector.py` is the orchestration point that produces `artifacts/pr_context.summary.txt`, and `.github/prompts/generate-pr.prompt.md` is intentionally strict about which summary sections can feed `## GitHub Auto-close`. Because current collector output does not emit `Issues to autoclose (verified or pending)` and leaves `PR Intent` unpopulated, deterministic issue IDs from feature docs cannot flow into `Closes #NNN`.
+
+### Implementation Patterns
+
+Current issue derivation in `collector.py` combines broad reference detection (`referenced_issues`) with close-candidate rendering, which causes narrative mentions (`#40/#42/#43`) to mix with the audited feature issue (`#46`). Minimal-risk fix is to add a narrow, deterministic pending-autoclose source keyed to explicit feature metadata (`Issue: #NN`) and readiness PASS, rather than reusing broad mention extraction.
+
+### Complete Examples
+
+```text
+Current behavior (from artifacts/pr_context.summary.txt):
+- PR Intent:
+  Author-asserted autoclose issues:
+  (blank)
+- Close candidates:
+  Auto-close issues (author asserted): #40 #42 #43 #46
+
+Prompt contract (.github/prompts/generate-pr.prompt.md):
+- Allowed Closes sources:
+  1) Issues to autoclose (verified or pending)
+  2) PR Intent -> Author-asserted autoclose issues
+- Close candidates is not a permitted source.
+```
+
+### API and Schema Documentation
+
+- Existing data model: `FeatureDocExcerpt(feature, excerpt, issue_refs, context_files)`.
+- Proposed schema extension (minimal):
+  - Add deterministic `primary_issue_ref: str | None` extracted from feature doc metadata line `- Issue: #NN`.
+  - Add optional `readiness_status: str | None` derived from latest `feature-audit.<timestamp>.md` (`PASS|NEEDS REVISION|BLOCKED`) when present.
+- Summary output extension:
+  - Add section header `===== Issues to autoclose (verified or pending) =====`.
+  - Values precedence:
+    1. Verified from GitHub PR metadata (`closingIssuesReferences`) when available.
+    2. Pending deterministic audited issue when `primary_issue_ref` exists and readiness is PASS.
+    3. Conservative none message.
+
+### Configuration Examples
+
+```text
+No new configuration keys required.
+Behavior should remain additive in pr_context summary schema.
+```
+
+### Technical Requirements
+
+- Maintain compatibility with `.github/prompts/generate-pr.prompt.md` by emitting one of its accepted sources without relaxing anti-hallucination constraints.
+- Avoid promoting narrative issue mentions into auto-close targets.
+- Keep conservative behavior when deterministic audited issue cannot be resolved or readiness is not PASS.
+
+**Mandatory unachievable objective callout**:
+- **None identified for implementation strategy.**
+
+## Recommended Approach
+
+Implement **deterministic pending-autoclose emission** in `pr_context.summary.txt` via a new `Issues to autoclose (verified or pending)` section, sourced from explicit feature metadata + readiness PASS.
+
+Detailed recommendation:
+1. Extend feature-doc parsing to derive `primary_issue_ref` from the explicit metadata line (`- Issue: #NN`) instead of broad mention scanning.
+2. Add readiness resolution helper that inspects latest `feature-audit.<timestamp>.md` in the active feature folder and returns readiness state.
+3. In `collector.collect_and_write()` compute `issues_to_autoclose`:
+   - If `verified_closing` exists, use it.
+   - Else if deterministic `primary_issue_ref` exists and readiness == `PASS`, use `[primary_issue_ref]` as **pending**.
+   - Else emit a conservative none reason.
+4. Render `===== Issues to autoclose (verified or pending) =====` before `Close candidates`.
+5. Keep `Close candidates` for diagnostics only; do not treat it as auto-close source.
+
+Rejected alternatives (brief, non-exhaustive):
+- Populate PR Intent `Author-asserted autoclose issues` automatically from all referenced issues.
+  - Rejected: high risk of false positives (`#40/#42/#43`) and weak semantic boundary between mentions vs intended closes.
+- Modify `.github/prompts/generate-pr.prompt.md` to accept `Close candidates`.
+  - Rejected: weakens strict source contract and increases hallucination/over-close risk; prompt already supports intended dedicated section.
+
+## Implementation Guidance
+
+- **Objectives**: Emit `Closes #46` deterministically when audited issue is known and readiness is PASS, while preserving conservative behavior and prompt-source safety.
+- **Key Tasks**:
+  - Add deterministic primary-issue extraction + readiness derivation in `feature_docs` flow.
+  - Add pending/verified auto-close summary section rendering in collector output.
+  - Update tests to enforce single-source deterministic behavior and prevent mention-based over-closing.
+  - Keep prompt compatibility unchanged (no required changes to `.github/prompts/generate-pr.prompt.md`).
+- **Dependencies**:
+  - Existing feature folder metadata (`issue.md`/`spec.md` lines with `Issue: #NN`).
+  - Existing readiness artifact convention (`feature-audit.<timestamp>.md`).
+- **Success Criteria**:
+  - `pr_context.summary.txt` contains `===== Issues to autoclose (verified or pending) =====` with `#46` in pending/verified state for PASS-ready audited feature.
+  - Generated PR body can produce `- Closes #46` using existing prompt rules.
+  - Narrative issue references are excluded from auto-close unless explicitly verified or asserted by approved source.
+
+- **Acceptance-oriented recommendations**:
+  - AC1: Add a collector regression asserting only audited primary issue appears in `Issues to autoclose (verified or pending)` for PASS readiness.
+  - AC2: Add negative regression asserting `#40/#42/#43` remain non-autoclose references when present only in narrative text.
+  - AC3: Add fallback regression asserting section emits conservative `None (...)` text when readiness is missing/non-PASS.
+  - AC4: Add integration assertion that prompt contract remains satisfied without changing allowed auto-close sources.
+
+- **Concise implementation map (likely touched files)**:
+  - `scripts/dev_tools/pr_context/feature_docs.py`
+    - Add helper(s) to parse explicit issue metadata and readiness from feature-audit artifacts.
+  - `scripts/dev_tools/pr_context/models.py`
+    - Extend `FeatureDocExcerpt` with deterministic primary issue/readiness fields (or add a dedicated metadata dataclass).
+  - `scripts/dev_tools/pr_context/collector.py`
+    - Compute `issues_to_autoclose` precedence and render new summary section.
+  - `scripts/dev_tools/pr_context/render_pr_helpers.py`
+    - Add formatter helper for `Issues to autoclose (verified or pending)` section.
+  - `tests/scripts/dev_tools/test_feature_docs.py`
+    - Add tests for explicit `Issue: #NN` extraction and readiness parsing.
+  - `tests/scripts/dev_tools/test_collect_pr_context.py`
+    - Add deterministic pending-autoclose + mention-exclusion regression tests.
+  - `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+    - Add summary section rendering + conservative fallback assertions.
+  - `tests/scripts/dev_tools/test_pr_context_integration.py`
+    - Add prompt-compatibility scenario validating `Closes #46` source eligibility.
+
+- **Verification commands (recommended)**:
+  - `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
+  - `poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q`
+  - `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q`
+  - `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q`
+  - `poetry run pytest tests/scripts/dev_tools/test_pr_context_integration.py -q`
+  - `poetry run black .`
+  - `poetry run ruff check`
+  - `poetry run pyright`
+  - `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/spec.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/spec.md
@@ -1,0 +1,285 @@
+# 2026-02-22-pr-does-not-autoclose-with-valid-issue-audit (Spec)
+
+- **Issue:** #48
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-02-22T22-33
+- **Status:** Draft
+- **Version:** 0.1
+
+## Context
+PR generation misses auto-close for issue #46 even when the active feature audit readiness is PASS and the feature docs declare `Issue: #46`. `pr_context` currently places `#46` under `Close candidates`, but the PR prompt only permits auto-close numbers from `Issues to autoclose (verified or pending)` or `PR Intent -> Author-asserted autoclose issues`.
+
+Environment:
+- OS/version: Windows host workspace
+- Python version: Poetry-managed interpreter
+- Command/flags used: `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
+- Data source or fixture: `artifacts/pr_context.summary.txt`, `artifacts/pr_context.appendix.txt`, `.github/prompts/generate-pr.prompt.md`, and active feature docs (`spec.md`/`user-story.md`) that declare `Issue: #46`
+
+Impact / Severity:
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+
+## Repro & Evidence
+Steps to Reproduce:
+1. Run `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`.
+2. Open `artifacts/pr_context.summary.txt` and confirm `Close candidates` contains `Auto-close issues (author asserted): #40, #42, #43, #46` while `PR Intent` shows `Author-asserted autoclose issues:` with no value.
+3. Confirm there is no `Issues to autoclose (verified or pending)` section in the summary output.
+4. Generate PR content using `.github/prompts/generate-pr.prompt.md` and observe the `GitHub Auto-close` output does not emit `Closes #46`.
+
+Expected:
+When the active feature has a deterministic issue ID (`Issue: #46` in `spec.md`/`user-story.md`) and feature-audit readiness is PASS, `pr_context` should emit an approved auto-close source so the PR author can produce `Closes #46` under existing prompt rules.
+
+Actual:
+`#46` appears only under `Close candidates`, which the PR prompt does not allow as an auto-close source. Because `PR Intent -> Author-asserted autoclose issues` is blank and no `Issues to autoclose (verified or pending)` section exists, generated PRs omit `Closes #46`.
+
+Logs / Screenshots:
+- [x] Attached minimal logs or screenshot
+- Snippet:
+	- `artifacts/pr_context.summary.txt`:
+		- `Author-asserted autoclose issues:` (blank in `PR Intent`)
+		- `Auto-close issues (author asserted): #40 #42 #43 #46` (under `Close candidates`)
+	- `.github/prompts/generate-pr.prompt.md` allows auto-close from only:
+		1) `Issues to autoclose (verified or pending)`
+		2) `PR Intent -> Author-asserted autoclose issues`
+
+
+## Scope & Non-Goals
+- In scope:
+- Emit a deterministic `===== Issues to autoclose (verified or pending) =====` section in `artifacts/pr_context.summary.txt`.
+- Source pending autoclose only from the active feature's explicit primary issue metadata (`- Issue: #NN`) when readiness is `PASS`.
+- Keep `Close candidates` as diagnostic output only; it must not be treated as an auto-close source.
+- Preserve compatibility with `.github/prompts/generate-pr.prompt.md` without expanding allowed source categories.
+- Out of scope / non-goals:
+- Modifying GitHub keyword semantics (`Closes`, `Fixes`, `Resolves`) or branch-default behavior.
+- Auto-populating `PR Intent -> Author-asserted autoclose issues` from broad issue mentions.
+- Changing unrelated `pr_context` sections (verification, CI status, risk narratives).
+- Explicitly excluded systems, integrations, or datasets:
+- External API calls or new GitHub integrations.
+- Non-active-feature docs as primary issue sources.
+
+## Root Cause Analysis
+Contract mismatch between `pr_context` rendering and PR prompt consumption:
+- `scripts/dev_tools/pr_context/collector.py` computes issue references and surfaces them in `Close candidates`, but does not populate the `PR Intent` author-asserted field.
+- The summary schema does not emit `Issues to autoclose (verified or pending)` for pending deterministic close targets.
+- Candidate issue derivation appears mention-based (includes `#40/#42/#43`) instead of using the active feature’s primary issue metadata (`Issue: #46`).
+
+Files to inspect:
+- `scripts/dev_tools/pr_context/collector.py`
+- `scripts/dev_tools/pr_context/feature_docs.py`
+- `tests/scripts/dev_tools/test_collect_pr_context.py`
+- `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+- `tests/scripts/dev_tools/test_pr_context_integration.py`
+- `.github/prompts/generate-pr.prompt.md`
+
+
+## Proposed Fix
+
+### Design summary (what changes where):
+- Extend feature-doc metadata extraction to parse deterministic primary issue from explicit metadata line `- Issue: #NN`.
+- Add readiness resolution from the latest `feature-audit.<timestamp>.md` in the active feature folder.
+- In collector rendering flow, compute `issues_to_autoclose` with strict precedence:
+	1) verified closing issues from PR metadata (`closingIssuesReferences`) when available,
+	2) pending deterministic primary issue when readiness is `PASS`,
+	3) conservative `None` fallback with reason.
+- Render `===== Issues to autoclose (verified or pending) =====` before `Close candidates` so prompt consumers can deterministically use an approved source.
+
+### Boundaries and invariants to preserve:
+- Never promote narrative mentions (for example `#40/#42/#43`) to autoclose targets.
+- Keep existing collector command and artifact paths unchanged.
+- Keep output deterministic (stable ordering, deduplicated issue refs).
+- Preserve prompt anti-hallucination contract: only approved sections may drive `Closes #NN`.
+
+### Dependencies or blocked work:
+- Depends on presence of explicit `Issue: #NN` metadata in active feature docs.
+- Depends on readiness artifact convention (`feature-audit.<timestamp>.md`) and `PASS` readiness semantics.
+- No blocking external dependency identified.
+
+### Implementation strategy (what changes, not sequencing):
+	Add a narrow metadata path for deterministic autoclose derivation, thread it into collector summary rendering, and lock behavior via unit/integration regressions that prove prompt-contract compatibility.
+	
+#### Files/modules to change:
+- `scripts/dev_tools/pr_context/feature_docs.py` (extract explicit primary issue, resolve readiness signal)
+- `scripts/dev_tools/pr_context/models.py` (extend excerpt metadata for primary issue/readiness)
+- `scripts/dev_tools/pr_context/collector.py` (compute verified/pending autoclose list and render section)
+- `scripts/dev_tools/pr_context/render_pr_helpers.py` (add formatter for new autoclose section)
+- `tests/scripts/dev_tools/test_feature_docs.py`
+- `tests/scripts/dev_tools/test_collect_pr_context.py`
+- `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+- `tests/scripts/dev_tools/test_pr_context_integration.py`
+
+#### Functions/classes/CLI commands impacted:
+- `gather_feature_excerpts(...)` and related metadata extraction helpers in `feature_docs.py`
+- `FeatureDocExcerpt` data contract in `models.py`
+- `collect_and_write(...)` in `collector.py`
+- Summary rendering helper(s) in `render_pr_helpers.py`
+- CLI command behavior for `poetry run python -m scripts.dev_tools.pr_context.collector --base <branch>` (output contract only, no new flags)
+
+#### Data flow and validation changes:
+- Parse primary issue from explicit metadata fields, not full-text mention scanning.
+- Resolve readiness from canonical audit artifact and gate pending autoclose on `PASS` only.
+- Build `issues_to_autoclose` list from verified or pending deterministic sources; deduplicate and preserve stable order.
+- Keep mention-derived issue refs in `Close candidates` only, explicitly separated from autoclose list.
+
+#### Error handling and logging updates:
+- Missing/invalid primary issue metadata: emit conservative `None` in autoclose section with explanatory text.
+- Missing readiness artifact or readiness not `PASS`: do not emit pending autoclose issue.
+- Preserve collector non-fatal behavior for partial metadata gaps; continue writing summary/appendix artifacts.
+
+#### Rollback/feature-flag considerations (if applicable):
+- No feature flag required; change is additive and backward compatible.
+- Rollback path is a straight revert of new section and metadata derivation logic.
+
+### Technical specifications (interfaces/contracts):
+- New summary section contract:
+	- Header: `===== Issues to autoclose (verified or pending) =====`
+	- Content priority: verified issues first; otherwise pending deterministic issue(s); otherwise explicit `None` reason.
+- Prompt compatibility contract:
+	- Section is intentionally named to match accepted source in `.github/prompts/generate-pr.prompt.md`.
+	- `Close candidates` remains non-authoritative for auto-close emission.
+
+#### Inputs/outputs and formats:
+- Inputs:
+	- Active feature docs including metadata line `- Issue: #NN`
+	- Feature audit artifacts (`feature-audit.<timestamp>.md`) for readiness state
+	- Optional GitHub PR metadata (`closingIssuesReferences`) from collector pipeline
+- Outputs:
+	- `artifacts/pr_context.summary.txt` includes new approved autoclose source section
+	- `artifacts/pr_context.appendix.txt` remains unchanged except for consistency references if needed
+- Format:
+	- Plain-text issue refs in `#NN` form, sorted deterministically
+
+#### Required configuration keys and defaults:
+- No new environment variables.
+- No new CLI flags.
+- Default behavior remains conservative when deterministic inputs are unavailable.
+
+#### Backward-compatibility expectations:
+- Existing collector invocation remains unchanged.
+- Existing consumers of `Close candidates` continue to work.
+- Added section is additive; legacy parsing of existing sections is unaffected.
+
+#### Performance constraints (latency/throughput/memory):
+- Keep additional parsing linear in number of active feature docs and audit files.
+- No new persistent cache or heavy I/O paths.
+- Expected runtime impact is negligible for current repo scale.
+
+## Assumptions, Constraints, Dependencies
+- Assumptions (environment, data, access):
+- Active feature folder for issue #48 contains authoritative metadata and accessible audit artifacts.
+- Prompt contract in `.github/prompts/generate-pr.prompt.md` remains authoritative for allowed autoclose sources.
+- Constraints (budget, performance, compatibility):
+- Minimal-surface bug fix; avoid broad refactors.
+- Must preserve deterministic output and conservative fallback behavior.
+- External dependencies (services, libraries, releases):
+- No new dependencies required.
+
+## Data / API / Config Impact
+- User-facing or API changes:
+- PR authors gain a deterministic approved source for `Closes #NN` emission when audited issue readiness is `PASS`.
+- Data or migration considerations:
+- No migration; artifact schema is extended with one additive summary section.
+- Logging/telemetry updates (if any):
+- Summary artifact gains explicit autoclose eligibility visibility (`verified`, `pending`, or `none`).
+- Compatibility notes (CLI flags, config schemas, versioning):
+- Collector CLI/config unchanged; prompt compatibility improved through section alignment, not prompt relaxation.
+
+## Test Strategy
+Seeded from issue:
+
+- [x] Unit coverage areas
+	- Add/extend tests so `pr_context` emits an approved auto-close source when feature docs provide a deterministic `Issue: #NN` and readiness is PASS.
+	- Add regression assertions that narrative mentions (`#40/#42/#43`) are not promoted to close targets.
+- [x] Integration scenario to retest
+	- Re-run `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40` and regenerate PR content.
+	- Verify generated `GitHub Auto-close` includes `Closes #46` and excludes `Closes #40/#42/#43` unless explicitly author-asserted in PR Intent.
+- [x] Manual verification notes
+	- Confirm summary includes either populated `PR Intent -> Author-asserted autoclose issues` or `Issues to autoclose (verified or pending)` with `#46`.
+	- Confirm behavior remains conservative when deterministic primary issue cannot be resolved.
+
+- Regression tests to add or update:
+- `tests/scripts/dev_tools/test_feature_docs.py`
+	- Add extraction tests for explicit `Issue: #NN` metadata and readiness parsing from `feature-audit` docs.
+- `tests/scripts/dev_tools/test_collect_pr_context.py`
+	- Add regression ensuring only deterministic audited issue is emitted in `Issues to autoclose (verified or pending)` for readiness `PASS`.
+	- Add regression ensuring narrative mentions (`#40/#42/#43`) are excluded from autoclose section.
+- `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
+	- Add summary rendering assertions for header presence, deterministic issue ordering, and conservative `None` fallback reasons.
+- `tests/scripts/dev_tools/test_pr_context_integration.py`
+	- Add contract test proving generated PR content can emit `Closes #46` from approved section and does not emit `Closes` for mention-only refs.
+- Unit tests (pytest) for the fixed behavior and boundaries:
+- Positive: explicit issue + `PASS` readiness -> pending deterministic issue appears in new section.
+- Positive: verified closing issues present -> verified issues are emitted as highest-priority source.
+- Negative: readiness missing/non-`PASS` -> no pending issue emitted.
+- Negative: malformed issue metadata -> no pending issue emitted.
+- Edge cases and negative scenarios (invalid inputs, missing data, boundary values):
+- Multiple active feature docs with mixed issue refs should still emit only deterministic eligible issue(s).
+- Duplicate issue references across sources should be deduplicated.
+- Empty feature-doc set should produce explicit `None` with reason.
+- Error handling and logging verification:
+- Assert collector completes and writes artifacts when readiness artifact is missing.
+- Assert summary text clearly communicates conservative fallback cause.
+- Coverage impact and targets for changed lines/modules:
+- Maintain repo policy target and achieve >=90% coverage for new/modified autoclose-related lines.
+- Toolchain commands to run (format → lint → type-check → test):
+- `poetry run black .`
+- `poetry run ruff check`
+- `poetry run pyright`
+- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
+- Manual validation steps (if required):
+- Re-run collector for repro branch and inspect `artifacts/pr_context.summary.txt`.
+- Confirm section includes `#46` only when readiness is `PASS`.
+- Regenerate PR body and confirm `GitHub Auto-close` emits `Closes #46` and excludes mention-only issues.
+
+### Executed verification commands and evidence
+- `poetry run pytest tests/scripts/dev_tools/test_feature_docs.py -q -k primary_issue_and_pass_readiness`
+	- Evidence: `evidence/regression-testing/pass-primary-issue-and-pass-readiness.2026-02-22T23-15.md`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k pass_readiness_autoclose_section`
+	- Evidence: `evidence/regression-testing/pass-pass-readiness-autoclose-section.2026-02-22T23-15.md`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context.py -q -k narrative_mentions_excluded_from_autoclose_section`
+	- Evidence: `evidence/regression-testing/pass-narrative-mention-exclusion.2026-02-22T23-15.md`
+- `poetry run pytest tests/scripts/dev_tools/test_collect_pr_context_part4.py -q -k non_pass_readiness_fallback`
+	- Evidence: `evidence/regression-testing/pass-non-pass-fallback.2026-02-22T23-15.md`
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
+	- Evidence: `evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md`
+- Final QA toolchain evidence:
+	- `evidence/qa-gates/black-final.2026-02-22T23-15.md`
+	- `evidence/qa-gates/ruff-final.2026-02-22T23-15.md`
+	- `evidence/qa-gates/pyright-final.2026-02-22T23-15.md`
+	- `evidence/qa-gates/pytest-final.2026-02-22T23-15.md`
+	- `evidence/qa-gates/final-pass-summary.2026-02-22T23-15.md`
+
+
+## Acceptance Criteria
+- [x] Running `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40` emits `===== Issues to autoclose (verified or pending) =====` in `artifacts/pr_context.summary.txt`.
+- [x] For audited issue metadata `Issue: #46` with readiness `PASS`, the new section includes `#46` (validated by targeted regression evidence) and remains compatible with existing prompt rules.
+- [x] Mention-only refs (`#40/#42/#43`) do not appear in the approved autoclose source section and are not emitted as `Closes` lines unless explicitly asserted through approved sources.
+- [x] Conservative fallback is emitted when deterministic inputs are missing (no primary issue, readiness not `PASS`, or malformed metadata).
+- [x] Regression coverage is added in `tests/scripts/dev_tools/test_feature_docs.py`, `tests/scripts/dev_tools/test_collect_pr_context.py`, and `tests/scripts/dev_tools/test_collect_pr_context_part4.py` with failing-before/fixing-after behavior.
+- [x] No unintended behavior change occurs for unrelated `pr_context` sections (verification, CI status, close candidates diagnostics).
+- [x] Full Python toolchain pass is recorded for final implementation (black, ruff, pyright, pytest --cov command).
+- [x] Feature docs and prompt-contract references remain consistent with deterministic autoclose emission behavior.
+
+## Risks & Mitigations
+- Technical or operational risks:
+- Risk: readiness parsing could drift from audit file conventions and suppress valid pending autoclose.
+- Risk: over-broad issue extraction could reintroduce false-positive auto-close issues.
+- Risk: downstream consumers may rely on old summary assumptions and mis-handle additive section.
+- Mitigations and rollbacks:
+- Restrict deterministic source to explicit `Issue: #NN` metadata and explicit readiness `PASS` only.
+- Add regression tests that lock out mention-based promotion.
+- Keep change additive and reversible; rollback by reverting new section and derivation path.
+
+## Rollout & Follow-up
+- Release/rollout steps:
+- Implement fix + tests on feature branch, regenerate artifacts, and validate PR output contract before merge.
+- Post-fix monitoring or clean-up tasks:
+- Verify subsequent PRs for audited features emit expected `Closes #NN` lines only from approved sources.
+- Track any false-negative cases where readiness exists but pending autoclose is not emitted; adjust parsing only with evidence.
+- Links: issue, PRs, related docs
+- Issue: `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/issue.md`
+- Research: `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/research.md`
+- Prompt contract: `.github/prompts/generate-pr.prompt.md`

--- a/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/user-story.md
+++ b/docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/user-story.md
@@ -1,0 +1,52 @@
+# `pr-does-not-autoclose-with-valid-issue-audit` — User Story
+
+- Issue: #48
+- Owner: drmoisan
+- Status: Draft
+- Last Updated: 2026-02-22
+
+## Story Statement
+
+- As a maintainer preparing a PR from an audited active feature, I want `pr_context` to emit deterministic autoclose issues from an approved section, so that I can reliably include `Closes #46` without violating prompt constraints.
+- As a reviewer validating release readiness, I want narrative issue mentions to remain diagnostic-only and excluded from auto-close emission, so that merged PRs do not close unrelated issues.
+
+## Problem / Why
+
+The current PR-context output places relevant issue refs under `Close candidates`, but the PR authoring prompt only accepts autoclose numbers from `Issues to autoclose (verified or pending)` or `PR Intent -> Author-asserted autoclose issues`. This contract mismatch causes legitimate audited issue closures (for example `#46`) to be omitted even when readiness is `PASS`. Fixing this improves deterministic, safe issue-closing behavior while preserving anti-hallucination controls.
+
+## Personas & Scenarios
+
+- Persona: repository maintainer generating PR content
+  - cares about deterministic, policy-compliant PR output
+  - must avoid closing wrong issues from incidental references
+  - wants audited issue closure to be emitted automatically when evidence is sufficient
+  - needs reproducible behavior from `pr_context` artifacts
+  - is constrained by strict prompt source rules
+- Scenario: maintainer generates a PR for an audited active feature with `Issue: #46`
+  - A concrete, step-by-step narrative that describes how a user accomplishes a goal in a real-world context using the system.
+  - who is acting?
+    - maintainer preparing PR text from generated artifacts
+  - what triggered the action?
+    - feature implementation is complete and audit readiness is `PASS`
+  - what steps do they take?
+    - run `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
+    - inspect `artifacts/pr_context.summary.txt` for `Issues to autoclose (verified or pending)`
+    - generate PR content using `.github/prompts/generate-pr.prompt.md`
+  - what obstacles or decisions occur?
+    - if readiness is missing/non-`PASS`, maintainer must not emit auto-close claims
+    - mention-only refs (`#40/#42/#43`) must be ignored for `Closes` lines
+  - what outcome do they expect?
+    - generated PR includes `Closes #46` only when deterministic eligibility is present, otherwise emits conservative no-autoclose behavior
+
+
+## Acceptance Criteria
+
+- [ ] `artifacts/pr_context.summary.txt` includes `===== Issues to autoclose (verified or pending) =====` after collector execution.
+- [ ] When active feature metadata contains `Issue: #46` and readiness is `PASS`, the approved section includes `#46` and PR output can emit `Closes #46`.
+- [ ] Mention-only refs (`#40/#42/#43`) are excluded from approved autoclose sources and do not appear as `Closes` lines.
+- [ ] When deterministic inputs are incomplete (missing/invalid issue metadata or non-`PASS` readiness), autoclose output remains conservative and does not claim closure.
+- [ ] Regression and integration tests cover positive path, invalid metadata path, readiness-gating path, and mention-exclusion path.
+
+## Non-Goals
+
+Do not relax `.github/prompts/generate-pr.prompt.md` source restrictions. Do not infer auto-close issues from generic narrative references. Do not modify unrelated `pr_context` sections beyond what is required to provide deterministic approved autoclose emission.

--- a/scripts/dev_tools/pr_context/collector.py
+++ b/scripts/dev_tools/pr_context/collector.py
@@ -36,6 +36,7 @@ from .render import (
     format_pr_details,
     select_default_base,
 )
+from .render_pr_helpers import build_issues_to_autoclose_section
 from .summary_helpers import (
     append_generation_timestamp,
     bucket_text,
@@ -289,6 +290,29 @@ def collect_and_write(
         author_asserted = sorted(set(author_asserted + referenced_issues))
         author_reason = "Detected issue references (classified)"
 
+    # Derive deterministic pending autoclose targets from explicit metadata only
+    # when feature readiness is PASS.
+    pending_primary: list[str] = []
+    for feature_doc in feature_docs:
+        if feature_doc.readiness_signal != "PASS":
+            continue
+        if not feature_doc.primary_issue_ref:
+            continue
+        if feature_doc.primary_issue_ref not in pending_primary:
+            pending_primary.append(feature_doc.primary_issue_ref)
+    readiness_signals = sorted(
+        {
+            feature_doc.readiness_signal
+            for feature_doc in feature_docs
+            if feature_doc.readiness_signal
+        }
+    )
+    issues_to_autoclose_section = build_issues_to_autoclose_section(
+        verified=verified,
+        pending_primary=pending_primary,
+        readiness_signals=readiness_signals,
+    )
+
     issues_to_fetch = sorted(set(verified + author_asserted + referenced_issues))
     issue_details: list[IssueDetails] = []
     if gh_available:
@@ -449,6 +473,8 @@ def collect_and_write(
         )
     summary_sections.extend(
         [
+            "",
+            issues_to_autoclose_section,
             "",
             close_candidates,
             "",

--- a/scripts/dev_tools/pr_context/feature_docs.py
+++ b/scripts/dev_tools/pr_context/feature_docs.py
@@ -81,6 +81,78 @@ def _verification_text(plan_text: str) -> str:
     return ""
 
 
+def _parse_primary_issue_from_metadata(
+    *, spec_text: str, story_text: str
+) -> str | None:
+    """Parse deterministic primary issue from metadata lines only.
+
+    Args:
+        spec_text: Full `spec.md` text for the feature.
+        story_text: Full `user-story.md` text for the feature.
+
+    Returns:
+        A normalized issue reference (for example `#46`) when an explicit
+        metadata line `Issue: #NN` is found; otherwise `None`.
+
+    Side Effects:
+        None.
+    """
+    # Search metadata-style lines only so narrative mentions never become the
+    # deterministic primary issue source.
+    pattern = re.compile(r"^\s*[-*]?\s*Issue:\s*(#\d+)\s*$", re.IGNORECASE)
+
+    # Prefer spec metadata first, then story metadata as fallback.
+    for source_text in (spec_text, story_text):
+        for line in source_text.splitlines():
+            match = pattern.match(line)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _parse_readiness_value(text: str) -> str | None:
+    """Normalize readiness value from a feature-audit markdown payload.
+
+    Args:
+        text: Raw markdown content from a `feature-audit.*.md` file.
+
+    Returns:
+        One of `PASS`, `NEEDS REVISION`, `BLOCKED`, or `None`.
+
+    Side Effects:
+        None.
+    """
+    match = re.search(r"^\s*Readiness:\s*(.+?)\s*$", text, flags=re.MULTILINE)
+    if not match:
+        return None
+    value = match.group(1).strip().upper()
+    if value in {"PASS", "NEEDS REVISION", "BLOCKED"}:
+        return value
+    return None
+
+
+def _resolve_readiness_signal(feature_dir: Path) -> str | None:
+    """Resolve readiness signal from the latest `feature-audit.*.md` file.
+
+    Args:
+        feature_dir: Active feature directory containing audit artifacts.
+
+    Returns:
+        `PASS`, `NEEDS REVISION`, `BLOCKED`, or `None` when no parseable
+        readiness metadata exists.
+
+    Side Effects:
+        Reads local feature audit files from disk.
+    """
+    audit_files = sorted(feature_dir.glob("feature-audit.*.md"))
+    # Evaluate newest-first based on lexicographic timestamp suffix.
+    for audit_path in reversed(audit_files):
+        readiness = _parse_readiness_value(_read_text(audit_path))
+        if readiness:
+            return readiness
+    return None
+
+
 def gather_feature_excerpts(
     root: Path, changed_files: Iterable[str]
 ) -> list[FeatureDocExcerpt]:
@@ -134,6 +206,11 @@ def gather_feature_excerpts(
 
         spec_text = _read_text(spec_path)
         plan_text = _read_text(plan_path)
+        primary_issue_ref = _parse_primary_issue_from_metadata(
+            spec_text=spec_text,
+            story_text=user_story_text,
+        )
+        readiness_signal = _resolve_readiness_signal(active_dir)
 
         spec_parts: list[str] = []
         for heading in (
@@ -216,6 +293,8 @@ def gather_feature_excerpts(
                 excerpt="\n".join(lines),
                 issue_refs=issue_refs,
                 context_files=sorted(set(context_files + evidence_context_files)),
+                primary_issue_ref=primary_issue_ref,
+                readiness_signal=readiness_signal,
             )
         )
 

--- a/scripts/dev_tools/pr_context/models.py
+++ b/scripts/dev_tools/pr_context/models.py
@@ -79,6 +79,8 @@ class FeatureDocExcerpt:
     excerpt: str
     issue_refs: list[str]
     context_files: list[str]
+    primary_issue_ref: str | None = None
+    readiness_signal: str | None = None
 
 
 @dataclass

--- a/scripts/dev_tools/pr_context/render_pr_helpers.py
+++ b/scripts/dev_tools/pr_context/render_pr_helpers.py
@@ -225,6 +225,53 @@ def build_close_candidates_section(
     )
 
 
+def build_issues_to_autoclose_section(
+    *,
+    verified: list[str],
+    pending_primary: list[str],
+    readiness_signals: list[str],
+) -> str:
+    """Render approved autoclose section from verified and deterministic pending refs.
+
+    Purpose:
+        Build the summary section consumed by PR-generation prompts for allowed
+        autoclose declarations.
+
+    Args:
+        verified: Issues verified from GitHub PR metadata (`closingIssuesReferences`).
+        pending_primary: Deterministic primary issue refs eligible when
+            readiness is PASS.
+        readiness_signals: Normalized readiness states observed in feature docs.
+
+    Returns:
+        A formatted section with header
+        `===== Issues to autoclose (verified or pending) =====` and either a
+        deterministic list or conservative fallback text.
+
+    Side Effects:
+        None.
+    """
+    # Preserve stable, deterministic ordering: verified issues first, then
+    # pending deterministic issues not already verified.
+    ordered: list[str] = []
+    for issue in verified + pending_primary:
+        if issue and issue not in ordered:
+            ordered.append(issue)
+
+    if ordered:
+        body = format_list(ordered, "(none)")
+    else:
+        # Use explicit conservative wording when readiness is missing/non-PASS.
+        if any(signal == "PASS" for signal in readiness_signals):
+            body = (
+                "None (no verified closing issues and no deterministic pending issue)"
+            )
+        else:
+            body = "None (no verified closing issues and readiness not PASS)"
+
+    return "\n".join([section("Issues to autoclose (verified or pending)"), body])
+
+
 def extract_changed_paths(context_text: str) -> list[str]:
     """Extract changed file paths from the 'Changed files' section text."""
     paths: list[str] = []

--- a/tests/scripts/dev_tools/test_collect_pr_context.py
+++ b/tests/scripts/dev_tools/test_collect_pr_context.py
@@ -15,6 +15,7 @@ from scripts.dev_tools.pr_context.collector import (
     PullRequestDetails,
     build_close_candidates_section,
     build_pr_context,
+    collect_and_write,
     convert_numstat,
     extension_summary,
     extract_issue_references,
@@ -24,6 +25,7 @@ from scripts.dev_tools.pr_context.collector import (
     gather_feature_excerpts,
     select_default_base,
 )
+from scripts.dev_tools.pr_context.models import FeatureDocExcerpt, PRContextResult
 from scripts.dev_tools.pr_context.summary_helpers import (
     issue_appendix as _issue_appendix,
 )
@@ -478,3 +480,181 @@ def test_scoping_doc_changes_marks_non_material_link_only():
     )
     assert changes
     assert changes[0][1] is False
+
+
+def test_narrative_mentions_excluded_from_autoclose_section(
+    monkeypatch: pytest.MonkeyPatch, mem_path: Path
+) -> None:
+    """Assert narrative refs stay out of approved autoclose section."""
+    outputs: list[tuple[Path, str]] = []
+
+    def fake_write_output(text: str, out_path: Path, append: bool) -> None:
+        _ = append
+        outputs.append((out_path, text))
+
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.write_output", fake_write_output
+    )
+
+    class StubGit:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self._root = mem_path
+
+        def resolve_root(self) -> Path:
+            return self._root
+
+        def branch_name(self) -> str:
+            return "feature/test"
+
+        def upstream(self) -> str:
+            return "origin/feature/test"
+
+        def remote_verbose(self) -> str:
+            return "origin https://example/repo (fetch)"
+
+        def status_short(self) -> str:
+            return "## feature/test"
+
+        def untracked(self) -> str:
+            return ""
+
+        def diff_name_status(self, *, staged: bool) -> str:
+            _ = staged
+            return ""
+
+        def diff_patch(self, *, staged: bool) -> str:
+            _ = staged
+            return ""
+
+        def rev_parse(self, ref: str) -> str:
+            return f"{ref}-sha"
+
+        def merge_base(self, base: str, head: str) -> str:
+            _ = base, head
+            return "base-sha"
+
+        def log(self, fmt: str, rev_range: str) -> str:
+            _ = fmt, rev_range
+            return ""
+
+        def diff_range(self, args: Sequence[str]) -> str:
+            if "--name-status" in args:
+                return "M\tdocs/features/active/test/spec.md"
+            if "--numstat" in args:
+                return "1\t0\tdocs/features/active/test/spec.md"
+            if "--shortstat" in args:
+                return " 1 files changed, 1 insertions(+), 0 deletions(-)"
+            if "--stat" in args:
+                return " spec.md | 1 +"
+            return ""
+
+        def run(
+            self, args: Sequence[str], *, allow_error: bool = False
+        ) -> CommandResult:
+            _ = args, allow_error
+            return CommandResult(stdout="resolved", stderr="", code=0)
+
+    class StubGh:
+        status_message = "ok"
+        available = True
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def ensure_available(self) -> None:
+            return None
+
+        def current_pr(self) -> PullRequestDetails | None:
+            return None
+
+        def classify_entity(self, number: str) -> str | None:
+            _ = number
+            return None
+
+        def ci_status(self, head_sha: str) -> tuple[str | None, list[str]]:
+            _ = head_sha
+            return "success", []
+
+    def fake_build_pr_context(
+        *,
+        git: StubGit,
+        gh: StubGh,
+        base_ref: str | None,
+        head_ref: str | None,
+        include_untracked: bool,
+        feature_issue_refs: Sequence[str] | None = None,
+        current_pr: PullRequestDetails | None = None,
+        gh_available: bool | None = None,
+    ) -> PRContextResult:
+        _ = (
+            git,
+            gh,
+            include_untracked,
+            feature_issue_refs,
+            current_pr,
+            gh_available,
+        )
+        return PRContextResult(
+            text=(
+                "===== Changed files (name-status) =====\n"
+                "M\tdocs/features/active/test/spec.md"
+            ),
+            referenced_issues=[],
+            referenced_prs=[],
+            verified_closing=[],
+            invalid_references=[],
+            base_ref=base_ref,
+            resolved_base="origin/main",
+            base_sha="base-sha",
+            head_ref=head_ref or "feature",
+            head_sha="head-sha",
+            merge_base="base-sha",
+            rev_range="base-sha..head-sha",
+            gh_available=True,
+        )
+
+    def fake_gather_feature_excerpts(
+        root: Path, paths: Sequence[str]
+    ) -> list[FeatureDocExcerpt]:
+        _ = root, paths
+        return [
+            FeatureDocExcerpt(
+                feature="test",
+                excerpt="Narrative mentions #40 #42 #43 in notes.",
+                issue_refs=["#40", "#42", "#43"],
+                context_files=["docs/features/active/test/spec.md"],
+                primary_issue_ref="#46",
+                readiness_signal="PASS",
+            )
+        ]
+
+    monkeypatch.setattr("scripts.dev_tools.pr_context.collector.GitClient", StubGit)
+    monkeypatch.setattr("scripts.dev_tools.pr_context.collector.GhClient", StubGh)
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.build_pr_context", fake_build_pr_context
+    )
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.gather_feature_excerpts",
+        fake_gather_feature_excerpts,
+    )
+
+    collect_and_write(
+        base="main",
+        head="feature",
+        out=mem_path / "summary.txt",
+        appendix_out=mem_path / "appendix.txt",
+        repo_root=mem_path,
+        append=False,
+        include_untracked=False,
+    )
+
+    summary_text = next(text for path, text in outputs if path.name == "summary.txt")
+    section_start = summary_text.index(
+        "===== Issues to autoclose (verified or pending) ====="
+    )
+    section_end = summary_text.index("===== Close candidates =====", section_start)
+    approved_section = summary_text[section_start:section_end]
+    assert "#46" in approved_section
+    assert "#40" not in approved_section
+    assert "#42" not in approved_section
+    assert "#43" not in approved_section

--- a/tests/scripts/dev_tools/test_collect_pr_context_part4.py
+++ b/tests/scripts/dev_tools/test_collect_pr_context_part4.py
@@ -688,3 +688,345 @@ def test_collector_reports_unparseable_evidence_without_claiming_completion(
 
     summary_text = next(text for path, text in outputs if path.name == "summary.txt")
     assert "No canonical verification evidence parsed" in summary_text
+
+
+def test_pass_readiness_autoclose_section(
+    monkeypatch: pytest.MonkeyPatch, mem_path: Path
+) -> None:
+    """Assert PASS readiness promotes deterministic primary issue."""
+    outputs: list[tuple[Path, str]] = []
+
+    def fake_write_output(text: str, out_path: Path, append: bool) -> None:
+        _ = append
+        outputs.append((out_path, text))
+
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.write_output", fake_write_output
+    )
+
+    class StubGit:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self._root = mem_path
+
+        def resolve_root(self) -> Path:
+            return self._root
+
+        def branch_name(self) -> str:
+            return "feature/test"
+
+        def upstream(self) -> str:
+            return "origin/feature/test"
+
+        def remote_verbose(self) -> str:
+            return "origin https://example/repo (fetch)"
+
+        def status_short(self) -> str:
+            return "## feature/test"
+
+        def untracked(self) -> str:
+            return ""
+
+        def diff_name_status(self, *, staged: bool) -> str:
+            _ = staged
+            return ""
+
+        def diff_patch(self, *, staged: bool) -> str:
+            _ = staged
+            return ""
+
+        def rev_parse(self, ref: str) -> str:
+            return f"{ref}-sha"
+
+        def merge_base(self, base: str, head: str) -> str:
+            _ = base, head
+            return "base-sha"
+
+        def log(self, fmt: str, rev_range: str) -> str:
+            _ = fmt, rev_range
+            return ""
+
+        def diff_range(self, args: Sequence[str]) -> str:
+            if "--name-status" in args:
+                return "M\tdocs/features/active/test/spec.md"
+            if "--numstat" in args:
+                return "1\t0\tdocs/features/active/test/spec.md"
+            if "--shortstat" in args:
+                return " 1 files changed, 1 insertions(+), 0 deletions(-)"
+            if "--stat" in args:
+                return " spec.md | 1 +"
+            return ""
+
+        def run(
+            self, args: Sequence[str], *, allow_error: bool = False
+        ) -> CommandResult:
+            _ = args, allow_error
+            return CommandResult(stdout="resolved", stderr="", code=0)
+
+    class StubGh:
+        status_message = "ok"
+        available = True
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def ensure_available(self) -> None:
+            return None
+
+        def current_pr(self) -> PullRequestDetails | None:
+            return None
+
+        def classify_entity(self, number: str) -> str | None:
+            _ = number
+            return None
+
+        def ci_status(self, head_sha: str) -> tuple[str | None, list[str]]:
+            _ = head_sha
+            return "success", []
+
+    def fake_build_pr_context(
+        *,
+        git: StubGit,
+        gh: StubGh,
+        base_ref: str | None,
+        head_ref: str | None,
+        include_untracked: bool,
+        feature_issue_refs: Sequence[str] | None = None,
+        current_pr: PullRequestDetails | None = None,
+        gh_available: bool | None = None,
+    ) -> PRContextResult:
+        _ = (
+            git,
+            gh,
+            include_untracked,
+            feature_issue_refs,
+            current_pr,
+            gh_available,
+        )
+        return PRContextResult(
+            text=(
+                "===== Changed files (name-status) =====\n"
+                "M\tdocs/features/active/test/spec.md"
+            ),
+            referenced_issues=[],
+            referenced_prs=[],
+            verified_closing=[],
+            invalid_references=[],
+            base_ref=base_ref,
+            resolved_base="origin/main",
+            base_sha="base-sha",
+            head_ref=head_ref or "feature",
+            head_sha="head-sha",
+            merge_base="base-sha",
+            rev_range="base-sha..head-sha",
+            gh_available=True,
+        )
+
+    def fake_gather_feature_excerpts(
+        root: Path, paths: Sequence[str]
+    ) -> list[FeatureDocExcerpt]:
+        _ = root, paths
+        return [
+            FeatureDocExcerpt(
+                feature="test",
+                excerpt="Feature doc excerpt",
+                issue_refs=["#40", "#42", "#43"],
+                context_files=["docs/features/active/test/spec.md"],
+                primary_issue_ref="#46",
+                readiness_signal="PASS",
+            )
+        ]
+
+    monkeypatch.setattr("scripts.dev_tools.pr_context.collector.GitClient", StubGit)
+    monkeypatch.setattr("scripts.dev_tools.pr_context.collector.GhClient", StubGh)
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.build_pr_context", fake_build_pr_context
+    )
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.gather_feature_excerpts",
+        fake_gather_feature_excerpts,
+    )
+
+    collect_and_write(
+        base="main",
+        head="feature",
+        out=mem_path / "summary.txt",
+        appendix_out=mem_path / "appendix.txt",
+        repo_root=mem_path,
+        append=False,
+        include_untracked=False,
+    )
+
+    summary_text = next(text for path, text in outputs if path.name == "summary.txt")
+    assert "===== Issues to autoclose (verified or pending) =====" in summary_text
+    assert "#46" in summary_text
+
+
+def test_non_pass_readiness_fallback(
+    monkeypatch: pytest.MonkeyPatch, mem_path: Path
+) -> None:
+    """Assert approved section emits explicit None fallback for non-PASS."""
+    outputs: list[tuple[Path, str]] = []
+
+    def fake_write_output(text: str, out_path: Path, append: bool) -> None:
+        _ = append
+        outputs.append((out_path, text))
+
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.write_output", fake_write_output
+    )
+
+    class StubGit:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self._root = mem_path
+
+        def resolve_root(self) -> Path:
+            return self._root
+
+        def branch_name(self) -> str:
+            return "feature/test"
+
+        def upstream(self) -> str:
+            return "origin/feature/test"
+
+        def remote_verbose(self) -> str:
+            return "origin https://example/repo (fetch)"
+
+        def status_short(self) -> str:
+            return "## feature/test"
+
+        def untracked(self) -> str:
+            return ""
+
+        def diff_name_status(self, *, staged: bool) -> str:
+            _ = staged
+            return ""
+
+        def diff_patch(self, *, staged: bool) -> str:
+            _ = staged
+            return ""
+
+        def rev_parse(self, ref: str) -> str:
+            return f"{ref}-sha"
+
+        def merge_base(self, base: str, head: str) -> str:
+            _ = base, head
+            return "base-sha"
+
+        def log(self, fmt: str, rev_range: str) -> str:
+            _ = fmt, rev_range
+            return ""
+
+        def diff_range(self, args: Sequence[str]) -> str:
+            if "--name-status" in args:
+                return "M\tdocs/features/active/test/spec.md"
+            if "--numstat" in args:
+                return "1\t0\tdocs/features/active/test/spec.md"
+            if "--shortstat" in args:
+                return " 1 files changed, 1 insertions(+), 0 deletions(-)"
+            if "--stat" in args:
+                return " spec.md | 1 +"
+            return ""
+
+        def run(
+            self, args: Sequence[str], *, allow_error: bool = False
+        ) -> CommandResult:
+            _ = args, allow_error
+            return CommandResult(stdout="resolved", stderr="", code=0)
+
+    class StubGh:
+        status_message = "ok"
+        available = True
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def ensure_available(self) -> None:
+            return None
+
+        def current_pr(self) -> PullRequestDetails | None:
+            return None
+
+        def classify_entity(self, number: str) -> str | None:
+            _ = number
+            return None
+
+        def ci_status(self, head_sha: str) -> tuple[str | None, list[str]]:
+            _ = head_sha
+            return "success", []
+
+    def fake_build_pr_context(
+        *,
+        git: StubGit,
+        gh: StubGh,
+        base_ref: str | None,
+        head_ref: str | None,
+        include_untracked: bool,
+        feature_issue_refs: Sequence[str] | None = None,
+        current_pr: PullRequestDetails | None = None,
+        gh_available: bool | None = None,
+    ) -> PRContextResult:
+        _ = (
+            git,
+            gh,
+            include_untracked,
+            feature_issue_refs,
+            current_pr,
+            gh_available,
+        )
+        return PRContextResult(
+            text=(
+                "===== Changed files (name-status) =====\n"
+                "M\tdocs/features/active/test/spec.md"
+            ),
+            referenced_issues=[],
+            referenced_prs=[],
+            verified_closing=[],
+            invalid_references=[],
+            base_ref=base_ref,
+            resolved_base="origin/main",
+            base_sha="base-sha",
+            head_ref=head_ref or "feature",
+            head_sha="head-sha",
+            merge_base="base-sha",
+            rev_range="base-sha..head-sha",
+            gh_available=True,
+        )
+
+    def fake_gather_feature_excerpts(
+        root: Path, paths: Sequence[str]
+    ) -> list[FeatureDocExcerpt]:
+        _ = root, paths
+        return [
+            FeatureDocExcerpt(
+                feature="test",
+                excerpt="Feature doc excerpt",
+                issue_refs=[],
+                context_files=["docs/features/active/test/spec.md"],
+                primary_issue_ref="#46",
+                readiness_signal="NEEDS REVISION",
+            )
+        ]
+
+    monkeypatch.setattr("scripts.dev_tools.pr_context.collector.GitClient", StubGit)
+    monkeypatch.setattr("scripts.dev_tools.pr_context.collector.GhClient", StubGh)
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.build_pr_context", fake_build_pr_context
+    )
+    monkeypatch.setattr(
+        "scripts.dev_tools.pr_context.collector.gather_feature_excerpts",
+        fake_gather_feature_excerpts,
+    )
+
+    collect_and_write(
+        base="main",
+        head="feature",
+        out=mem_path / "summary.txt",
+        appendix_out=mem_path / "appendix.txt",
+        repo_root=mem_path,
+        append=False,
+        include_untracked=False,
+    )
+
+    summary_text = next(text for path, text in outputs if path.name == "summary.txt")
+    assert "===== Issues to autoclose (verified or pending) =====" in summary_text
+    assert "None (no verified closing issues and readiness not PASS)" in summary_text

--- a/tests/scripts/dev_tools/test_feature_docs.py
+++ b/tests/scripts/dev_tools/test_feature_docs.py
@@ -328,3 +328,45 @@ def test_feature_doc_and_render_helpers_share_verification_then_test_plan_fallba
     assert feature_docs_verification
     assert render_verification_notes
     assert "Verification-first notes should win." in render_verification_notes
+
+
+def test_primary_issue_and_pass_readiness(mem_path: Path) -> None:
+    """Assert Issue metadata is primary and latest feature-audit PASS is surfaced."""
+    feature_dir = (
+        mem_path
+        / "docs"
+        / "features"
+        / "active"
+        / "2026-02-22-pr-context-verification-contract-gap-46"
+    )
+    feature_dir.mkdir(parents=True)
+    (mem_path / "docs" / "features" / "potential" / "promoted").mkdir(parents=True)
+
+    (feature_dir / "spec.md").write_text(
+        "- Issue: #46\n"
+        "## Context\n"
+        "Narrative mentions #40 #42 #43 should not become primary metadata issue.\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "user-story.md").write_text(
+        "## Story Statement\n" "- Keep deterministic issue metadata.\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "plan.md").write_text("## Tasks\n- [x] done\n", encoding="utf-8")
+
+    (feature_dir / "feature-audit.2026-02-22T20-00.md").write_text(
+        "Readiness: NEEDS REVISION\n", encoding="utf-8"
+    )
+    (feature_dir / "feature-audit.2026-02-22T21-00.md").write_text(
+        "Readiness: PASS\n", encoding="utf-8"
+    )
+
+    excerpts = gather_feature_excerpts(
+        mem_path,
+        [
+            "docs/features/active/2026-02-22-pr-context-verification-contract-gap-46/spec.md"
+        ],
+    )
+    assert len(excerpts) == 1
+    assert excerpts[0].primary_issue_ref == "#46"
+    assert excerpts[0].readiness_signal == "PASS"


### PR DESCRIPTION
Fix pr_context to emit approved auto-close issues for PASS audited features

## Summary
- Add a prompt-approved `Issues to autoclose (verified or pending)` section to `artifacts/pr_context.summary.txt` so PR generation can safely emit `Closes` lines.
- Derive pending autoclose targets deterministically from explicit feature doc metadata (`Issue: #NN`) and gate on feature audit readiness (`Readiness: PASS`).
- Add/extend regression tests covering PASS readiness, mention-only exclusion, and conservative fallback behavior.
- Include feature docs and evidence artifacts under `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/` for traceability.

## Why
- The PR authoring prompt only accepts autoclose numbers from `Issues to autoclose (verified or pending)` or `PR Intent -> Author-asserted autoclose issues`, but prior `pr_context` output placed issue refs under `Close candidates` (not an allowed source).
- This contract mismatch caused legitimate audited issue closures (example given in feature docs: `#46`) to be omitted even when readiness was `PASS`, while also risking accidental inclusion of narrative mentions.

## What Changed
- Core behavior / architecture
  - Emit `===== Issues to autoclose (verified or pending) =====` in the PR context summary and populate it deterministically.
  - Extend feature doc parsing to identify an explicit primary issue from metadata and resolve readiness from the latest `feature-audit.*.md`.
- Tests
  - Add/extend regression coverage in:
    - `tests/scripts/dev_tools/test_feature_docs.py`
    - `tests/scripts/dev_tools/test_collect_pr_context.py`
    - `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
- Docs / templates / agents
  - Add feature folder docs and audit/evidence artifacts under `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/` (spec, user story, plan, audits, QA gate evidence, regression evidence).

## Architecture / How It Fits Together
- `scripts/dev_tools/pr_context/feature_docs.py` gathers active feature excerpts and derives deterministic metadata:
  - Primary issue from explicit `Issue: #NN` metadata (not narrative mentions).
  - Readiness from the latest `feature-audit.*.md` (`Readiness: PASS|NEEDS REVISION|BLOCKED`).
- `scripts/dev_tools/pr_context/collector.py` assembles the PR context summary and renders:
  - `Issues to autoclose (verified or pending)` with precedence (verified closing issues first, then deterministic pending when readiness is PASS, else conservative `None`).
  - `Close candidates` remains diagnostic output.

## Verification
### Completed
- Evidence-backed final toolchain pass (single clean pass):
  - `poetry run black .` (EXIT_CODE: 0)
  - `poetry run ruff check` (EXIT_CODE: 0)
  - `poetry run pyright` (EXIT_CODE: 0)
  - `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` (EXIT_CODE: 0; `780 passed`; `TOTAL coverage 81%`)
  - Summary evidence: `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/qa-gates/final-pass-summary.2026-02-22T23-15.md`
- Collector contract evidence:
  - `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40` (EXIT_CODE: 0) and asserts the new section header is present.
  - Evidence: `docs/features/active/2026-02-22-pr-does-not-autoclose-with-valid-issue-audit-48/evidence/other/pass-collector-autoclose-contract.2026-02-22T23-15.md`
- CI status (HEAD): `(not available)` in `artifacts/pr_context.summary.txt`.

### Recommended
- Re-run locally (especially if PR Intent fields will be updated) to refresh artifacts:
  - `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/bootstrap-utilities-#40`
- Run repo-standard Python gates:
  - `poetry run black .`
  - `poetry run ruff check`
  - `poetry run pyright`
  - `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`

## Backward Compatibility / Migration Notes
- Additive change to the PR context summary: introduces a new summary section `Issues to autoclose (verified or pending)` without removing existing sections.
- No CLI flag changes noted for `scripts.dev_tools.pr_context.collector`.

## Risks and Mitigations
- Risk: Strict parsing of `Readiness:` or `Issue:` metadata could suppress pending autoclose when metadata is malformed.
  - Mitigation: Conservative fallback behavior is explicit (no autoclose claims when readiness is not PASS or metadata is missing).
- Risk: Over-closing unrelated issues due to narrative issue mentions.
  - Mitigation: Deterministic autoclose sourcing is restricted to explicit metadata and PASS gating; diagnostic references remain in `Close candidates`.

## Review Guide
- Start with the new summary contract output in `artifacts/pr_context.summary.txt` (ensure the new section exists and is populated as expected).
- Review core logic changes:
  - `scripts/dev_tools/pr_context/feature_docs.py`
  - `scripts/dev_tools/pr_context/render_pr_helpers.py`
  - `scripts/dev_tools/pr_context/collector.py`
  - `scripts/dev_tools/pr_context/models.py`
- Review regression tests:
  - `tests/scripts/dev_tools/test_feature_docs.py`
  - `tests/scripts/dev_tools/test_collect_pr_context.py`
  - `tests/scripts/dev_tools/test_collect_pr_context_part4.py`
- Skim feature folder docs/evidence for traceability (spec/user-story + QA gate evidence + collector contract evidence).

## Follow-ups
- Fill in `PR Intent` in `artifacts/pr_context.summary.txt` (Primary outcome / user impact / risks) and regenerate context artifacts before merge if you want those fields reflected in the final PR narrative.
- If/when CI becomes available for the head SHA, consider regenerating PR context so CI status can be reflected.

## GitHub Auto-close
- Closes #48

## Related issues / PRs
- Related issue: #40
- Related issue: #42
- Related issue: #43
- Related issue: #46