### PR TITLE
(fix(dev-tools)): honor explicit minor-audit work mode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -646,8 +646,7 @@
 				"${relativeFile}",
 				"--promotion-type",
 				"${input:PotentialPromotionType}",
-				"--work-mode",
-				"${input:PotentialWorkMode}"
+				"--work-mode=${input:PotentialWorkMode}"
 			],
 			"command": "poetry",
 			"detail": "Creates a feature issue from the active editor file (workspace-relative) using gh issue create (non-interactive) via Python.",

--- a/scripts/dev_tools/potential_to_issue.py
+++ b/scripts/dev_tools/potential_to_issue.py
@@ -16,7 +16,6 @@ from scripts.dev_tools.potential_to_issue_content import (
     build_body,
     build_bug_body,
     build_minor_audit_body,
-    evaluate_minor_audit_eligibility,
     extract_last_updated,
     get_feature_name,
     get_feature_path,
@@ -403,11 +402,8 @@ def promote_potential(
     selected_mode = "full"
     fallback_reason = ""
     if work_mode == "minor-audit" and promotion_type != "bug":
-        eligible, eligibility_reason = evaluate_minor_audit_eligibility(content)
-        if eligible:
-            selected_mode = "minor-audit"
-        else:
-            fallback_reason = eligibility_reason
+        # Honor explicit user selection for non-bug promotions.
+        selected_mode = "minor-audit"
 
     # Route issue-body generation based on promotion type and eligible work mode.
     if promotion_type == "bug":

--- a/tests/scripts/dev_tools/test_potential_to_issue.py
+++ b/tests/scripts/dev_tools/test_potential_to_issue.py
@@ -689,8 +689,8 @@ def test_work_mode_marker_minor_audit() -> None:
     assert lines[first_section_index - 1] == "- Work Mode: minor-audit"
 
 
-def test_work_mode_marker_fallback_full() -> None:
-    """Verify fallback-to-full issue bodies persist full marker above first section."""
+def test_work_mode_marker_honors_explicit_minor_audit() -> None:
+    """Verify explicit minor-audit requests persist a minor-audit marker."""
     workspace = Path("/workspace")
     potential = workspace / "docs/features/potential/fallback-marker.md"
     fs = FakeFileSystem()
@@ -725,16 +725,16 @@ def test_work_mode_marker_fallback_full() -> None:
     lines = body.splitlines()
     first_section_index = lines.index("## Problem / Why")
     assert first_section_index > 0
-    assert lines[first_section_index - 1] == "- Work Mode: full"
+    assert lines[first_section_index - 1] == "- Work Mode: minor-audit"
 
 
-def test_promote_potential_persists_selected_work_mode_after_fallback() -> None:
-    """Verify fallback selection persists as a full marker when minor is ineligible."""
-    test_work_mode_marker_fallback_full()
+def test_promote_potential_persists_explicit_selected_work_mode() -> None:
+    """Verify explicit selection persists as minor-audit."""
+    test_work_mode_marker_honors_explicit_minor_audit()
 
 
-def test_promote_potential_minor_audit_rejects_missing_eligibility_inputs() -> None:
-    """Verify ineligible minor-audit requests fall back and emit reason messages."""
+def test_promote_potential_minor_audit_honors_explicit_user_selection() -> None:
+    """Verify explicit minor-audit selection is honored."""
     workspace = Path("/workspace")
     potential = workspace / "docs/features/potential/not-eligible.md"
     fs = FakeFileSystem()
@@ -765,8 +765,8 @@ def test_promote_potential_minor_audit_rejects_missing_eligibility_inputs() -> N
         emit=messages.append,
     )
     assert outcome.exit_code == 0
-    assert any("Selected mode: full" in m for m in messages)
-    assert any("Fallback reason:" in m for m in messages)
+    assert any("Selected mode: minor-audit" in m for m in messages)
+    assert not any("Fallback reason:" in m for m in messages)
 
 
 def test_promote_potential_full_mode_preserves_existing_body_contract() -> None:


### PR DESCRIPTION
- Pass --work-mode as a single argument in the VS Code promote task to preserve the selected mode
- Stop downgrading non-bug minor-audit requests via eligibility heuristics
- Update promotion tests to assert explicit minor-audit persists and no fallback reason is emitted