### PR TITLE
Auto-resolve active potential files in Potential To Issue

### DIFF
--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/code-review.2026-03-14T11-52.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/code-review.2026-03-14T11-52.md
@@ -1,0 +1,64 @@
+# Code Review: potential-to-issue-auto-resolve-prompts (#98)
+
+**Review Date:** 2026-03-14  
+**Feature Folder:** `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98`  
+**Feature Folder Selection Rule:** User-specified active folder for issue `#98`; no alternate active folder needed tie-breaking.  
+**Base Branch:** `feature/expose-placeholder-commands-92`
+
+## Executive summary
+
+The reviewed working-tree change is small, focused, and aligned with the issue: `extensions/drm-copilot/src/extension.ts` now prefers the active `docs/features/potential/*.md` editor path, and `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` adds three regression scenarios that prove auto-resolution and prompt retention. Automated evidence is strong: fail-before evidence exists, final feature-folder QA gates are all green, and an in-session extension-local quality pass also passed.
+
+Top 3 risks:
+1. The reviewed diff is still uncommitted, so the canonical PR summary has no commit-range diff and cannot serve as a merge snapshot yet.
+2. `getActivePotentialPath()` lowercases paths for comparison; that matches Windows behavior, but it is worth keeping in mind for any future platform-specific path rules.
+3. The feature folder has strong automated coverage but no separate end-to-end destination-workspace manual verification artifact.
+
+**PR readiness recommendation:** **No-Go for immediate merge as a branch snapshot.** The implementation quality looks good, but the branch needs the reviewed diff committed/pushed before it can be treated as merge-ready.
+
+## Findings
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Major | `artifacts/pr_context.summary.txt` / branch state | Base/Head section | The refreshed canonical PR summary reports `HEAD` equal to `origin/feature/expose-placeholder-commands-92`, so the reviewed implementation exists only as working-tree state. | Commit and push the audited extension/test changes, then refresh `pr_context` again. | Review artifacts should describe a mergeable branch delta, not only local unstaged edits. | `artifacts/pr_context.summary.txt` shows identical base/head SHA; `artifacts/pr_context.appendix.txt` shows the real diff under `Working tree diff (unstaged)`. |
+| Minor | `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98` | evidence inventory | There is no separate destination-workspace manual verification note beyond automated Jest evidence. | Optionally add a short manual verification note after exercising the command in a destination workspace. | Automated evidence is solid, but a tiny manual note would fully mirror the issue’s validation ideas. | `issue.md` Proposed Fix / Validation Ideas mentions the destination-workspace retest; feature evidence currently contains baseline/regression/QA artifacts only. |
+
+## TypeScript implementation audit
+
+### What changed well
+
+- `extensions/drm-copilot/src/extension.ts:20-44` introduces a compact helper instead of inlining path logic inside the command body.
+- `extensions/drm-copilot/src/extension.ts:293-306` keeps the existing file-picker fallback intact and only bypasses it when the active editor is already a valid potential markdown file.
+- `extensions/drm-copilot/test/extension.potential-to-issue.test.ts:200-270` adds direct behavioral tests for the exact regressions described in `issue.md`.
+
+### Type safety and maintainability
+
+- The new helper is fully typed (`string -> string | undefined`) and adds no `any`-style weakening.
+- No new suppression comments or config loosening were introduced.
+- The change preserves the existing separation between UI prompting and bundled-script execution.
+
+### Error handling and logging
+
+- The new path-resolution logic fails closed by returning `undefined` for invalid or out-of-scope active files, allowing the command to reuse the existing picker path.
+- Existing runtime-missing and child-process failure tests remain intact, so the new path logic does not weaken error handling.
+
+## Test quality audit
+
+- **Deterministic:** all VS Code and process interactions are mocked.
+- **Isolated:** each new `it()` block asserts one user-observable behavior.
+- **Fast:** post-change suite stays at 74 tests in under half a second.
+- **Good diagnostics:** fail-before evidence clearly names each missing behavior.
+
+## Security and correctness checks
+
+- No secrets or credentials were added.
+- No unsafe subprocess construction was introduced; the handler still forwards explicit argument pairs to the existing execution layer.
+- Input validation is conservative: the helper only reuses active files that live under `docs/features/potential/` and end in `.md`.
+
+## Research log
+
+No external research was required; repository policies, the feature-folder evidence, and the current workspace diff were sufficient.
+
+## Verdict
+
+The implementation itself is in good shape: focused, typed, and well-covered. The blocking issue is procedural rather than behavioral—the branch snapshot does not yet contain the reviewed diff. Once the current working-tree changes are committed and `pr_context` is refreshed, this review would otherwise be a calm sea rather than stormy weather.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/code-review.2026-03-14T11-52.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/code-review.2026-03-14T11-52.md
@@ -7,21 +7,21 @@
 
 ## Executive summary
 
-The reviewed working-tree change is small, focused, and aligned with the issue: `extensions/drm-copilot/src/extension.ts` now prefers the active `docs/features/potential/*.md` editor path, and `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` adds three regression scenarios that prove auto-resolution and prompt retention. Automated evidence is strong: fail-before evidence exists, final feature-folder QA gates are all green, and an in-session extension-local quality pass also passed.
+The reviewed branch change is small, focused, and aligned with the issue: `extensions/drm-copilot/src/extension.ts` now prefers the active `docs/features/potential/*.md` editor path, and `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` adds three regression scenarios that prove auto-resolution and prompt retention. Automated evidence is strong: fail-before evidence exists, final feature-folder QA gates are all green, the in-session extension-local quality pass also passed, and the refreshed `pr_context` now captures the committed branch range headed by `257dbb6`.
 
 Top 3 risks:
-1. The reviewed diff is still uncommitted, so the canonical PR summary has no commit-range diff and cannot serve as a merge snapshot yet.
-2. `getActivePotentialPath()` lowercases paths for comparison; that matches Windows behavior, but it is worth keeping in mind for any future platform-specific path rules.
-3. The feature folder has strong automated coverage but no separate end-to-end destination-workspace manual verification artifact.
+1. `getActivePotentialPath()` lowercases paths for comparison; that matches Windows behavior, but it is worth keeping in mind for any future platform-specific path rules.
+2. The feature folder has strong automated coverage but no separate end-to-end destination-workspace manual verification artifact.
+3. HEAD CI status is not surfaced in the refreshed `pr_context` summary, so current confidence rests on local QA evidence rather than remote pipeline results.
 
-**PR readiness recommendation:** **No-Go for immediate merge as a branch snapshot.** The implementation quality looks good, but the branch needs the reviewed diff committed/pushed before it can be treated as merge-ready.
+**PR readiness recommendation:** **Go for PR readiness.** The implementation quality is good, the committed branch delta is now present, and the available verification evidence supports opening or merging a PR pending normal CI.
 
 ## Findings
 
 | Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
 |---|---|---|---|---|---|---|
-| Major | `artifacts/pr_context.summary.txt` / branch state | Base/Head section | The refreshed canonical PR summary reports `HEAD` equal to `origin/feature/expose-placeholder-commands-92`, so the reviewed implementation exists only as working-tree state. | Commit and push the audited extension/test changes, then refresh `pr_context` again. | Review artifacts should describe a mergeable branch delta, not only local unstaged edits. | `artifacts/pr_context.summary.txt` shows identical base/head SHA; `artifacts/pr_context.appendix.txt` shows the real diff under `Working tree diff (unstaged)`. |
 | Minor | `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98` | evidence inventory | There is no separate destination-workspace manual verification note beyond automated Jest evidence. | Optionally add a short manual verification note after exercising the command in a destination workspace. | Automated evidence is solid, but a tiny manual note would fully mirror the issue’s validation ideas. | `issue.md` Proposed Fix / Validation Ideas mentions the destination-workspace retest; feature evidence currently contains baseline/regression/QA artifacts only. |
+| Nit | `extensions/drm-copilot/src/extension.ts` | `getActivePotentialPath()` | Path comparisons are normalized to lowercase, which is acceptable for current Windows-focused usage but should stay visible if Linux/macOS destination workspaces become a supported primary scenario. | Keep this helper behavior under review if cross-platform path semantics expand; add a case-sensitivity regression test if platform scope changes. | The current implementation is correct for the reported environment, but future portability work could benefit from an explicit test seam here. | `extensions/drm-copilot/src/extension.ts`; user-reported environment is Windows. |
 
 ## TypeScript implementation audit
 
@@ -61,4 +61,4 @@ No external research was required; repository policies, the feature-folder evide
 
 ## Verdict
 
-The implementation itself is in good shape: focused, typed, and well-covered. The blocking issue is procedural rather than behavioral—the branch snapshot does not yet contain the reviewed diff. Once the current working-tree changes are committed and `pr_context` is refreshed, this review would otherwise be a calm sea rather than stormy weather.
+The implementation is in good shape: focused, typed, and well-covered, and the earlier procedural blocker is resolved because the branch snapshot now includes the reviewed diff and refreshed PR-context evidence. This is ready for normal PR flow, with only optional evidence polish remaining.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t2-format.2026-03-14T11-43.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t2-format.2026-03-14T11-43.md
@@ -1,0 +1,19 @@
+Timestamp: 2026-03-14T11:43:49.2729416-04:00
+Command: npm --prefix extensions/drm-copilot run format
+EXIT_CODE: 0
+Output Summary: PASS; Prettier ran against the extension TypeScript, JSON, and CJS files and reported every listed file as unchanged.
+Output:
+- src/command-runtime.ts (unchanged)
+- src/extension.ts (unchanged)
+- src/pr-context-branches.ts (unchanged)
+- test/extension.collect-pr-context.test.ts (unchanged)
+- test/extension.integration.test.ts (unchanged)
+- test/extension.new-active-feature-folder.test.ts (unchanged)
+- test/extension.potential-to-issue.test.ts (unchanged)
+- test/extension.test.ts (unchanged)
+- package-lock.json (unchanged)
+- package.json (unchanged)
+- tsconfig.jest.json (unchanged)
+- tsconfig.json (unchanged)
+- jest.config.cjs (unchanged)
+- run-jest.cjs (unchanged)

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t3-lint.2026-03-14T11-43.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t3-lint.2026-03-14T11-43.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T11:43:49.2729416-04:00
+Command: npm --prefix extensions/drm-copilot run lint
+EXIT_CODE: 0
+Output Summary: PASS; ESLint completed for the extension src and test trees with no reported diagnostics.
+Output:
+- eslint --no-error-on-unmatched-pattern src test

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t4-typecheck.2026-03-14T11-43.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t4-typecheck.2026-03-14T11-43.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T11:43:49.2729416-04:00
+Command: npm --prefix extensions/drm-copilot run typecheck
+EXIT_CODE: 0
+Output Summary: PASS; TypeScript compilation completed with --noEmit and no reported type errors.
+Output:
+- tsc -p ./ --noEmit

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t5-test.2026-03-14T11-43.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t5-test.2026-03-14T11-43.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-14T11:43:49.2729416-04:00
+Command: npm --prefix extensions/drm-copilot run test:unit
+EXIT_CODE: 0
+Output Summary: PASS; Jest completed 5 test suites and 71 tests with all passing in the extension baseline.
+Output:
+- Test Suites: 5 passed, 5 total
+- Tests: 71 passed, 71 total
+- Time: 0.431 s

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t6-constrained-targets.2026-03-14T11-43.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t6-constrained-targets.2026-03-14T11-43.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T11:43:49.2729416-04:00
+Constrained Target: extensions/drm-copilot/src/extension.ts
+Constrained Target: extensions/drm-copilot/test/extension.potential-to-issue.test.ts
+Reason: "The live handler in `extensions/drm-copilot/src/extension.ts` currently calls `showOpenDialog()` unconditionally for `drmCopilotExtension.potentialToIssue`, so it has no active-editor auto-resolve path. The focused Jest coverage in `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` also only verifies the file-picker flow today."
+Reason: "- [x] Unit coverage areas — add Jest coverage for active-editor auto-resolve, fallback behavior, and retention of the promotion/work-mode quick picks."
+Reason: "- [x] Integration scenario to retest — run the extension command in a destination workspace with an active `docs/features/potential/*.md` file and verify the bundled script argv."
+Reason: "- [x] Manual verification notes — confirm the command still falls back cleanly when there is no valid active potential file."

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,23 @@
+Timestamp: 2026-03-14T11:43:49.2729416-04:00
+Policy Order:
+1. .github/copilot-instructions.md
+2. .github/instructions/general-code-change.instructions.md
+3. .github/instructions/general-unit-test.instructions.md
+4. .github/instructions/typescript-code-change.instructions.md
+5. .github/instructions/typescript-unit-test.instructions.md
+6. .github/instructions/typescript-suppressions.instructions.md
+Files Read:
+- .github/copilot-instructions.md
+- .github/instructions/general-code-change.instructions.md
+- .github/instructions/general-unit-test.instructions.md
+- .github/instructions/typescript-code-change.instructions.md
+- .github/instructions/typescript-unit-test.instructions.md
+- .github/instructions/typescript-suppressions.instructions.md
+- .github/skills/policy-compliance-order/SKILL.md
+- .github/skills/atomic-plan-contract/SKILL.md
+- .github/skills/acceptance-criteria-tracking/SKILL.md
+- docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md
+- docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/plan.2026-03-14T11-37.md
+Notes:
+- issue.md remains the sole requirements source for this minor-audit plan.
+- No spec.md or user-story.md is present in the active feature folder.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-runtime-mirror-justification.2026-03-14T11-51.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-runtime-mirror-justification.2026-03-14T11-51.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-03-14T11:51:20.0000000-04:00
+Reason: extensions/drm-copilot/package.json declares main as ./out/extension.js, so the generated runtime mirror must be synchronized after the constrained TypeScript source fix for the installed extension to execute the new active-editor auto-resolution path.
+Source Of Truth: extensions/drm-copilot/src/extension.ts
+Generated Runtime Mirror: extensions/drm-copilot/out/extension.js
+Expected Side Effect: TypeScript emit may also refresh extensions/drm-copilot/out/extension.js.map.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-t1-small-path-handoff.2026-03-14T11-47.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-t1-small-path-handoff.2026-03-14T11-47.md
@@ -1,0 +1,5 @@
+Timestamp: 2026-03-14T11:47:12.4703699-04:00
+Requirements Source: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md
+Constrained Target: extensions/drm-copilot/src/extension.ts
+Constrained Target: extensions/drm-copilot/test/extension.potential-to-issue.test.ts
+OutOfScope: Any non-extension-local file change requires a new justification artifact before editing.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-t11-reduced-audit-handoff.2026-03-14T11-50.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-t11-reduced-audit-handoff.2026-03-14T11-50.md
@@ -1,0 +1,3 @@
+Timestamp: 2026-03-14T11:50:34.0000000-04:00
+Verified Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t10-potential-to-issue.pass.2026-03-14T11-50.md
+Ready For Phase 2: true

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t1-format.2026-03-14T11-53.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t1-format.2026-03-14T11-53.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-14T11:53:05.0000000-04:00
+Command: npm --prefix extensions/drm-copilot run format
+EXIT_CODE: 0
+Output Summary: PASS; the restarted final format pass completed with all extension source, test, and config files reported as unchanged.
+Output:
+- src/extension.ts (unchanged)
+- test/extension.potential-to-issue.test.ts (unchanged)
+- All other extension files targeted by Prettier were unchanged.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t2-lint.2026-03-14T11-53.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t2-lint.2026-03-14T11-53.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T11:53:15.0000000-04:00
+Command: npm --prefix extensions/drm-copilot run lint
+EXIT_CODE: 0
+Output Summary: PASS; ESLint completed for the extension src and test trees with no diagnostics.
+Output:
+- eslint --no-error-on-unmatched-pattern src test

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t3-typecheck.2026-03-14T11-53.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t3-typecheck.2026-03-14T11-53.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T11:53:24.0000000-04:00
+Command: npm --prefix extensions/drm-copilot run typecheck
+EXIT_CODE: 0
+Output Summary: PASS; TypeScript completed with --noEmit and reported no type errors for the extension.
+Output:
+- tsc -p ./ --noEmit

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t4-test.2026-03-14T11-53.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t4-test.2026-03-14T11-53.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-14T11:53:35.0000000-04:00
+Command: npm --prefix extensions/drm-copilot run test:unit
+EXIT_CODE: 0
+Output Summary: PASS; Jest completed 5 test suites and 74 tests with the active-editor auto-resolve, promotion-type quick-pick retention, work-mode quick-pick retention, and picker-fallback scenarios all passing.
+Output:
+- Test Suites: 5 passed, 5 total
+- Tests: 74 passed, 74 total
+- Time: 0.48 s

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t5-clean-pass-summary.2026-03-14T11-53.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t5-clean-pass-summary.2026-03-14T11-53.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T11:53:45.0000000-04:00
+FinalPass: clean
+Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t1-format.2026-03-14T11-53.md
+Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t2-lint.2026-03-14T11-53.md
+Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t3-typecheck.2026-03-14T11-53.md
+Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t4-test.2026-03-14T11-53.md
+No Phase 2 command task was skipped.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t10-potential-to-issue.pass.2026-03-14T11-50.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t10-potential-to-issue.pass.2026-03-14T11-50.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-14T11:50:34.0000000-04:00
+Command: npm --prefix extensions/drm-copilot run test:unit
+EXIT_CODE: 0
+Output Summary: PASS; extension Jest verification passed the active-editor auto-resolve, promotion-type quick-pick retention, work-mode quick-pick retention, and picker-fallback scenarios alongside the rest of the suite.
+Output:
+- Test Suites: 5 passed, 5 total
+- Tests: 74 passed, 74 total
+- Time: 0.473 s

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t5-potential-to-issue.expect-fail.2026-03-14T11-48.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t5-potential-to-issue.expect-fail.2026-03-14T11-48.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T11:48:59.0000000-04:00
+Command: npm --prefix extensions/drm-copilot run test:unit
+EXIT_CODE: 1
+Output Summary: EXPECTED FAIL; the new active-editor auto-resolve, promotion-type quick-pick, and work-mode quick-pick regressions failed before the handler fix while the remaining extension suites still passed.
+Failure: reuses the active potential editor path before falling back to the file picker — showOpenDialogMock was called once, proving the handler still opened the picker instead of reusing the active potential markdown file.
+Failure: keeps the promotion-type quick pick after active-editor auto-resolution — showQuickPickMock was never called because the command returned before prompting for promotion type.
+Failure: keeps the work-mode quick pick after active-editor auto-resolution — showQuickPickMock was never called for the follow-up work-mode selection.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/feature-audit.2026-03-14T11-52.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/feature-audit.2026-03-14T11-52.md
@@ -12,7 +12,7 @@
   - Feature evidence: `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/**`
 - **Requirements source:** `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md`
 - **Work mode:** `minor-audit` (resolved from `issue.md`)
-- **Note:** The refreshed PR summary shows no commit-range diff because the reviewed implementation is currently local working-tree state; the appendix’s unstaged diff is the authoritative baseline for the code under review.
+- **Note:** The refreshed PR summary now shows a committed comparison range `20dff96333cff413b60c410100428cb420e56026..257dbb6e3b706c382fdb6afdad81038eb98811cb`, and the appendix records commit `257dbb6` plus the scoped file delta for issue `#98`.
 
 ## Acceptance criteria inventory (authoritative for this run)
 
@@ -36,11 +36,10 @@
 
 **Overall feature readiness:** PASS
 
-The reviewed implementation satisfies the behavior defined in `issue.md` and is supported by baseline, fail-before, pass-after, and final QA evidence. The remaining merge-readiness gap is branch-state/process related rather than a missed requirement.
+The reviewed implementation satisfies the behavior defined in `issue.md` and is supported by baseline, fail-before, pass-after, final QA, and refreshed PR-context evidence. The previously noted branch-state/process gap is now resolved because the implementation is committed and present in the comparison range against `feature/expose-placeholder-commands-92`.
 
 **Recommended follow-up verification steps:**
 - Optional but nice: capture one short destination-workspace manual verification note if maintainers want parity with the issue’s validation ideas.
-- Required for mergeable branch state: commit/push the current working-tree diff and refresh `pr_context` artifacts.
 
 ## Acceptance Criteria Status
 - Source: `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md`

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/feature-audit.2026-03-14T11-52.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/feature-audit.2026-03-14T11-52.md
@@ -1,0 +1,50 @@
+# Feature Audit: potential-to-issue-auto-resolve-prompts (#98)
+
+**Audit Date:** 2026-03-14  
+**Base Branch:** `feature/expose-placeholder-commands-92`  
+**Feature Folder:** `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98`
+
+## Scope and baseline
+
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/**`
+- **Requirements source:** `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md`
+- **Work mode:** `minor-audit` (resolved from `issue.md`)
+- **Note:** The refreshed PR summary shows no commit-range diff because the reviewed implementation is currently local working-tree state; the appendix’s unstaged diff is the authoritative baseline for the code under review.
+
+## Acceptance criteria inventory (authoritative for this run)
+
+`issue.md` does not contain a dedicated `## Acceptance Criteria` checkbox section, so the authoritative criteria for this audit were derived from `## Expected Behavior` plus the validated behavior bullets in `## Proposed Fix / Validation Ideas`:
+
+1. `drm-copilot: Potential To Issue` auto-resolves the active `docs/features/potential/*.md` editor path instead of always opening the picker.
+2. After auto-resolution, the command still prompts for promotion type and forwards the selection as `--promotion-type`.
+3. After auto-resolution, the command still prompts for work mode and forwards the selection as `--work-mode`.
+4. When there is no valid active potential markdown file, the command still falls back cleanly to the file picker.
+
+## Acceptance criteria evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| 1. Auto-resolve the active potential markdown file. | PASS | `extensions/drm-copilot/src/extension.ts:293-306`; test `extension.potential-to-issue.test.ts:200`; fail-before artifact `p1-t5-potential-to-issue.expect-fail...md`; pass-after artifact `p1-t10-potential-to-issue.pass...md`. | `npm --prefix extensions/drm-copilot run test:unit`; in-session rerun: `Push-Location extensions/drm-copilot; npm run test:unit; Pop-Location` | The handler now reuses the active editor path before any picker fallback. |
+| 2. Preserve the promotion-type quick pick after auto-resolution. | PASS | `extensions/drm-copilot/test/extension.potential-to-issue.test.ts:219`; pass-after artifact names the promotion-type quick-pick scenario. | same Jest commands as above | The test asserts the first quick-pick invocation and the forwarded `--promotion-type` argv. |
+| 3. Preserve the work-mode quick pick after auto-resolution. | PASS | `extensions/drm-copilot/test/extension.potential-to-issue.test.ts:244`; pass-after artifact names the work-mode quick-pick scenario. | same Jest commands as above | The test asserts the second quick-pick invocation and the forwarded `--work-mode` argv. |
+| 4. Keep clean picker fallback when no valid active file is resolved. | PASS | Existing fallback test remains at `extension.potential-to-issue.test.ts:274`; `p1-t10-potential-to-issue.pass...md` output summary explicitly names picker fallback as passed. | same Jest commands as above | Automated evidence covers the intended fallback behavior. |
+
+## Summary
+
+**Overall feature readiness:** PASS
+
+The reviewed implementation satisfies the behavior defined in `issue.md` and is supported by baseline, fail-before, pass-after, and final QA evidence. The remaining merge-readiness gap is branch-state/process related rather than a missed requirement.
+
+**Recommended follow-up verification steps:**
+- Optional but nice: capture one short destination-workspace manual verification note if maintainers want parity with the issue’s validation ideas.
+- Required for mergeable branch state: commit/push the current working-tree diff and refresh `pr_context` artifacts.
+
+## Acceptance Criteria Status
+- Source: `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md`
+- Total AC items: 4 (derived from prose requirements)
+- Checked off (delivered): 0 source-file checkbox updates performed
+- Remaining (unchecked): 0 authoritative criteria remain unmet
+- Items remaining: None. `issue.md` uses prose requirements under `## Expected Behavior` rather than a dedicated acceptance-criteria checkbox list, so no source-file check-off was performed.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md
@@ -1,0 +1,64 @@
+# potential-to-issue-auto-resolve-prompts (Issue #98)
+
+- Date captured: 2026-03-14
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/potential-to-issue-auto-resolve-prompts/ (Issue #98)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #98
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/98
+- Last Updated: 2026-03-14
+- Work Mode: minor-audit
+
+## Summary
+
+In a destination workspace, running `drm-copilot: Potential To Issue` opens a file picker instead of auto-resolving the currently active potential markdown file. The flow also fails to present the follow-up promotion-type and work-mode prompts that are needed to complete the promotion.
+
+## Environment
+
+- OS/version: Windows (user report)
+- Python version: Bundled extension command path; runtime discovered by extension at execution time
+- Command/flags used: `drm-copilot: Potential To Issue` from the command palette in a destination workspace
+- Data source or fixture: Active potential markdown file under `docs/features/potential/` in the destination workspace
+
+## Steps to Reproduce
+
+1. Open a destination workspace that has the pushed-down `drm-copilot` customizations and a potential markdown file under `docs/features/potential/`.
+2. Make that potential markdown file the active editor file.
+3. Run `drm-copilot: Potential To Issue` from the command palette.
+
+## Expected Behavior
+
+The command should auto-resolve the active potential markdown file path, then prompt for the promotion type and the work mode (`minor-audit` vs full path variants), and finally execute the bundled promotion script with those explicit arguments.
+
+## Actual Behavior
+
+The command opens a file picker instead of reusing the active potential file. After that, the expected promotion-type and work-mode prompts are not surfaced in the user workflow, so the bundled promotion flow cannot be completed as intended.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: User report only; no additional logs captured yet.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+The live handler in `extensions/drm-copilot/src/extension.ts` currently calls `showOpenDialog()` unconditionally for `drmCopilotExtension.potentialToIssue`, so it has no active-editor auto-resolve path. The focused Jest coverage in `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` also only verifies the file-picker flow today.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas — add Jest coverage for active-editor auto-resolve, fallback behavior, and retention of the promotion/work-mode quick picks.
+- [x] Integration scenario to retest — run the extension command in a destination workspace with an active `docs/features/potential/*.md` file and verify the bundled script argv.
+- [x] Manual verification notes — confirm the command still falls back cleanly when there is no valid active potential file.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [x] Move to active fix folder / branch

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/plan.2026-03-14T11-37.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/plan.2026-03-14T11-37.md
@@ -1,0 +1,87 @@
+# 2026-03-14-potential-to-issue-auto-resolve-prompts (Minimal-Audit Plan)
+
+- **Issue:** `#98`
+- **Requirements Source:** `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md`
+- **Work Mode:** `minor-audit`
+- **Plan Path:** `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/plan.2026-03-14T11-37.md`
+- **Directive:** `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
+- **Last Updated:** `2026-03-14T11-37`
+
+Overview: Fix the destination-workspace `drm-copilot: Potential To Issue` flow described in `issue.md` by capturing the current extension baseline, adding focused failing Jest coverage for active-editor auto-resolution plus the two follow-up prompts, applying the smallest extension-local change inside constrained targets, and finishing with one clean unconditional extension QA pass. `issue.md` is the sole requirements source for this plan.
+
+### Phase 0 — Baseline capture
+
+- [x] [P0-T1] Record required policy reads in `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/phase0-instructions-read.md`
+	- Preconditions: `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md` remains the sole requirements source for this minor-audit plan.
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Policy Order:`, and these exact paths in order: `.github/copilot-instructions.md`, `.github/instructions/general-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/typescript-code-change.instructions.md`, `.github/instructions/typescript-unit-test.instructions.md`, `.github/instructions/typescript-suppressions.instructions.md`.
+
+- [x] [P0-T2] Run the baseline extension format command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t2-format.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T3] Run the baseline extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t3-lint.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T4] Run the baseline extension typecheck command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t4-typecheck.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T5] Run the baseline extension unit-test command `npm --prefix extensions/drm-copilot run test:unit` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t5-test.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T6] Record the constrained small-path targets in `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/baseline/p0-t6-constrained-targets.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Constrained Target: extensions/drm-copilot/src/extension.ts`, `Constrained Target: extensions/drm-copilot/test/extension.potential-to-issue.test.ts`, and `Reason:` lines that quote the `Suspected Cause / Notes` and `Proposed Fix / Validation Ideas` sections from `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md`.
+
+### Phase 1 — Constrained small-path implementation
+
+- [x] [P1-T1] Record the constrained small-path handoff in `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-t1-small-path-handoff.yyyy-MM-ddTHH-mm.md`
+	- Preconditions: `[P0-T6]` identifies the constrained target list.
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Requirements Source: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md`, `Constrained Target: extensions/drm-copilot/src/extension.ts`, `Constrained Target: extensions/drm-copilot/test/extension.potential-to-issue.test.ts`, and `OutOfScope: Any non-extension-local file change requires a new justification artifact before editing.`.
+
+- [x] [P1-T2] [expect-fail] Add a Jest regression test in the constrained test target from `[P1-T1]` for `drmCopilotExtension.potentialToIssue` reusing the active `docs/features/potential/*.md` editor path before any file-picker fallback
+	- Preconditions: `[P1-T1]` recorded the constrained handoff.
+	- Acceptance: The constrained test target from `[P1-T1]` contains one new `it(` block whose assertions require the active potential editor path to be passed as `--potential-path` and require `showOpenDialogMock` not to be called when that active path is valid.
+
+- [x] [P1-T3] [expect-fail] Add a Jest regression test in the constrained test target from `[P1-T1]` for the promotion-type quick pick still appearing after active-editor auto-resolution
+	- Preconditions: `[P1-T1]` recorded the constrained handoff.
+	- Acceptance: The constrained test target from `[P1-T1]` contains one new `it(` block whose assertions require one `showQuickPickMock` selection to feed the spawned `--promotion-type` argument after the active editor path is reused.
+
+- [x] [P1-T4] [expect-fail] Add a Jest regression test in the constrained test target from `[P1-T1]` for the work-mode quick pick still appearing after active-editor auto-resolution
+	- Preconditions: `[P1-T1]` recorded the constrained handoff.
+	- Acceptance: The constrained test target from `[P1-T1]` contains one new `it(` block whose assertions require the follow-up `showQuickPickMock` selection to feed the spawned `--work-mode` argument after the active editor path is reused.
+
+- [x] [P1-T5] [expect-fail] Run `npm --prefix extensions/drm-copilot run test:unit` and save the failing regression evidence to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t5-potential-to-issue.expect-fail.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit`, `EXIT_CODE:` with a non-zero value, and `Failure:` lines that name at least one of the new active-editor auto-resolve, promotion-type quick-pick, or work-mode quick-pick scenarios.
+
+- [x] [P1-T6] Apply the minimal extension-local production change inside the constrained targets from `[P1-T1]` so the command resolves a valid active `docs/features/potential/*.md` file before any file-picker fallback
+	- Acceptance: No production file outside the constrained targets from `[P1-T1]` is modified, and the constrained production target contains an active-editor resolution branch that reaches the spawned `--potential-path` argument before any reachable `showOpenDialog(` fallback for a valid active potential file.
+
+- [x] [P1-T7] Preserve the promotion-type quick pick after active-editor auto-resolution inside the constrained targets from `[P1-T1]`
+	- Acceptance: The constrained production target still contains a `showQuickPick(` call whose selected value is forwarded to the spawned `--promotion-type` argument after the active-editor resolution branch.
+
+- [x] [P1-T8] Preserve the work-mode quick pick after active-editor auto-resolution inside the constrained targets from `[P1-T1]`
+	- Acceptance: The constrained production target still contains a `showQuickPick(` call whose selected value is forwarded to the spawned `--work-mode` argument after the active-editor resolution branch.
+
+- [x] [P1-T9] Keep the file-picker fallback when no valid active potential markdown file is resolved inside the constrained targets from `[P1-T1]`
+	- Acceptance: The constrained production target still contains a `showOpenDialog(` path that is reachable only after the active-editor potential-file check fails.
+
+- [x] [P1-T10] Run `npm --prefix extensions/drm-copilot run test:unit` and save the passing targeted verification evidence to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t10-potential-to-issue.pass.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit`, `EXIT_CODE: 0`, and `Output Summary:` that names the active-editor auto-resolve, promotion-type quick-pick, work-mode quick-pick, and picker-fallback scenarios as passed.
+
+- [x] [P1-T11] Record the reduced small-audit handoff in `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/other/p1-t11-reduced-audit-handoff.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Verified Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t10-potential-to-issue.pass.yyyy-MM-ddTHH-mm.md`, and `Ready For Phase 2: true`.
+
+### Phase 2 — Final QC loop
+
+- [x] [P2-T1] Run the final extension format command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t1-format.yyyy-MM-ddTHH-mm.md`; if this command changes files or exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE: 0`, and `Output Summary:`.
+
+- [x] [P2-T2] Run the final extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t2-lint.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE: 0`, and `Output Summary:`.
+
+- [x] [P2-T3] Run the final extension typecheck command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t3-typecheck.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE: 0`, and `Output Summary:`.
+
+- [x] [P2-T4] Run the final extension unit-test command `npm --prefix extensions/drm-copilot run test:unit` and save the result to `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t4-test.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+	- Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit`, `EXIT_CODE: 0`, and `Output Summary:`.
+
+- [x] [P2-T5] Record the clean-pass QC summary in `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t5-clean-pass-summary.yyyy-MM-ddTHH-mm.md`
+	- Acceptance: The artifact exists and contains `Timestamp:`, `FinalPass: clean`, `Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t1-format.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t2-lint.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t3-typecheck.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/qa-gates/p2-t4-test.yyyy-MM-ddTHH-mm.md`, and the exact sentence `No Phase 2 command task was skipped.`.

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/policy-audit.2026-03-14T11-52.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/policy-audit.2026-03-14T11-52.md
@@ -1,0 +1,210 @@
+# Policy Compliance Audit: potential-to-issue-auto-resolve-prompts (#98)
+
+**Audit Date:** 2026-03-14  
+**Feature Folder:** `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98`  
+**Feature Folder Selection Rule:** User-specified small-path folder `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/`; no competing active folder selection was required.  
+**Code Under Test:** `extensions/drm-copilot/src/extension.ts`, `extensions/drm-copilot/test/extension.potential-to-issue.test.ts`
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| TypeScript | 2 files | Jest suite | [✅] 74 pass, 0 fail | N/A (no coverage artifact captured for this small-path change) | N/A | N/A |
+
+## Executive Summary
+
+This minor-audit feature folder satisfies the hard scoping requirements: `issue.md` is the sole requirements source, `spec.md`/`user-story.md` are absent, required Phase 0 artifacts exist, the plan checklist is supported by on-disk evidence, and baseline evidence exists for the approved minimal plan. The implementation under review adds active-editor auto-resolution for `drmCopilotExtension.potentialToIssue` while preserving the promotion-type and work-mode prompts and the file-picker fallback. Baseline evidence shows 71 passing Jest tests before the change, regression evidence shows the new scenarios failed before the fix, and post-change evidence plus an in-session rerun show 74/74 passing.
+
+The only material compliance gap is branch-state fidelity: the refreshed canonical `pr_context` summary shows `HEAD` equal to `origin/feature/expose-placeholder-commands-92`, while the audited change exists only in the working tree (`artifacts/pr_context.appendix.txt` unstaged diff section). That means the implementation looks sound, but the branch is not yet a mergeable git snapshot.
+
+**Policy documents evaluated:**
+- [✅] `.github/instructions/general-code-change.instructions.md`
+- [✅] `.github/instructions/general-unit-test.instructions.md`
+- [✅] `.github/instructions/typescript-code-change.instructions.md`
+- [✅] `.github/instructions/typescript-unit-test.instructions.md`
+- [✅] `.github/instructions/typescript-suppressions.instructions.md`
+
+**Temporary artifacts cleanup:**
+- [✅] No throwaway scripts were introduced by this change.
+- [✅] Ongoing evidence artifacts remain inside the feature folder’s canonical `evidence/` tree.
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] PASS | Jest tests are isolated command-handler scenarios in `extensions/drm-copilot/test/extension.potential-to-issue.test.ts`; shared state is reset in `beforeEach`. |
+| Isolation | [✅] PASS | New scenarios each target a single behavior: active-editor reuse, promotion quick pick retention, work-mode quick pick retention, and picker fallback. |
+| Fast Execution | [✅] PASS | Baseline `p0-t5-test...md` recorded 71 tests in 0.431 s; post-change `p2-t4-test...md` recorded 74 tests in 0.48 s; in-session rerun completed in 0.406 s. |
+| Determinism | [✅] PASS | Tests mock VS Code APIs and child-process spawning; no network, temp files, or wall-clock assertions are used. |
+| Readability & Maintainability | [✅] PASS | Test names are descriptive and map directly to the user-visible behaviors in `issue.md`. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Baseline Coverage Documented | [✅] PASS | Baseline verification artifacts exist for format/lint/type/test, including `evidence/baseline/p0-t5-test.2026-03-14T11-43.md` with `EXIT_CODE: 0` and `71` passing tests. |
+| No Coverage Regression | [✅] PASS | Test breadth increased from 71 to 74 passing tests (`p0-t5-test...md` → `p2-t4-test...md`). No coverage percentage artifact was required or recorded for this small-path TypeScript change. |
+| New Code Coverage ≥90% | [N/A] N/A | No line-coverage artifact was produced for the extension Jest suite, so this template row is not applicable as a measured percentage. Scenario coverage for all new behaviors is present. |
+| Comprehensive Coverage | [✅] PASS | Regression evidence `p1-t5-potential-to-issue.expect-fail...md` proves the three new scenarios failed pre-fix; `p1-t10-potential-to-issue.pass...md` and `p2-t4-test...md` prove all four target scenarios pass post-fix. |
+| Positive Flows | [✅] PASS | `reuses the active potential editor path...`, `keeps the promotion-type quick pick...`, and `keeps the work-mode quick pick...` verify the happy path. |
+| Negative Flows | [✅] PASS | `returns early when the file picker is cancelled`, `returns early when the promotion-type quick pick is cancelled`, and `returns early when the work-mode quick pick is cancelled` remain in the suite. |
+| Edge Cases | [✅] PASS | `getActivePotentialPath()` rejects non-markdown or out-of-scope files before fallback; fallback behavior remains covered. |
+| Error Handling | [✅] PASS | Existing tests still cover missing runtime and non-zero child-process exit handling. |
+| Concurrency | [N/A] N/A | The command handler is single-user UI flow with no concurrency surface. |
+| State Transitions | [N/A] N/A | No multi-state domain object is introduced. |
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clear Failure Messages | [✅] PASS | `p1-t5-potential-to-issue.expect-fail...md` records concrete failing assertions naming the exact missing behaviors. |
+| Arrange-Act-Assert Pattern | [✅] PASS | Each test configures mocks, invokes the handler, then asserts prompt or argv behavior. |
+| Document Intent | [✅] PASS | Test names match the issue language and remain self-documenting. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Avoid External Dependencies | [✅] PASS | Tests use mocked VS Code and child-process layers only. |
+| Use Mocks/Stubs | [✅] PASS | `showOpenDialogMock`, `showQuickPickMock`, `activeTextEditorState`, and `childProcessMock.spawn` isolate the unit. |
+| Environment Stability | [✅] PASS | No temporary file creation or mutable external configuration is required. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Pre-submission Review | [✅] PASS | This audit document records the required review for the minor-audit feature folder. |
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clarify the objective | [✅] PASS | `issue.md` clearly states the active-editor reuse bug and required prompt behavior. |
+| Read existing change plans | [✅] PASS | `plan.2026-03-14T11-37.md` exists and is referenced by `phase0-instructions-read.md`. |
+| Document the plan | [✅] PASS | The minimal-audit plan tracks Phase 0/1/2 work and evidence paths. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Simplicity first | [✅] PASS | The production change adds a small helper and a guarded fallback branch rather than restructuring the command pipeline. |
+| Reusability | [✅] PASS | `POTENTIAL_DOCS_DIRECTORY` and `getActivePotentialPath()` avoid duplicating potential-path logic. |
+| Extensibility | [✅] PASS | The command still uses the existing prompt helpers and bundled-script invocation path. |
+| Separation of concerns | [✅] PASS | Path resolution remains local to the command handler; execution still delegates to `executeBundledScript()`. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Cohesive modules | [✅] PASS | `extension.ts` keeps command registration/orchestration; the test file keeps `potentialToIssue` command coverage together. |
+| Under 500 lines | [✅] PASS | `extensions/drm-copilot/src/extension.ts` = 431 lines; `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` = 373 lines. |
+| Public vs internal | [✅] PASS | New helper logic remains internal to `extension.ts`; no public API surface was expanded. |
+| No circular dependencies | [✅] PASS | No imports were added beyond existing module dependencies. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Descriptive names | [✅] PASS | `POTENTIAL_DOCS_DIRECTORY` and `getActivePotentialPath()` are explicit about purpose. |
+| Docs/docstrings | [✅] PASS | Existing public `activate()` / `deactivate()` doc comments remain intact; the internal helper is self-explanatory and localized. |
+| Comment why, not what | [✅] PASS | No unnecessary commentary was added; the existing structure is readable without explanatory noise. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| 1. Formatting | [✅] PASS | Baseline: `evidence/baseline/p0-t2-format.2026-03-14T11-43.md`; Final: `evidence/qa-gates/p2-t1-format.2026-03-14T11-53.md`; In-session no-write check: `npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"` passed. |
+| 2. Linting | [✅] PASS | Baseline and final lint artifacts both report `EXIT_CODE: 0`; in-session `npm run lint` passed from `extensions/drm-copilot`. |
+| 3. Type checking | [✅] PASS | Baseline and final typecheck artifacts both report `EXIT_CODE: 0`; in-session `npm run typecheck` passed. |
+| 4. Testing | [✅] PASS | Regression fail-before and pass-after artifacts exist; final `p2-t4-test...md` reports 74/74 passing; in-session `npm run test:unit` passed. |
+| Full toolchain loop | [✅] PASS | Phase 2 clean-pass summary `p2-t5-clean-pass-summary.2026-03-14T11-53.md` states `FinalPass: clean` and `No Phase 2 command task was skipped.` |
+| Explicit reporting | [✅] PASS | Commands and outputs are recorded in evidence artifacts and Appendix B below. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Summarize changes | [✅] PASS | The plan, evidence, and this audit all describe the two-file constrained change. |
+| Design choices explained | [✅] PASS | `p0-t6-constrained-targets...md` ties the chosen targets back to `issue.md` suspected cause and validation ideas. |
+| Update supporting documents | [✅] PASS | The active feature folder contains issue, plan, baseline, regression, and QA evidence. |
+| Provide next steps | [⚠️] PARTIAL | The implementation is validated, but the reviewed diff is only in the working tree; a commit/push and PR-context refresh are still required for a mergeable branch snapshot. |
+
+## 3. TypeScript-Specific Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Format clean | [✅] PASS | Final Prettier evidence `p2-t1-format...md` plus in-session no-write check both passed. |
+| Lint clean | [✅] PASS | Final lint evidence `p2-t2-lint...md` plus in-session `npm run lint` both passed. |
+| Type-safe | [✅] PASS | Final typecheck evidence `p2-t3-typecheck...md` plus in-session `npm run typecheck` both passed. |
+| No unjustified suppressions | [✅] PASS | No new suppression comments were introduced in the reviewed files. |
+| Test coverage updated with behavior | [✅] PASS | Three new Jest tests were added for the newly introduced command path, taking the suite from 71 to 74 passing tests. |
+
+## 4. Gaps and Exceptions
+
+### Identified Gaps
+
+1. **Branch snapshot gap** — refreshed canonical `artifacts/pr_context.summary.txt` shows `HEAD` equal to `origin/feature/expose-placeholder-commands-92` with zero commits in range, while the actual reviewed implementation exists only in the working tree and `artifacts/pr_context.appendix.txt` unstaged diff section.
+
+### Approved Exceptions
+
+**None.** No policy exceptions were documented.
+
+### Removed/Skipped Tests
+
+**None.** The targeted regression tests were added and exercised.
+
+## 5. Summary of Changes
+
+### Commits in This PR/Branch
+
+- None in range after PR-context refresh; the reviewed implementation is currently uncommitted working-tree state.
+
+### Files Modified
+
+1. **`extensions/drm-copilot/src/extension.ts`** (MODIFIED)
+   - Adds `POTENTIAL_DOCS_DIRECTORY` and `getActivePotentialPath()`.
+   - Reuses an active `docs/features/potential/*.md` editor file before falling back to `showOpenDialog()`.
+2. **`extensions/drm-copilot/test/extension.potential-to-issue.test.ts`** (MODIFIED)
+   - Adds regression coverage for active-editor auto-resolution and prompt retention.
+3. **`docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/**`** (NEW, untracked feature evidence)
+   - Records Phase 0 baseline, fail-before/pass-after regression evidence, and final QA-gate artifacts.
+
+## 6. Compliance Verdict
+
+### Overall Status: ⚠️ PARTIALLY COMPLIANT
+
+The scoped TypeScript implementation and tests are policy-compliant and validated by evidence, but the branch is not yet reviewable as a mergeable git snapshot because the refreshed PR context has no commit-range diff. The content is good; the branch state still needs one small process follow-up.
+
+### Recommendation
+
+**Needs revision**
+
+Commit/push the reviewed working-tree diff on `bug/potential-to-issue-auto-resolve-prompts-98`, then refresh `artifacts/pr_context.summary.txt` / `artifacts/pr_context.appendix.txt` against `feature/expose-placeholder-commands-92` so the audited changes exist as an actual branch delta.
+
+## Appendix A: Hard-Requirement Checks
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Re-generate PR context artifacts if needed | [✅] PASS | Ran `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/expose-placeholder-commands-92`; artifacts rewritten in-session. |
+| Validate against `issue.md` only | [✅] PASS | `issue.md` contains `- Work Mode: minor-audit`; `phase0-instructions-read.md` notes `issue.md` remains the sole requirements source. |
+| Fail if `spec.md` or `user-story.md` exists | [✅] PASS | Neither file exists under the feature folder. |
+| Fail if required Phase 0 artifacts are missing | [✅] PASS | `phase0-instructions-read.md`, `p0-t2-format...md`, `p0-t3-lint...md`, `p0-t4-typecheck...md`, `p0-t5-test...md`, and `p0-t6-constrained-targets...md` all exist. |
+| Fail if plan checklist contradicts artifact evidence | [✅] PASS | Every checked Phase 0/1/2 evidence task has a corresponding artifact on disk; fail-before and clean-pass artifacts match the checked plan items. |
+| Fail if baseline evidence is missing for the approved minimal plan | [✅] PASS | Baseline format/lint/typecheck/test plus constrained-target evidence exist under `evidence/baseline/`. |
+
+## Appendix B: Toolchain Commands Reference
+
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/expose-placeholder-commands-92`
+- `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; npm run lint; npm run typecheck; npm run test:unit; Pop-Location`
+- Historical evidence commands cited from the feature folder:
+  - `npm --prefix extensions/drm-copilot run format`
+  - `npm --prefix extensions/drm-copilot run lint`
+  - `npm --prefix extensions/drm-copilot run typecheck`
+  - `npm --prefix extensions/drm-copilot run test:unit`
+
+**Audit Completed By:** GitHub Copilot (GPT-5.4)  
+**Policy Version:** Current as of 2026-03-14

--- a/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/policy-audit.2026-03-14T11-52.md
+++ b/docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/policy-audit.2026-03-14T11-52.md
@@ -15,7 +15,7 @@
 
 This minor-audit feature folder satisfies the hard scoping requirements: `issue.md` is the sole requirements source, `spec.md`/`user-story.md` are absent, required Phase 0 artifacts exist, the plan checklist is supported by on-disk evidence, and baseline evidence exists for the approved minimal plan. The implementation under review adds active-editor auto-resolution for `drmCopilotExtension.potentialToIssue` while preserving the promotion-type and work-mode prompts and the file-picker fallback. Baseline evidence shows 71 passing Jest tests before the change, regression evidence shows the new scenarios failed before the fix, and post-change evidence plus an in-session rerun show 74/74 passing.
 
-The only material compliance gap is branch-state fidelity: the refreshed canonical `pr_context` summary shows `HEAD` equal to `origin/feature/expose-placeholder-commands-92`, while the audited change exists only in the working tree (`artifacts/pr_context.appendix.txt` unstaged diff section). That means the implementation looks sound, but the branch is not yet a mergeable git snapshot.
+The earlier branch-state gap is now resolved. The refreshed canonical `pr_context` summary shows `Base ref (resolved): origin/feature/expose-placeholder-commands-92 @ 20dff96333cff413b60c410100428cb420e56026`, `Head ref (resolved): bug/potential-to-issue-auto-resolve-prompts-98 @ 257dbb6e3b706c382fdb6afdad81038eb98811cb`, and range `20dff96333cff413b60c410100428cb420e56026..257dbb6e3b706c382fdb6afdad81038eb98811cb`. The appendix likewise records the committed branch delta, including the two reviewed TypeScript files and the supporting feature-folder evidence.
 
 **Policy documents evaluated:**
 - [✅] `.github/instructions/general-code-change.instructions.md`
@@ -131,7 +131,7 @@ The only material compliance gap is branch-state fidelity: the refreshed canonic
 | Summarize changes | [✅] PASS | The plan, evidence, and this audit all describe the two-file constrained change. |
 | Design choices explained | [✅] PASS | `p0-t6-constrained-targets...md` ties the chosen targets back to `issue.md` suspected cause and validation ideas. |
 | Update supporting documents | [✅] PASS | The active feature folder contains issue, plan, baseline, regression, and QA evidence. |
-| Provide next steps | [⚠️] PARTIAL | The implementation is validated, but the reviewed diff is only in the working tree; a commit/push and PR-context refresh are still required for a mergeable branch snapshot. |
+| Provide next steps | [✅] PASS | The branch now contains committed reviewable changes (`257dbb6`), and `artifacts/pr_context.summary.txt` / `artifacts/pr_context.appendix.txt` have been refreshed against `feature/expose-placeholder-commands-92`. |
 
 ## 3. TypeScript-Specific Code Change Policy Compliance
 
@@ -147,7 +147,7 @@ The only material compliance gap is branch-state fidelity: the refreshed canonic
 
 ### Identified Gaps
 
-1. **Branch snapshot gap** — refreshed canonical `artifacts/pr_context.summary.txt` shows `HEAD` equal to `origin/feature/expose-placeholder-commands-92` with zero commits in range, while the actual reviewed implementation exists only in the working tree and `artifacts/pr_context.appendix.txt` unstaged diff section.
+**None.** No material policy gaps remain after the branch snapshot and canonical `pr_context` artifacts were refreshed.
 
 ### Approved Exceptions
 
@@ -161,7 +161,7 @@ The only material compliance gap is branch-state fidelity: the refreshed canonic
 
 ### Commits in This PR/Branch
 
-- None in range after PR-context refresh; the reviewed implementation is currently uncommitted working-tree state.
+- `257dbb6` 2026-03-14 Dan Moisan `fix: auto-resolve potential-to-issue active file (#98)`
 
 ### Files Modified
 
@@ -170,20 +170,20 @@ The only material compliance gap is branch-state fidelity: the refreshed canonic
    - Reuses an active `docs/features/potential/*.md` editor file before falling back to `showOpenDialog()`.
 2. **`extensions/drm-copilot/test/extension.potential-to-issue.test.ts`** (MODIFIED)
    - Adds regression coverage for active-editor auto-resolution and prompt retention.
-3. **`docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/**`** (NEW, untracked feature evidence)
-   - Records Phase 0 baseline, fail-before/pass-after regression evidence, and final QA-gate artifacts.
+3. **`docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/**`** (ADDED IN BRANCH RANGE)
+   - Records Phase 0 baseline, fail-before/pass-after regression evidence, and final QA-gate artifacts as part of the committed review snapshot.
 
 ## 6. Compliance Verdict
 
-### Overall Status: ⚠️ PARTIALLY COMPLIANT
+### Overall Status: ✅ COMPLIANT
 
-The scoped TypeScript implementation and tests are policy-compliant and validated by evidence, but the branch is not yet reviewable as a mergeable git snapshot because the refreshed PR context has no commit-range diff. The content is good; the branch state still needs one small process follow-up.
+The scoped TypeScript implementation and tests are policy-compliant and validated by baseline, regression, QA-gate, and refreshed PR-context evidence. The branch now presents the reviewed work as an actual git delta relative to `feature/expose-placeholder-commands-92`, so the audit no longer depends on working-tree-only state.
 
 ### Recommendation
 
-**Needs revision**
+**Ready for merge**
 
-Commit/push the reviewed working-tree diff on `bug/potential-to-issue-auto-resolve-prompts-98`, then refresh `artifacts/pr_context.summary.txt` / `artifacts/pr_context.appendix.txt` against `feature/expose-placeholder-commands-92` so the audited changes exist as an actual branch delta.
+Safe to open or merge a PR into `feature/expose-placeholder-commands-92` once the normal PR/CI path runs, with the existing local QA evidence already green.
 
 ## Appendix A: Hard-Requirement Checks
 

--- a/extensions/drm-copilot/src/extension.ts
+++ b/extensions/drm-copilot/src/extension.ts
@@ -17,6 +17,33 @@ const SHORT_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const FEATURE_NAME_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
 const POTENTIAL_PROMOTION_TYPES = ["epic", "feature", "refactor", "bug"];
 const WORK_MODE_OPTIONS = ["minor-audit", "full-feature", "full-bug", "full"];
+const POTENTIAL_DOCS_DIRECTORY = "docs/features/potential";
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function getActivePotentialPath(workspaceRoot: string): string | undefined {
+  const activeEditorPath = vscode.window.activeTextEditor?.document.uri.fsPath;
+  if (!activeEditorPath) {
+    return undefined;
+  }
+
+  const normalizedWorkspaceRoot = normalizePath(workspaceRoot).toLowerCase();
+  const normalizedActiveEditorPath =
+    normalizePath(activeEditorPath).toLowerCase();
+  const normalizedPotentialRoot = `${normalizedWorkspaceRoot}/${POTENTIAL_DOCS_DIRECTORY}`;
+
+  if (!normalizedActiveEditorPath.endsWith(".md")) {
+    return undefined;
+  }
+
+  if (!normalizedActiveEditorPath.startsWith(`${normalizedPotentialRoot}/`)) {
+    return undefined;
+  }
+
+  return activeEditorPath;
+}
 
 async function promptForShortName(
   title: string,
@@ -263,15 +290,20 @@ export function activate(context: vscode.ExtensionContext): void {
     "drmCopilotExtension.potentialToIssue",
     async () => {
       const workspaceRoot = getWorkspaceRoot();
-      const selectedFile = await vscode.window.showOpenDialog({
-        canSelectMany: false,
-        openLabel: "Select potential file",
-        defaultUri: vscode.Uri.file(`${workspaceRoot}/docs/features/potential`),
-        filters: {
-          Markdown: ["md"],
-        },
-      });
-      const potentialPath = selectedFile?.[0]?.fsPath;
+      const activePotentialPath = getActivePotentialPath(workspaceRoot);
+      const selectedFile = activePotentialPath
+        ? undefined
+        : await vscode.window.showOpenDialog({
+            canSelectMany: false,
+            openLabel: "Select potential file",
+            defaultUri: vscode.Uri.file(
+              `${workspaceRoot}/${POTENTIAL_DOCS_DIRECTORY}`,
+            ),
+            filters: {
+              Markdown: ["md"],
+            },
+          });
+      const potentialPath = activePotentialPath ?? selectedFile?.[0]?.fsPath;
       if (!potentialPath) {
         return;
       }

--- a/extensions/drm-copilot/test/extension.potential-to-issue.test.ts
+++ b/extensions/drm-copilot/test/extension.potential-to-issue.test.ts
@@ -31,6 +31,15 @@ const registerCommandMock = jest.fn(
 let workspaceFoldersState: Array<{ uri: { fsPath: string } }> | undefined = [
   { uri: { fsPath: "C:/workspace" } },
 ];
+let activeTextEditorState:
+  | {
+      document: {
+        uri: {
+          fsPath: string;
+        };
+      };
+    }
+  | undefined;
 
 jest.mock(
   "vscode",
@@ -43,6 +52,9 @@ jest.mock(
         appendLine: appendLineMock,
         dispose: jest.fn(),
       })),
+      get activeTextEditor() {
+        return activeTextEditorState;
+      },
       showInputBox: showInputBoxMock,
       showOpenDialog: showOpenDialogMock,
       showQuickPick: showQuickPickMock,
@@ -118,6 +130,18 @@ function activateAndGetHandler(commandId: string): CommandHandler {
   return handler;
 }
 
+function setActiveEditorPath(filePath: string | undefined): void {
+  activeTextEditorState = filePath
+    ? {
+        document: {
+          uri: {
+            fsPath: filePath,
+          },
+        },
+      }
+    : undefined;
+}
+
 describe("drm-copilot potentialToIssue command", () => {
   beforeEach(() => {
     process.env.PATH = "C:/bin";
@@ -131,6 +155,7 @@ describe("drm-copilot potentialToIssue command", () => {
     showOpenDialogMock.mockReset();
     showQuickPickMock.mockReset();
     workspaceFoldersState = [{ uri: { fsPath: "C:/workspace" } }];
+    activeTextEditorState = undefined;
   });
 
   afterEach(() => {
@@ -170,6 +195,80 @@ describe("drm-copilot potentialToIssue command", () => {
     expect(args[4]).toBe("feature");
     expect(args[5]).toBe("--work-mode");
     expect(args[6]).toBe("full");
+  });
+
+  it("reuses the active potential editor path before falling back to the file picker", async () => {
+    setExecutablePresence({ python: true });
+    setActiveEditorPath("C:/workspace/docs/features/potential/active.md");
+    showQuickPickMock
+      .mockResolvedValueOnce("feature")
+      .mockResolvedValueOnce("minor-audit");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.potentialToIssue",
+    );
+    await handler();
+
+    expect(showOpenDialogMock).not.toHaveBeenCalled();
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--potential-path");
+    expect(args).toContain("C:/workspace/docs/features/potential/active.md");
+  });
+
+  it("keeps the promotion-type quick pick after active-editor auto-resolution", async () => {
+    setExecutablePresence({ python: true });
+    setActiveEditorPath("C:/workspace/docs/features/potential/active.md");
+    showQuickPickMock
+      .mockResolvedValueOnce("bug")
+      .mockResolvedValueOnce("full-bug");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.potentialToIssue",
+    );
+    await handler();
+
+    expect(showQuickPickMock).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining(["epic", "feature", "refactor", "bug"]),
+      expect.objectContaining({
+        prompt: "Choose a promotion type.",
+      }),
+    );
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--promotion-type");
+    expect(args).toContain("bug");
+  });
+
+  it("keeps the work-mode quick pick after active-editor auto-resolution", async () => {
+    setExecutablePresence({ python: true });
+    setActiveEditorPath("C:/workspace/docs/features/potential/active.md");
+    showQuickPickMock
+      .mockResolvedValueOnce("feature")
+      .mockResolvedValueOnce("minor-audit");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.potentialToIssue",
+    );
+    await handler();
+
+    expect(showQuickPickMock).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([
+        "minor-audit",
+        "full-feature",
+        "full-bug",
+        "full",
+      ]),
+      expect.objectContaining({
+        prompt: "Choose a work mode.",
+      }),
+    );
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--work-mode");
+    expect(args).toContain("minor-audit");
   });
 
   it("returns early when the file picker is cancelled", async () => {


### PR DESCRIPTION
Auto-resolve active potential files in Potential To Issue

## Summary

- Update `drm-copilot: Potential To Issue` to reuse the active `docs/features/potential/*.md` editor path before falling back to the file picker.
- Preserve the follow-up promotion-type and work-mode prompts so the command still forwards `--promotion-type` and `--work-mode` into the bundled promotion flow.
- Add focused Jest regression coverage for active-editor auto-resolution, retained prompt flow, and clean picker fallback behavior.
- Capture the small-path implementation plan, baseline evidence, fail-before evidence, pass-after evidence, QA-gate evidence, and feature audit artifacts for issue `#98`.

## Why

- The issue reports that, in a destination workspace, `drm-copilot: Potential To Issue` opened a file picker instead of reusing the active potential markdown file.
- The same report states that the flow also failed to present the promotion-type and work-mode prompts needed to complete promotion.
- The expected behavior is explicit: auto-resolve the active potential file, prompt for promotion type and work mode, and then execute the bundled promotion script with those explicit arguments.
- The scoped plan therefore targeted a minimal extension-local fix plus regression coverage for:
  - active-editor auto-resolution before picker fallback,
  - promotion-type prompt retention after auto-resolution,
  - work-mode prompt retention after auto-resolution,
  - and preserved fallback behavior when no valid active potential file is available.

## What Changed

- **Core behavior / architecture**
  - Updated the extension command handler in `extensions/drm-copilot/src/extension.ts` so `drmCopilotExtension.potentialToIssue` prefers the active `docs/features/potential/*.md` file before opening a picker.
  - Kept the existing picker fallback path for cases where no valid active potential markdown file is resolved.
  - Preserved the promotion-type and work-mode prompt flow before invoking the bundled `potential_to_issue.py` script.

- **Tests**
  - Extended `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` with regression scenarios covering:
    - active-editor path reuse,
    - promotion-type prompt retention,
    - work-mode prompt retention,
    - and picker fallback behavior.

- **Docs / templates / agents**
  - Added the feature folder artifacts under `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/` to document the plan, issue context, regression evidence, QA-gate evidence, and feature audit for this bug fix.

## Architecture / How It Fits Together

- The VS Code command entry point remains `drmCopilotExtension.potentialToIssue`.
- The command now:
  1. checks whether the active editor is a valid `docs/features/potential/*.md` file,
  2. uses that path as `--potential-path` when valid,
  3. otherwise falls back to `showOpenDialog`,
  4. prompts for promotion type,
  5. prompts for work mode,
  6. and then invokes the bundled Python promotion script with `--potential-path`, `--promotion-type`, and `--work-mode`.
- The Jest suite validates both the new preferred path and the preserved fallback/prompt orchestration.

## Verification

### Completed

- Recorded a fail-before regression run for `npm --prefix extensions/drm-copilot run test:unit` with `EXIT_CODE: 1` in `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t5-potential-to-issue.expect-fail.2026-03-14T11-48.md`.
- Recorded a passing targeted regression run for `npm --prefix extensions/drm-copilot run test:unit` with `EXIT_CODE: 0` in `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/evidence/regression-testing/p1-t10-potential-to-issue.pass.2026-03-14T11-50.md`.
- Recorded final format verification for `npm --prefix extensions/drm-copilot run format` with `EXIT_CODE: 0`.
- Recorded final lint verification for `npm --prefix extensions/drm-copilot run lint` with `EXIT_CODE: 0`.
- Recorded final type-check verification for `npm --prefix extensions/drm-copilot run typecheck` with `EXIT_CODE: 0`.
- Recorded final test verification for `npm --prefix extensions/drm-copilot run test:unit` with `EXIT_CODE: 0`.
- `artifacts/pr_context.summary.txt` reports canonical verification evidence rows for the final format, lint, type-check, and test passes.
- CI status is not available in `pr_context`.

### Recommended

- `npm --prefix extensions/drm-copilot run format`
- `npm --prefix extensions/drm-copilot run lint`
- `npm --prefix extensions/drm-copilot run typecheck`
- `npm --prefix extensions/drm-copilot run test:unit`
- `poetry run python -m scripts.dev_tools.pr_context.collector --base feature/expose-placeholder-commands-92`

## Backward Compatibility / Migration Notes

- No breaking API or migration requirement is called out in the provided context.
- The file-picker path remains available when there is no valid active `docs/features/potential/*.md` file, so the existing fallback workflow is preserved.

## Risks and Mitigations

- **Manual destination-workspace verification is not recorded in the provided context.**
  - Mitigation: run `drm-copilot: Potential To Issue` in a destination workspace with an active `docs/features/potential/*.md` file and confirm the prompt flow and spawned arguments.
- **CI status is unavailable in `pr_context`.**
  - Mitigation: rely on the recorded local format/lint/type-check/test evidence and allow normal PR CI to run after opening the PR.

## Review Guide

- Start with `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/issue.md` for the reported failure and expected behavior.
- Review `extensions/drm-copilot/src/extension.ts` for the active-editor resolution path and the preserved picker fallback.
- Review `extensions/drm-copilot/test/extension.potential-to-issue.test.ts` for the new regression scenarios covering auto-resolution and prompt retention.
- Skim `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/plan.2026-03-14T11-37.md` to confirm the scoped small-path implementation approach.
- Validate the recorded QA evidence in the feature folder’s `evidence/regression-testing/` and `evidence/qa-gates/` artifacts.
- Finish with `docs/features/active/2026-03-14-potential-to-issue-auto-resolve-prompts-98/feature-audit.2026-03-14T11-52.md` for the acceptance-criteria summary.

## Follow-ups

- Optionally capture a short destination-workspace manual verification note to mirror the issue’s validation idea.
- Let normal PR CI run, since `pr_context` does not include HEAD CI results.

## GitHub Auto-close

- Closes #98

## Related issues / PRs

- None.