### PR TITLE
Fix/vscode-references-specific-ide-version

### DIFF
--- a/scripts/dev-tools/new-potential-entry.ps1
+++ b/scripts/dev-tools/new-potential-entry.ps1
@@ -3,6 +3,8 @@ param(
     [string] $ShortName
 )
 
+. (Join-Path -Path $PSScriptRoot -ChildPath 'vscode-cli.helpers.ps1')
+
 function Test-ValidShortName {
     [CmdletBinding()]
     [OutputType([bool])]
@@ -97,11 +99,12 @@ function Invoke-VSCodeOpen {
         [scriptblock] $StartProcess = { param([string]$FilePath, $ArgumentList) Start-Process $FilePath -ArgumentList $ArgumentList }
     )
 
-    $codeCmd = & $GetCommand 'code'
-    if ($codeCmd) {
-        & $StartProcess 'code' $Files
+    $codeCommand = Resolve-VSCodeCliCommand -GetCommand $GetCommand
+    if ($codeCommand) {
+        & $StartProcess $codeCommand $Files
         return $true
     }
+
     return $false
 }
 
@@ -139,7 +142,7 @@ Set-Content -Path $target -Value $content -Encoding UTF8
 
 $opened = Invoke-VSCodeOpen -Files @($target, $backlog)
 if (-not $opened) {
-    Write-Warning "VS Code 'code' command not found. Open files manually:"
+    Write-Warning "VS Code CLI command not found (expected 'code' or 'code-insiders'). Open files manually:"
     Write-Output "  $target"
     Write-Output "  $backlog"
 }

--- a/scripts/dev-tools/publish-sideloaded-extension.ps1
+++ b/scripts/dev-tools/publish-sideloaded-extension.ps1
@@ -27,8 +27,8 @@ param(
     [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path,
 
     [Parameter()]
-    [ValidateNotNullOrEmpty()]
-    [string]$CodeCommand = "code",
+    [AllowEmptyString()]
+    [string]$CodeCommand = "",
 
     [Parameter()]
     [switch]$UseInsiders,
@@ -52,6 +52,8 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'vscode-cli.helpers.ps1')
 
 function Invoke-ExternalCommand {
     [CmdletBinding()]
@@ -186,10 +188,6 @@ if (-not (Test-Path -LiteralPath $packageJsonPath)) {
     throw "package.json not found at RepoRoot: $packageJsonPath"
 }
 
-if ($UseInsiders) {
-    $CodeCommand = "code-insiders"
-}
-
 if (-not (Test-Path -LiteralPath $VsixOutputDir)) {
     if ($PSCmdlet.ShouldProcess($VsixOutputDir, 'Create output directory')) {
         New-Item -ItemType Directory -Path $VsixOutputDir -Force | Out-Null
@@ -220,6 +218,15 @@ if (-not (Test-Path -LiteralPath $vsixPath)) {
 }
 
 if (-not $SkipInstall) {
+    $hasExplicitCodeCommand = $PSBoundParameters.ContainsKey('CodeCommand')
+    $preferredCodeCommand = if ($hasExplicitCodeCommand) { $CodeCommand } else { $null }
+    $resolvedCodeCommand = Resolve-VSCodeCliCommand -PreferredCommand $preferredCodeCommand -PreferInsiders:$UseInsiders
+    if (-not $resolvedCodeCommand) {
+        throw "Could not find a VS Code CLI command on PATH (expected 'code' or 'code-insiders')."
+    }
+
+    $CodeCommand = $resolvedCodeCommand
+
     $installArgs = @("--install-extension", $vsixPath)
     if ($Force) {
         $installArgs += "--force"

--- a/scripts/dev-tools/vscode-cli.helpers.ps1
+++ b/scripts/dev-tools/vscode-cli.helpers.ps1
@@ -1,0 +1,63 @@
+function Test-IsVSCodeInsidersSession {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [scriptblock] $GetEnvironmentVariable = { param([string]$Name) [Environment]::GetEnvironmentVariable($Name) }
+    )
+
+    $termProgramVersion = & $GetEnvironmentVariable 'TERM_PROGRAM_VERSION'
+    $askPassMain = & $GetEnvironmentVariable 'VSCODE_GIT_ASKPASS_MAIN'
+    $termProgram = & $GetEnvironmentVariable 'TERM_PROGRAM'
+
+    if ($termProgramVersion -and ($termProgramVersion -imatch 'insider')) {
+        return $true
+    }
+
+    if ($askPassMain -and ($askPassMain -imatch 'insider')) {
+        return $true
+    }
+
+    if ($termProgram -and ($termProgram -imatch 'insider')) {
+        return $true
+    }
+
+    return $false
+}
+
+function Resolve-VSCodeCliCommand {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [AllowEmptyString()]
+        [string] $PreferredCommand,
+        [switch] $PreferInsiders,
+        [scriptblock] $GetCommand = { param([string]$Name) Get-Command $Name -ErrorAction SilentlyContinue },
+        [scriptblock] $GetEnvironmentVariable = { param([string]$Name) [Environment]::GetEnvironmentVariable($Name) }
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($PreferredCommand)) {
+        $preferredCommandResult = & $GetCommand $PreferredCommand
+        if ($preferredCommandResult) {
+            return $PreferredCommand
+        }
+
+        throw "VS Code CLI command '$PreferredCommand' was explicitly requested but was not found on PATH."
+    }
+
+    $preferInsidersCommand = $PreferInsiders.IsPresent -or (Test-IsVSCodeInsidersSession -GetEnvironmentVariable $GetEnvironmentVariable)
+    $candidateCommands = if ($preferInsidersCommand) {
+        @('code-insiders', 'code')
+    }
+    else {
+        @('code', 'code-insiders')
+    }
+
+    foreach ($candidate in $candidateCommands) {
+        $resolvedCommand = & $GetCommand $candidate
+        if ($resolvedCommand) {
+            return $candidate
+        }
+    }
+
+    return $null
+}

--- a/tests/scripts/dev-tools/new-potential-entry.Tests.ps1
+++ b/tests/scripts/dev-tools/new-potential-entry.Tests.ps1
@@ -215,10 +215,13 @@ Describe "new-potential-entry.ps1 - Convert-TemplateContent" {
 Describe "new-potential-entry.ps1 - Invoke-VSCodeOpen" {
     BeforeAll {
         $script:scriptPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../scripts/dev-tools/new-potential-entry.ps1"
+        $script:vscodeHelperPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../scripts/dev-tools/vscode-cli.helpers.ps1"
     }
 
     Context "VS Code command detection and execution" {
         BeforeEach {
+            . (Import-ScriptFunction -Path $script:vscodeHelperPath -Name "Test-IsVSCodeInsidersSession")
+            . (Import-ScriptFunction -Path $script:vscodeHelperPath -Name "Resolve-VSCodeCliCommand")
             . (Import-ScriptFunction -Path $script:scriptPath -Name "Invoke-VSCodeOpen")
         }
 
@@ -244,6 +247,121 @@ Describe "new-potential-entry.ps1 - Invoke-VSCodeOpen" {
                 -StartProcess { param($FilePath, $ArgumentList) $FilePath | Should -Be 'code'; $ArgumentList | Should -Be $files }
 
             $result | Should -Be $true
+        }
+
+        It "prefers code-insiders when running in an Insiders session and both commands are available" {
+            $files = @("file1.md", "file2.md")
+            $originalTermProgramVersion = $env:TERM_PROGRAM_VERSION
+
+            try {
+                $env:TERM_PROGRAM_VERSION = "1.110.0-insider"
+                $result = Invoke-VSCodeOpen -Files $files `
+                    -GetCommand {
+                        param($Name)
+                        if ($Name -in @("code-insiders", "code")) {
+                            return [pscustomobject]@{ Name = $Name }
+                        }
+                        return $null
+                    } `
+                    -StartProcess {
+                        param($FilePath, $ArgumentList)
+                        $FilePath | Should -Be 'code-insiders'
+                        $ArgumentList | Should -Be $files
+                    }
+
+                $result | Should -Be $true
+            }
+            finally {
+                $env:TERM_PROGRAM_VERSION = $originalTermProgramVersion
+            }
+        }
+    }
+}
+
+Describe "vscode-cli.helpers.ps1 - Resolve-VSCodeCliCommand" {
+    BeforeAll {
+        $script:vscodeHelperPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../scripts/dev-tools/vscode-cli.helpers.ps1"
+    }
+
+    Context "Explicit command preference" {
+        BeforeEach {
+            . (Import-ScriptFunction -Path $script:vscodeHelperPath -Name "Test-IsVSCodeInsidersSession")
+            . (Import-ScriptFunction -Path $script:vscodeHelperPath -Name "Resolve-VSCodeCliCommand")
+        }
+
+        It "returns the explicitly requested command when available" {
+            $result = Resolve-VSCodeCliCommand -PreferredCommand "code" -GetCommand {
+                param($Name)
+                if ($Name -eq "code") {
+                    return [pscustomobject]@{ Name = $Name }
+                }
+
+                return $null
+            }
+
+            $result | Should -Be "code"
+        }
+
+        It "throws when the explicitly requested command is unavailable" {
+            {
+                Resolve-VSCodeCliCommand -PreferredCommand "code" -GetCommand { param($Name) $null = $Name; $null }
+            } | Should -Throw "*explicitly requested*"
+        }
+    }
+
+    Context "Automatic command selection" {
+        BeforeEach {
+            . (Import-ScriptFunction -Path $script:vscodeHelperPath -Name "Test-IsVSCodeInsidersSession")
+            . (Import-ScriptFunction -Path $script:vscodeHelperPath -Name "Resolve-VSCodeCliCommand")
+        }
+
+        It "prefers code-insiders when TERM_PROGRAM_VERSION indicates insiders" {
+            $result = Resolve-VSCodeCliCommand `
+                -GetCommand {
+                    param($Name)
+                    if ($Name -in @("code-insiders", "code")) {
+                        return [pscustomobject]@{ Name = $Name }
+                    }
+
+                    return $null
+                } `
+                -GetEnvironmentVariable {
+                    param($Name)
+                    if ($Name -eq "TERM_PROGRAM_VERSION") {
+                        return "1.110.0-insider"
+                    }
+
+                    return $null
+                }
+
+            $result | Should -Be "code-insiders"
+        }
+
+        It "falls back to code when insiders is preferred but unavailable" {
+            $result = Resolve-VSCodeCliCommand `
+                -GetCommand {
+                    param($Name)
+                    if ($Name -eq "code") {
+                        return [pscustomobject]@{ Name = $Name }
+                    }
+
+                    return $null
+                } `
+                -GetEnvironmentVariable {
+                    param($Name)
+                    if ($Name -eq "TERM_PROGRAM_VERSION") {
+                        return "1.110.0-insider"
+                    }
+
+                    return $null
+                }
+
+            $result | Should -Be "code"
+        }
+
+        It "returns null when no VS Code command is available" {
+            $result = Resolve-VSCodeCliCommand -GetCommand { param($Name) $null = $Name; $null }
+            $result | Should -Be $null
         }
     }
 }


### PR DESCRIPTION
- Add VS Code CLI helper to select code vs code-insiders and detect Insiders sessions
- Use resolved CLI command in new-potential-entry open logic and VSIX sideload installer
- Expand Pester coverage for Insiders preference, explicit command errors, and fallbacks