### PR TITLE
(fix(orchestration)): enforce short-path promotion, planning, and audit flow

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -1,13 +1,17 @@
 ---
 name: orchestrator
 model: GPT-5.3-Codex (copilot)
-description: Orchestrate end-to-end feature/bug delivery by estimating change budget, routing small changes directly to a typed engineer, and routing larger efforts through scope → promotion → research/spec → atomic planning/execution → feature review until complete.
+description: Orchestrate end-to-end feature/bug delivery by estimating change budget, routing small changes through promotion -> folder -> minimal-plan -> development -> QC -> small-audit, and routing larger efforts through scope -> promotion -> research -> spec -> atomic planning -> atomic execution -> feature review until complete.
 argument-hint: "Provide objective, affected files (if known), and whether this is likely bug or feature. The orchestrator will estimate change budget, choose the workflow path, delegate to specialist agents, and persist until completion."
 tools: [execute, read, edit, search, agent, web, todo]
 handoffs:
   - label: Small-scope implementation path
     agent: python-typed-engineer
-    prompt: "Estimate and confirm scope (1-3 production Python files + corresponding tests). If confirmed, complete end-to-end workflow: baseline, planning (including atomic plan creation and preflight readiness), implementation, QA gates, and final report with Ruff/Pyright/test/coverage deltas."
+    prompt: "Estimate and confirm scope (1-3 production Python files + corresponding tests). If confirmed, execute the short-path development phase against the provided `${feature-folder}` and minimal plan context: baseline capture, implementation, and full QA gates with final Ruff/Pyright/test/coverage deltas."
+    send: true
+  - label: Post-implementation small-path audit
+    agent: feature_code_review_agent
+    prompt: "Use `.github/prompts/review-feature.prompt.md` for `${feature-folder}` in short-path/minor-audit mode. Generate reduced audit artifacts required for short path (policy + feature acceptance focus) and trigger remediation planning only if required by that reduced gate."
     send: true
   - label: Fill potential entry details
     agent: prd_feature
@@ -97,17 +101,66 @@ Use these reusable skills to avoid duplicating shared operations:
 
 ## Small path (budget 1-3 production files and 1-3 test files)
 
-Delegate directly to `python-typed-engineer` using handoff **Small-scope implementation path**.
+Follow this exact sequence.
+
+### Step S1 — Scope potential feature/bug
+
+S1.1 Determine type and set `${promotion-type}`:
+- `feature` or `bug`
+
+S1.2 Generate `${short-name}`:
+- lowercase slug, hyphen-separated
+
+S1.3 Ensure potential entry exists using exact command by type when missing:
+- If `${promotion-type}` is `feature`:
+  - `${workspaceFolder}/scripts/dev-tools/new-potential-entry.ps1 -ShortName ${short-name}`
+- If `${promotion-type}` is `bug`:
+  - `${workspaceFolder}/scripts/dev_tools/new_potential_bug_entry.py --short-name ${short-name}`
+
+S1.4 Detect created/existing potential markdown file path and save as `${relativeFile}`.
+
+### Step S2 — Promote with short-path flag
+
+S2.1 Promote to issue using existing tooling with short-path flag set:
+- `poetry run python -m scripts.dev_tools.potential_to_issue --potential-path ${relativeFile} --promotion-type ${promotion-type} --work-mode minor-audit`
+
+S2.2 Set `${long-name}` from `${relativeFile}` filename without `.md`.
+
+S2.3 Parse promoted document to capture `${issue-num}`.
+
+S2.4 Create branch with exact name:
+- `${promotion-type}/${short-name}-${issue-num}`
+
+S2.5 Create active feature folder with short-path flag set:
+- `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name ${long-name} --type ${promotion-type} --issue-number ${issue-num} --work-mode minor-audit`
+
+S2.6 Capture created folder path as `${feature-folder}`.
+
+### Step S3 — Create minimal short-path plan
+
+Create a minimal plan artifact in `${feature-folder}` that includes:
+- baseline capture tasks,
+- explicit delegation task for handoff **Small-scope implementation path**,
+- final QC task block (format/lint/type/test as applicable).
+
+### Step S4 — Delegate short-path development
+
+Delegate to `python-typed-engineer` using handoff **Small-scope implementation path**.
 
 Required delegation expectations:
-- plan + execute end-to-end,
+- baseline + implementation + QA closure,
 - strict QA gates,
 - final Ruff/Pyright/test/coverage deltas,
-- completion report.
+- completion report referencing `${feature-folder}` and the minimal plan.
 
-After handoff completion:
-- record completion in checkpoint,
-- provide concise final outcome to user.
+### Step S5 — Validate QC and run reduced audit
+
+S5.1 Confirm short-path QC completion from delegate output.
+
+S5.2 Delegate handoff **Post-implementation small-path audit**.
+
+Hard enforcement for S5:
+- Do not mark small path complete until reduced audit artifacts are present in `${feature-folder}`.
 
 ---
 
@@ -205,7 +258,11 @@ On each invocation:
 4. If user explicitly asks to restart:
    - reset checkpoint and start at Phase 0.
 
-Checkpoint writes are mandatory after each completed sub-step in the large path sequence and after final completion in the small path.
+Checkpoint writes are mandatory after each completed sub-step in the large and small path sequences and after final completion.
+
+Artifact verification gate before mission completion (small path):
+- At least one short-path `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
+- At least one short-path `feature-audit.<timestamp>.md` exists under `${feature-folder}`.
 
 Artifact verification gate before mission completion (large path):
 - At least one `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
@@ -218,7 +275,7 @@ Artifact verification gate before mission completion (large path):
 You are complete only when:
 - selected path has run end-to-end,
 - all required delegations completed,
-- feature review completed (large path),
+- feature review completed (large path) or reduced small-path audit completed (small path),
 - checkpoint indicates completed mission,
 - user receives concise summary with produced paths/artifacts and branch info.
 

--- a/.github/agents/powershell-orchestrator.agent.md
+++ b/.github/agents/powershell-orchestrator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: powershell-orchestrator
 model: GPT-5.3-Codex (copilot)
-description: Orchestrate end-to-end PowerShell feature/bug delivery by estimating change budget, routing small changes directly to powershell-typed-engineer, and routing larger efforts through scope → promotion → research/spec → atomic planning/execution → feature review until complete.
+description: Orchestrate end-to-end PowerShell feature/bug delivery by estimating change budget, routing small changes through promotion -> folder -> minimal-plan -> development -> QC -> small-audit, and routing larger efforts through scope -> promotion -> research -> spec -> atomic planning -> atomic execution -> feature review until complete.
 argument-hint: "Provide objective, affected files (if known), and whether this is likely bug or feature. The orchestrator will estimate change budget, choose the workflow path, delegate to specialist agents, and persist until completion."
 target: vscode
 tools: ['execute/getTerminalOutput', 'execute/runTask', 'execute/createAndRunTask', 'execute/runInTerminal', 'read/terminalSelection', 'read/terminalLastCommand', 'read/getTaskOutput', 'read/problems', 'read/readFile', 'agent', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web', 'todo']

--- a/.github/agents/python-orchestrator.agent.md
+++ b/.github/agents/python-orchestrator.agent.md
@@ -1,13 +1,17 @@
 ---
 name: python-orchestrator
 model: GPT-5.3-Codex (copilot)
-description: Orchestrate end-to-end Python feature/bug delivery by estimating change budget, routing small changes directly to python-typed-engineer, and routing larger efforts through scope → promotion → research/spec → atomic planning/execution → feature review until complete.
+description: Orchestrate end-to-end Python feature/bug delivery by estimating change budget, routing small changes through promotion -> folder -> minimal-plan -> development -> QC -> small-audit, and routing larger efforts through scope -> promotion -> research -> spec -> atomic planning -> atomic execution -> feature review until complete.
 argument-hint: "Provide objective, affected files (if known), and whether this is likely bug or feature. The orchestrator will estimate change budget, choose the workflow path, delegate to specialist agents, and persist until completion."
 tools: ['execute/getTerminalOutput', 'execute/runTask', 'execute/createAndRunTask', 'execute/runInTerminal', 'read/terminalSelection', 'read/terminalLastCommand', 'read/getTaskOutput', 'read/problems', 'read/readFile', 'agent', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web', 'todo']
 handoffs:
   - label: Small-scope implementation path
     agent: python-typed-engineer
-    prompt: "Estimate and confirm scope (1-3 production Python files + corresponding tests). If confirmed, complete end-to-end workflow: baseline, planning (including atomic plan creation and preflight readiness), implementation, QA gates, and final report with Ruff/Pyright/test/coverage deltas."
+    prompt: "Estimate and confirm scope (1-3 production Python files + corresponding tests). If confirmed, execute the short-path development phase against the provided `${feature-folder}` and minimal plan context: baseline capture, implementation, and full QA gates with final Ruff/Pyright/test/coverage deltas."
+    send: true
+  - label: Post-implementation small-path audit
+    agent: feature_code_review_agent
+    prompt: "Use `.github/prompts/review-feature.prompt.md` for `${feature-folder}` in short-path/minor-audit mode. Generate reduced audit artifacts required for short path (policy + feature acceptance focus) and trigger remediation planning only if required by that reduced gate."
     send: true
   - label: Fill potential entry details
     agent: prd_feature
@@ -97,17 +101,66 @@ Use these reusable skills to avoid duplicating shared operations:
 
 ## Small path (budget 1-3 production Python files and 1-3 test Python files)
 
-Delegate directly to `python-typed-engineer` using handoff **Small-scope implementation path**.
+Follow this exact sequence.
+
+### Step S1 — Scope potential feature/bug
+
+S1.1 Determine type and set `${promotion-type}`:
+- `feature` or `bug`
+
+S1.2 Generate `${short-name}`:
+- lowercase slug, hyphen-separated
+
+S1.3 Ensure potential entry exists using exact command by type when missing:
+- If `${promotion-type}` is `feature`:
+  - `${workspaceFolder}/scripts/dev-tools/new-potential-entry.ps1 -ShortName ${short-name}`
+- If `${promotion-type}` is `bug`:
+  - `${workspaceFolder}/scripts/dev_tools/new_potential_bug_entry.py --short-name ${short-name}`
+
+S1.4 Detect created/existing potential markdown file path and save as `${relativeFile}`.
+
+### Step S2 — Promote with short-path flag
+
+S2.1 Promote to issue using existing tooling with short-path flag set:
+- `poetry run python -m scripts.dev_tools.potential_to_issue --potential-path ${relativeFile} --promotion-type ${promotion-type} --work-mode minor-audit`
+
+S2.2 Set `${long-name}` from `${relativeFile}` filename without `.md`.
+
+S2.3 Parse promoted document to capture `${issue-num}`.
+
+S2.4 Create branch with exact name:
+- `${promotion-type}/${short-name}-${issue-num}`
+
+S2.5 Create active feature folder with short-path flag set:
+- `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name ${long-name} --type ${promotion-type} --issue-number ${issue-num} --work-mode minor-audit`
+
+S2.6 Capture created folder path as `${feature-folder}`.
+
+### Step S3 — Create minimal short-path plan
+
+Create a minimal plan artifact in `${feature-folder}` that includes:
+- baseline capture tasks,
+- explicit delegation task for handoff **Small-scope implementation path**,
+- final QC task block (Black → Ruff → Pyright → Pytest as applicable).
+
+### Step S4 — Delegate short-path development
+
+Delegate to `python-typed-engineer` using handoff **Small-scope implementation path**.
 
 Required delegation expectations:
-- plan + execute end-to-end,
+- baseline + implementation + QA closure,
 - strict QA gates,
 - final Ruff/Pyright/test/coverage deltas,
-- completion report.
+- completion report referencing `${feature-folder}` and the minimal plan.
 
-After handoff completion:
-- record completion in checkpoint,
-- provide concise final outcome to user.
+### Step S5 — Validate QC and run reduced audit
+
+S5.1 Confirm short-path QC completion from delegate output.
+
+S5.2 Delegate handoff **Post-implementation small-path audit**.
+
+Hard enforcement for S5:
+- Do not mark small path complete until reduced audit artifacts are present in `${feature-folder}`.
 
 ---
 
@@ -205,7 +258,11 @@ On each invocation:
 4. If user explicitly asks to restart:
    - reset checkpoint and start at Phase 0.
 
-Checkpoint writes are mandatory after each completed sub-step in the large path sequence and after final completion in the small path.
+Checkpoint writes are mandatory after each completed sub-step in the large and small path sequences and after final completion.
+
+Artifact verification gate before mission completion (small path):
+- At least one short-path `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
+- At least one short-path `feature-audit.<timestamp>.md` exists under `${feature-folder}`.
 
 Artifact verification gate before mission completion (large path):
 - At least one `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
@@ -218,7 +275,7 @@ Artifact verification gate before mission completion (large path):
 You are complete only when:
 - selected path has run end-to-end,
 - all required delegations completed,
-- feature review completed (large path),
+- feature review completed (large path) or reduced small-path audit completed (small path),
 - checkpoint indicates completed mission,
 - user receives concise summary with produced paths/artifacts and branch info.
 

--- a/.github/skills/atomic-plan-contract/SKILL.md
+++ b/.github/skills/atomic-plan-contract/SKILL.md
@@ -20,6 +20,26 @@ Use this skill when:
 - Tasks must start with: `- [ ] [P#-T#]` (or `[x]` for completed)
 - Task IDs must match their phase and be sequential per phase.
 
+## Short-Path Minimal Plan Contract
+
+When orchestration selects short path, a minimal plan is still mandatory and must include these blocks:
+
+1) Baseline capture block
+- policy reads in required order,
+- baseline toolchain/test state capture for touched language(s).
+
+2) Delegated implementation block
+- explicit handoff task to the small-path implementation engineer,
+- acceptance criteria for implementation completion.
+
+3) Final QC block
+- full language-appropriate QA loop (format → lint → type-check when applicable → test),
+- rerun behavior when any step changes files or fails.
+
+4) Reduced audit block
+- explicit post-implementation small-audit handoff,
+- reduced artifact checks required by short-path policy.
+
 ## Phase 0 Requirements
 
 Phase 0 must include tasks to read policy files in the order defined in `policy-compliance-order`.

--- a/.github/skills/feature-promotion-lifecycle/SKILL.md
+++ b/.github/skills/feature-promotion-lifecycle/SKILL.md
@@ -11,6 +11,7 @@ Canonical variable model and command sequence for promoting potential feature/bu
 
 Use this skill when:
 - A large-scope change requires feature/bug promotion workflow.
+- A short-path workflow still requires promotion/folder initialization before delegated implementation.
 - An orchestrator must create potential docs, promote to issue, branch, and active feature folder.
 - Downstream research/spec agents depend on deterministic paths and identifiers.
 
@@ -23,6 +24,7 @@ Use this skill when:
 - `${issue-num}`: promoted GitHub issue number
 - `${feature-folder}`: active feature folder path
 - `${work-mode}`: `full` or `minor-audit`
+- `${short-path-flag}`: `--work-mode minor-audit` (mandatory for short-path promotion/folder creation)
 
 ## Canonical Command Sequence
 
@@ -38,6 +40,25 @@ Use this skill when:
 
 4) Create active feature folder:
 - `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name ${long-name} --type ${promotion-type} --issue-number ${issue-num} --work-mode ${work-mode}`
+
+## Canonical Short-Path Sequence (Minor Audit Mode)
+
+When orchestrator routing selects short path, promotion/folder initialization still occurs and MUST use `minor-audit` mode.
+
+1) Promote potential doc with short-path flag:
+- `poetry run python -m scripts.dev_tools.potential_to_issue --potential-path ${relativeFile} --promotion-type ${promotion-type} --work-mode minor-audit`
+
+2) Create branch:
+- `${promotion-type}/${short-name}-${issue-num}`
+
+3) Create active feature folder with short-path flag:
+- `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name ${long-name} --type ${promotion-type} --issue-number ${issue-num} --work-mode minor-audit`
+
+4) Create minimal short-path plan in `${feature-folder}` containing:
+- baseline capture,
+- delegation task for the small-path implementation engineer,
+- final QC block,
+- reduced small-audit handoff after implementation.
 
 ## Required Outputs for Downstream Handoffs
 

--- a/.github/skills/powershell-change-budget-router/SKILL.md
+++ b/.github/skills/powershell-change-budget-router/SKILL.md
@@ -21,6 +21,16 @@ Use this skill when:
 - `1-2` production files (+ corresponding tests) → **small path** (`powershell-typed-engineer` direct mode).
 - `>2` production files → **large path** (`powershell-orchestrator`).
 
+## Orchestrated Small-Path Requirements
+
+When routed through `powershell-orchestrator`, small path still requires lifecycle scaffolding before implementation:
+- promote potential item to GitHub issue with `--work-mode minor-audit`,
+- create active feature folder with `--work-mode minor-audit`,
+- create a minimal short-path plan (baseline, delegated implementation, QC, reduced audit),
+- run reduced small-audit after implementation and QC.
+
+Direct invocation of `powershell-typed-engineer` remains implementation-focused and does not replace orchestrator lifecycle steps.
+
 ## Direct-Mode Rejection Rule
 
 If `powershell-typed-engineer` is invoked directly and estimated scope is `>2` production files:

--- a/.github/skills/powershell-orchestration-state-machine/SKILL.md
+++ b/.github/skills/powershell-orchestration-state-machine/SKILL.md
@@ -29,9 +29,15 @@ Use this skill when:
 - `long-name`
 - `issue-num`
 - `feature-folder`
+- `work-mode` (`full` or `minor-audit`)
+- `plan-path` (minimal or full plan path)
 - `completed_steps`
 - `next_step`
 - `last_updated`
+
+For short-path runs, also persist:
+- `small_path_qc_summary`
+- `small_path_audit_artifacts`
 
 ## Update Protocol
 


### PR DESCRIPTION
- Require short-path runs to promote potential entries with minor-audit mode, create active folders, and execute minimal-plan baseline/QC/audit gates across orchestrator contracts and shared skills
- Add a dedicated small-path post-implementation audit handoff and short-path artifact/state expectations for completion checks
- Correct extension package identity to use drm-copilot and add a regression test asserting canonical manifest name/displayName
- Capture the extension naming defect in a drafted potential bug report for downstream promotion