### PR TITLE
Bug/pylance-pyright-out-of-sync-#54

### DIFF
--- a/docs/features/potential/promoted/2026-02-23-pylance-pyright-out-of-sync.md
+++ b/docs/features/potential/promoted/2026-02-23-pylance-pyright-out-of-sync.md
@@ -1,0 +1,86 @@
+# pylance-pyright-out-of-sync (Issue #54)
+
+- Date captured: 2026-02-23
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/pylance-pyright-out-of-sync/ (Issue #54)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #54
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/54
+- Last Updated: 2026-02-23
+## Summary
+
+Pylance (strict mode) reports four Python diagnostics in this workspace that are not being surfaced by the `poetry run pyright --project pyproject.toml` quality gate. This creates a type-safety gap between editor feedback and CI/toolchain enforcement.
+
+We need to tighten `pyproject.toml` Pyright configuration so it is at least as strict as Pylance strict mode for this repo, then resolve the four currently reported diagnostics.
+
+## Environment
+
+- OS/version: Windows (workspace host)
+- Python version: 3.12 (from `pyproject.toml` / tool configuration)
+- Command/flags used: `poetry run pyright --project pyproject.toml` (passes), compared with VS Code Pylance strict diagnostics in-editor
+- Data source or fixture: Current repository workspace (`scripts/`, `src/`, `tests/`) including nested mirrored folder (`drm-copilot/`)
+
+## Steps to Reproduce
+
+1. Open the repository in VS Code with Pylance strict diagnostics enabled.
+2. Run `poetry run pyright --project pyproject.toml` from repo root and observe that Pyright does not report these four issues.
+3. Inspect the Diagnostics panel for Python and open the flagged files.
+4. Observe four Pylance diagnostics currently present:
+	- `scripts/dev_tools/agentic_sync.py` line 671: `Type of "payload" is partially unknown` (`dict[str, Unknown]`).
+	- `drm-copilot/scripts/dev_tools/agentic_sync.py` line 671: same partially unknown payload diagnostic.
+	- `drm-copilot/scripts/dev_tools/fix_all.py` line 546: `runner_factory` argument type identity mismatch (`drm-copilot.scripts...` vs `scripts...`).
+	- `drm-copilot/scripts/dev_tools/fix_all.py` line 547: `logger` argument type identity mismatch (`drm-copilot.scripts...` vs `scripts...`).
+
+## Expected Behavior
+
+Pyright configuration in `pyproject.toml` should be strict enough that `poetry run pyright --project pyproject.toml` reports the same (or stricter) actionable type issues that Pylance strict mode reports for tracked source files.
+
+Both editor-time and CI/toolchain-time type checking should agree on error visibility for the same codebase scope.
+
+## Actual Behavior
+
+Pylance reports four strict-mode diagnostics, but Pyright as currently configured does not fail on those issues in the normal project type-check path.
+
+Key error text observed in editor diagnostics includes:
+- `Type of "payload" is partially unknown` (`dict[str, Unknown]`)
+- `Argument of type "((str, StepLogger) -> CommandRunner) | None" cannot be assigned ...` with module-path identity mismatch (`drm-copilot.scripts...` vs `scripts...`)
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet:
+	- `scripts/dev_tools/agentic_sync.py:671` → `Type of "payload" is partially unknown` / `Type of "payload" is "dict[str, Unknown]"`
+	- `drm-copilot/scripts/dev_tools/fix_all.py:546-547` → incompatible argument type diagnostics due to cross-module type identity mismatch (`drm-copilot.scripts.dev_tools.fix_all.*` vs `scripts.dev_tools.fix_all.*`)
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+- `pyproject.toml` currently sets `typeCheckingMode = "strict"` but also relaxes at least one strict diagnostic (`reportMissingTypeArgument = "none"`), and may not be aligned with the effective strict profile Pylance is applying in-editor.
+- Workspace structure includes a nested mirrored repo folder (`drm-copilot/`) that appears to produce duplicated module identities (`scripts...` vs `drm-copilot.scripts...`) in diagnostics.
+- `agentic_sync.py` payload inference likely needs explicit typed payload models (e.g., typed dict/dataclass serialization boundaries) to avoid `Unknown` propagation.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas
+	- Add/adjust tests around `render_sync_summary` payload typing path in `scripts/dev_tools/agentic_sync.py`.
+	- Add/adjust tests around `run_fix_all` wrapper typing boundary in `scripts/dev_tools/fix_all.py` to keep public/runtime alias signatures consistent.
+- [ ] Integration scenario to retest
+	- Retest full Python QC sequence with stricter Pyright settings: `black` → `ruff` → `pyright --project pyproject.toml` → `pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`.
+	- Validate editor and CLI parity by confirming the four diagnostics are either surfaced by Pyright pre-fix and resolved post-fix.
+- [ ] Manual verification notes
+	- Update `[tool.pyright]` in `pyproject.toml` so effective strictness is equal to or greater than Pylance strict mode for this repo.
+	- Resolve the four current diagnostics (two payload/unknown-type entries, two module-identity argument-type mismatches).
+	- Confirm zero Pylance diagnostics for affected files and zero Pyright diagnostics in the final toolchain pass.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ exclude_lines = [
 
 [tool.pyright]
 typeCheckingMode = "strict"
-reportMissingTypeArgument = "none"
+reportMissingTypeArgument = "error"
 pythonVersion = "3.12"
 venvPath = "."
 venv = ".venv"
@@ -136,6 +136,7 @@ exclude = [
   ".idea",
   ".ruff_cache",
   ".venv",
+    "drm-copilot",
   "build",
     "dist",
     "node_modules"

--- a/scripts/dev_tools/agentic_sync.py
+++ b/scripts/dev_tools/agentic_sync.py
@@ -17,7 +17,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Literal, Protocol, TypedDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +30,32 @@ ROOT_FOLDERS: tuple[Path, ...] = (
 
 DecisionType = Literal["equivalent-mtime", "equivalent-content", "synced"]
 ForceDirection = Literal["left-to-right", "right-to-left"]
+
+
+class SyncActionPayload(TypedDict):
+    """JSON payload schema for a serialized ``SyncAction`` entry."""
+
+    root: str
+    relative_path: str
+    left_path: str
+    right_path: str
+    left_mtime: float
+    right_mtime: float
+    decision: DecisionType
+    source: str | None
+    sync_mtime: float | None
+    forced: bool
+
+
+class SyncSummaryPayload(TypedDict):
+    """JSON payload schema for a serialized ``SyncSummary`` artifact."""
+
+    repo_left: str
+    repo_right: str
+    started_at: str
+    finished_at: str
+    force_direction: ForceDirection | None
+    actions: list[SyncActionPayload]
 
 
 class SyncFileSystem(Protocol):
@@ -650,7 +676,7 @@ def render_sync_summary(summary: SyncSummary) -> str:
     """
 
     # Serialize dataclasses into JSON-friendly structures.
-    actions_payload: list[dict[str, object]] = []
+    actions_payload: list[SyncActionPayload] = []
     # Serialize actions in order to preserve traceability.
     for action in summary.actions:
         actions_payload.append(
@@ -668,7 +694,7 @@ def render_sync_summary(summary: SyncSummary) -> str:
             }
         )
 
-    payload = {
+    payload: SyncSummaryPayload = {
         "repo_left": summary.repo_left,
         "repo_right": summary.repo_right,
         "started_at": summary.started_at.isoformat(),

--- a/scripts/dev_tools/fix_all.py
+++ b/scripts/dev_tools/fix_all.py
@@ -9,7 +9,7 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, TextIO, cast
 
-from scripts.dev_tools.fix_all_runtime import run_fix_all as run_fix_all_runtime
+from .fix_all_runtime import run_fix_all as run_fix_all_runtime
 
 if TYPE_CHECKING:
     import threading
@@ -278,7 +278,7 @@ def is_vt_enabled_for_stream(stream: TextIO) -> bool:
     if windll is None:
         return False
 
-    kernel32 = cast(Kernel32Api, windll.kernel32)
+    kernel32 = cast("Kernel32Api", windll.kernel32)
     handle = kernel32.GetStdHandle(std_output_handle)
     if handle in (0, -1):
         return False

--- a/scripts/dev_tools/fix_all_runtime.py
+++ b/scripts/dev_tools/fix_all_runtime.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from scripts.dev_tools.fix_all import BranchResult, CommandRunner, StepLogger
+    from .fix_all import BranchResult, CommandRunner, StepLogger
 
 
 def run_fix_all(
@@ -22,7 +22,7 @@ def run_fix_all(
     complete_all: bool = False,
 ) -> int:
     """Run the fix-all pipeline in parallel branches."""
-    from scripts.dev_tools import fix_all as api
+    from . import fix_all as api
 
     step_logger = logger or api.StepLogger()
     cancel_event = threading.Event()

--- a/tests/scripts/dev_tools/test_pyright_config_alignment.py
+++ b/tests/scripts/dev_tools/test_pyright_config_alignment.py
@@ -1,0 +1,25 @@
+"""Regression tests for Pyright configuration alignment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _read_pyproject_text() -> str:
+    """Load and return the repository ``pyproject.toml`` text."""
+    pyproject_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    return pyproject_path.read_text(encoding="utf-8")
+
+
+def test_pyright_does_not_disable_missing_type_argument_reporting() -> None:
+    """Pyright strict config should not suppress missing type argument diagnostics."""
+    pyproject_text = _read_pyproject_text()
+    assert 'reportMissingTypeArgument = "none"' not in pyproject_text
+    assert 'reportMissingTypeArgument = "error"' in pyproject_text
+
+
+def test_pyright_excludes_nested_mirror_workspace_folder() -> None:
+    """Pyright config should exclude nested mirror workspace roots."""
+    pyproject_text = _read_pyproject_text()
+    # Keep this check explicit so duplicate-root regressions are caught quickly.
+    assert '  "drm-copilot",' in pyproject_text


### PR DESCRIPTION
- Enable missing type argument reporting in Pyright strict config
- Exclude nested mirror workspace root to avoid duplicate module identity
- Add typed payload schemas for agentic sync summary serialization
- Use package-relative imports in fix-all runtime boundary to prevent type mismatches
- Add regression tests to guard Pyright config alignment

Closes: #54