### PR TITLE
Bug/new-active-folder-minor-audit

### DIFF
--- a/scripts/dev_tools/new_active_feature_folder_docs.py
+++ b/scripts/dev_tools/new_active_feature_folder_docs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 from scripts.dev_tools.new_active_feature_folder_markdown import (
@@ -263,23 +262,4 @@ def should_use_minor_audit_mode(
         raise ValueError("work_mode must be one of: minor-audit, full")
     if work_mode == "full":
         return False, ""
-    if feature_type != "feature":
-        return False, "fallback: minor-audit only applies to feature type"
-
-    lower = potential_content.lower()
-    if "bootstrapped" in lower or "pre-cooked" in lower:
-        return True, ""
-
-    production_files = len(
-        re.findall(
-            r"^\s*-\s*(?:production\s+)?file\s*:",
-            potential_content,
-            flags=re.MULTILINE,
-        )
-    )
-    has_low_risk = "low integration risk" in lower or "risk: low" in lower
-    if production_files <= 3 and has_low_risk:
-        return True, ""
-    if production_files > 3:
-        return False, "fallback: production file count exceeds 3"
-    return False, "fallback: missing low integration risk signal"
+    return True, ""

--- a/scripts/dev_tools/potential_to_issue.py
+++ b/scripts/dev_tools/potential_to_issue.py
@@ -399,20 +399,11 @@ def promote_potential(
 
     relative_path = Path(_relative_path()).as_posix()
 
-    selected_mode = "full"
+    selected_mode = work_mode
     fallback_reason = ""
-    if work_mode == "minor-audit" and promotion_type != "bug":
-        # Honor explicit user selection for non-bug promotions.
-        selected_mode = "minor-audit"
 
     # Route issue-body generation based on promotion type and eligible work mode.
-    if promotion_type == "bug":
-        bug_sections = {
-            heading: get_section(content, heading) or PLACEHOLDER
-            for heading in BUG_SECTION_HEADINGS
-        }
-        body = build_bug_body(bug_sections, relative_path)
-    elif selected_mode == "minor-audit":
+    if selected_mode == "minor-audit":
         problem = get_section(content, "Problem / Why") or PLACEHOLDER
         implementation_intent = get_section(content, "Proposed Behavior") or PLACEHOLDER
         acceptance_criteria = (
@@ -437,6 +428,12 @@ def promote_potential(
             evidence_checklist,
             relative_path,
         )
+    elif promotion_type == "bug":
+        bug_sections = {
+            heading: get_section(content, heading) or PLACEHOLDER
+            for heading in BUG_SECTION_HEADINGS
+        }
+        body = build_bug_body(bug_sections, relative_path)
     else:
         problem = get_section(content, "Problem / Why") or PLACEHOLDER
         behavior = get_section(content, "Proposed Behavior") or PLACEHOLDER

--- a/tests/scripts/dev_tools/test_new_active_feature_folder_part3.py
+++ b/tests/scripts/dev_tools/test_new_active_feature_folder_part3.py
@@ -431,10 +431,10 @@ def test_minor_audit_preserves_issue_frontmatter_and_spacing() -> None:
     assert lines[marker_index + 2] == "## Problem / Why"
 
 
-def test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible(
+def test_create_active_folder_minor_audit_honors_explicit_selection(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Verify ineligible minor-audit requests fall back to full mode with reason."""
+    """Verify explicit minor-audit stays selected even when heuristics are unmet."""
     fs = FakeFileSystem()
     workspace = Path("/workspace")
     _seed_feature_template(fs, workspace)
@@ -462,6 +462,7 @@ def test_create_active_folder_minor_audit_falls_back_to_full_when_not_eligible(
         work_mode="minor-audit",
     )
     out = capsys.readouterr().out
-    assert fs.exists(result.target / "user-story.md")
-    assert "Selected mode: full" in out
-    assert "Fallback reason:" in out
+    issue_md = fs.read_text(result.target / "issue.md")
+    assert "- Work Mode: minor-audit" in issue_md
+    assert "Selected mode: minor-audit" in out
+    assert "Fallback reason:" not in out

--- a/tests/scripts/dev_tools/test_new_active_feature_folder_part4.py
+++ b/tests/scripts/dev_tools/test_new_active_feature_folder_part4.py
@@ -91,8 +91,8 @@ def _seed_bug_template(fs: mod.FileSystem, workspace: Path) -> None:
     )
 
 
-def test_work_mode_marker_fallback_issue_md_full() -> None:
-    """Verify minor-audit fallback issue.md persists full marker above first section."""
+def test_work_mode_marker_minor_audit_issue_md_even_when_heuristics_fail() -> None:
+    """Verify explicit minor-audit keeps the minor marker above the first section."""
     fs = FakeFileSystem()
     workspace = Path("/workspace")
     _seed_feature_template(fs, workspace)
@@ -129,7 +129,7 @@ def test_work_mode_marker_fallback_issue_md_full() -> None:
     lines = issue_md.splitlines()
     first_section_index = lines.index("## Problem / Why")
     assert first_section_index > 0
-    assert lines[first_section_index - 2] == "- Work Mode: full"
+    assert lines[first_section_index - 2] == "- Work Mode: minor-audit"
     assert lines[first_section_index - 1] == ""
 
 
@@ -149,10 +149,10 @@ def test_create_active_folder_full_mode_remains_backward_compatible() -> None:
     assert fs.exists(result.target / "user-story.md")
 
 
-def test_create_active_folder_fallback_reason_output(
+def test_create_active_folder_minor_audit_has_no_fallback_reason(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Verify fallback reason output appears when minor-audit cannot be used."""
+    """Verify explicit minor-audit does not emit fallback output."""
     fs = FakeFileSystem()
     workspace = Path("/workspace")
     _seed_feature_template(fs, workspace)
@@ -166,7 +166,8 @@ def test_create_active_folder_fallback_reason_output(
     )
     assert result.target
     out = capsys.readouterr().out
-    assert "Fallback reason:" in out
+    assert "Fallback reason:" not in out
+    assert "Selected mode: minor-audit" in out
 
 
 def test_parse_args_includes_work_mode(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scripts/dev_tools/test_potential_to_issue.py
+++ b/tests/scripts/dev_tools/test_potential_to_issue.py
@@ -652,6 +652,46 @@ def test_promote_potential_minor_audit_adds_required_issue_sections() -> None:
     assert "## Evidence Checklist" in body
 
 
+def test_promote_potential_bug_honors_explicit_minor_audit() -> None:
+    """Verify bug promotions honor explicit minor-audit selection."""
+    workspace = Path("/workspace")
+    potential = workspace / "docs/features/potential/bug-minor.md"
+    fs = FakeFileSystem()
+    fs.files[potential] = "\n".join(
+        [
+            "# Bug Minor Audit",
+            "## Problem / Why",
+            "problem",
+            "## Proposed Behavior",
+            "behavior",
+            "## Acceptance Criteria (early draft)",
+            "criteria",
+            "## Constraints & Risks",
+            "constraints",
+            "## Test Conditions to Consider",
+            "tests",
+        ]
+    )
+    messages: list[str] = []
+    gh = FakeGhClient(
+        mod.GhResult(["Created: https://example.com/issues/58"], 0), mod.GhResult([], 0)
+    )
+    outcome = mod.promote_potential(
+        potential_path=str(potential),
+        promotion_type="bug",
+        fs=fs,
+        gh=gh,
+        workspace=workspace,
+        work_mode="minor-audit",
+        emit=messages.append,
+    )
+    assert outcome.exit_code == 0
+    body = gh.calls[0][1][1]
+    assert "## Implementation Intent" in body
+    assert any("Selected mode: minor-audit" in m for m in messages)
+    assert not any("Fallback reason:" in m for m in messages)
+
+
 def test_work_mode_marker_minor_audit() -> None:
     """Verify minor-audit issue bodies persist marker above first section heading."""
     workspace = Path("/workspace")


### PR DESCRIPTION
- Always select minor-audit when requested and suppress fallback reasons
- Route bug promotions through the minor-audit body builder when selected
- Update unit tests for work-mode marker persistence and selection output