### PR TITLE
Fix coverage and test configuration integration across repo and extension workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ htmlcov/
 .mypy_cache/
 .pytype/
 .pyre/
+
+coverage/
+extensions/drm-copilot/coverage

--- a/.vscode/settings_required.json
+++ b/.vscode/settings_required.json
@@ -1,5 +1,5 @@
 {	
-    "coverage-gutters.coverageBaseDir": "artifacts/pester/**",
+    "coverage-gutters.coverageBaseDir": "**",
     "coverage-gutters.coverageFileNames": [
         "lcov.info",
         "cov.xml",
@@ -20,8 +20,10 @@
         "powershell-coverage.koverage.xml"
     ],
     "koverage.coverageFilePaths": [
+        "coverage",
         "artifacts/pester",
-        "artifacts/pester/kcov/kcov-merged"
+        "artifacts/pester/kcov/kcov-merged",
+        "artifacts/python"
     ],
     "jest.jestCommandLine": "npm run test:unit --",
     "jest.rootPath": ".",

--- a/.vscode/settings_required.json
+++ b/.vscode/settings_required.json
@@ -25,9 +25,11 @@
     ],
     "jest.jestCommandLine": "npm run test:unit --",
     "jest.rootPath": ".",
+    "jest.runMode": "on-demand",
+    "jest.useJest30": true,
     "powershell.cwd": "${workspaceFolder}",
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
     "python.testing.pytestArgs": ["tests"],
-    "python.testing.autoTestDiscoverOnSaveEnabled": true
+    "python.testing.autoTestDiscoverOnSaveEnabled": false
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -293,7 +293,8 @@
 				"pytest",
 				"--cov=src/lexile_corpus_tuner",
 				"--cov=scripts/dev_tools",
-				"--cov-report=term-missing"
+				"--cov-report=term-missing",
+				"--cov-report=lcov:artifacts/python/lcov.info"
 			],
 			"command": "poetry",
 			"group": {
@@ -496,6 +497,26 @@
 			},
 			"problemMatcher": [],
 			"type": "shell"
+		},
+		{
+			"dependsOn": [
+				"TS: 4 Jest: unit tests with coverage",
+				"QC: 4 Pytest: run tests with coverage",
+				"PoshQC: 4 test (Pester)"
+			],
+			"dependsOrder": "sequence",
+			"detail": "Runs Jest, Python, and PowerShell tests with coverage to refresh all Koverage sources.",
+			"group": {
+				"isDefault": false,
+				"kind": "test"
+			},
+			"label": "QC: Coverage: All Providers",
+			"presentation": {
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": []
 		},
 		{
 			"dependsOn": [
@@ -1124,6 +1145,27 @@
 				"kind": "test"
 			},
 			"label": "TS: 4 Jest: unit tests",
+			"presentation": {
+				"close": false,
+				"panel": "new",
+				"reveal": "always",
+				"showReuseMessage": false
+			},
+			"problemMatcher": [],
+			"type": "shell"
+		},
+		{
+			"args": [
+				"run",
+				"test:unit:coverage"
+			],
+			"command": "npm",
+			"detail": "Runs Jest unit tests with coverage and writes coverage/lcov.info.",
+			"group": {
+				"isDefault": false,
+				"kind": "test"
+			},
+			"label": "TS: 4 Jest: unit tests with coverage",
 			"presentation": {
 				"close": false,
 				"panel": "new",

--- a/extensions/drm-copilot/jest.config.cjs
+++ b/extensions/drm-copilot/jest.config.cjs
@@ -6,5 +6,4 @@ module.exports = {
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.jest.json" }],
-  },
-};
+  },  coverageProvider: "v8",};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,4 +10,5 @@ module.exports = {
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.jest.json" }],
   },
+  coverageProvider: "v8",
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pretest": "npm run compile && npm run compile:integration-tests && npm run lint",
     "lint": "eslint --no-error-on-unmatched-pattern src tests",
     "test:unit": "jest --config jest.config.cjs",
+    "test:unit:coverage": "jest --config jest.config.cjs --coverage",
     "test:integration": "vscode-test",
     "test": "vscode-test"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ select = [
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-ra"
+addopts = "-ra --cov-report=lcov:artifacts/python/lcov.info"
 testpaths = ["tests"]
 
 [tool.coverage.run]

--- a/tests/scripts/dev-tools/publish-sideloaded-extension.Tests.ps1
+++ b/tests/scripts/dev-tools/publish-sideloaded-extension.Tests.ps1
@@ -15,10 +15,10 @@ Describe "publish-sideloaded-extension.ps1 - Resolve-ExtensionProjectRoot" {
     }
 
     It "selects the extension folder when root package.json is not a VS Code extension manifest" {
-        $repoRoot = "C:\repo"
-        $repoPackagePath = "C:\repo\package.json"
-        $extensionRoot = "C:\repo\extensions\drm-copilot"
-        $extensionPackagePath = "C:\repo\extensions\drm-copilot\package.json"
+        $repoRoot = "/repo"
+        $repoPackagePath = "/repo/package.json"
+        $extensionRoot = "/repo/extensions/drm-copilot"
+        $extensionPackagePath = "/repo/extensions/drm-copilot/package.json"
 
         Mock -CommandName Test-Path -MockWith {
             param([string]$LiteralPath)
@@ -46,8 +46,8 @@ Describe "publish-sideloaded-extension.ps1 - Resolve-ExtensionProjectRoot" {
     }
 
     It "keeps repo root when package.json already has engines.vscode" {
-        $repoRoot = "C:\repo"
-        $repoPackagePath = "C:\repo\package.json"
+        $repoRoot = "/repo"
+        $repoPackagePath = "/repo/package.json"
 
         Mock -CommandName Test-Path -MockWith {
             param([string]$LiteralPath)
@@ -67,6 +67,17 @@ Describe "publish-sideloaded-extension.ps1 - Resolve-ExtensionProjectRoot" {
 
         $result = Resolve-ExtensionProjectRoot -RepoRoot $repoRoot
         $result | Should -Be $repoRoot
+    }
+
+    It "treats a manifest without engines.vscode as non-extension metadata" {
+        $manifest = [pscustomobject]@{
+            name    = 'repo-package'
+            engines = [pscustomobject]@{}
+        }
+
+        $result = Test-IsVsCodeExtensionManifest -Manifest $manifest
+
+        $result | Should -BeFalse
     }
 }
 

--- a/tests/scripts/dev-tools/run-actionlint.Tests.ps1
+++ b/tests/scripts/dev-tools/run-actionlint.Tests.ps1
@@ -19,21 +19,21 @@ Describe "run-actionlint.ps1" {
     Context "Resolve-ActionlintPath" {
         It "resolves paths correctly from script location" {
             # Arrange
-            $testScriptPath = 'C:\repo\scripts\dev-tools\run-actionlint.ps1'
+            $testScriptPath = '/repo/scripts/dev-tools/run-actionlint.ps1'
 
-            Mock -CommandName Split-Path -MockWith { 'C:\repo\scripts\dev-tools' }
+            Mock -CommandName Split-Path -MockWith { '/repo/scripts/dev-tools' }
             Mock -CommandName Resolve-Path -MockWith {
-                [PSCustomObject]@{ Path = 'C:\repo' }
+                [PSCustomObject]@{ Path = '/repo' }
             }
             Mock -CommandName Join-Path -MockWith {
                 param($Path, $ChildPath)
                 $null = $Path
                 if ($ChildPath -eq '..\..') {
-                    return 'C:\repo'
+                    return '/repo'
                 } elseif ($ChildPath -eq 'tools\actionlint\bin') {
-                    return 'C:\repo\tools\actionlint\bin'
+                    return '/repo/tools/actionlint/bin'
                 } else {
-                    return 'C:\repo\tools\actionlint\bin\actionlint.exe'
+                    return '/repo/tools/actionlint/bin/actionlint.exe'
                 }
             }
 
@@ -41,25 +41,25 @@ Describe "run-actionlint.ps1" {
             $result = Resolve-ActionlintPath -ScriptPath $testScriptPath
 
             # Assert
-            $result.RepoRoot | Should -Be 'C:\repo'
-            $result.BinDir | Should -Be 'C:\repo\tools\actionlint\bin'
-            $result.ExePath | Should -Be 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $result.RepoRoot | Should -Be '/repo'
+            $result.BinDir | Should -Be '/repo/tools/actionlint/bin'
+            $result.ExePath | Should -Be '/repo/tools/actionlint/bin/actionlint.exe'
         }
 
         It "returns PSCustomObject with expected properties" {
             # Arrange
-            Mock -CommandName Split-Path -MockWith { 'C:\test\scripts\dev-tools' }
-            Mock -CommandName Resolve-Path -MockWith { [PSCustomObject]@{ Path = 'C:\test' } }
+            Mock -CommandName Split-Path -MockWith { '/test/scripts/dev-tools' }
+            Mock -CommandName Resolve-Path -MockWith { [PSCustomObject]@{ Path = '/test' } }
             Mock -CommandName Join-Path -MockWith {
                 param($Path, $ChildPath)
                 $null = $Path
-                if ($ChildPath -eq '..\..') { return 'C:\test' }
-                elseif ($ChildPath -eq 'tools\actionlint\bin') { return 'C:\test\tools\actionlint\bin' }
-                else { return 'C:\test\tools\actionlint\bin\actionlint.exe' }
+                if ($ChildPath -eq '..\..') { return '/test' }
+                elseif ($ChildPath -eq 'tools\actionlint\bin') { return '/test/tools/actionlint/bin' }
+                else { return '/test/tools/actionlint/bin/actionlint.exe' }
             }
 
             # Act
-            $result = Resolve-ActionlintPath -ScriptPath 'C:\test\scripts\dev-tools\run-actionlint.ps1'
+            $result = Resolve-ActionlintPath -ScriptPath '/test/scripts/dev-tools/run-actionlint.ps1'
 
             # Assert
             $result | Should -BeOfType [PSCustomObject]
@@ -73,14 +73,14 @@ Describe "run-actionlint.ps1" {
         It "returns command source when actionlint is found on PATH" {
             # Arrange
             Mock -CommandName Get-Command -MockWith {
-                [PSCustomObject]@{ Source = 'C:\tools\actionlint.exe' }
+                [PSCustomObject]@{ Source = '/tools/actionlint.exe' }
             }
 
             # Act
             $result = Find-ActionlintOnPath
 
             # Assert
-            $result | Should -Be 'C:\tools\actionlint.exe'
+            $result | Should -Be '/tools/actionlint.exe'
             Should -Invoke Get-Command -Times 1 -Exactly
         }
 
@@ -123,7 +123,7 @@ Describe "run-actionlint.ps1" {
                 param($MessageData)
                 $script:infoMessages += $MessageData
             }
-            Mock -CommandName New-Item -MockWith { [PSCustomObject]@{ FullName = 'C:\repo\tools\actionlint\bin' } }
+            Mock -CommandName New-Item -MockWith { [PSCustomObject]@{ FullName = '/repo/tools/actionlint/bin' } }
             Mock -CommandName Invoke-WebRequest -MockWith { }
             Mock -CommandName Expand-Archive -MockWith { }
             Mock -CommandName Remove-Item -MockWith { }
@@ -136,17 +136,17 @@ Describe "run-actionlint.ps1" {
 
         It "creates bin directory if it does not exist" {
             # Act
-            $null = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $null = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe'
 
             # Assert
             Should -Invoke New-Item -Times 1 -Exactly -ParameterFilter {
-                $ItemType -eq 'Directory' -and $Path -eq 'C:\repo\tools\actionlint\bin'
+                $ItemType -eq 'Directory' -and $Path -eq '/repo/tools/actionlint/bin'
             }
         }
 
         It "downloads actionlint from GitHub releases" {
             # Act
-            $null = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe' -Version '1.7.7'
+            $null = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe' -Version '1.7.7'
 
             # Assert
             Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
@@ -156,17 +156,17 @@ Describe "run-actionlint.ps1" {
 
         It "extracts downloaded archive to bin directory" {
             # Act
-            $null = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $null = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe'
 
             # Assert
             Should -Invoke Expand-Archive -Times 1 -Exactly -ParameterFilter {
-                $DestinationPath -eq 'C:\repo\tools\actionlint\bin'
+                $DestinationPath -eq '/repo/tools/actionlint/bin'
             }
         }
 
         It "removes zip file after extraction" {
             # Act
-            $null = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $null = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe'
 
             # Assert
             Should -Invoke Remove-Item -Times 1 -Exactly -ParameterFilter {
@@ -176,10 +176,10 @@ Describe "run-actionlint.ps1" {
 
         It "returns exe path on successful installation" {
             # Act
-            $result = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $result = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe'
 
             # Assert
-            $result | Should -Be 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $result | Should -Be '/repo/tools/actionlint/bin/actionlint.exe'
         }
 
         It "throws error when exe not found after extraction" {
@@ -187,13 +187,13 @@ Describe "run-actionlint.ps1" {
             Mock -CommandName Test-Path -MockWith { $false }
 
             # Act & Assert
-            { Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe' } |
+            { Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe' } |
                 Should -Throw -ExpectedMessage '*actionlint.exe was not found*'
         }
 
         It "writes information messages during installation" {
             # Act
-            $null = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $null = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe'
 
             # Assert - verify at least the first info message is written
             $script:infoMessages | Should -Not -BeNullOrEmpty
@@ -202,7 +202,7 @@ Describe "run-actionlint.ps1" {
 
         It "uses custom version when provided" {
             # Act
-            $null = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe' -Version '1.6.0'
+            $null = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe' -Version '1.6.0'
 
             # Assert
             Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
@@ -212,7 +212,7 @@ Describe "run-actionlint.ps1" {
 
         It "defaults to version 1.7.7 when not specified" {
             # Act
-            $null = Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe'
+            $null = Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe'
 
             # Assert
             Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
@@ -332,19 +332,19 @@ Describe "run-actionlint.ps1" {
 
         It "invokes provided process delegate and returns exit code" {
             $script:lastInvocation = $null
-            $exit = Invoke-ActionlintCommand -CommandPath 'C:\bin\actionlint.exe' -Arguments @('-verbose') -InvokeProcess {
+            $exit = Invoke-ActionlintCommand -CommandPath '/bin/actionlint.exe' -Arguments @('-verbose') -InvokeProcess {
                 param([string]$ActionlintCommand, [string[]]$ActionlintArgs)
                 $script:lastInvocation = @{ Command = $ActionlintCommand; Args = $ActionlintArgs }
                 $global:LASTEXITCODE = 0
             }
 
             $exit | Should -Be 0
-            $script:lastInvocation.Command | Should -Be 'C:\bin\actionlint.exe'
+            $script:lastInvocation.Command | Should -Be '/bin/actionlint.exe'
             $script:lastInvocation.Args | Should -Be @('-verbose')
         }
 
         It "returns exit code and writes error on failure" {
-            $exit = Invoke-ActionlintCommand -CommandPath 'C:\bin\actionlint.exe' -Arguments @('-check') -InvokeProcess {
+            $exit = Invoke-ActionlintCommand -CommandPath '/bin/actionlint.exe' -Arguments @('-check') -InvokeProcess {
                 param([string]$ActionlintCommand, [string[]]$ActionlintArgs)
                 [void] $ActionlintCommand
                 [void] $ActionlintArgs
@@ -363,15 +363,15 @@ Describe "run-actionlint.ps1" {
                 $global:LASTEXITCODE = 0
             }
 
-            $null = Invoke-ActionlintCommand -CommandPath 'C:\bin\actionlint.exe' -Arguments @('--color')
+            $null = Invoke-ActionlintCommand -CommandPath '/bin/actionlint.exe' -Arguments @('--color')
 
-            $script:captured.Command | Should -Be 'C:\bin\actionlint.exe'
+            $script:captured.Command | Should -Be '/bin/actionlint.exe'
             $script:captured.Args | Should -Be @('--color')
         }
 
         It "handles zero arguments correctly" {
             $script:lastInvocation = $null
-            $exit = Invoke-ActionlintCommand -CommandPath 'C:\bin\actionlint.exe' -InvokeProcess {
+            $exit = Invoke-ActionlintCommand -CommandPath '/bin/actionlint.exe' -InvokeProcess {
                 param([string]$ActionlintCommand, [string[]]$ActionlintArgs)
                 $script:lastInvocation = @{ Command = $ActionlintCommand; Args = $ActionlintArgs }
                 $global:LASTEXITCODE = 0
@@ -443,7 +443,7 @@ Describe "run-actionlint.ps1" {
             }
 
             # Act & Assert
-            { Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe' } |
+            { Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe' } |
                 Should -Throw
         }
 
@@ -458,7 +458,7 @@ Describe "run-actionlint.ps1" {
             }
 
             # Act & Assert
-            { Install-Actionlint -BinDir 'C:\repo\tools\actionlint\bin' -ExePath 'C:\repo\tools\actionlint\bin\actionlint.exe' } |
+            { Install-Actionlint -BinDir '/repo/tools/actionlint/bin' -ExePath '/repo/tools/actionlint/bin/actionlint.exe' } |
                 Should -Throw
         }
 
@@ -486,16 +486,16 @@ Describe "run-actionlint.ps1" {
             Mock -CommandName Test-Path -MockWith { $true }
 
             # Act
-            $result = Install-Actionlint -BinDir 'C:\repo with spaces\tools' -ExePath 'C:\repo with spaces\tools\actionlint.exe'
+            $result = Install-Actionlint -BinDir '/repo with spaces/tools' -ExePath '/repo with spaces/tools/actionlint.exe'
 
             # Assert
-            $result | Should -Be 'C:\repo with spaces\tools\actionlint.exe'
+            $result | Should -Be '/repo with spaces/tools/actionlint.exe'
         }
 
         It "Add-DirectoryToPath handles paths with trailing separator" {
             # Arrange
-            $env:PATH = 'C:\existing'
-            $newDir = 'C:\new\'
+            $env:PATH = '/existing'
+            $newDir = '/new/'
 
             # Act
             Add-DirectoryToPath -Directory $newDir

--- a/tests/scripts/dev-tools/tree.Tests.ps1
+++ b/tests/scripts/dev-tools/tree.Tests.ps1
@@ -13,19 +13,19 @@ Describe "Show-Tree function" {
         It "lists files and directories with proper formatting" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "file.txt"; FullName = "C:\root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "folder"; FullName = "C:\root\folder"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
+                [pscustomobject]@{ Name = "file.txt"; FullName = "/root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "folder"; FullName = "/root\folder"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
                 param($LiteralPath, $Force)
                 $null = $Force
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -36,15 +36,15 @@ Describe "Show-Tree function" {
 
         It "formats directory entries with [dir] prefix in mixed mode" {
             # Arrange
-            $items = @([pscustomobject]@{ Name = "mydir"; FullName = "C:\root\mydir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
+            $items = @([pscustomobject]@{ Name = "mydir"; FullName = "/root\mydir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $output | Should -Contain "[dir] mydir"
@@ -52,15 +52,15 @@ Describe "Show-Tree function" {
 
         It "formats file entries with space prefix in mixed mode" {
             # Arrange
-            $items = @([pscustomobject]@{ Name = "readme.md"; FullName = "C:\root\readme.md"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
+            $items = @([pscustomobject]@{ Name = "readme.md"; FullName = "/root\readme.md"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $output | Should -Match "^\s{6}readme\.md$"
@@ -71,17 +71,17 @@ Describe "Show-Tree function" {
         It "excludes hidden files when IncludeHiddenEntries is false" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "visible.txt"; FullName = "C:\root\visible.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "hidden.txt"; FullName = "C:\root\hidden.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Hidden }
+                [pscustomobject]@{ Name = "visible.txt"; FullName = "/root\visible.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "hidden.txt"; FullName = "/root\hidden.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Hidden }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -92,17 +92,17 @@ Describe "Show-Tree function" {
         It "includes hidden files when IncludeHiddenEntries is true" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "visible.txt"; FullName = "C:\root\visible.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "hidden.txt"; FullName = "C:\root\hidden.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Hidden }
+                [pscustomobject]@{ Name = "visible.txt"; FullName = "/root\visible.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "hidden.txt"; FullName = "/root\hidden.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Hidden }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$true -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$true -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -112,15 +112,15 @@ Describe "Show-Tree function" {
 
         It "excludes hidden directories when IncludeHiddenEntries is false" {
             # Arrange
-            $items = @([pscustomobject]@{ Name = ".hidden-dir"; FullName = "C:\root\.hidden-dir"; PSIsContainer = $true; Attributes = ([IO.FileAttributes]::Hidden -bor [IO.FileAttributes]::Directory) })
+            $items = @([pscustomobject]@{ Name = ".hidden-dir"; FullName = "/root\.hidden-dir"; PSIsContainer = $true; Attributes = ([IO.FileAttributes]::Hidden -bor [IO.FileAttributes]::Directory) })
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             ($output -join "`n") | Should -Not -Match "\.hidden-dir"
@@ -131,17 +131,17 @@ Describe "Show-Tree function" {
         It "excludes items by exact name match" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "keep.txt"; FullName = "C:\root\keep.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "node_modules"; FullName = "C:\root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
+                [pscustomobject]@{ Name = "keep.txt"; FullName = "/root\keep.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "node_modules"; FullName = "/root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @("node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @("node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -152,18 +152,18 @@ Describe "Show-Tree function" {
         It "excludes multiple items from the exclusion list" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "keep.txt"; FullName = "C:\root\keep.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = ".git"; FullName = "C:\root\.git"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
-                [pscustomobject]@{ Name = "node_modules"; FullName = "C:\root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
+                [pscustomobject]@{ Name = "keep.txt"; FullName = "/root\keep.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = ".git"; FullName = "/root\.git"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
+                [pscustomobject]@{ Name = "node_modules"; FullName = "/root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @(".git", "node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @(".git", "node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -174,15 +174,15 @@ Describe "Show-Tree function" {
 
         It "handles empty exclusion list" {
             # Arrange
-            $items = @([pscustomobject]@{ Name = "file.txt"; FullName = "C:\root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
+            $items = @([pscustomobject]@{ Name = "file.txt"; FullName = "/root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             ($output -join "`n") | Should -Match "file\.txt"
@@ -193,17 +193,17 @@ Describe "Show-Tree function" {
         It "shows only directories with backslash suffix when DirectoriesOnly is true" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "file.txt"; FullName = "C:\root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "folder"; FullName = "C:\root\folder"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
+                [pscustomobject]@{ Name = "file.txt"; FullName = "/root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "folder"; FullName = "/root\folder"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$true
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$true
 
             # Assert
             $outputText = $output -join "`n"
@@ -213,15 +213,15 @@ Describe "Show-Tree function" {
 
         It "omits [dir] prefix in DirectoriesOnly mode" {
             # Arrange
-            $items = @([pscustomobject]@{ Name = "mydir"; FullName = "C:\root\mydir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
+            $items = @([pscustomobject]@{ Name = "mydir"; FullName = "/root\mydir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$true
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$true
 
             # Assert
             ($output -join "`n") | Should -Not -Match "\[dir\]"
@@ -231,17 +231,17 @@ Describe "Show-Tree function" {
         It "skips files entirely in DirectoriesOnly mode" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "readme.md"; FullName = "C:\root\readme.md"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "another.txt"; FullName = "C:\root\another.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal }
+                [pscustomobject]@{ Name = "readme.md"; FullName = "/root\readme.md"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "another.txt"; FullName = "/root\another.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$true
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$true
 
             # Assert
             $output | Should -BeNullOrEmpty
@@ -251,19 +251,19 @@ Describe "Show-Tree function" {
     Context "Recursive traversal" {
         It "recursively traverses subdirectories" {
             # Arrange
-            $rootItems = @([pscustomobject]@{ Name = "subdir"; FullName = "C:\root\subdir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
-            $subItems = @([pscustomobject]@{ Name = "nested.txt"; FullName = "C:\root\subdir\nested.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
+            $rootItems = @([pscustomobject]@{ Name = "subdir"; FullName = "/root\subdir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
+            $subItems = @([pscustomobject]@{ Name = "nested.txt"; FullName = "/root\subdir\nested.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
 
             Mock -CommandName Get-ChildItem -MockWith {
                 param($LiteralPath, $Force)
                 $null = $Force
-                if ($LiteralPath -eq "C:\root") { return $rootItems }
-                if ($LiteralPath -eq "C:\root\subdir") { return $subItems }
+                if ($LiteralPath -eq "/root") { return $rootItems }
+                if ($LiteralPath -eq "/root\subdir") { return $subItems }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -273,21 +273,21 @@ Describe "Show-Tree function" {
 
         It "applies correct indentation for nested items" {
             # Arrange
-            $rootItems = @([pscustomobject]@{ Name = "level1"; FullName = "C:\root\level1"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
-            $level1Items = @([pscustomobject]@{ Name = "level2"; FullName = "C:\root\level1\level2"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
-            $level2Items = @([pscustomobject]@{ Name = "deep.txt"; FullName = "C:\root\level1\level2\deep.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
+            $rootItems = @([pscustomobject]@{ Name = "level1"; FullName = "/root\level1"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
+            $level1Items = @([pscustomobject]@{ Name = "level2"; FullName = "/root\level1\level2"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory })
+            $level2Items = @([pscustomobject]@{ Name = "deep.txt"; FullName = "/root\level1\level2\deep.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
 
             Mock -CommandName Get-ChildItem -MockWith {
                 param($LiteralPath, $Force)
                 $null = $Force
-                if ($LiteralPath -eq "C:\root") { return $rootItems }
-                if ($LiteralPath -eq "C:\root\level1") { return $level1Items }
-                if ($LiteralPath -eq "C:\root\level1\level2") { return $level2Items }
+                if ($LiteralPath -eq "/root") { return $rootItems }
+                if ($LiteralPath -eq "/root\level1") { return $level1Items }
+                if ($LiteralPath -eq "/root\level1\level2") { return $level2Items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $output | Should -Not -BeNullOrEmpty
@@ -300,24 +300,24 @@ Describe "Show-Tree function" {
         It "stops recursion at excluded directories" {
             # Arrange
             $rootItems = @(
-                [pscustomobject]@{ Name = "allowed"; FullName = "C:\root\allowed"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
-                [pscustomobject]@{ Name = "node_modules"; FullName = "C:\root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
+                [pscustomobject]@{ Name = "allowed"; FullName = "/root\allowed"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
+                [pscustomobject]@{ Name = "node_modules"; FullName = "/root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
             )
-            $allowedItems = @([pscustomobject]@{ Name = "file.txt"; FullName = "C:\root\allowed\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
+            $allowedItems = @([pscustomobject]@{ Name = "file.txt"; FullName = "/root\allowed\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
 
             Mock -CommandName Get-ChildItem -MockWith {
                 param($LiteralPath, $Force)
                 $null = $Force
-                if ($LiteralPath -eq "C:\root") { return $rootItems }
-                if ($LiteralPath -eq "C:\root\allowed") { return $allowedItems }
-                if ($LiteralPath -eq "C:\root\node_modules") {
+                if ($LiteralPath -eq "/root") { return $rootItems }
+                if ($LiteralPath -eq "/root\allowed") { return $allowedItems }
+                if ($LiteralPath -eq "/root\node_modules") {
                     throw "Should not traverse excluded directory"
                 }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @("node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @("node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -333,7 +333,7 @@ Describe "Show-Tree function" {
             Mock -CommandName Get-ChildItem -MockWith { return @() }
 
             # Act
-            $output = Show-Tree -Path "C:\empty" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/empty" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $output | Should -BeNullOrEmpty
@@ -341,15 +341,15 @@ Describe "Show-Tree function" {
 
         It "handles paths with special characters" {
             # Arrange
-            $items = @([pscustomobject]@{ Name = "file (1).txt"; FullName = "C:\root\file (1).txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
+            $items = @([pscustomobject]@{ Name = "file (1).txt"; FullName = "/root\file (1).txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal })
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             ($output -join "`n") | Should -Match "file \(1\)\.txt"
@@ -358,18 +358,18 @@ Describe "Show-Tree function" {
         It "sorts items alphabetically by name" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "zebra.txt"; FullName = "C:\root\zebra.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "apple.txt"; FullName = "C:\root\apple.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "banana.txt"; FullName = "C:\root\banana.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal }
+                [pscustomobject]@{ Name = "zebra.txt"; FullName = "/root\zebra.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "apple.txt"; FullName = "/root\apple.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "banana.txt"; FullName = "/root\banana.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @() -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $output[0] | Should -Match "apple"
@@ -382,18 +382,18 @@ Describe "Show-Tree function" {
         It "applies both exclusion and hidden filters together" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "visible.txt"; FullName = "C:\root\visible.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
-                [pscustomobject]@{ Name = "hidden.txt"; FullName = "C:\root\hidden.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Hidden },
-                [pscustomobject]@{ Name = "exclude-me"; FullName = "C:\root\exclude-me"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
+                [pscustomobject]@{ Name = "visible.txt"; FullName = "/root\visible.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal },
+                [pscustomobject]@{ Name = "hidden.txt"; FullName = "/root\hidden.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Hidden },
+                [pscustomobject]@{ Name = "exclude-me"; FullName = "/root\exclude-me"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @("exclude-me") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
+            $output = Show-Tree -Path "/root" -ExcludeNames @("exclude-me") -IncludeHiddenEntries:$false -DirectoriesOnly:$false
 
             # Assert
             $outputText = $output -join "`n"
@@ -405,19 +405,19 @@ Describe "Show-Tree function" {
         It "applies DirectoriesOnly with exclusions and hidden filters" {
             # Arrange
             $items = @(
-                [pscustomobject]@{ Name = "visible-dir"; FullName = "C:\root\visible-dir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
-                [pscustomobject]@{ Name = ".hidden-dir"; FullName = "C:\root\.hidden-dir"; PSIsContainer = $true; Attributes = ([IO.FileAttributes]::Hidden -bor [IO.FileAttributes]::Directory) },
-                [pscustomobject]@{ Name = "node_modules"; FullName = "C:\root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
-                [pscustomobject]@{ Name = "file.txt"; FullName = "C:\root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal }
+                [pscustomobject]@{ Name = "visible-dir"; FullName = "/root\visible-dir"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
+                [pscustomobject]@{ Name = ".hidden-dir"; FullName = "/root\.hidden-dir"; PSIsContainer = $true; Attributes = ([IO.FileAttributes]::Hidden -bor [IO.FileAttributes]::Directory) },
+                [pscustomobject]@{ Name = "node_modules"; FullName = "/root\node_modules"; PSIsContainer = $true; Attributes = [IO.FileAttributes]::Directory },
+                [pscustomobject]@{ Name = "file.txt"; FullName = "/root\file.txt"; PSIsContainer = $false; Attributes = [IO.FileAttributes]::Normal }
             )
 
             Mock -CommandName Get-ChildItem -MockWith {
-                if ($LiteralPath -eq "C:\root") { return $items }
+                if ($LiteralPath -eq "/root") { return $items }
                 return @()
             }
 
             # Act
-            $output = Show-Tree -Path "C:\root" -ExcludeNames @("node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$true
+            $output = Show-Tree -Path "/root" -ExcludeNames @("node_modules") -IncludeHiddenEntries:$false -DirectoriesOnly:$true
 
             # Assert
             $outputText = $output -join "`n"
@@ -435,6 +435,15 @@ Describe "tree.ps1 script integration" {
     }
 
     Context "Parameter handling and output" {
+        It "executes the main script flow with a resolved root" {
+            Mock -CommandName Resolve-Path -MockWith { [pscustomobject]@{ Path = '/repo' } }
+            Mock -CommandName Get-ChildItem -MockWith { @() }
+
+            $output = & $script:scriptPath -Root '/repo' -Exclude @()
+
+            $output | Should -Contain 'Tree for repo'
+        }
+
         It "resolves the root path correctly" {
             # Verify script uses Resolve-Path for root path
             $scriptContent = Get-Content -Path $script:scriptPath -Raw

--- a/tests/scripts/powershell/PoshQC/PoshQC.Comprehensive.Tests.ps1
+++ b/tests/scripts/powershell/PoshQC/PoshQC.Comprehensive.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'Get-PoshQCFileList' {
             InModuleScope PoshQC {
                 Mock -CommandName Resolve-Path -MockWith { throw 'Path not found' }
 
-                { Get-PoshQCFileList -Root 'C:\nonexistent' } | Should -Throw
+                { Get-PoshQCFileList -Root '/missing' } | Should -Throw
             }
         }
     }
@@ -150,7 +150,7 @@ Describe 'Invoke-PoshQCFormat' {
                 Mock -CommandName Import-Module -MockWith { }
                 Mock -CommandName Test-Path -MockWith { $false }
 
-                { Invoke-PoshQCFormat -Root $PSScriptRoot -SettingsPath 'C:\nonexistent.psd1' } | Should -Throw '*Settings not found*'
+                { Invoke-PoshQCFormat -Root $PSScriptRoot -SettingsPath '/missing.psd1' } | Should -Throw '*Settings not found*'
             }
         }
     }
@@ -238,7 +238,7 @@ Describe 'Invoke-PoshQCAnalyze' {
                 Mock -CommandName Import-Module -MockWith { }
                 Mock -CommandName Test-Path -MockWith { $false }
 
-                { Invoke-PoshQCAnalyze -Root $PSScriptRoot -SettingsPath 'C:\nonexistent.psd1' } | Should -Throw '*Settings not found*'
+                { Invoke-PoshQCAnalyze -Root $PSScriptRoot -SettingsPath '/missing.psd1' } | Should -Throw '*Settings not found*'
             }
         }
     }
@@ -339,7 +339,7 @@ Describe 'Invoke-PoshQCTest' {
                 Mock -CommandName Import-Module -MockWith { }
                 Mock -CommandName Test-Path -MockWith { $false }
 
-                { Invoke-PoshQCTest -Root $PSScriptRoot -SettingsPath 'C:\nonexistent.psd1' } | Should -Throw '*Settings not found*'
+                { Invoke-PoshQCTest -Root $PSScriptRoot -SettingsPath '/missing.psd1' } | Should -Throw '*Settings not found*'
             }
         }
     }

--- a/tests/scripts/powershell/PoshQC/PoshQC.EntryPoints.Tests.ps1
+++ b/tests/scripts/powershell/PoshQC/PoshQC.EntryPoints.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Invoke-PoshQCFormat' {
 
 Describe 'Invoke-PoshQCAnalyze' {
     It 'validates settings path exists' {
-        { Invoke-PoshQCAnalyze -Root $PSScriptRoot -SettingsPath 'C:\nonexistent\settings.psd1' } | Should -Throw '*Settings not found*'
+        { Invoke-PoshQCAnalyze -Root $PSScriptRoot -SettingsPath '/missing/settings.psd1' } | Should -Throw '*Settings not found*'
     }
 }
 

--- a/tests/scripts/powershell/PoshQC/PoshQC.Tests.ps1
+++ b/tests/scripts/powershell/PoshQC/PoshQC.Tests.ps1
@@ -288,20 +288,20 @@ Describe 'Convert-PoshQCCoverageToRelative' {
             $mockXmlContent = @'
 <?xml version="1.0" encoding="UTF-8"?>
 <report name="Pester">
-  <package name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools">
-  <class name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools/collect-commit-context" sourcefilename="collect-commit-context.ps1">
+    <package name="/repo-root/scripts/dev-tools">
+    <class name="/repo-root/scripts/dev-tools/collect-commit-context" sourcefilename="collect-commit-context.ps1">
   </class>
   </package>
-  <package name="/tmp/repos/lexile-corpus-tuner/scripts/powershell/PoshQC">
+    <package name="/repo-root/scripts/powershell/PoshQC">
   <sourcefile name="PoshQC.psm1">
   </sourcefile>
   </package>
 </report>
 '@
 
-            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/tmp/repos/lexile-corpus-tuner' -PassThru
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/repo-root' -PassThru
 
-            $result | Should -Not -Match '/tmp/repos/lexile-corpus-tuner/'
+            $result | Should -Not -Match '/repo-root/'
             $result | Should -Match '<package name="scripts/dev-tools">'
             $result | Should -Match '<class name="scripts/dev-tools/collect-commit-context"'
             $result | Should -Match '<package name="scripts/powershell/PoshQC">'
@@ -311,17 +311,17 @@ Describe 'Convert-PoshQCCoverageToRelative' {
             $mockXmlContent = @'
 <?xml version="1.0" encoding="UTF-8"?>
 <report name="Pester">
-  <package name="C:\repos\lexile-corpus-tuner\scripts\dev-tools">
-  <class name="C:\repos\lexile-corpus-tuner\scripts\dev-tools\collect-commit-context" sourcefilename="collect-commit-context.ps1">
+    <package name="\repo-root\scripts\dev-tools">
+    <class name="\repo-root\scripts\dev-tools\collect-commit-context" sourcefilename="collect-commit-context.ps1">
   </class>
   </package>
 </report>
 '@
 
-            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot 'C:\repos\lexile-corpus-tuner' -PassThru
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '\repo-root' -PassThru
 
-            $result | Should -Not -Match 'C:/repos/lexile-corpus-tuner/'
-            $result | Should -Not -Match 'C:\\repos\\lexile-corpus-tuner\\'
+            $result | Should -Not -Match '/repo-root/'
+            $result | Should -Not -Match '\\repo-root\\'
             $result | Should -Match 'scripts'
         }
 
@@ -329,17 +329,17 @@ Describe 'Convert-PoshQCCoverageToRelative' {
             $mockXmlContent = @'
 <?xml version="1.0" encoding="UTF-8"?>
 <report name="Pester">
-  <package name="C:/repos/lexile-corpus-tuner/scripts/dev-tools">
-  <class name="C:\repos\lexile-corpus-tuner\scripts\powershell\PoshQC" sourcefilename="PoshQC.psm1">
+    <package name="/repo-root/scripts/dev-tools">
+    <class name="\repo-root\scripts\powershell\PoshQC" sourcefilename="PoshQC.psm1">
   </class>
   </package>
 </report>
 '@
 
-            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot 'C:\repos\lexile-corpus-tuner' -PassThru
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/repo-root' -PassThru
 
-            $result | Should -Not -Match 'C:/repos/lexile-corpus-tuner/'
-            $result | Should -Not -Match 'C:\\repos\\lexile-corpus-tuner\\'
+            $result | Should -Not -Match '/repo-root/'
+            $result | Should -Not -Match '\\repo-root\\'
             $result | Should -Match 'scripts'
         }
     }
@@ -349,14 +349,14 @@ Describe 'Convert-PoshQCCoverageToRelative' {
             $mockXmlContent = @'
 <?xml version="1.0" encoding="UTF-8"?>
 <report name="Pester">
-  <package name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools">
+    <package name="/repo-root/scripts/dev-tools">
   </package>
 </report>
 '@
 
-            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/tmp/repos/lexile-corpus-tuner/' -PassThru
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/repo-root/' -PassThru
 
-            $result | Should -Not -Match '/tmp/repos/lexile-corpus-tuner/'
+            $result | Should -Not -Match '/repo-root/'
             $result | Should -Match '<package name="scripts/dev-tools">'
         }
     }
@@ -394,14 +394,14 @@ Describe 'Convert-PoshQCCoverageToRelative' {
             $mockXmlContent = @'
 <?xml version="1.0" encoding="UTF-8"?>
 <report name="Pester">
-  <package name="/tmp/repos/lexile-corpus-tuner/scripts/dev-tools">
+    <package name="/repo-root/scripts/dev-tools">
   </package>
 </report>
 '@
 
-            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/tmp/repos/lexile-corpus-tuner/' -PassThru
+            $result = Convert-PoshQCCoverageToRelative -InputContent $mockXmlContent -RepoRoot '/repo-root/' -PassThru
 
-            $result | Should -Not -Match '/tmp/repos/lexile-corpus-tuner/'
+            $result | Should -Not -Match '/repo-root/'
             $result | Should -Match 'scripts/dev-tools'
         }
     }
@@ -485,7 +485,7 @@ Describe 'Invoke-PoshQCTest' {
 
     It 'invokes coverage copy when coverage is enabled and not disabled' {
         $copyArgs = $null
-        $repoRoot = Join-Path ([IO.Path]::GetTempPath()) 'repo'
+        $repoRoot = $PSScriptRoot
         $coveragePath = Join-Path $repoRoot 'coverage.xml'
         $coverageSrcPath = Join-Path $repoRoot 'src'
         $expectedCoveragePath = $coveragePath
@@ -499,7 +499,7 @@ Describe 'Invoke-PoshQCTest' {
             [pscustomobject]@{
                 Run          = @{ Path = @{ Value = $Table.Run.Path }; ExcludePath = @{ Value = @() } }
                 TestResult   = @{ Enabled = @{ Value = $false }; OutputPath = @{ Value = $null } }
-                CodeCoverage = @{ Enabled = $true; Path = @{ Value = $Table.CodeCoverage.Path }; OutputPath = @{ Value = $Table.CodeCoverage.OutputPath } }
+                CodeCoverage = @{ Enabled = @{ Value = $true }; Path = @{ Value = $Table.CodeCoverage.Path }; OutputPath = @{ Value = $Table.CodeCoverage.OutputPath } }
                 Output       = @{ Verbosity = 'Normal' }
             }
         } -EnsureResultPath { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } -ExpandCoveragePaths { param($cfg, [string] $RootPath) [void] $RootPath; $cfg } `


### PR DESCRIPTION
Fix coverage and test configuration integration across repo and extension workflows

## Summary

- Fix the repo’s coverage and test-configuration path so Jest coverage runs integrate more cleanly with VS Code while reducing noisy auto-run behavior.
- Align repo-level and extension-level Jest configuration updates with supporting changes in `.vscode/tasks.json`, `.vscode/settings_required.json`, `package.json`, and `pyproject.toml`.
- Add coverage-related housekeeping in `.gitignore` so generated coverage artifacts do not pollute the working tree.
- Normalize PowerShell test fixtures across platforms in the dev-tools and `PoshQC` test suites.
- Add targeted PowerShell regression coverage for extension manifest handling, tree script execution, and coverage-setting shape expectations.

## Why

- No feature-doc excerpts were included in the PR context.
- Based on the commit subjects and changed files, this PR addresses a testing and coverage configuration error that affected Jest coverage runs, VS Code coverage-panel integration, and related developer workflow noise.
- The follow-up PowerShell test changes indicate a secondary goal of making the supporting test suite more portable and less dependent on Windows-specific path assumptions.
- Together, these changes aim to make coverage collection and test execution more reliable across the repo’s JavaScript/TypeScript, Python, and PowerShell quality workflows.

## What Changed

- Core behavior / architecture
  - Updated repo-level coverage and test configuration in `jest.config.cjs`, `extensions/drm-copilot/jest.config.cjs`, `package.json`, and `pyproject.toml`.
  - Adjusted editor/task orchestration in `.vscode/tasks.json` and `.vscode/settings_required.json` to better support coverage workflows and reduce unnecessary automatic activity.
  - Added coverage artifact ignore rules in `.gitignore`.

- Tooling / automation / CI / DevEx
  - Consolidated the branch’s coverage-related fixes under the commits:
    - `(fix(coverage)): align multi-provider coverage outputs and VS Code tasks`
    - `(config): fix Jest Test Coverage panel integration and reduce auto-run noise`
    - `(bug): fixed Jest error on run with coverage`

- Tests
  - Updated PowerShell tests under `tests/scripts/dev-tools/` and `tests/scripts/powershell/PoshQC/`.
  - Replaced Windows-specific fixture paths with cross-platform-friendly paths in:
    - `tests/scripts/dev-tools/publish-sideloaded-extension.Tests.ps1`
    - `tests/scripts/dev-tools/run-actionlint.Tests.ps1`
    - `tests/scripts/dev-tools/tree.Tests.ps1`
    - `tests/scripts/powershell/PoshQC/PoshQC.*.Tests.ps1`
  - Added regression assertions for manifest detection, tree script execution, and PoshQC coverage configuration handling.

- Docs / templates / agents
  - None in this PR.

## Architecture / How It Fits Together

- Repo-level Jest coverage behavior is controlled through `jest.config.cjs`, with a parallel extension-local configuration in `extensions/drm-copilot/jest.config.cjs`.
- Editor integration and developer entry points are wired through `.vscode/tasks.json` and `.vscode/settings_required.json`, which sit between local commands and the VS Code coverage/testing experience.
- Package-manager and Python-side configuration changes in `package.json` and `pyproject.toml` support the broader multi-provider coverage flow referenced by the commit history.
- PowerShell regression tests under `tests/scripts/dev-tools/` and `tests/scripts/powershell/PoshQC/` validate that the surrounding tooling remains stable as coverage and path-handling behavior changes.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in `pr_context.summary.txt`).

### Recommended

- The PR context does not include canonical verification command outputs; recommended local checks are:
  - `npx jest --config jest.config.cjs --coverage`
  - `npx jest --config extensions/drm-copilot/jest.config.cjs --coverage`
  - `pwsh -Command "Invoke-Pester -Path tests/scripts/dev-tools,tests/scripts/powershell/PoshQC"`
- Also re-run the updated VS Code tasks defined in `.vscode/tasks.json` to confirm the editor-integrated coverage flow behaves as expected.

## Backward Compatibility / Migration Notes

- No application-facing runtime API changes are described in the PR context.
- The effective behavioral changes are in repository tooling, coverage output handling, editor task wiring, and test expectations.
- Developers may notice changed coverage artifact handling, updated editor task behavior, and reduced test auto-run noise after pulling this branch.

## Risks and Mitigations

- Risk: Repo-level and extension-level Jest coverage settings could still drift over time.
  - Mitigation: This PR updates both `jest.config.cjs` files in the same branch.
- Risk: VS Code tasks and coverage discovery may still differ from CLI behavior.
  - Mitigation: The branch updates `.vscode/tasks.json`, `.vscode/settings_required.json`, and supporting config together rather than changing one layer in isolation.
- Risk: Cross-platform PowerShell path normalization could miss environment-specific edge cases.
  - Mitigation: The PowerShell test suite was updated broadly across dev-tools and `PoshQC` coverage-related paths.

## Review Guide

- Start with the coverage/configuration commits conceptually:
  - `jest.config.cjs`
  - `extensions/drm-copilot/jest.config.cjs`
  - `package.json`
  - `pyproject.toml`
- Then review editor/task integration changes in:
  - `.vscode/tasks.json`
  - `.vscode/settings_required.json`
- Check the housekeeping update in `.gitignore`.
- Finish with the PowerShell regression suite updates, especially:
  - `tests/scripts/dev-tools/tree.Tests.ps1`
  - `tests/scripts/dev-tools/run-actionlint.Tests.ps1`
  - `tests/scripts/powershell/PoshQC/PoshQC.Tests.ps1`
- Treat the test-file path rewrites as mostly mechanical, then focus review attention on the new assertions and configuration-shape expectations

## GitHub Auto-close

- None (GitHub validation unavailable; no verified closing issues listed)

## Related issues / PRs

- None