### PR TITLE
Add acceptance-criteria tracking and canonical full-feature/full-bug work modes

### DIFF
--- a/.github/agents/atomic_executor.agent.md
+++ b/.github/agents/atomic_executor.agent.md
@@ -17,6 +17,7 @@ If you believe the plan is incomplete or non-executable, you must **stop before 
 Use these reusable skills to avoid duplicating shared operations:
 - `policy-compliance-order`
 - `atomic-plan-contract`
+- `acceptance-criteria-tracking`
 
 ---
 
@@ -77,9 +78,11 @@ Use `atomic-plan-contract` as the system-of-record for mode gate behavior, inclu
 During preflight (before [P0-T1]), resolve work mode from feature `issue.md` marker first:
 
 - `- Work Mode: minor-audit`
-- `- Work Mode: full`
+- `- Work Mode: full-feature`
+- `- Work Mode: full-bug`
+- legacy `- Work Mode: full` => interpret as `full-feature`
 
-If the marker is missing or malformed, fail closed to `full`.
+If the marker is missing or malformed, fail closed to `full-feature`.
 
 When selected mode is `minor-audit`, preflight MUST reject plans that do not include explicit baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks. In these cases return:
 
@@ -192,6 +195,9 @@ Start with:
 ### 3.5 Check-off rules (binary)
 - Only mark the task `[x]` when verification passes.
 - If partial progress exists but acceptance criteria do not pass, leave it unchecked.
+
+### 3.5.1 Acceptance criteria check-off (requirement source files)
+After verifying a plan task, determine whether the completed work satisfies any acceptance criteria in the resolved AC source file(s) per `acceptance-criteria-tracking`. If so, check off the corresponding `- [ ]` items in those source files immediately and report the check-off. At plan completion, include the AC Status Summary defined in `acceptance-criteria-tracking`.
 
 ### 3.6 Progress reporting
 At the end of each message, include an updated copy of the plan’s checklist (or at least the current phase + next 5 upcoming tasks), with completed tasks checked off.

--- a/.github/agents/atomic_planning.agent.md
+++ b/.github/agents/atomic_planning.agent.md
@@ -92,11 +92,13 @@ When planning from a feature folder, resolve the selected work mode in this exac
 
 1. Persisted marker in `issue.md` metadata block:
    - `- Work Mode: minor-audit`
-   - `- Work Mode: full`
-2. Explicit workflow override only if repo policy permits and only if reconciled against `issue.md`.
-3. fail closed to `full` when the marker is missing or malformed.
+   - `- Work Mode: full-feature`
+   - `- Work Mode: full-bug`
+2. Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`.
+3. Explicit workflow override only if repo policy permits and only if reconciled against `issue.md`.
+4. fail closed to `full-feature` when the marker is missing or malformed.
 
-For `minor-audit`, preflight-required plan gates MUST include baseline evidence, targeted verification evidence, and end-state evidence tasks. For `full`, retain full-document and full QA obligations.
+For `minor-audit`, preflight-required plan gates MUST include baseline evidence, targeted verification evidence, and end-state evidence tasks. For `full-feature`, retain full-document and full QA obligations. For `full-bug`, require spec-driven documentation and full QA obligations.
 
 ---
 

--- a/.github/agents/csharp-atomic-executor.agent.md
+++ b/.github/agents/csharp-atomic-executor.agent.md
@@ -17,6 +17,13 @@ You are an **execution-only agent**. Execute an `atomic_planner` plan exactly as
 
 If the plan is incomplete or non-executable, stop only during preflight and request a plan delta.
 
+# Shared skills (apply before proceeding)
+
+Use these reusable skills to avoid duplicating shared operations:
+- `policy-compliance-order`
+- `atomic-plan-contract`
+- `acceptance-criteria-tracking`
+
 # Core behavior
 
 ## 1) Plan is authoritative
@@ -29,8 +36,10 @@ Before any execution, validate plan structure and policy compatibility:
 
 - Resolve mode from `issue.md` marker first:
   - `- Work Mode: minor-audit`
-  - `- Work Mode: full`
-- If marker is missing or malformed, fail closed to `full`.
+  - `- Work Mode: full-feature`
+  - `- Work Mode: full-bug`
+  - legacy `- Work Mode: full` => interpret as `full-feature`
+- If marker is missing or malformed, fail closed to `full-feature`.
 - When selected mode is `minor-audit`, reject plans that do not include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 
 - Canonical headings: `### Phase N — <Title>`
@@ -99,6 +108,7 @@ At completion, report:
 - type-check delta
 - failing test delta
 - per-file coverage delta (and overall if applicable)
+- AC Status Summary per `acceptance-criteria-tracking`
 - final updated checklist status
 
 # Blocking protocol

--- a/.github/agents/csharp-atomic-planning.agent.md
+++ b/.github/agents/csharp-atomic-planning.agent.md
@@ -93,14 +93,17 @@ Use the `atomic-plan-contract` skill as the system-of-record for plan format, Ph
 When planning from a feature folder, resolve mode from `issue.md` marker first:
 
 - `- Work Mode: minor-audit`
-- `- Work Mode: full`
+- `- Work Mode: full-feature`
+- `- Work Mode: full-bug`
+- legacy `- Work Mode: full` => interpret as `full-feature`
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Branch-specific required task sets:
 
 - `minor-audit`: include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
-- `full`: retain full-document expectations and full QA obligations.
+- `full-feature`: retain full-document expectations and full QA obligations.
+- `full-bug`: require spec-driven expectations and full QA obligations.
 
 ---
 

--- a/.github/agents/csharp-orchestrator.agent.md
+++ b/.github/agents/csharp-orchestrator.agent.md
@@ -24,7 +24,7 @@ handoffs:
     send: true
   - label: Execute approved C# atomic plan
     agent: csharp-atomic-executor
-    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce C# quality gates from agent policy.\n4) Complete final QA loop (format → analyze/lint → type-check → test) and report analyzer/type/test/coverage deltas.\n\nOutput requirements:\n- execution summary\n- QA summary\n- analyzer/type/test/coverage deltas\n- updated plan checklist state"
+    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce C# quality gates from agent policy.\n4) Complete final QA loop (format → analyze/lint → type-check → test) and report analyzer/type/test/coverage deltas.\n5) Track and check off acceptance criteria in AC source files per `acceptance-criteria-tracking` as tasks deliver verified work. Include AC Status Summary at completion.\n\nOutput requirements:\n- execution summary\n- QA summary\n- analyzer/type/test/coverage deltas\n- AC Status Summary\n- updated plan checklist state"
     send: true
   - label: Post-implementation feature review
     agent: feature_code_review_agent
@@ -46,6 +46,7 @@ Use these reusable skills to avoid duplicating shared operations:
 - `csharp-change-budget-router`
 - `csharp-orchestration-state-machine`
 - `feature-promotion-lifecycle`
+- `acceptance-criteria-tracking`
 
 # Non-negotiable mission behavior
 

--- a/.github/agents/epic-review.agent.md
+++ b/.github/agents/epic-review.agent.md
@@ -129,11 +129,14 @@ If the epic deviates from this shape, continue anyway and document deviations.
 ## 2.5) Work-mode marker contract and doc completeness
 - Read work mode from `issue.md` using the persisted marker line:
   - `- Work Mode: minor-audit`
-  - `- Work Mode: full`
+  - `- Work Mode: full-feature`
+  - `- Work Mode: full-bug`
+- Legacy compatibility: if `issue.md` still contains `- Work Mode: full`, interpret it as `full-feature`.
 - Branch doc completeness and AC extraction by marker:
   - For `Work Mode: minor-audit`, `spec.md` and `user-story.md` may be absent by design; use `issue.md` as the AC source.
-  - For `Work Mode: full`, require and evaluate `spec.md` and `user-story.md` as AC sources.
-- Fail closed: if the marker is missing or malformed, fallback to full behavior for doc completeness and AC extraction.
+  - For `Work Mode: full-feature`, require and evaluate `spec.md` and `user-story.md` as AC sources.
+  - For `Work Mode: full-bug`, require and evaluate `spec.md` as the AC source; do not require `user-story.md` unless the docs explicitly justify it.
+- Fail closed: if the marker is missing or malformed, fallback to `full-feature` behavior for doc completeness and AC extraction.
 
 ## 3) Version selection rule (deterministic)
 For each feature folder:

--- a/.github/agents/feature-review.agent.md
+++ b/.github/agents/feature-review.agent.md
@@ -35,6 +35,7 @@ Use these reusable skills to avoid duplicating shared operations:
 - `policy-audit-template-usage`
 - `remediation-handoff-atomic-planner`
  - `pr-context-artifacts`
+- `acceptance-criteria-tracking`
 
 # Constraints (feature review)
 
@@ -60,11 +61,14 @@ Use these reusable skills to avoid duplicating shared operations:
 ## 3) Work-mode marker contract (deterministic)
 - Read the persisted marker from `issue.md` using the exact line format:
    - `- Work Mode: minor-audit`
-   - `- Work Mode: full`
+   - `- Work Mode: full-feature`
+   - `- Work Mode: full-bug`
+- Legacy compatibility: if `issue.md` still contains `- Work Mode: full`, interpret it as `full-feature`.
 - Branch acceptance-criteria (AC) source by marker value:
    - When `Work Mode: minor-audit`, treat `issue.md` as the AC source of truth.
-   - When `Work Mode: full`, treat `spec.md` and `user-story.md` as AC sources of truth.
-- Fail closed: if marker is missing or malformed, fallback to full mode behavior (`spec.md` + `user-story.md`).
+   - When `Work Mode: full-feature`, treat `spec.md` and `user-story.md` as AC sources of truth.
+   - When `Work Mode: full-bug`, treat `spec.md` as the AC source of truth.
+- Fail closed: if marker is missing or malformed, fallback to `full-feature` behavior (`spec.md` + `user-story.md`).
 
 
 # Execution plan (phased, deterministic)
@@ -193,6 +197,11 @@ Create `<FEATURE_FOLDER>/feature-audit.<timestamp>.md` (same timestamp) with:
    - Overall feature readiness: PASS / NEEDS REVISION / BLOCKED
    - Top gaps preventing PASS (if any)
    - Recommended follow-up verification steps (only when UNVERIFIED criteria exist)
+
+5) Acceptance criteria check-off
+   - For each criterion evaluated as **PASS**, check it off in the AC source file(s) per `acceptance-criteria-tracking` (change `- [ ]` to `- [x]`).
+   - For criteria evaluated as PARTIAL, FAIL, or UNVERIFIED, leave them unchecked.
+   - Include the AC Status Summary defined in `acceptance-criteria-tracking`.
 
 ## Phase G — Remediation (only if necessary)
 Trigger remediation if ANY of the following:

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -19,7 +19,7 @@ handoffs:
     send: true
   - label: Validate small-path delivery and post-QC docs
     agent: atomic_executor
-    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, and produce post-QC validation documentation deltas. If validation fails, return precise remediation deltas."
+    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, check off delivered acceptance criteria in AC source files per `acceptance-criteria-tracking`, and produce post-QC validation documentation deltas. If validation fails, return precise remediation deltas."
     send: true
   - label: Post-implementation small-path audit
     agent: feature_code_review_agent
@@ -43,7 +43,7 @@ handoffs:
     send: true
   - label: Execute approved atomic plan
     agent: atomic_executor
-    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce quality gates and suppression constraints from applicable repo policies.\n4) Complete final QA loop for every language command task explicitly present in the approved plan and report lint/type/test/coverage deltas; do not treat SKIPPED as success for final-QC command tasks unless the plan task text explicitly authorizes SKIPPED.\n5) When language policy requires coverage, execute coverage-enabled test commands and produce numeric baseline/post/new-code coverage results; if those metrics are missing, mark execution as remediation-required rather than PASS.\n\nOutput requirements:\n- execution summary\n- QA summary\n- lint/type/test/coverage deltas\n- updated plan checklist state"
+    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce quality gates and suppression constraints from applicable repo policies.\n4) Complete final QA loop for every language command task explicitly present in the approved plan and report lint/type/test/coverage deltas; do not treat SKIPPED as success for final-QC command tasks unless the plan task text explicitly authorizes SKIPPED.\n5) When language policy requires coverage, execute coverage-enabled test commands and produce numeric baseline/post/new-code coverage results; if those metrics are missing, mark execution as remediation-required rather than PASS.\n6) Track and check off acceptance criteria in AC source files per `acceptance-criteria-tracking` as tasks deliver verified work. Include AC Status Summary at completion.\n\nOutput requirements:\n- execution summary\n- QA summary\n- lint/type/test/coverage deltas\n- AC Status Summary\n- updated plan checklist state"
     send: true
   - label: Post-implementation feature review
     agent: feature_code_review_agent
@@ -65,6 +65,7 @@ Use these reusable skills to avoid duplicating shared operations:
 - `pr-base-branch-merge-base`
 - `feature-promotion-lifecycle`
 - `atomic-plan-contract`
+- `acceptance-criteria-tracking`
 
 # Non-negotiable mission behavior
 

--- a/.github/agents/powershell-atomic-executor.agent.md
+++ b/.github/agents/powershell-atomic-executor.agent.md
@@ -17,6 +17,13 @@ You are an **execution-only agent**. Execute an `atomic_planner` plan exactly as
 
 If the plan is incomplete or non-executable, stop only during preflight and request a plan delta.
 
+# Shared skills (apply before proceeding)
+
+Use these reusable skills to avoid duplicating shared operations:
+- `policy-compliance-order`
+- `atomic-plan-contract`
+- `acceptance-criteria-tracking`
+
 # Core behavior
 
 ## 1) Plan is authoritative
@@ -29,8 +36,10 @@ Before any execution, validate plan structure and policy compatibility:
 
 - Resolve mode from `issue.md` marker first:
 	- `- Work Mode: minor-audit`
-	- `- Work Mode: full`
-- If marker is missing or malformed, fail closed to `full`.
+	- `- Work Mode: full-feature`
+	- `- Work Mode: full-bug`
+	- legacy `- Work Mode: full` => interpret as `full-feature`
+- If marker is missing or malformed, fail closed to `full-feature`.
 - Enforce minor-audit evidence-task gate before execution when selected mode is `minor-audit`.
 - When selected mode is `minor-audit`, reject plans that do not include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 
@@ -99,6 +108,7 @@ At completion, report:
 - analyzer delta
 - failing test delta
 - per-file coverage delta (and overall if applicable)
+- AC Status Summary per `acceptance-criteria-tracking`
 - final updated checklist status
 
 # Blocking protocol

--- a/.github/agents/powershell-atomic-planning.agent.md
+++ b/.github/agents/powershell-atomic-planning.agent.md
@@ -91,16 +91,18 @@ Use the `atomic-plan-contract` skill as the system-of-record for plan format, Ph
 
 When planning from a feature folder, resolve mode using this ordered precedence:
 
-- Persisted marker in `issue.md` (`- Work Mode: minor-audit` or `- Work Mode: full`)
+- Persisted marker in `issue.md` (`- Work Mode: minor-audit`, `- Work Mode: full-feature`, or `- Work Mode: full-bug`)
+- Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`
 - Explicit workflow override only if repo policy allows and only if reconciled against issue.md
-- fail closed to full when marker is missing or malformed
+- fail closed to `full-feature` when marker is missing or malformed
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Branch-specific required task sets:
 
 - `minor-audit`: include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
-- `full`: retain full-document expectations and full QA obligations.
+- `full-feature`: retain full-document expectations and full QA obligations.
+- `full-bug`: require spec-driven expectations and full QA obligations.
 
 ---
 

--- a/.github/agents/powershell-orchestrator.agent.md
+++ b/.github/agents/powershell-orchestrator.agent.md
@@ -20,7 +20,7 @@ handoffs:
     send: true
   - label: Validate small-path delivery and post-QC docs
     agent: atomic_executor
-    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, and produce post-QC validation documentation deltas. If validation fails, return precise remediation deltas."
+    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, check off delivered acceptance criteria in AC source files per `acceptance-criteria-tracking`, and produce post-QC validation documentation deltas. If validation fails, return precise remediation deltas."
     send: true
   - label: Post-implementation small-path audit
     agent: feature_code_review_agent
@@ -44,7 +44,7 @@ handoffs:
     send: true
   - label: Execute approved PowerShell atomic plan
     agent: powershell_atomic_executor
-    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce PowerShell quality gates and DI/mocking constraints from agent policy.\n4) Complete final QA loop (format → analyze → test, plus coverage when enforced) and report analyzer/test/coverage deltas.\n\nOutput requirements:\n- execution summary\n- QA summary\n- analyzer/test/coverage deltas\n- updated plan checklist state"
+    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce PowerShell quality gates and DI/mocking constraints from agent policy.\n4) Complete final QA loop (format → analyze → test, plus coverage when enforced) and report analyzer/test/coverage deltas.\n5) Track and check off acceptance criteria in AC source files per `acceptance-criteria-tracking` as tasks deliver verified work. Include AC Status Summary at completion.\n\nOutput requirements:\n- execution summary\n- QA summary\n- analyzer/test/coverage deltas\n- AC Status Summary\n- updated plan checklist state"
     send: true
   - label: Post-implementation feature review
     agent: feature_code_review_agent
@@ -67,6 +67,7 @@ Use these reusable skills to avoid duplicating shared operations:
 - `powershell-change-budget-router`
 - `powershell-orchestration-state-machine`
 - `feature-promotion-lifecycle`
+- `acceptance-criteria-tracking`
 
 # Non-negotiable mission behavior
 

--- a/.github/agents/python-atomic-executor.agent.md
+++ b/.github/agents/python-atomic-executor.agent.md
@@ -17,6 +17,13 @@ You are an **execution-only agent**. Execute an `atomic_planner` plan exactly as
 
 If the plan is incomplete or non-executable, stop only during preflight and request a plan delta.
 
+# Shared skills (apply before proceeding)
+
+Use these reusable skills to avoid duplicating shared operations:
+- `policy-compliance-order`
+- `atomic-plan-contract`
+- `acceptance-criteria-tracking`
+
 # Core behavior
 
 ## 1) Plan is authoritative
@@ -29,8 +36,10 @@ Before any execution, validate plan structure and policy compatibility:
 
 - Resolve mode from `issue.md` marker first:
   - `- Work Mode: minor-audit`
-  - `- Work Mode: full`
-- If marker is missing or malformed, fail closed to `full`.
+  - `- Work Mode: full-feature`
+  - `- Work Mode: full-bug`
+  - legacy `- Work Mode: full` => interpret as `full-feature`
+- If marker is missing or malformed, fail closed to `full-feature`.
 - Enforce minor-audit evidence-task gate before execution when selected mode is `minor-audit`.
 - When selected mode is `minor-audit`, reject plans that do not include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 
@@ -101,6 +110,7 @@ At completion, report:
 - Pyright delta
 - failing test delta
 - per-file coverage delta (and overall if applicable)
+- AC Status Summary per `acceptance-criteria-tracking`
 - final updated checklist status
 
 # Blocking protocol

--- a/.github/agents/python-atomic-planning.agent.md
+++ b/.github/agents/python-atomic-planning.agent.md
@@ -91,16 +91,18 @@ Use the `atomic-plan-contract` skill as the system-of-record for plan format, Ph
 
 When planning from a feature folder, resolve mode using this ordered precedence:
 
-- Persisted marker in `issue.md` (`- Work Mode: minor-audit` or `- Work Mode: full`)
+- Persisted marker in `issue.md` (`- Work Mode: minor-audit`, `- Work Mode: full-feature`, or `- Work Mode: full-bug`)
+- Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`
 - Explicit workflow override only if repo policy allows and only if reconciled against issue.md
-- fail closed to full when marker is missing or malformed
+- fail closed to `full-feature` when marker is missing or malformed
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Branch-specific required task sets:
 
 - `minor-audit`: include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
-- `full`: retain full-document expectations and full QA obligations.
+- `full-feature`: retain full-document expectations and full QA obligations.
+- `full-bug`: require spec-driven expectations and full QA obligations.
 
 ---
 

--- a/.github/agents/python-orchestrator.agent.md
+++ b/.github/agents/python-orchestrator.agent.md
@@ -19,7 +19,7 @@ handoffs:
     send: true
   - label: Validate small-path delivery and post-QC docs
     agent: atomic_executor
-    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, and produce post-QC validation documentation deltas. If validation fails, return precise remediation deltas."
+    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, check off delivered acceptance criteria in AC source files per `acceptance-criteria-tracking`, and produce post-QC validation documentation deltas. If validation fails, return precise remediation deltas."
     send: true
   - label: Post-implementation small-path audit
     agent: feature_code_review_agent
@@ -43,7 +43,7 @@ handoffs:
     send: true
   - label: Execute approved Python atomic plan
     agent: python-atomic-executor
-    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce Python quality gates and typing/suppression constraints from agent policy.\n4) Complete final QA loop (Black → Ruff → Pyright → Pytest, plus coverage when enforced) and report lint/type/test/coverage deltas.\n\nOutput requirements:\n- execution summary\n- QA summary\n- Ruff/Pyright/test/coverage deltas\n- updated plan checklist state"
+    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce Python quality gates and typing/suppression constraints from agent policy.\n4) Complete final QA loop (Black → Ruff → Pyright → Pytest, plus coverage when enforced) and report lint/type/test/coverage deltas.\n5) Track and check off acceptance criteria in AC source files per `acceptance-criteria-tracking` as tasks deliver verified work. Include AC Status Summary at completion.\n\nOutput requirements:\n- execution summary\n- QA summary\n- Ruff/Pyright/test/coverage deltas\n- AC Status Summary\n- updated plan checklist state"
     send: true
   - label: Post-implementation feature review
     agent: feature_code_review_agent
@@ -65,6 +65,7 @@ Use these reusable skills to avoid duplicating shared operations:
 - `pr-base-branch-merge-base`
 - `feature-promotion-lifecycle`
 - `atomic-plan-contract`
+- `acceptance-criteria-tracking`
 
 # Non-negotiable mission behavior
 

--- a/.github/agents/python-typed-engineer.agent.md
+++ b/.github/agents/python-typed-engineer.agent.md
@@ -26,14 +26,17 @@ handoffs:
 For feature-scoped work, resolve mode from `issue.md` marker first:
 
 - `- Work Mode: minor-audit`
-- `- Work Mode: full`
+- `- Work Mode: full-feature`
+- `- Work Mode: full-bug`
+- legacy `- Work Mode: full` => interpret as `full-feature`
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Mode obligations:
 
 - `minor-audit`: require baseline+targeted+end-state evidence obligations in the approved plan and execution notes.
-- `full`: require full-doc expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-feature`: require full-doc expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-bug`: require spec-driven expectations (`spec.md` required, `user-story.md` absent unless explicitly required) and full QA loop obligations.
 
 You are a senior Python engineer specializing in:
 

--- a/.github/agents/status_updater.agent.md
+++ b/.github/agents/status_updater.agent.md
@@ -1,6 +1,6 @@
 ---
 name: status_updater_agent
-description: Synchronize status across epic docs, feature docs, atomic plans, and (optionally) GitHub Issues. Check off delivered but unchecked plan items, reconcile issue/doc status, and document acceptance-criteria evidence in spec.md and user-story.md when fully delivered. Derive all paths from EpicRootFolder using the same epic directory rules. No user questions.
+description: Synchronize status across epic docs, feature docs, atomic plans, and (optionally) GitHub Issues. Check off delivered but unchecked plan items, reconcile issue/doc status, and document acceptance-criteria evidence in the authoritative requirement source files when fully delivered. Derive all paths from EpicRootFolder using the same epic directory rules. No user questions.
 argument-hint: "Provide EpicRootFolder (absolute or workspace-relative path, e.g., docs/features/active/2026-02-02-some-epic-47). Optional: AllowGitHubMutations=true|false (default false) to permit using gh CLI to update remote issues; otherwise generate recommended gh commands only. This agent will: (1) read initiative.md/issue.md/orchestration.md (if present), (2) enumerate feature subfolders, (3) select current version (highest vN) and latest plan.<timestamp>.md, (4) update plan checkboxes when evidence exists, (5) sync local issue.md/spec/user-story with issue status and content, (6) add acceptance evidence when all AC are delivered, and (7) write <EPIC_FOLDER>/status-sync.<timestamp>.md. Timestamp format: yyyy-MM-ddTHH-mm."
 target: vscode
 tools:
@@ -31,12 +31,13 @@ You are a **status synchronizer** specializing in:
 Primary outcomes:
 1) Mark delivered-but-unchecked plan items as complete (with evidence).
 2) Synchronize documentation and GitHub issue status/content (best-effort, with safe defaults).
-3) If ALL acceptance criteria in spec.md and user-story.md are delivered, document evidence that they have been delivered.
+3) If ALL acceptance criteria in the authoritative requirement source file(s) are delivered, document evidence that they have been delivered.
 
 # Shared skills (apply before proceeding)
 
 Use these reusable skills to avoid duplicating shared operations:
 - `evidence-and-timestamp-conventions`
+- `acceptance-criteria-tracking`
 
 Your output is NOT new feature work. Your output is:
 - Updated markdown files (plans + issue/spec/user-story) where evidence supports changes.
@@ -96,11 +97,14 @@ Within the selected current version scope:
 ## 4.5) Work-mode marker contract (deterministic)
 - Read the persisted marker from `issue.md` using exact line format:
    - `- Work Mode: minor-audit`
-   - `- Work Mode: full`
+   - `- Work Mode: full-feature`
+   - `- Work Mode: full-bug`
+- Legacy compatibility: if `issue.md` still contains `- Work Mode: full`, interpret it as `full-feature`.
 - Branch `Delivered` computation and evidence targets by marker value:
    - For `Work Mode: minor-audit`, evaluate acceptance completion from `issue.md` criteria and write acceptance evidence to `issue.md`.
-   - For `Work Mode: full`, evaluate acceptance completion from `spec.md` and `user-story.md` and write acceptance evidence to `spec.md` and `user-story.md`.
-- Fail closed: if marker is missing or malformed, fallback to full behavior (`spec.md` + `user-story.md`) for Delivered computation and evidence writing.
+   - For `Work Mode: full-feature`, evaluate acceptance completion from `spec.md` and `user-story.md` and write acceptance evidence to `spec.md` and `user-story.md`.
+   - For `Work Mode: full-bug`, evaluate acceptance completion from `spec.md` and write acceptance evidence to `spec.md`.
+- Fail closed: if marker is missing or malformed, fallback to `full-feature` behavior (`spec.md` + `user-story.md`) for Delivered computation and evidence writing.
 
 # GitHub Issues mutation rules (safe by default)
 
@@ -165,7 +169,7 @@ Goal: keep `issue.md` (local) and (if accessible) the GitHub Issue aligned with 
 ### Reconciliation rule (deterministic)
 For each epic/feature:
 1) Determine “Delivered” status by docs evidence:
-   - Delivered = ALL acceptance criteria across spec.md and user-story.md have evidence (section C)
+   - Delivered = ALL acceptance criteria across the authoritative AC source file(s) for the selected work mode have evidence (section C)
    - Otherwise Not Delivered
 2) Compare that status to:
    - Local `issue.md` status indicators (if present)
@@ -187,25 +191,26 @@ Then:
     - Keep prior content under a “History / Prior Notes” section.
 
 ## C) Acceptance criteria evidence documentation
-Goal: if ALL acceptance criteria in spec.md and user-story.md have been delivered, document evidence in those docs.
+Goal: if ALL acceptance criteria in the authoritative AC source file(s) have been delivered, document evidence in those files.
 
 Process per feature:
-1) Extract acceptance criteria from `spec.md` and `user-story.md`:
+1) Resolve authoritative AC source file(s) per the work-mode marker contract and `acceptance-criteria-tracking`.
+2) Extract acceptance criteria from those source file(s):
    - Prefer sections titled: “Acceptance Criteria”, “AC”, “Done when”
    - Parse checklists and bullet lists as criteria items
-2) For each criterion:
+3) For each criterion:
    - Find best evidence:
      - tests/commands (preferred)
      - code + tests
      - explicit verification steps in the plan that have been executed
-3) If ALL criteria have evidence:
-   - Append to BOTH `spec.md` and `user-story.md` a section:
+4) If ALL criteria have evidence:
+   - Append to each authoritative AC source file a section:
      - `## Acceptance Criteria Evidence (as of <timestamp>)`
      - Table: Criterion | Evidence | Verification command(s)
    - Evidence should reference:
      - file paths, test names, and the exact commands run
      - avoid large raw logs; summarize and point to where the evidence lives
-4) If NOT all criteria have evidence:
+5) If NOT all criteria have evidence:
    - Do not claim delivered.
    - Optionally add:
      - `## Acceptance Criteria Evidence (partial, as of <timestamp>)`
@@ -230,7 +235,8 @@ For each feature directory:
 
 ## Phase C — Build acceptance-criteria evidence map
 For each feature:
-1) Extract acceptance criteria from `spec.md` and `user-story.md`.
+1) Resolve authoritative AC source file(s) from the work-mode marker.
+2) Extract acceptance criteria from those source file(s).
 2) Evaluate evidence for each criterion (prefer runnable verification).
 3) Decide Delivered status (all criteria evidenced or not).
 

--- a/.github/skills/acceptance-criteria-tracking/SKILL.md
+++ b/.github/skills/acceptance-criteria-tracking/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: acceptance-criteria-tracking
+description: 'Track and check off acceptance criteria in requirement source files (issue.md, spec.md, user-story.md) as they are delivered. Use when executing plans, reviewing features, or validating delivery to keep AC checkboxes current.'
+---
+
+# Acceptance Criteria Tracking
+
+Shared protocol for identifying, tracking, and checking off acceptance criteria (AC) in their source requirement files as work is delivered and verified.
+
+## When to Use This Skill
+
+Use this skill when:
+- Executing an atomic plan that delivers work satisfying acceptance criteria.
+- Reviewing a feature branch and verifying acceptance criteria.
+- Validating small-path or large-path delivery against requirement files.
+- Any agent completes work that satisfies one or more acceptance criteria from `issue.md`, `spec.md`, or `user-story.md`.
+
+## AC Source Resolution (by Work Mode)
+
+Resolve the authoritative acceptance-criteria source file(s) using the work-mode marker from `issue.md`, per the mode rules in `feature-promotion-lifecycle` and `atomic-plan-contract`:
+
+| Work Mode | AC Source File(s) |
+|---|---|
+| `minor-audit` | `issue.md` only |
+| `full-feature` | `spec.md` and `user-story.md` |
+| `full-bug` | `spec.md` only |
+| legacy `full` | normalize to `full-feature` for compatibility |
+| missing / malformed | fail closed to `full-feature` (`spec.md` + `user-story.md`) |
+
+Deterministic mode rule: use the persisted `- Work Mode: ...` marker from `issue.md` as the single source of truth. `full-feature` always means `spec.md` **and** `user-story.md`; `full-bug` always means `spec.md` **only**; legacy `full` always normalizes to `full-feature`.
+
+When multiple AC source files exist, track checkboxes in **each** applicable file independently.
+
+## AC Identification
+
+Acceptance criteria are markdown checkbox items within AC source files, typically under headings such as:
+- `## Acceptance Criteria`
+- `### Acceptance Criteria`
+- `## Done When` or similar
+
+AC items use the standard markdown checkbox format:
+- `- [ ] <criterion text>` (not yet delivered)
+- `- [x] <criterion text>` (delivered and verified)
+
+If AC items are not in checkbox format (e.g., numbered lists or prose), do NOT reformat them. Instead, note their status in the agent's own tracking artifacts (plan checklist, feature-audit, etc.) and document that the source file uses a non-checkbox format.
+
+## Check-Off Protocol
+
+### Rules (non-negotiable)
+
+1. **Evidence before check-off**: Only mark an AC item `[x]` after the work satisfying it has been **implemented and verified** (e.g., tests pass, toolchain clean, code reviewed).
+2. **One-at-a-time**: Check off each AC item individually as the corresponding work is verified. Do not batch-check items without individual verification.
+3. **Preserve text**: When checking off, change only `- [ ]` to `- [x]`. Do not modify the criterion text.
+4. **Leave unmet items unchecked**: If an AC item cannot be fully delivered or verified, leave it as `- [ ]` and document the gap in the appropriate artifact (plan checklist, remediation inputs, or feature-audit).
+5. **No phantom criteria**: Do not add new AC items to source files. AC items are authored by planning/scoping agents, not by executors or reviewers.
+
+### When Executors Check Off AC
+
+During plan execution, after completing a task whose work satisfies an acceptance criterion:
+
+1. Identify which AC item(s) in the resolved source file(s) are satisfied by the completed task.
+2. Verify the work meets the criterion (task acceptance criteria passed, tests pass, etc.).
+3. Update the AC source file(s): change `- [ ]` to `- [x]` for the satisfied criterion.
+4. Report the check-off in the task's progress output (e.g., "Checked off AC: `<criterion text>` in `issue.md`").
+
+Timing: Check off AC items as soon as the corresponding plan task passes verification — do not defer all AC updates to the end of plan execution.
+
+### When Reviewers Check Off AC
+
+During feature review (feature-audit phase):
+
+1. For each AC item evaluated as **PASS** in the feature-audit evaluation table, check it off in the source file(s) if not already checked.
+2. For items evaluated as **PARTIAL**, **FAIL**, or **UNVERIFIED**, leave them unchecked and document the gap.
+3. Report any newly checked-off items in the feature-audit artifact.
+
+### When Orchestrators Enforce AC Tracking
+
+Orchestrators do not directly check off AC items. Instead:
+
+1. Ensure delegated executors and reviewers reference this skill.
+2. After executor or reviewer completion, verify that AC source files reflect delivered work (spot-check; do not re-execute verification).
+3. If AC items remain unchecked after all delegated work completes, flag them in the orchestration summary as outstanding acceptance criteria.
+
+## AC Status Summary (Required at Completion)
+
+At the end of plan execution or feature review, report an AC summary:
+
+```
+### Acceptance Criteria Status
+- Source: <file path(s)>
+- Total AC items: <N>
+- Checked off (delivered): <M>
+- Remaining (unchecked): <N - M>
+- Items remaining: <list of unchecked criterion texts, if any>
+```
+
+This summary must appear in:
+- The executor's final completion report (after last plan task).
+- The reviewer's feature-audit artifact (Phase F or equivalent).

--- a/.github/skills/atomic-plan-contract/SKILL.md
+++ b/.github/skills/atomic-plan-contract/SKILL.md
@@ -145,12 +145,15 @@ When a plan is generated or validated from a feature folder, resolve selected mo
 
 1) Persisted marker in `issue.md` metadata block:
 	- `- Work Mode: minor-audit`
-	- `- Work Mode: full`
-2) Explicit workflow override only when repo policy allows and only when reconciled against `issue.md`
-3) Fail closed to `full` when marker is missing or malformed
+	- `- Work Mode: full-feature`
+	- `- Work Mode: full-bug`
+2) Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`
+3) Explicit workflow override only when repo policy allows and only when reconciled against `issue.md`
+4) Fail closed to `full-feature` when marker is missing or malformed
 
 ## Mode-Specific Mandatory Plan Gates
 
 - `minor-audit` plans MUST include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 - `minor-audit` plans MUST NOT treat missing `spec.md` or `user-story.md` as automatic blockers.
-- `full` plans MUST enforce full-document expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-feature` plans MUST enforce full-document expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-bug` plans MUST enforce spec-driven expectations (`spec.md` required, `user-story.md` optional/absent by default) and full QA loop obligations.

--- a/.github/skills/feature-promotion-lifecycle/SKILL.md
+++ b/.github/skills/feature-promotion-lifecycle/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when:
 - `${long-name}`: `${relativeFile}` filename without `.md`
 - `${issue-num}`: promoted GitHub issue number
 - `${feature-folder}`: active feature folder path
-- `${work-mode}`: `full` or `minor-audit`
+- `${work-mode}`: `minor-audit`, `full-feature`, or `full-bug` (legacy `full` is accepted only as an alias for `full-feature`)
 - `${short-path-flag}`: `--work-mode minor-audit` (mandatory for short-path promotion/folder creation)
 
 ## Canonical Command Sequence
@@ -79,11 +79,14 @@ Before delegating research/spec/planning, provide:
 
 Mode-aware expectations:
 - For `minor-audit`, `issue.md` is the primary acceptance-criteria source and `spec.md`/`user-story.md` may be intentionally absent by design.
-- For `full`, `spec.md` and `user-story.md` are expected alongside `issue.md`.
+- For `full-feature`, `spec.md` and `user-story.md` are expected alongside `issue.md`.
+- For `full-bug`, `spec.md` is expected alongside `issue.md`; `user-story.md` should be absent unless the requirements explicitly justify it.
 
 Selected-mode persistence requirements:
 - Producer outputs MUST persist exactly one marker in `issue.md` metadata above the first `##` heading:
 	- `- Work Mode: minor-audit`
-	- `- Work Mode: full`
+	- `- Work Mode: full-feature`
+	- `- Work Mode: full-bug`
 - Persisted marker MUST represent selected mode after eligibility checks, not requested mode.
-- If a requested `minor-audit` path is rejected by eligibility checks, tooling MUST fail closed to `full`, emit fallback reason, and persist `- Work Mode: full`.
+- If a legacy requested `full` path is accepted, tooling MUST normalize it to `full-feature` before persistence.
+- If a requested `minor-audit` path is rejected by eligibility checks, tooling MUST fail closed to `full-feature`, emit fallback reason, and persist `- Work Mode: full-feature`.

--- a/.github/skills/powershell-orchestration-state-machine/SKILL.md
+++ b/.github/skills/powershell-orchestration-state-machine/SKILL.md
@@ -29,7 +29,7 @@ Use this skill when:
 - `long-name`
 - `issue-num`
 - `feature-folder`
-- `work-mode` (`full` or `minor-audit`)
+- `work-mode` (`minor-audit`, `full-feature`, or `full-bug`; normalize legacy `full` to `full-feature` before persistence)
 - `plan-path` (minimal or full plan path)
 - `completed_steps`
 - `next_step`

--- a/docs/engineering/Feature Playbook.md
+++ b/docs/engineering/Feature Playbook.md
@@ -31,9 +31,11 @@ VS Code tasks wrap these scripts: see `.vscode/tasks.json` (e.g., “Feature: Ne
 -## 2. Create the active feature folder
 - Run `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name <name> --type feature --issue-number <issue|auto>` (or VS Code task “Feature: Create Active Folder”).
 - Creates `docs/features/active/<name>-<issue>/` with:
-  - `user-story.md`
-  - `spec.md`
+  - `issue.md`
   - `plan.md`
+  - `spec.md` and `user-story.md` for `full-feature`
+  - `spec.md` only for `full-bug`
+  - `minor-audit` may intentionally omit `spec.md` and `user-story.md`
 - Seeds Problem/Behavior/AC/Test Conditions from the promoted doc, fills headers (Issue/Owner/Last Updated), and moves the promoted potential file into the active folder as `issue.md`.
 
 ## 3. Branch
@@ -43,7 +45,10 @@ VS Code tasks wrap these scripts: see `.vscode/tasks.json` (e.g., “Feature: Ne
 
 ## 4. Docs and tests first
 - Update/add tests before or alongside code.
-- Update `user-story.md`, `spec.md`, `plan.md` in the active folder.
+- Update the active-folder requirement docs for the selected work mode:
+  - `full-feature`: `user-story.md`, `spec.md`, `plan.md`
+  - `full-bug`: `spec.md`, `plan.md`
+  - `minor-audit`: `issue.md`, `plan.md` (with `spec.md`/`user-story.md` optional by design)
 - Test locations: `tests/transform/`, `tests/document/`, `tests/integration/`, `tests/features/<feature-name>/` (as needed).
 
 ## 5. Incremental development
@@ -115,7 +120,7 @@ VS Code tasks wrap these scripts: see `.vscode/tasks.json` (e.g., “Feature: Ne
 | **3**                                      | **Requirements & Constraint Discovery**                 | **Task Researcher**                     | Functional + non-functional constraints emerge here but are not yet finalized or committed. Still exploratory.                                                                   |
 | **4**                                      | **Domain & Impact Analysis**                            | **Task Researcher**                     | Identifies affected subsystems, data, APIs, compatibility risks. Output is research evidence, not decisions.                                                                     |
 | **5**                                      | **Solution Exploration (Option Space)**                 | **Task Researcher**                     | Multiple approaches evaluated; tradeoffs documented; one approach recommended; alternatives deleted.                                                                             |
-| **6**                                      | **Feature Specification Authoring (Design Commitment)** | **PRD / Feature Docs Completion Agent** | Completes `user-story.md` and `spec.md`. This is where intent becomes a **commitment**: behavior, APIs, data, constraints, risks.                                                |
+| **6**                                      | **Feature Specification Authoring (Design Commitment)** | **PRD / Feature Docs Completion Agent** | For `full-feature`, completes `user-story.md` and `spec.md`; for `full-bug`, completes `spec.md` (and only adds `user-story.md` when explicitly required). This is where intent becomes a **commitment**: behavior, APIs, data, constraints, risks. |
 | **7**                                      | **Acceptance Criteria & DoD Finalization**              | **PRD / Feature Docs Completion Agent** | Acceptance criteria become stable, testable, and exhaustive. Feature is now “commit-ready.”                                                                                      |
 | **8**                                      | **Atomic Development Plan Authoring (Plan-of-Record)**  | **Atomic Planning Agent**               | **Critical distinction**: this is the *true* atomic plan. It cannot exist until the spec is complete. Tasks are binary, ordered, verifiable.                                     |
 | **9**                                      | **Deterministic Plan Execution**                        | **Atomic Execution Agent**              | Executes the atomic plan verbatim. No replanning, no scope change, strict policy and acceptance-criteria verification.                                                           |

--- a/docs/features/templates/README.md
+++ b/docs/features/templates/README.md
@@ -4,7 +4,10 @@ Use these templates to keep planning consistent.
 
 - Copy the `feature` folder to `docs/features/active/<feature-name>/`.
 - Keep the folder name kebab-case and include the GitHub issue number if known (for example `speakerless-auto-detection-42`).
-- Fill in `user-story.md`, `spec.md`, and `plan.md` before coding.
+- Fill in the work-mode-specific requirement docs before coding:
+	- `full-feature`: `user-story.md`, `spec.md`, and `plan.md`
+	- `full-bug`: `spec.md` and `plan.md`
+	- `minor-audit`: `issue.md` and `plan.md` (with `spec.md`/`user-story.md` optional by design)
 - When the feature ships, move the folder to `docs/features/archive/<YYYY-MM-DD>-<feature-name>/` to keep a clean working set.
 - For refactors (no user-facing change), use `refactor/spec.md` and `refactor/plan.md` to capture intent, invariants, and execution steps.
 - For epics/initiatives (tracking multiple child features/workstreams), use `epic/initiative.md` to record goals, decomposition, milestones, and validation across children.

--- a/extensions/drm-copilot/resources/customizations/.github/agents/atomic_executor.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/atomic_executor.agent.md
@@ -77,9 +77,11 @@ Use `atomic-plan-contract` as the system-of-record for mode gate behavior, inclu
 During preflight (before [P0-T1]), resolve work mode from feature `issue.md` marker first:
 
 - `- Work Mode: minor-audit`
-- `- Work Mode: full`
+- `- Work Mode: full-feature`
+- `- Work Mode: full-bug`
+- legacy `- Work Mode: full` => interpret as `full-feature`
 
-If the marker is missing or malformed, fail closed to `full`.
+If the marker is missing or malformed, fail closed to `full-feature`.
 
 When selected mode is `minor-audit`, preflight MUST reject plans that do not include explicit baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks. In these cases return:
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/atomic_planning.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/atomic_planning.agent.md
@@ -92,11 +92,13 @@ When planning from a feature folder, resolve the selected work mode in this exac
 
 1. Persisted marker in `issue.md` metadata block:
    - `- Work Mode: minor-audit`
-   - `- Work Mode: full`
-2. Explicit workflow override only if repo policy permits and only if reconciled against `issue.md`.
-3. fail closed to `full` when the marker is missing or malformed.
+   - `- Work Mode: full-feature`
+   - `- Work Mode: full-bug`
+2. Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`.
+3. Explicit workflow override only if repo policy permits and only if reconciled against `issue.md`.
+4. fail closed to `full-feature` when the marker is missing or malformed.
 
-For `minor-audit`, preflight-required plan gates MUST include baseline evidence, targeted verification evidence, and end-state evidence tasks. For `full`, retain full-document and full QA obligations.
+For `minor-audit`, preflight-required plan gates MUST include baseline evidence, targeted verification evidence, and end-state evidence tasks. For `full-feature`, retain full-document and full QA obligations. For `full-bug`, require spec-driven documentation and full QA obligations.
 
 ---
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/csharp-atomic-executor.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/csharp-atomic-executor.agent.md
@@ -29,8 +29,10 @@ Before any execution, validate plan structure and policy compatibility:
 
 - Resolve mode from `issue.md` marker first:
   - `- Work Mode: minor-audit`
-  - `- Work Mode: full`
-- If marker is missing or malformed, fail closed to `full`.
+  - `- Work Mode: full-feature`
+  - `- Work Mode: full-bug`
+  - legacy `- Work Mode: full` => interpret as `full-feature`
+- If marker is missing or malformed, fail closed to `full-feature`.
 - When selected mode is `minor-audit`, reject plans that do not include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 
 - Canonical headings: `### Phase N — <Title>`

--- a/extensions/drm-copilot/resources/customizations/.github/agents/csharp-atomic-planning.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/csharp-atomic-planning.agent.md
@@ -93,14 +93,17 @@ Use the `atomic-plan-contract` skill as the system-of-record for plan format, Ph
 When planning from a feature folder, resolve mode from `issue.md` marker first:
 
 - `- Work Mode: minor-audit`
-- `- Work Mode: full`
+- `- Work Mode: full-feature`
+- `- Work Mode: full-bug`
+- legacy `- Work Mode: full` => interpret as `full-feature`
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Branch-specific required task sets:
 
 - `minor-audit`: include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
-- `full`: retain full-document expectations and full QA obligations.
+- `full-feature`: retain full-document expectations and full QA obligations.
+- `full-bug`: require spec-driven expectations and full QA obligations.
 
 ---
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/epic-review.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/epic-review.agent.md
@@ -129,11 +129,14 @@ If the epic deviates from this shape, continue anyway and document deviations.
 ## 2.5) Work-mode marker contract and doc completeness
 - Read work mode from `issue.md` using the persisted marker line:
   - `- Work Mode: minor-audit`
-  - `- Work Mode: full`
+  - `- Work Mode: full-feature`
+  - `- Work Mode: full-bug`
+- Legacy compatibility: if `issue.md` still contains `- Work Mode: full`, interpret it as `full-feature`.
 - Branch doc completeness and AC extraction by marker:
   - For `Work Mode: minor-audit`, `spec.md` and `user-story.md` may be absent by design; use `issue.md` as the AC source.
-  - For `Work Mode: full`, require and evaluate `spec.md` and `user-story.md` as AC sources.
-- Fail closed: if the marker is missing or malformed, fallback to full behavior for doc completeness and AC extraction.
+  - For `Work Mode: full-feature`, require and evaluate `spec.md` and `user-story.md` as AC sources.
+  - For `Work Mode: full-bug`, require and evaluate `spec.md` as the AC source; do not require `user-story.md` unless the docs explicitly justify it.
+- Fail closed: if the marker is missing or malformed, fallback to `full-feature` behavior for doc completeness and AC extraction.
 
 ## 3) Version selection rule (deterministic)
 For each feature folder:

--- a/extensions/drm-copilot/resources/customizations/.github/agents/feature-review.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/feature-review.agent.md
@@ -60,11 +60,14 @@ Use these reusable skills to avoid duplicating shared operations:
 ## 3) Work-mode marker contract (deterministic)
 - Read the persisted marker from `issue.md` using the exact line format:
    - `- Work Mode: minor-audit`
-   - `- Work Mode: full`
+   - `- Work Mode: full-feature`
+   - `- Work Mode: full-bug`
+- Legacy compatibility: if `issue.md` still contains `- Work Mode: full`, interpret it as `full-feature`.
 - Branch acceptance-criteria (AC) source by marker value:
    - When `Work Mode: minor-audit`, treat `issue.md` as the AC source of truth.
-   - When `Work Mode: full`, treat `spec.md` and `user-story.md` as AC sources of truth.
-- Fail closed: if marker is missing or malformed, fallback to full mode behavior (`spec.md` + `user-story.md`).
+   - When `Work Mode: full-feature`, treat `spec.md` and `user-story.md` as AC sources of truth.
+   - When `Work Mode: full-bug`, treat `spec.md` as the AC source of truth.
+- Fail closed: if marker is missing or malformed, fallback to `full-feature` behavior (`spec.md` + `user-story.md`).
 
 
 # Execution plan (phased, deterministic)

--- a/extensions/drm-copilot/resources/customizations/.github/agents/powershell-atomic-executor.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/powershell-atomic-executor.agent.md
@@ -29,8 +29,10 @@ Before any execution, validate plan structure and policy compatibility:
 
 - Resolve mode from `issue.md` marker first:
 	- `- Work Mode: minor-audit`
-	- `- Work Mode: full`
-- If marker is missing or malformed, fail closed to `full`.
+	- `- Work Mode: full-feature`
+	- `- Work Mode: full-bug`
+	- legacy `- Work Mode: full` => interpret as `full-feature`
+- If marker is missing or malformed, fail closed to `full-feature`.
 - Enforce minor-audit evidence-task gate before execution when selected mode is `minor-audit`.
 - When selected mode is `minor-audit`, reject plans that do not include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/powershell-atomic-planning.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/powershell-atomic-planning.agent.md
@@ -91,16 +91,18 @@ Use the `atomic-plan-contract` skill as the system-of-record for plan format, Ph
 
 When planning from a feature folder, resolve mode using this ordered precedence:
 
-- Persisted marker in `issue.md` (`- Work Mode: minor-audit` or `- Work Mode: full`)
+- Persisted marker in `issue.md` (`- Work Mode: minor-audit`, `- Work Mode: full-feature`, or `- Work Mode: full-bug`)
+- Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`
 - Explicit workflow override only if repo policy allows and only if reconciled against issue.md
-- fail closed to full when marker is missing or malformed
+- fail closed to `full-feature` when marker is missing or malformed
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Branch-specific required task sets:
 
 - `minor-audit`: include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
-- `full`: retain full-document expectations and full QA obligations.
+- `full-feature`: retain full-document expectations and full QA obligations.
+- `full-bug`: require spec-driven expectations and full QA obligations.
 
 ---
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/python-atomic-executor.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/python-atomic-executor.agent.md
@@ -29,8 +29,10 @@ Before any execution, validate plan structure and policy compatibility:
 
 - Resolve mode from `issue.md` marker first:
   - `- Work Mode: minor-audit`
-  - `- Work Mode: full`
-- If marker is missing or malformed, fail closed to `full`.
+  - `- Work Mode: full-feature`
+  - `- Work Mode: full-bug`
+  - legacy `- Work Mode: full` => interpret as `full-feature`
+- If marker is missing or malformed, fail closed to `full-feature`.
 - Enforce minor-audit evidence-task gate before execution when selected mode is `minor-audit`.
 - When selected mode is `minor-audit`, reject plans that do not include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/python-atomic-planning.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/python-atomic-planning.agent.md
@@ -91,16 +91,18 @@ Use the `atomic-plan-contract` skill as the system-of-record for plan format, Ph
 
 When planning from a feature folder, resolve mode using this ordered precedence:
 
-- Persisted marker in `issue.md` (`- Work Mode: minor-audit` or `- Work Mode: full`)
+- Persisted marker in `issue.md` (`- Work Mode: minor-audit`, `- Work Mode: full-feature`, or `- Work Mode: full-bug`)
+- Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`
 - Explicit workflow override only if repo policy allows and only if reconciled against issue.md
-- fail closed to full when marker is missing or malformed
+- fail closed to `full-feature` when marker is missing or malformed
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Branch-specific required task sets:
 
 - `minor-audit`: include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
-- `full`: retain full-document expectations and full QA obligations.
+- `full-feature`: retain full-document expectations and full QA obligations.
+- `full-bug`: require spec-driven expectations and full QA obligations.
 
 ---
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/python-typed-engineer.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/python-typed-engineer.agent.md
@@ -26,14 +26,17 @@ handoffs:
 For feature-scoped work, resolve mode from `issue.md` marker first:
 
 - `- Work Mode: minor-audit`
-- `- Work Mode: full`
+- `- Work Mode: full-feature`
+- `- Work Mode: full-bug`
+- legacy `- Work Mode: full` => interpret as `full-feature`
 
-If marker is missing or malformed, fail closed to `full`.
+If marker is missing or malformed, fail closed to `full-feature`.
 
 Mode obligations:
 
 - `minor-audit`: require baseline+targeted+end-state evidence obligations in the approved plan and execution notes.
-- `full`: require full-doc expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-feature`: require full-doc expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-bug`: require spec-driven expectations (`spec.md` required, `user-story.md` absent unless explicitly required) and full QA loop obligations.
 
 You are a senior Python engineer specializing in:
 

--- a/extensions/drm-copilot/resources/customizations/.github/agents/status_updater.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/status_updater.agent.md
@@ -1,6 +1,6 @@
 ---
 name: status_updater_agent
-description: Synchronize status across epic docs, feature docs, atomic plans, and (optionally) GitHub Issues. Check off delivered but unchecked plan items, reconcile issue/doc status, and document acceptance-criteria evidence in spec.md and user-story.md when fully delivered. Derive all paths from EpicRootFolder using the same epic directory rules. No user questions.
+description: Synchronize status across epic docs, feature docs, atomic plans, and (optionally) GitHub Issues. Check off delivered but unchecked plan items, reconcile issue/doc status, and document acceptance-criteria evidence in the authoritative requirement source files when fully delivered. Derive all paths from EpicRootFolder using the same epic directory rules. No user questions.
 argument-hint: "Provide EpicRootFolder (absolute or workspace-relative path, e.g., docs/features/active/2026-02-02-some-epic-47). Optional: AllowGitHubMutations=true|false (default false) to permit using gh CLI to update remote issues; otherwise generate recommended gh commands only. This agent will: (1) read initiative.md/issue.md/orchestration.md (if present), (2) enumerate feature subfolders, (3) select current version (highest vN) and latest plan.<timestamp>.md, (4) update plan checkboxes when evidence exists, (5) sync local issue.md/spec/user-story with issue status and content, (6) add acceptance evidence when all AC are delivered, and (7) write <EPIC_FOLDER>/status-sync.<timestamp>.md. Timestamp format: yyyy-MM-ddTHH-mm."
 target: vscode
 tools:
@@ -31,12 +31,13 @@ You are a **status synchronizer** specializing in:
 Primary outcomes:
 1) Mark delivered-but-unchecked plan items as complete (with evidence).
 2) Synchronize documentation and GitHub issue status/content (best-effort, with safe defaults).
-3) If ALL acceptance criteria in spec.md and user-story.md are delivered, document evidence that they have been delivered.
+3) If ALL acceptance criteria in the authoritative requirement source file(s) are delivered, document evidence that they have been delivered.
 
 # Shared skills (apply before proceeding)
 
 Use these reusable skills to avoid duplicating shared operations:
 - `evidence-and-timestamp-conventions`
+- `acceptance-criteria-tracking`
 
 Your output is NOT new feature work. Your output is:
 - Updated markdown files (plans + issue/spec/user-story) where evidence supports changes.
@@ -96,11 +97,14 @@ Within the selected current version scope:
 ## 4.5) Work-mode marker contract (deterministic)
 - Read the persisted marker from `issue.md` using exact line format:
    - `- Work Mode: minor-audit`
-   - `- Work Mode: full`
+   - `- Work Mode: full-feature`
+   - `- Work Mode: full-bug`
+- Legacy compatibility: if `issue.md` still contains `- Work Mode: full`, interpret it as `full-feature`.
 - Branch `Delivered` computation and evidence targets by marker value:
    - For `Work Mode: minor-audit`, evaluate acceptance completion from `issue.md` criteria and write acceptance evidence to `issue.md`.
-   - For `Work Mode: full`, evaluate acceptance completion from `spec.md` and `user-story.md` and write acceptance evidence to `spec.md` and `user-story.md`.
-- Fail closed: if marker is missing or malformed, fallback to full behavior (`spec.md` + `user-story.md`) for Delivered computation and evidence writing.
+   - For `Work Mode: full-feature`, evaluate acceptance completion from `spec.md` and `user-story.md` and write acceptance evidence to `spec.md` and `user-story.md`.
+   - For `Work Mode: full-bug`, evaluate acceptance completion from `spec.md` and write acceptance evidence to `spec.md`.
+- Fail closed: if marker is missing or malformed, fallback to `full-feature` behavior (`spec.md` + `user-story.md`) for Delivered computation and evidence writing.
 
 # GitHub Issues mutation rules (safe by default)
 
@@ -165,7 +169,7 @@ Goal: keep `issue.md` (local) and (if accessible) the GitHub Issue aligned with 
 ### Reconciliation rule (deterministic)
 For each epic/feature:
 1) Determine “Delivered” status by docs evidence:
-   - Delivered = ALL acceptance criteria across spec.md and user-story.md have evidence (section C)
+   - Delivered = ALL acceptance criteria across the authoritative AC source file(s) for the selected work mode have evidence (section C)
    - Otherwise Not Delivered
 2) Compare that status to:
    - Local `issue.md` status indicators (if present)
@@ -187,25 +191,26 @@ Then:
     - Keep prior content under a “History / Prior Notes” section.
 
 ## C) Acceptance criteria evidence documentation
-Goal: if ALL acceptance criteria in spec.md and user-story.md have been delivered, document evidence in those docs.
+Goal: if ALL acceptance criteria in the authoritative AC source file(s) have been delivered, document evidence in those files.
 
 Process per feature:
-1) Extract acceptance criteria from `spec.md` and `user-story.md`:
+1) Resolve authoritative AC source file(s) per the work-mode marker contract and `acceptance-criteria-tracking`.
+2) Extract acceptance criteria from those source file(s):
    - Prefer sections titled: “Acceptance Criteria”, “AC”, “Done when”
    - Parse checklists and bullet lists as criteria items
-2) For each criterion:
+3) For each criterion:
    - Find best evidence:
      - tests/commands (preferred)
      - code + tests
      - explicit verification steps in the plan that have been executed
-3) If ALL criteria have evidence:
-   - Append to BOTH `spec.md` and `user-story.md` a section:
+4) If ALL criteria have evidence:
+   - Append to each authoritative AC source file a section:
      - `## Acceptance Criteria Evidence (as of <timestamp>)`
      - Table: Criterion | Evidence | Verification command(s)
    - Evidence should reference:
      - file paths, test names, and the exact commands run
      - avoid large raw logs; summarize and point to where the evidence lives
-4) If NOT all criteria have evidence:
+5) If NOT all criteria have evidence:
    - Do not claim delivered.
    - Optionally add:
      - `## Acceptance Criteria Evidence (partial, as of <timestamp>)`
@@ -230,9 +235,10 @@ For each feature directory:
 
 ## Phase C — Build acceptance-criteria evidence map
 For each feature:
-1) Extract acceptance criteria from `spec.md` and `user-story.md`.
-2) Evaluate evidence for each criterion (prefer runnable verification).
-3) Decide Delivered status (all criteria evidenced or not).
+1) Resolve authoritative AC source file(s) from the work-mode marker.
+2) Extract acceptance criteria from those source file(s).
+3) Evaluate evidence for each criterion (prefer runnable verification).
+4) Decide Delivered status (all criteria evidenced or not).
 
 ## Phase D — Update plan checkboxes (evidence-driven)
 For each feature with a current plan:

--- a/extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md
@@ -145,12 +145,15 @@ When a plan is generated or validated from a feature folder, resolve selected mo
 
 1) Persisted marker in `issue.md` metadata block:
 	- `- Work Mode: minor-audit`
-	- `- Work Mode: full`
-2) Explicit workflow override only when repo policy allows and only when reconciled against `issue.md`
-3) Fail closed to `full` when marker is missing or malformed
+	- `- Work Mode: full-feature`
+	- `- Work Mode: full-bug`
+2) Legacy compatibility marker `- Work Mode: full` resolves to `full-feature`
+3) Explicit workflow override only when repo policy allows and only when reconciled against `issue.md`
+4) Fail closed to `full-feature` when marker is missing or malformed
 
 ## Mode-Specific Mandatory Plan Gates
 
 - `minor-audit` plans MUST include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 - `minor-audit` plans MUST NOT treat missing `spec.md` or `user-story.md` as automatic blockers.
-- `full` plans MUST enforce full-document expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-feature` plans MUST enforce full-document expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
+- `full-bug` plans MUST enforce spec-driven expectations (`spec.md` required, `user-story.md` optional/absent by default) and full QA loop obligations.

--- a/extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when:
 - `${long-name}`: `${relativeFile}` filename without `.md`
 - `${issue-num}`: promoted GitHub issue number
 - `${feature-folder}`: active feature folder path
-- `${work-mode}`: `full` or `minor-audit`
+- `${work-mode}`: `minor-audit`, `full-feature`, or `full-bug` (legacy `full` is accepted only as an alias for `full-feature`)
 - `${short-path-flag}`: `--work-mode minor-audit` (mandatory for short-path promotion/folder creation)
 
 ## Canonical Command Sequence
@@ -79,11 +79,14 @@ Before delegating research/spec/planning, provide:
 
 Mode-aware expectations:
 - For `minor-audit`, `issue.md` is the primary acceptance-criteria source and `spec.md`/`user-story.md` may be intentionally absent by design.
-- For `full`, `spec.md` and `user-story.md` are expected alongside `issue.md`.
+- For `full-feature`, `spec.md` and `user-story.md` are expected alongside `issue.md`.
+- For `full-bug`, `spec.md` is expected alongside `issue.md`; `user-story.md` should be absent unless the requirements explicitly justify it.
 
 Selected-mode persistence requirements:
 - Producer outputs MUST persist exactly one marker in `issue.md` metadata above the first `##` heading:
 	- `- Work Mode: minor-audit`
-	- `- Work Mode: full`
+	- `- Work Mode: full-feature`
+	- `- Work Mode: full-bug`
 - Persisted marker MUST represent selected mode after eligibility checks, not requested mode.
-- If a requested `minor-audit` path is rejected by eligibility checks, tooling MUST fail closed to `full`, emit fallback reason, and persist `- Work Mode: full`.
+- If a legacy requested `full` path is accepted, tooling MUST normalize it to `full-feature` before persistence.
+- If a requested `minor-audit` path is rejected by eligibility checks, tooling MUST fail closed to `full-feature`, emit fallback reason, and persist `- Work Mode: full-feature`.

--- a/extensions/drm-copilot/resources/customizations/.github/skills/powershell-orchestration-state-machine/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/powershell-orchestration-state-machine/SKILL.md
@@ -29,7 +29,7 @@ Use this skill when:
 - `long-name`
 - `issue-num`
 - `feature-folder`
-- `work-mode` (`full` or `minor-audit`)
+- `work-mode` (`minor-audit`, `full-feature`, or `full-bug`; normalize legacy `full` to `full-feature` before persistence)
 - `plan-path` (minimal or full plan path)
 - `completed_steps`
 - `next_step`

--- a/scripts/dev_tools/new_active_feature_folder_docs.py
+++ b/scripts/dev_tools/new_active_feature_folder_docs.py
@@ -258,8 +258,11 @@ def should_use_minor_audit_mode(
     potential_content: str,
 ) -> tuple[bool, str]:
     """Return whether minor-audit path should be used and fallback reason."""
-    if work_mode not in ("minor-audit", "full"):
-        raise ValueError("work_mode must be one of: minor-audit, full")
-    if work_mode == "full":
+    del feature_type, potential_content
+    if work_mode not in ("minor-audit", "full-feature", "full-bug", "full"):
+        raise ValueError(
+            "work_mode must be one of: minor-audit, full-feature, full-bug, full"
+        )
+    if work_mode != "minor-audit":
         return False, ""
     return True, ""

--- a/scripts/dev_tools/new_active_feature_folder_flow.py
+++ b/scripts/dev_tools/new_active_feature_folder_flow.py
@@ -33,6 +33,7 @@ from scripts.dev_tools.new_active_feature_folder_models import (
     resolve_workspace,
     validate_feature_name,
 )
+from scripts.dev_tools.prompt_mode_contract import normalize_requested_work_mode
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -105,8 +106,9 @@ def create_active_folder(
         resolved_feature_name, workspace_path, filesystem
     )
     potential_content = filesystem.read_text(potential_file) if potential_file else ""
+    selected_work_mode = normalize_requested_work_mode(work_mode, feature_type)
     use_minor_audit, fallback_reason = should_use_minor_audit_mode(
-        work_mode=work_mode,
+        work_mode=selected_work_mode,
         feature_type=feature_type,
         potential_content=potential_content,
     )
@@ -252,14 +254,14 @@ def create_active_folder(
             moved_content = filesystem.read_text(potential_issue_path)
             filesystem.write_text(
                 potential_issue_path,
-                upsert_work_mode_marker(moved_content, "full"),
+                upsert_work_mode_marker(moved_content, selected_work_mode),
             )
             print(f"Moved potential file to {potential_issue_path}")
 
     if potential_file:
         print(f"Seeded docs from potential: {potential_file.name}")
 
-    print(f"Selected mode: {'minor-audit' if use_minor_audit else 'full'}")
+    print(f"Selected mode: {'minor-audit' if use_minor_audit else selected_work_mode}")
     if fallback_reason:
         print(f"Fallback reason: {fallback_reason}")
 
@@ -320,9 +322,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--work-mode",
-        choices=["minor-audit", "full"],
+        choices=["minor-audit", "full-feature", "full-bug", "full"],
         default="full",
-        help="Work mode routing for minor-audit vs full feature flow.",
+        help=(
+            "Work mode routing. Canonical values are minor-audit, full-feature, "
+            "and full-bug; full is accepted as a backward-compatible alias."
+        ),
     )
     return parser.parse_args()
 

--- a/scripts/dev_tools/new_active_feature_folder_markdown.py
+++ b/scripts/dev_tools/new_active_feature_folder_markdown.py
@@ -42,7 +42,9 @@ def get_section(content: str, name: str) -> str:
 def upsert_work_mode_marker(content: str, mode: str) -> str:
     """Insert or update work-mode marker directly above first `##` heading."""
     marker_line = f"- Work Mode: {mode}"
-    marker_pattern = re.compile(r"^- Work Mode:\s*(minor-audit|full)\s*$")
+    marker_pattern = re.compile(
+        r"^- Work Mode:\s*(minor-audit|full-feature|full-bug|full)\s*$"
+    )
     lines = [line for line in content.splitlines() if not marker_pattern.match(line)]
 
     for idx, line in enumerate(lines):

--- a/scripts/dev_tools/potential_to_issue.py
+++ b/scripts/dev_tools/potential_to_issue.py
@@ -24,12 +24,16 @@ from scripts.dev_tools.potential_to_issue_content import (
     parse_issue_reference,
     update_metadata_lines,
 )
+from scripts.dev_tools.prompt_mode_contract import (
+    ACCEPTED_WORK_MODES,
+    normalize_requested_work_mode,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
 PROMOTION_TYPES = ("epic", "feature", "refactor", "bug")
-WORK_MODES = ("minor-audit", "full")
+WORK_MODES = ACCEPTED_WORK_MODES
 TITLE_PREFIXES = {
     "epic": "Epic",
     "feature": "Feature",
@@ -350,7 +354,8 @@ def promote_potential(
         fs (FileSystem | None): Optional filesystem adapter override.
         gh (GhClient | None): Optional gh client adapter override.
         workspace (Path | None): Optional workspace root override.
-        work_mode (str): Work-mode routing (`minor-audit` or `full`).
+        work_mode (str): Work-mode routing (`minor-audit`, `full-feature`,
+            `full-bug`, or legacy `full`).
         emit (Callable[[str], None]): Status message emitter callback.
 
     Returns:
@@ -399,7 +404,10 @@ def promote_potential(
 
     relative_path = Path(_relative_path()).as_posix()
 
-    selected_mode = work_mode
+    try:
+        selected_mode = normalize_requested_work_mode(work_mode, promotion_type)
+    except ValueError as exc:
+        raise PromotionError(str(exc)) from exc
     fallback_reason = ""
 
     # Route issue-body generation based on promotion type and eligible work mode.
@@ -433,7 +441,7 @@ def promote_potential(
             heading: get_section(content, heading) or PLACEHOLDER
             for heading in BUG_SECTION_HEADINGS
         }
-        body = build_bug_body(bug_sections, relative_path)
+        body = build_bug_body(selected_mode, bug_sections, relative_path)
     else:
         problem = get_section(content, "Problem / Why") or PLACEHOLDER
         behavior = get_section(content, "Proposed Behavior") or PLACEHOLDER
@@ -544,7 +552,10 @@ def parse_args() -> argparse.Namespace:
         "--work-mode",
         choices=WORK_MODES,
         default="full",
-        help="Work mode routing for full vs minor-audit issue body generation.",
+        help=(
+            "Work mode routing. Canonical values are minor-audit, full-feature, "
+            "and full-bug; full is accepted as a backward-compatible alias."
+        ),
     )
     return parser.parse_args()
 

--- a/scripts/dev_tools/potential_to_issue_content.py
+++ b/scripts/dev_tools/potential_to_issue_content.py
@@ -75,7 +75,7 @@ def build_body(
     tests: str,
     relative_path: str,
 ) -> str:
-    """Construct the standard full-mode issue body."""
+    """Construct the standard full-feature issue body."""
     return (
         f"- Work Mode: {work_mode}\n"
         f"## Problem / Why\n{problem}\n\n"
@@ -87,9 +87,12 @@ def build_body(
     )
 
 
-def build_bug_body(sections: dict[str, str], relative_path: str) -> str:
+def build_bug_body(work_mode: str, sections: dict[str, str], relative_path: str) -> str:
     """Construct the bug issue body from canonical bug section headings."""
-    parts = [f"## {heading}\n{sections[heading]}" for heading in BUG_SECTION_HEADINGS]
+    parts = [f"- Work Mode: {work_mode}"]
+    parts.extend(
+        f"## {heading}\n{sections[heading]}" for heading in BUG_SECTION_HEADINGS
+    )
     parts.append(f"## Source\nFrom: {relative_path}")
     return "\n\n".join(parts) + "\n"
 

--- a/scripts/dev_tools/prompt_mode_contract.py
+++ b/scripts/dev_tools/prompt_mode_contract.py
@@ -4,13 +4,58 @@ Purpose:
     Centralize parsing and fail-closed work-mode resolution so all prompt
     resolvers use one deterministic contract:
     1) Parse persisted issue marker when valid.
-    2) Fall back to full when marker is missing or malformed.
-    3) Surface an auditable fallback reason string.
+    2) Normalize legacy `full` markers to a canonical full-mode variant.
+    3) Fall back to `full-feature` when marker is missing or malformed.
+    4) Surface an auditable fallback or normalization reason string.
 """
 
 from __future__ import annotations
 
 import re
+
+CANONICAL_WORK_MODES = ("minor-audit", "full-feature", "full-bug")
+LEGACY_FULL_MODE = "full"
+ACCEPTED_WORK_MODES = (*CANONICAL_WORK_MODES, LEGACY_FULL_MODE)
+
+
+def normalize_requested_work_mode(requested_mode: str, promotion_type: str) -> str:
+    """Normalize a requested work mode into a canonical persisted value.
+
+    Purpose:
+        Convert user-facing or legacy CLI values into canonical persisted
+        markers. Plain `full` remains accepted for backward compatibility but is
+        normalized to the deterministic variant that matches the promotion
+        target.
+
+    Args:
+        requested_mode (str): Requested work mode from CLI or caller.
+        promotion_type (str): Promotion or feature type (`feature`, `bug`, etc.).
+
+    Returns:
+        str: Canonical work mode (`minor-audit`, `full-feature`, or `full-bug`).
+
+    Raises:
+        ValueError: If the request is invalid or incompatible with the type.
+    """
+    if requested_mode not in ACCEPTED_WORK_MODES:
+        raise ValueError(
+            "work_mode must be one of: minor-audit, full-feature, full-bug, full"
+        )
+
+    if requested_mode == "minor-audit":
+        return requested_mode
+
+    is_bug = promotion_type == "bug"
+    if requested_mode == LEGACY_FULL_MODE:
+        return "full-bug" if is_bug else "full-feature"
+
+    if requested_mode == "full-bug" and not is_bug:
+        raise ValueError("full-bug may only be used with bug work")
+
+    if requested_mode == "full-feature" and is_bug:
+        raise ValueError("full-feature may not be used with bug work")
+
+    return requested_mode
 
 
 def parse_issue_work_mode(issue_content: str) -> tuple[str | None, bool]:
@@ -25,14 +70,15 @@ def parse_issue_work_mode(issue_content: str) -> tuple[str | None, bool]:
 
     Returns:
         tuple[str | None, bool]:
-            - Parsed mode (`minor-audit` or `full`) when valid; otherwise None.
+                        - Parsed mode (`minor-audit`, `full-feature`, `full-bug`, or legacy
+                            `full`) when valid; otherwise None.
             - Boolean indicating whether a malformed marker line was detected.
 
     Side Effects:
         None.
     """
     valid_match = re.search(
-        r"(?im)^-\s*Work Mode:\s*(minor-audit|full)\s*$",
+        r"(?im)^-\s*Work Mode:\s*(minor-audit|full-feature|full-bug|full)\s*$",
         issue_content,
     )
     if valid_match is not None:
@@ -47,14 +93,15 @@ def resolve_selected_work_mode(issue_content: str | None) -> str:
 
     Purpose:
         Provide a deterministic selected mode for templates by honoring a valid
-        marker when present and failing closed to `full` for all other states.
+        marker when present, normalize legacy `full` to `full-feature`, and fail
+        closed to `full-feature` for all other states.
 
     Args:
         issue_content (str | None): Raw issue content, or None when the file is
             unavailable.
 
     Returns:
-        str: `minor-audit` or `full`.
+        str: `minor-audit`, `full-feature`, or `full-bug`.
 
     Side Effects:
         None.
@@ -64,13 +111,15 @@ def resolve_selected_work_mode(issue_content: str | None) -> str:
     # - If a valid marker exists, trust it as the selected mode.
     # - Otherwise, fail closed to full.
     if issue_content is None:
-        return "full"
+        return "full-feature"
 
     parsed_mode, _has_malformed_marker = parse_issue_work_mode(issue_content)
     if parsed_mode is not None:
+        if parsed_mode == LEGACY_FULL_MODE:
+            return "full-feature"
         return parsed_mode
 
-    return "full"
+    return "full-feature"
 
 
 def build_fallback_reason(issue_content: str | None) -> str:
@@ -91,14 +140,18 @@ def build_fallback_reason(issue_content: str | None) -> str:
         None.
     """
     if issue_content is None:
-        return "issue.md missing; fail closed to full"
+        return "issue.md missing; fail closed to full-feature"
 
     parsed_mode, has_malformed_marker = parse_issue_work_mode(issue_content)
     if parsed_mode is not None:
+        if parsed_mode == LEGACY_FULL_MODE:
+            return (
+                "issue.md Work Mode marker uses legacy full; normalized to full-feature"
+            )
         return "none"
 
     # Branch by marker quality so diagnostics are explicit and actionable.
     if has_malformed_marker:
-        return "issue.md Work Mode marker malformed; fail closed to full"
+        return "issue.md Work Mode marker malformed; fail closed to full-feature"
 
-    return "issue.md Work Mode marker missing; fail closed to full"
+    return "issue.md Work Mode marker missing; fail closed to full-feature"

--- a/scripts/dev_tools/resolve_execute_plan_prompt.py
+++ b/scripts/dev_tools/resolve_execute_plan_prompt.py
@@ -12,8 +12,8 @@ Supported variables:
     - ${name}: Feature name derived from folder naming convention.
     - ${spec}: Path to spec.md under ${folderpath}.
     - ${research}: Path to research.md under ${folderpath}, annotated when missing.
-    - ${user-story}: Path to user-story.md under ${folderpath}, section removed
-      when missing.
+        - ${user-story}: Path to user-story.md under ${folderpath}, section removed
+            when missing.
 """
 
 from __future__ import annotations
@@ -318,7 +318,7 @@ def resolve_mode_context(folderpath: str, workspace_root: Path) -> tuple[str, st
     except OSError:
         return (
             resolve_selected_work_mode(None),
-            "issue.md unreadable; fail closed to full",
+            "issue.md unreadable; fail closed to full-feature",
         )
 
     selected_mode = resolve_selected_work_mode(issue_content)

--- a/scripts/dev_tools/resolve_file_prompt.py
+++ b/scripts/dev_tools/resolve_file_prompt.py
@@ -464,7 +464,8 @@ def _resolve_work_mode_from_issue(
         workspace_root (Path): Workspace root used for file resolution.
 
     Returns:
-        tuple[str, str]: Selected work mode (`minor-audit` or `full`) and a
+        tuple[str, str]: Selected work mode (`minor-audit`, `full-feature`, or
+        `full-bug`) and a
         human-readable fallback reason.
     """
     issue_path = workspace_root / Path(folderpath) / "issue.md"
@@ -476,7 +477,7 @@ def _resolve_work_mode_from_issue(
     except OSError:
         return (
             resolve_selected_work_mode(None),
-            "issue.md unreadable; fail closed to full",
+            "issue.md unreadable; fail closed to full-feature",
         )
 
     selected_mode = resolve_selected_work_mode(issue_content)

--- a/scripts/dev_tools/resolve_hard_lock_prompt.py
+++ b/scripts/dev_tools/resolve_hard_lock_prompt.py
@@ -142,8 +142,8 @@ def _resolve_work_mode_from_issue(
 
     Purpose:
         Enforce deterministic mode selection for prompt templates by reading the
-        persisted issue marker first and failing closed to `full` on missing or
-        malformed data.
+        persisted issue marker first and failing closed to `full-feature` on
+        missing or malformed data.
 
     Args:
         target_path: Target plan file path.
@@ -161,7 +161,7 @@ def _resolve_work_mode_from_issue(
     except OSError:
         return (
             resolve_selected_work_mode(None),
-            "issue.md unreadable; fail closed to full",
+            "issue.md unreadable; fail closed to full-feature",
         )
 
     return resolve_selected_work_mode(issue_content), build_fallback_reason(

--- a/tests/scripts/dev_tools/test_new_active_feature_folder_part4.py
+++ b/tests/scripts/dev_tools/test_new_active_feature_folder_part4.py
@@ -133,8 +133,8 @@ def test_work_mode_marker_minor_audit_issue_md_even_when_heuristics_fail() -> No
     assert lines[first_section_index - 1] == ""
 
 
-def test_create_active_folder_full_mode_remains_backward_compatible() -> None:
-    """Verify explicit full mode keeps backward-compatible document outputs."""
+def test_create_active_folder_full_mode_alias_remains_backward_compatible() -> None:
+    """Verify legacy full alias still creates full-feature document outputs."""
     fs = FakeFileSystem()
     workspace = Path("/workspace")
     _seed_feature_template(fs, workspace)
@@ -294,7 +294,7 @@ globals()[
 
 
 def test_create_active_folder_full_mode_persists_full_marker_in_issue_md() -> None:
-    """Verify explicit full mode persists a single full marker in moved issue.md."""
+    """Verify legacy full alias persists canonical full-feature marker in issue.md."""
     fs = FakeFileSystem()
     workspace = Path("/workspace")
     _seed_feature_template(fs, workspace)
@@ -332,11 +332,55 @@ def test_create_active_folder_full_mode_persists_full_marker_in_issue_md() -> No
     issue_md = fs.read_text(result.target / "issue.md")
     lines = issue_md.splitlines()
     marker_lines = [line for line in lines if line.startswith("- Work Mode:")]
-    assert marker_lines == ["- Work Mode: full"]
+    assert marker_lines == ["- Work Mode: full-feature"]
     first_section_index = lines.index("## Problem / Why")
-    marker_index = lines.index("- Work Mode: full")
+    marker_index = lines.index("- Work Mode: full-feature")
     assert marker_index == first_section_index - 2
     assert lines[first_section_index - 1] == ""
+
+
+def test_create_active_folder_bug_full_alias_persists_full_bug_marker() -> None:
+    """Verify legacy full alias normalizes to full-bug for bug folder creation."""
+    fs = FakeFileSystem()
+    workspace = Path("/workspace")
+    _seed_bug_template(fs, workspace)
+    potential_path = (
+        workspace
+        / "docs"
+        / "features"
+        / "potential"
+        / "promoted"
+        / "2026-02-22-bug-mode-test.md"
+    )
+    fs.write_text(
+        potential_path,
+        "\n".join(
+            [
+                "- Issue: #52",
+                "## Summary",
+                "summary",
+                "## Expected Behavior",
+                "expected",
+                "## Actual Behavior",
+                "actual",
+            ]
+        ),
+    )
+
+    result = mod.create_active_folder(
+        feature_name="bug-mode-test",
+        feature_type="bug",
+        issue_number="auto",
+        workspace=workspace,
+        fs=fs,
+        code_launcher=FakeCodeLauncher(),
+        work_mode="full",
+    )
+
+    issue_md = fs.read_text(result.target / "issue.md")
+    assert "- Work Mode: full-bug" in issue_md
+    assert fs.exists(result.target / "spec.md")
+    assert not fs.exists(result.target / "user-story.md")
 
 
 def _minor_audit_behavior_unchanged_with_auto_resolve_option_absent() -> None:

--- a/tests/scripts/dev_tools/test_potential_to_issue.py
+++ b/tests/scripts/dev_tools/test_potential_to_issue.py
@@ -577,7 +577,7 @@ def test_parse_args_and_main_paths(monkeypatch: pytest.MonkeyPatch) -> None:
         potential_path: str, promotion_type: str, work_mode: str
     ) -> mod.PromotionOutcome:
         """Return a successful promotion outcome for main-path testing."""
-        assert work_mode in {"full", "minor-audit"}
+        assert work_mode in {"full", "minor-audit", "full-feature", "full-bug"}
         return mod.PromotionOutcome(0, [], None)
 
     monkeypatch.setattr(mod, "parse_args", fake_parse_args)
@@ -810,7 +810,7 @@ def test_promote_potential_minor_audit_honors_explicit_user_selection() -> None:
 
 
 def test_promote_potential_full_mode_preserves_existing_body_contract() -> None:
-    """Verify explicit full mode preserves legacy full-body section contract."""
+    """Verify legacy full alias preserves the full-feature body contract."""
     workspace = Path("/workspace")
     potential = workspace / "docs/features/potential/full-mode.md"
     fs = FakeFileSystem()
@@ -841,8 +841,45 @@ def test_promote_potential_full_mode_preserves_existing_body_contract() -> None:
         work_mode="full",
     )
     body = gh.calls[0][1][1]
+    assert "- Work Mode: full-feature" in body
     assert "## Proposed Behavior" in body
     assert "## Implementation Intent" not in body
+
+
+def test_promote_potential_full_alias_normalizes_bug_to_full_bug() -> None:
+    """Verify legacy full alias normalizes to full-bug for bug promotions."""
+    workspace = Path("/workspace")
+    potential = workspace / "docs/features/potential/full-bug-mode.md"
+    fs = FakeFileSystem()
+    fs.files[potential] = "\n".join(
+        [
+            "# Full Bug Mode",
+            "## Summary",
+            "summary",
+            "## Expected Behavior",
+            "expected",
+            "## Actual Behavior",
+            "actual",
+        ]
+    )
+    gh = FakeGhClient(
+        mod.GhResult(["Created: https://example.com/issues/100"], 0),
+        mod.GhResult([], 0),
+    )
+
+    mod.promote_potential(
+        potential_path=str(potential),
+        promotion_type="bug",
+        fs=fs,
+        gh=gh,
+        workspace=workspace,
+        work_mode="full",
+    )
+
+    body = gh.calls[0][1][1]
+    assert "- Work Mode: full-bug" in body
+    assert "## Summary" in body
+    assert "## Proposed Behavior" not in body
 
 
 def test_promote_potential_body_omits_token_like_secret_strings() -> None:

--- a/tests/scripts/dev_tools/test_prompt_mode_contract.py
+++ b/tests/scripts/dev_tools/test_prompt_mode_contract.py
@@ -14,24 +14,29 @@ def test_parse_issue_work_mode_valid_minor_marker() -> None:
     assert malformed is False
 
 
-def test_parse_issue_work_mode_valid_full_marker() -> None:
-    """Parse valid full marker from issue content."""
-    mode, malformed = parse_issue_work_mode("- Work Mode: full\n")
-    assert mode == "full"
+def test_parse_issue_work_mode_valid_full_feature_marker() -> None:
+    """Parse valid full-feature marker from issue content."""
+    mode, malformed = parse_issue_work_mode("- Work Mode: full-feature\n")
+    assert mode == "full-feature"
     assert malformed is False
 
 
+def test_resolve_selected_work_mode_normalizes_legacy_full_marker() -> None:
+    """Normalize legacy full markers to the canonical full-feature variant."""
+    assert resolve_selected_work_mode("- Work Mode: full\n") == "full-feature"
+
+
 def test_resolve_selected_work_mode_fails_closed_when_marker_missing() -> None:
-    """Resolve to full when marker is absent."""
-    assert resolve_selected_work_mode("# no marker here\n") == "full"
+    """Resolve to full-feature when marker is absent."""
+    assert resolve_selected_work_mode("# no marker here\n") == "full-feature"
 
 
 def test_resolve_selected_work_mode_fails_closed_when_marker_malformed() -> None:
-    """Resolve to full when marker has unsupported value."""
-    assert resolve_selected_work_mode("- Work Mode: maybe\n") == "full"
+    """Resolve to full-feature when marker has unsupported value."""
+    assert resolve_selected_work_mode("- Work Mode: maybe\n") == "full-feature"
 
 
 def test_build_fallback_reason_is_explicit_for_missing_marker() -> None:
     """Return explicit fallback reason text for missing marker scenario."""
     reason = build_fallback_reason("# no marker\n")
-    assert reason == "issue.md Work Mode marker missing; fail closed to full"
+    assert reason == "issue.md Work Mode marker missing; fail closed to full-feature"

--- a/tests/scripts/dev_tools/test_resolve_execute_plan_prompt_part2.py
+++ b/tests/scripts/dev_tools/test_resolve_execute_plan_prompt_part2.py
@@ -485,7 +485,7 @@ def test_resolve_mode_context_mode_minor_audit(monkeypatch: pytest.MonkeyPatch) 
 def test_resolve_mode_context_mode_fails_closed_when_marker_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Fail closed to full mode when issue marker is missing."""
+    """Fail closed to full-feature mode when issue marker is missing."""
     workspace = Path("/workspace")
     folderpath = "docs/features/active/feature-x"
     issue_path = workspace / folderpath / "issue.md"
@@ -504,14 +504,14 @@ def test_resolve_mode_context_mode_fails_closed_when_marker_missing(
 
     mode, reason = module.resolve_mode_context(folderpath, workspace)
 
-    assert mode == "full"
+    assert mode == "full-feature"
     assert "marker missing" in reason
 
 
 def test_resolve_mode_context_mode_fails_closed_when_issue_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Fail closed to full when issue.md file does not exist."""
+    """Fail closed to full-feature when issue.md file does not exist."""
     workspace = Path("/workspace")
     folderpath = "docs/features/active/feature-x"
 
@@ -522,14 +522,14 @@ def test_resolve_mode_context_mode_fails_closed_when_issue_missing(
 
     mode, reason = module.resolve_mode_context(folderpath, workspace)
 
-    assert mode == "full"
-    assert reason == "issue.md missing; fail closed to full"
+    assert mode == "full-feature"
+    assert reason == "issue.md missing; fail closed to full-feature"
 
 
 def test_resolve_mode_context_mode_fails_closed_when_issue_unreadable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Fail closed to full with unreadable reason when issue.md read fails."""
+    """Fail closed to full-feature with unreadable reason when issue.md read fails."""
     workspace = Path("/workspace")
     folderpath = "docs/features/active/feature-x"
     issue_path = workspace / folderpath / "issue.md"
@@ -546,5 +546,5 @@ def test_resolve_mode_context_mode_fails_closed_when_issue_unreadable(
 
     mode, reason = module.resolve_mode_context(folderpath, workspace)
 
-    assert mode == "full"
-    assert reason == "issue.md unreadable; fail closed to full"
+    assert mode == "full-feature"
+    assert reason == "issue.md unreadable; fail closed to full-feature"

--- a/tests/scripts/dev_tools/test_resolve_file_prompt.py
+++ b/tests/scripts/dev_tools/test_resolve_file_prompt.py
@@ -300,7 +300,7 @@ def test_resolve_prompt_minor_audit_injects_three_phase_override() -> None:
 
 
 def test_resolve_prompt_work_mode_fails_closed_when_marker_missing() -> None:
-    """Resolve ${work-mode} to full when issue.md marker is missing."""
+    """Resolve ${work-mode} to full-feature when issue.md marker is missing."""
     template = "Mode=${work-mode};Reason=${fallback-reason}"
     cwd = Path.cwd()
     feature_dir = cwd / "docs" / "features" / "active" / "2026-02-23-minor-audit-58"
@@ -323,12 +323,12 @@ def test_resolve_prompt_work_mode_fails_closed_when_marker_missing() -> None:
     ):
         result = resolve_prompt(template, target, cwd)
 
-    assert "Mode=full" in result
+    assert "Mode=full-feature" in result
     assert "marker missing" in result
 
 
 def test_resolve_prompt_work_mode_fails_closed_when_marker_malformed() -> None:
-    """Resolve ${work-mode} to full when issue.md marker value is malformed."""
+    """Resolve ${work-mode} to full-feature when issue.md marker value is malformed."""
     template = "Mode=${work-mode};Reason=${fallback-reason}"
     cwd = Path.cwd()
     feature_dir = cwd / "docs" / "features" / "active" / "2026-02-23-minor-audit-58"
@@ -351,8 +351,36 @@ def test_resolve_prompt_work_mode_fails_closed_when_marker_malformed() -> None:
     ):
         result = resolve_prompt(template, target, cwd)
 
-    assert "Mode=full" in result
+    assert "Mode=full-feature" in result
     assert "marker malformed" in result
+
+
+def test_resolve_prompt_work_mode_normalizes_legacy_full_marker() -> None:
+    """Resolve legacy full markers to the canonical full-feature variant."""
+    template = "Mode=${work-mode};Reason=${fallback-reason}"
+    cwd = Path.cwd()
+    feature_dir = cwd / "docs" / "features" / "active" / "2026-02-23-minor-audit-58"
+    target = feature_dir / "plan.md"
+
+    issue_path = feature_dir / "issue.md"
+
+    def _exists(self: Path) -> bool:
+        return self == issue_path
+
+    def _read_text(self: Path, encoding: str = "utf-8") -> str:
+        del encoding
+        if self == issue_path:
+            return "- Work Mode: full\n"
+        raise FileNotFoundError(str(self))
+
+    with (
+        patch.object(Path, "exists", _exists),
+        patch.object(Path, "read_text", _read_text),
+    ):
+        result = resolve_prompt(template, target, cwd)
+
+    assert "Mode=full-feature" in result
+    assert "legacy full; normalized to full-feature" in result
 
 
 def test_resolve_prompt_removes_user_story_clause_when_missing() -> None:

--- a/tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py
+++ b/tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py
@@ -161,7 +161,7 @@ def test_resolve_prompt_uses_parent_issue_for_versioned_plan_path() -> None:
     def _read_text(self: Path, encoding: str = "utf-8") -> str:
         del encoding
         if self == parent_issue:
-            return "- Work Mode: full\n"
+            return "- Work Mode: full-feature\n"
         raise FileNotFoundError(str(self))
 
     with (
@@ -170,7 +170,7 @@ def test_resolve_prompt_uses_parent_issue_for_versioned_plan_path() -> None:
     ):
         result = resolve_prompt(template, target, workspace_root)
 
-    assert "Mode=full" in result
+    assert "Mode=full-feature" in result
     assert "Reason=none" in result
 
 
@@ -196,8 +196,8 @@ def test_resolve_prompt_mode_fallback_when_issue_unreadable() -> None:
     ):
         result = resolve_prompt(template, target, workspace_root)
 
-    assert "Mode=full" in result
-    assert "issue.md unreadable; fail closed to full" in result
+    assert "Mode=full-feature" in result
+    assert "issue.md unreadable; fail closed to full-feature" in result
 
 
 def test_copy_to_clipboard_with_pyperclip_success() -> None:
@@ -456,7 +456,7 @@ def test_main_resume_template_kind(mem_path: Path) -> None:
 
     issue_file = workspace / "docs" / "issue.md"
     issue_file.parent.mkdir(parents=True)
-    issue_file.write_text("- Work Mode: full\n", encoding="utf-8")
+    issue_file.write_text("- Work Mode: full-feature\n", encoding="utf-8")
 
     target_file = workspace / "docs" / "plan.md"
     target_file.write_text("# Plan", encoding="utf-8")
@@ -485,4 +485,4 @@ def test_main_resume_template_kind(mem_path: Path) -> None:
 
     assert exit_code == 0
     assert "Resume docs/plan.md" in mock_stdout.getvalue()
-    assert "mode=full" in mock_stdout.getvalue()
+    assert "mode=full-feature" in mock_stdout.getvalue()


### PR DESCRIPTION
Add acceptance-criteria tracking and canonical full-feature/full-bug work modes

## Summary

- Introduces explicit acceptance-criteria tracking across agent workflows so verified work can be checked off in the authoritative requirement source files instead of being tracked only in plan or review artifacts.
- Replaces the ambiguous legacy `full` work-mode behavior with canonical `full-feature` and `full-bug` modes, while preserving backward compatibility by normalizing legacy `full` markers to `full-feature`.
- Centralizes work-mode parsing and fail-closed resolution in the Python dev-tooling flow so promotion, active-folder creation, and prompt resolution all use the same contract.
- Updates review, orchestration, and status-sync agent contracts to resolve acceptance-criteria source files by work mode and to report acceptance-criteria status summaries.
- Mirrors the updated agent and skill contracts into the extension customization resources so the packaged customization set stays aligned with the repository source.
- Expands regression coverage for mode normalization, bug-specific full-mode handling, and prompt-resolution fallback behavior.

## Why

- The previous workflow only distinguished `minor-audit` from a legacy `full` mode, which left bug-vs-feature behavior implicit and made acceptance-criteria ownership less precise.
- This PR makes work-mode semantics deterministic by separating `full-feature` and `full-bug`, defining which requirement files are authoritative for each mode, and preserving a fail-closed fallback to `full-feature`.
- It also closes a workflow gap where delivered work could be verified without immediately updating the acceptance-criteria checkboxes in the requirement source files, which weakens status reporting and review handoffs.

## What Changed

- Core behavior / architecture
  - Added `.github/skills/acceptance-criteria-tracking/SKILL.md` as the shared protocol for resolving acceptance-criteria source files and checking off verified criteria.
  - Updated `scripts/dev_tools/prompt_mode_contract.py` to normalize legacy `full`, support `full-feature` and `full-bug`, and fail closed to `full-feature`.
  - Updated active-folder creation, issue promotion, and prompt-resolution flows to persist and consume canonical work-mode markers.

- Tooling / automation / DevEx
  - Updated executor, planner, orchestrator, reviewer, and status-updater agent contracts to reference the acceptance-criteria tracking protocol and the new work-mode split.
  - Updated related shared skills such as `atomic-plan-contract`, `feature-promotion-lifecycle`, and `powershell-orchestration-state-machine`.
  - Mirrored the same contract changes into `extensions/drm-copilot/resources/customizations/...` so extension-packaged customizations match the repo source.

- Tests
  - Added and updated regression coverage for:
    - legacy `full` normalization to `full-feature`
    - bug flows normalizing legacy `full` to `full-bug`
    - prompt-resolution fallback behavior when work-mode markers are missing, malformed, or unreadable
    - active-folder and promotion flows persisting canonical markers

- Docs / templates / agents
  - Updated `docs/engineering/Feature Playbook.md` and `docs/features/templates/README.md` to describe work-mode-specific document expectations for `minor-audit`, `full-feature`, and `full-bug`.

## Architecture / How It Fits Together

- `scripts/dev_tools/prompt_mode_contract.py` is the central work-mode contract:
  - parses persisted `issue.md` markers
  - normalizes legacy `full`
  - resolves fail-closed defaults
- Python workflow entry points consume that contract:
  - `new_active_feature_folder_*`
  - `potential_to_issue*`
  - `resolve_*prompt.py`
- Agent and skill definitions then use the same mode semantics to decide:
  - which requirement files are authoritative (`issue.md`, `spec.md`, `user-story.md`)
  - when acceptance criteria should be checked off
  - what completion summaries must be reported
- The extension customization mirrors package those same updated rules for downstream use in the VS Code extension resources.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in `pr_context.summary.txt`).
- `pr_context.summary.txt` reports: `No canonical verification evidence parsed`.

### Recommended

- `poetry run black scripts/dev_tools tests/scripts/dev_tools`
- `poetry run ruff check scripts/dev_tools tests/scripts/dev_tools`
- `poetry run pyright scripts/dev_tools`
- `poetry run pytest tests/scripts/dev_tools/test_prompt_mode_contract.py tests/scripts/dev_tools/test_potential_to_issue.py tests/scripts/dev_tools/test_new_active_feature_folder_part4.py tests/scripts/dev_tools/test_resolve_file_prompt.py tests/scripts/dev_tools/test_resolve_execute_plan_prompt_part2.py tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`

## Backward Compatibility / Migration Notes

- Legacy `- Work Mode: full` markers remain accepted, but the canonical persisted/reported value is now `full-feature`.
- Bug-oriented full-mode flows now persist `full-bug`, which changes the expected authoritative requirement sources from `spec.md` + `user-story.md` to `spec.md` only unless explicitly justified otherwise.
- Consumers that still assume `full` is the only non-`minor-audit` value should be updated to handle `full-feature` and `full-bug`.

## Risks and Mitigations

- Risk: workflow consumers may still assume only `minor-audit` and `full` exist.
  - Mitigation: the shared contract now normalizes legacy `full` and documents explicit fail-closed behavior.
- Risk: repo and extension customization rules could drift.
  - Mitigation: the extension resource mirrors were updated in the same change set.
- Risk: acceptance criteria could still be reported as delivered without source-file checkoffs if a downstream agent ignores the new protocol.
  - Mitigation: executor, reviewer, orchestrator, and status-updater contracts now explicitly require acceptance-criteria tracking and status summaries.
- Risk: bug-feature doc expectations may be applied inconsistently.
  - Mitigation: the playbook, templates, prompt resolvers, and tests were all updated around the same mode split.

## Review Guide

- Review `.github/skills/acceptance-criteria-tracking/SKILL.md` first to understand the new shared protocol and source-resolution rules.
- Review `scripts/dev_tools/prompt_mode_contract.py` next; it is the canonical normalization and fallback implementation.
- Review the Python dev-tool flow changes in:
  - `scripts/dev_tools/new_active_feature_folder_flow.py`
  - `scripts/dev_tools/potential_to_issue.py`
  - `scripts/dev_tools/potential_to_issue_content.py`
  - `scripts/dev_tools/resolve_*prompt.py`
- Review the targeted regression tests to confirm the new canonical markers and bug-mode behavior.
- Review the root `.github/agents/*` and `.github/skills/*` changes as the contract layer.
- Review the mirrored extension customization updates last; they should largely reflect the root contract changes.
- Skim the docs updates in `docs/engineering/Feature Playbook.md` and `docs/features/templates/README.md` for the user-facing workflow impact.

## Follow-ups

- Decide whether existing feature folders that still persist legacy `- Work Mode: full` should be proactively rewritten to canonical markers.
- Consider capturing canonical verification evidence in future PR context generation so completed checks can be reported directly in PR descriptions.
- Keep future agent/skill contract changes synchronized between the repo source and extension customization mirrors.

## GitHub Auto-close

- None (no verified closing issues listed; fill “Author-asserted autoclose issues” in PR Intent to enable auto-close)

## Related issues / PRs

- None