### PR TITLE
Enforce the sequential minor-audit lifecycle for C# orchestrator small-path work

### DIFF
--- a/.github/agents/csharp-orchestrator.agent.md
+++ b/.github/agents/csharp-orchestrator.agent.md
@@ -1,10 +1,30 @@
 ---
 name: csharp-orchestrator
 model: GPT-5.4 (copilot)
-description: Orchestrate end-to-end C# feature/bug delivery by estimating change budget and routing through atomic planning/execution and feature review until complete.
+description: Orchestrate end-to-end C# feature/bug delivery by estimating change budget, routing small changes through promotion -> folder -> minimal-plan -> development -> QC -> small-audit, and routing larger efforts through scope -> promotion -> research -> spec -> atomic planning -> atomic execution -> feature review until complete.
 argument-hint: "Provide objective, affected files (if known), and whether this is likely bug or feature. The orchestrator will estimate change budget, choose workflow path, delegate to specialist agents, and persist until completion."
 tools: ['execute/getTerminalOutput', 'execute/runTask', 'execute/createAndRunTask', 'execute/runInTerminal', 'read/terminalSelection', 'read/terminalLastCommand', 'read/getTaskOutput', 'read/problems', 'read/readFile', 'agent', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web', 'todo']
 handoffs:
+  - label: Build minimal-audit atomic plan (preflight all clear)
+    agent: atomic_planner
+    prompt: "Generate a minimal-audit atomic plan for `${feature-folder}` using `${feature-folder}/issue.md` as the only requirements source (no spec/user-story/research). Use directive `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`. Target plan file path is `${plan-path}` and MUST be updated in place. Do NOT create additional `plan.*.md` siblings during drafting or preflight revision loops. The plan MUST include exactly 3 phases: Phase 0 baseline capture, Phase 1 placeholder for constrained small-path implementation work, Phase 2 final QC loop. Final-QC command tasks MUST be unconditional when present in the plan: do not add IN_SCOPE/OUT_OF_SCOPE branching and do not allow SKIPPED as a valid completion state for those tasks. Require validation-only preflight through `atomic_executor` and iterate until final `PREFLIGHT: ALL CLEAR` while preserving the same target path. Return `plan-path` and final preflight signal."
+    send: true
+  - label: Execute Phase 0 only
+    agent: atomic_executor
+    prompt: "Execute the approved plan in `${feature-folder}` with strict phase scoping: run Phase 0 only and stop. Return execution summary and updated checklist state. Do not execute Phase 1 or Phase 2."
+    send: true
+  - label: Small-scope implementation path
+    agent: csharp-typed-engineer
+    prompt: "Estimate and confirm scope (1-3 production C# files + corresponding tests). If confirmed, execute the constrained short-path implementation phase from the approved minimal-audit plan and return analyzer/type/test/coverage deltas."
+    send: true
+  - label: Validate small-path delivery and post-QC docs
+    agent: atomic_executor
+    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, check off delivered acceptance criteria in AC source files per `acceptance-criteria-tracking`, and produce post-QC validation documentation deltas. Validation MUST fail if minor-audit integrity is broken (`spec.md` or `user-story.md` exists, required Phase 0 artifacts are missing, or checklist state contradicts artifact evidence). If validation fails, return precise remediation deltas."
+    send: true
+  - label: Post-implementation small-path audit
+    agent: feature_code_review_agent
+    prompt: "Use `.github/agents/feature-review.agent.md` as the governing agent contract together with `.github/prompts/review-feature.prompt.md` for `${feature-folder}` in short-path/minor-audit mode. Generate the reduced audit artifacts required for short path (policy + feature acceptance focus) and trigger remediation planning only if required by that reduced gate. The orchestrator MUST treat the delegated review artifacts as authoritative and MUST NOT author replacement audit files directly."
+    send: true
   - label: Fill potential entry details
     agent: prd_feature
     prompt: "Populate the generated potential entry docs without changing headings/template scaffolding. Add detail only, based on user objective and repository context."
@@ -27,7 +47,7 @@ handoffs:
     send: true
   - label: Post-implementation feature review
     agent: feature_code_review_agent
-    prompt: "Use `.github/prompts/review-feature.prompt.md` for this feature folder and generate policy/code/feature audits. Pass `PRBaseBranch` from orchestration context (default to `main` if missing). If remediation is required, trigger atomic planner remediation flow automatically."
+    prompt: "Use `.github/prompts/review-feature.prompt.md` for this feature folder and generate policy/code/feature audits. Resolve `PRBaseBranch` via `pr-base-branch-merge-base` and pass that resolved branch from orchestration context (do not default to `main` unless merge-base resolution fails for all candidates). If remediation is required, trigger atomic planner remediation flow automatically."
     send: true
 ---
 
@@ -42,9 +62,11 @@ You do not perform deep implementation yourself when delegated specialists exist
 Use these reusable skills to avoid duplicating shared operations:
 - `policy-compliance-order`
 - `pr-context-artifacts`
+- `pr-base-branch-merge-base`
 - `csharp-change-budget-router`
 - `csharp-orchestration-state-machine`
 - `feature-promotion-lifecycle`
+- `atomic-plan-contract`
 - `acceptance-criteria-tracking`
 
 # Non-negotiable mission behavior
@@ -60,7 +82,7 @@ Use these reusable skills to avoid duplicating shared operations:
   - `objective`
   - `change_budget_estimate`
   - `path_selected` (`small` or `large`)
-  - variables (`promotion-type`, `short-name`, `relativeFile`, `long-name`, `issue-num`, `feature-folder`)
+  - variables (`promotion-type`, `short-name`, `relativeFile`, `long-name`, `issue-num`, `feature-folder`, `plan-path`)
   - `completed_steps`
   - `next_step`
   - `last_updated`
@@ -79,6 +101,7 @@ Use these reusable skills to avoid duplicating shared operations:
   - `${long-name}`: `${relativeFile}` filename without `.md`
   - `${issue-num}`: promoted GitHub issue number
   - `${feature-folder}`: created active feature folder path
+  - `${plan-path}`: workspace-relative path to the single plan file that must be updated in-place across all planning/preflight iterations
 
 # Workflow router
 
@@ -95,14 +118,117 @@ Use these reusable skills to avoid duplicating shared operations:
 
 ## Small path (budget 1-3 production C# files and 1-3 test C# files)
 
-Use this exact sequence:
+Follow this exact sequence.
 
-1. Delegate to `csharp-atomic-planning` via handoff **Build C# atomic plan (preflight all clear)**.
-2. Require return of concrete `plan-path` and `PREFLIGHT: ALL CLEAR`.
-3. Delegate to `csharp-atomic-executor` via handoff **Execute approved C# atomic plan** using the approved `plan-path`.
-4. Require execution summary, QA summary, and analyzer/type/test/coverage deltas.
-5. Delegate to `feature_code_review_agent` via handoff **Post-implementation feature review**; use the delegated artifacts as authoritative and do NOT create `policy-audit.*.md`, `feature-audit.*.md`, or `code-review.*.md` directly from orchestration.
-6. Do not record completion in checkpoint or respond as done until the delegated review artifacts exist on disk under `${feature-folder}`.
+### Step S1 — Scope potential feature/bug
+
+S1.1 Determine type and set `${promotion-type}`:
+- `feature` or `bug`
+
+S1.2 Generate `${short-name}`:
+- lowercase slug, hyphen-separated
+
+S1.3 Ensure potential entry exists using exact command by type when missing:
+- If `${promotion-type}` is `feature`:
+  - `${workspaceFolder}/scripts/dev-tools/new-potential-entry.ps1 -ShortName ${short-name}`
+- If `${promotion-type}` is `bug`:
+  - `${workspaceFolder}/scripts/dev_tools/new_potential_bug_entry.py --short-name ${short-name}`
+
+S1.4 Detect created/existing potential markdown file path and save as `${relativeFile}`.
+
+### Step S2 — Promote with short-path flag
+
+S2.1 Promote to issue using existing tooling with short-path flag set:
+- `poetry run python -m scripts.dev_tools.potential_to_issue --potential-path ${relativeFile} --promotion-type ${promotion-type} --work-mode minor-audit`
+
+S2.2 Set `${long-name}` from `${relativeFile}` filename without `.md`.
+
+S2.3 Parse promoted document to capture `${issue-num}`.
+
+S2.4 Create branch with exact name:
+- `${promotion-type}/${short-name}-${issue-num}`
+
+S2.5 Create active feature folder with short-path flag set:
+- `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name ${long-name} --type ${promotion-type} --issue-number ${issue-num} --work-mode minor-audit`
+
+S2.6 Capture created folder path as `${feature-folder}`.
+
+S2.7 Verify short-path folder integrity before proceeding:
+- `${feature-folder}/issue.md` MUST exist and contain `- Work Mode: minor-audit`.
+- `${feature-folder}/spec.md` MUST NOT exist.
+- `${feature-folder}/user-story.md` MUST NOT exist.
+- If any integrity check fails, stop and remediate before planning.
+
+### Step S3 — Build minimal-audit atomic plan with preflight
+
+S3.0 Resolve `${plan-path}` before delegating:
+- If one or more `plan*.md` files already exist in `${feature-folder}`, set `${plan-path}` to the earliest existing template file and reuse it.
+- If none exist, create exactly one canonical plan file path and persist it as `${plan-path}`.
+
+S3.1 Delegate handoff **Build minimal-audit atomic plan (preflight all clear)**.
+
+Hard enforcement for S3:
+- Handoff MUST include directive `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`.
+- Handoff MUST include `${plan-path}` and require in-place updates to that single file.
+- Generated plan MUST include exactly 3 phases:
+  - Phase 0 baseline capture,
+  - Phase 1 placeholder for constrained small-path implementation work,
+  - Phase 2 final QC loop.
+- Plan MUST treat `${feature-folder}/issue.md` as sole requirements source (no `spec.md`).
+- Final-QC command tasks in the generated plan MUST be unconditional when present; no IN_SCOPE/OUT_OF_SCOPE branches and no SKIPPED completion path unless explicitly required by the user.
+- Do not mark S3 complete until delegate returns `plan-path` and `PREFLIGHT: ALL CLEAR`.
+
+### Step S4 — Execute baseline phase only
+
+S4.1 Delegate handoff **Execute Phase 0 only** using approved `plan-path`.
+
+Hard enforcement for S4:
+- Execute only Phase 0.
+- Persist checkpoint with Phase 0 completion evidence.
+- Do not mark S4 complete unless `phase0-instructions-read.md` and the baseline command-step artifacts referenced by the plan exist on disk, and the corresponding Phase 0 checklist items are checked from execution evidence rather than inferred summary text.
+
+### Step S5 — Branch by bootstrap mode
+
+S5.1 If request is `manual bootstrap`:
+- Save checkpoint with `next_step` at Phase 1 resume point.
+- Stop execution and return resume instructions.
+
+S5.2 If request is small development (not manual bootstrap):
+- Continue to Step S6.
+
+### Step S6 — Delegate constrained small-path development
+
+Delegate to `csharp-typed-engineer` using handoff **Small-scope implementation path**.
+
+Required delegation expectations:
+- implement only Phase 1 placeholder scope,
+- strict QA gates,
+- final analyzer/type/test/coverage deltas,
+- completion report referencing `${feature-folder}` and approved `plan-path`.
+
+### Step S7 — Validate delivery and post-QC documentation
+
+S7.1 Delegate handoff **Validate small-path delivery and post-QC docs**.
+
+Hard enforcement for S7:
+- Validation MUST be against `${feature-folder}/issue.md`.
+- Plan checklist updates MUST be persisted before audit.
+- Validation MUST fail if minor-audit integrity is broken (`spec.md` or `user-story.md` exists, required Phase 0 artifacts are missing, or checklist state contradicts artifact evidence).
+
+### Step S8 — Run reduced audit and remediation loop
+
+S8.1 Delegate handoff **Post-implementation small-path audit**.
+
+S8.2 If audit triggers remediation:
+- generate remediation inputs + remediation plan,
+- execute remediation,
+- re-run reduced audit,
+- repeat until ready-to-merge gate passes.
+
+Hard enforcement for S8:
+- Orchestrator MUST delegate the short-path audit to `feature_code_review_agent` as defined in `.github/agents/feature-review.agent.md`; direct creation or replacement of `policy-audit.*.md`, `feature-audit.*.md`, or `code-review.*.md` by the orchestrator is prohibited.
+- Do not mark small path complete until reduced audit artifacts are present in `${feature-folder}` and remediation loop (if any) is closed.
+- Do not accept PASS reduced-audit outcomes when required baseline evidence is missing, when plan checklist state is not evidence-backed, or when minor-audit folders contain `spec.md`/`user-story.md`.
 
 ---
 
@@ -200,7 +326,13 @@ On each invocation:
 4. If user explicitly asks to restart:
    - reset checkpoint and start at Phase 0.
 
-Checkpoint writes are mandatory after each completed sub-step in the large path sequence and after final completion in the small path.
+Checkpoint writes are mandatory after each completed sub-step in the large and small path sequences and after final completion.
+
+Artifact verification gate before mission completion (small path):
+- At least one short-path `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
+- At least one short-path `feature-audit.<timestamp>.md` exists under `${feature-folder}`.
+- `phase0-instructions-read.md` and baseline command-step artifacts required by the approved plan exist under `${feature-folder}`.
+- If remediation triggered, `remediation-inputs.<timestamp>.md` and `remediation-plan.<timestamp>.md` must exist and the latest re-audit must pass.
 
 Artifact verification gate before mission completion (large path):
 - At least one `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
@@ -213,7 +345,7 @@ Artifact verification gate before mission completion (large path):
 You are complete only when:
 - selected path has run end-to-end,
 - all required delegations completed,
-- feature review completed for the selected path,
+- feature review completed (large path) or reduced small-path audit completed (small path),
 - checkpoint indicates completed mission,
 - user receives concise summary with produced paths/artifacts and branch info.
 

--- a/.github/prompts/orchestrate-csharp-work.prompt.md
+++ b/.github/prompts/orchestrate-csharp-work.prompt.md
@@ -22,7 +22,17 @@ Coordinate the user request from intake to completion using the correct path bas
 
 1. Estimate rough change budget first (production C# files and test C# files).
 2. If budget is **1–3 production C# files** (+ corresponding tests):
-   - Delegate directly to `csharp-typed-engineer` for plan + implementation + QA closure.
+   - Execute enforced small-path lifecycle:
+     1) Scope/create potential entry and promote with `--work-mode minor-audit`
+     2) Create branch and active feature folder with `--work-mode minor-audit`
+     3) Delegate plan creation to `atomic_planner` with directive `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
+     4) Require `atomic_executor` preflight until `PREFLIGHT: ALL CLEAR`
+     5) Delegate to `atomic_executor` to execute **Phase 0 only**
+     6) Branch behavior:
+        - manual bootstrap: save state and stop for manual resume
+        - non-bootstrap small development: delegate constrained implementation to `csharp-typed-engineer`
+     7) Delegate post-delivery validation to `atomic_executor` for validation against issue.md and persist checklist/doc updates
+     8) Run reduced small-path audit and remediation loop until ready-to-merge
 3. If budget is **>3 production C# files** or **>3 test C# files**:
    - Execute full large-path lifecycle:
      1) Scope and create potential entry (`feature` vs `bug`, short-name creation)
@@ -48,3 +58,9 @@ On completion, report:
 - Key captured variables (`promotion-type`, `short-name`, `issue-num`, `feature-folder` when applicable)
 - Created/updated artifact paths
 - Final readiness summary and any remaining action items
+
+For small path also report:
+- approved `plan-path`
+- preflight result (`PREFLIGHT: ALL CLEAR`)
+- whether `manual bootstrap` branch was taken
+- Phase 0 execution evidence and stored `next_step` for resume

--- a/.github/skills/csharp-change-budget-router/SKILL.md
+++ b/.github/skills/csharp-change-budget-router/SKILL.md
@@ -18,14 +18,26 @@ Use this skill when:
 
 1) Estimate rough change budget first based on likely **production C# files** touched.
 2) Route:
-- `1-3` production files (+ corresponding tests) → **small path** (atomic plan + execution route).
+- `1-3` production files (+ corresponding tests) → **small path** (`csharp-typed-engineer` direct mode).
 - `>3` production files or `>3` test files → **large path** (orchestration workflow with promotion/research/spec/planning/execution/review).
+
+## Orchestrated Small-Path Requirements
+
+When routed through `csharp-orchestrator`, small path still requires lifecycle scaffolding before implementation:
+- promote potential item to GitHub issue with `--work-mode minor-audit`,
+- create active feature folder with `--work-mode minor-audit`,
+- delegate minimal-audit plan creation to `atomic_planner` with `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`,
+- require `atomic_executor` preflight until `PREFLIGHT: ALL CLEAR`,
+- execute Phase 0 only via atomic_executor before branching,
+- run reduced small-audit after implementation and QC.
+
+Direct invocation of `csharp-typed-engineer` remains implementation-focused and does not replace orchestrator lifecycle steps.
 
 ## Direct-Mode Rejection Rule
 
 If direct implementation is requested but estimated scope is `>3` production files:
 - Stop before implementation.
-- Return explicit routing instruction to invoke `csharp-orchestrator`.
+- Return explicit routing instruction to invoke `csharp-orchestrator` (or `.github/prompts/orchestrate-csharp-work.prompt.md`).
 
 ## Documentation Expectations
 

--- a/.github/skills/csharp-orchestration-state-machine/SKILL.md
+++ b/.github/skills/csharp-orchestration-state-machine/SKILL.md
@@ -29,9 +29,18 @@ Use this skill when:
 - `long-name`
 - `issue-num`
 - `feature-folder`
+- `work-mode` (`minor-audit`, `full-feature`, or `full-bug`; normalize legacy `full` to `full-feature` before persistence)
+- `plan-path` (minimal or full plan path)
 - `completed_steps`
 - `next_step`
 - `last_updated`
+
+For short-path runs, also persist:
+- `small_path_qc_summary`
+- `small_path_audit_artifacts`
+- `bootstrap_mode` (`manual-bootstrap` or `auto-small-dev`)
+- `phase0_execution_summary`
+- `resume_after_manual_bootstrap` (next step token)
 
 ## Update Protocol
 

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/code-review.2026-03-14T18-49.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/code-review.2026-03-14T18-49.md
@@ -1,0 +1,68 @@
+# Code Review: orchestrator-not-following-sequential-tasks (#101)
+
+**Review Date:** 2026-03-14  
+**Feature Folder:** `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101`  
+**Feature Folder Selection Rule:** User-specified active folder for issue `#101`; it matches the issue suffix `-101` and was used directly without alternate-folder tie-breaking.  
+**Base Branch:** `development`
+
+## Executive summary
+
+The reviewed change is focused and internally consistent: it updates the root C# orchestrator agent, the C# orchestration prompt, the C# router/state-machine skills, and the bundled extension customization mirrors so the small path no longer jumps straight to planning or implementation. The branch also adds a targeted Python regression file, `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`, which captures the original contract drift as fail-before evidence and proves the repaired contract surface with six passing assertions.
+
+The strongest evidence comes from the feature folder itself: five red regression artifacts, one consolidated green regression artifact, a QA summary describing the changed root and mirror files, and a clean repo-root Python QC pass. The only operational wrinkle is that the refreshed `pr_context` against `development` shows an empty committed range because the #101 work is presently in the working tree rather than in branch commits; that affects PR metadata visibility, not the implementation quality reviewed here.
+
+Top 3 risks:
+1. The review scope is not yet represented in committed branch history, so future reviewers will need a post-commit `pr_context` refresh before opening a PR.
+2. There is no fresh end-to-end `/orchestrate-csharp-work` rerun artifact after the contract update; current confidence rests on contract-level tests plus the feature evidence trail.
+3. The router skill intentionally distinguishes direct `csharp-typed-engineer` use from orchestrated small-path behavior; that nuance is now documented, but future edits could reintroduce ambiguity if parity tests are removed.
+
+**PR readiness recommendation:** **Go for implementation quality.** Commit the current working-tree changes and refresh PR context before opening the PR so the branch diff becomes visible in the canonical comparison artifacts.
+
+## Findings
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `artifacts/pr_context.summary.txt` | `Base/Head` and `Range` sections | The refreshed PR-context comparison against `development` shows `HEAD == merge-base`, so the intended #101 review scope is not yet visible as committed branch history. | Commit the current #101 changes, then rerun `poetry run python -m scripts.dev_tools.pr_context.collector --base development` before opening a PR. | Reviewing the live working tree is fine for this session, but canonical PR review artifacts should describe a real branch diff, not just local edits. | `artifacts/pr_context.summary.txt` after refresh reports `Range: dc0502de6e7b02ea76720fb898c038f01ad13f92..dc0502de6e7b02ea76720fb898c038f01ad13f92`. |
+| Nit | `.github/skills/csharp-change-budget-router/SKILL.md` | route bullets + `## Orchestrated Small-Path Requirements` | The skill now correctly explains the orchestrated short path, but readers must combine the top routing bullets with the later section to understand why `csharp-orchestrator` behaves differently from direct `csharp-typed-engineer` usage. | Keep the direct-mode/orchestrated-mode distinction explicit in future edits and preserve the regression test that locks the wording in place. | This is not incorrect today; it is simply a place where future wording drift could reintroduce the very confusion issue #101 is fixing. | `.github/skills/csharp-change-budget-router/SKILL.md`; `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py::test_csharp_change_budget_router_requires_orchestrated_small_path_wording`. |
+| Nit | `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/**` | validation coverage | The feature has strong contract-level red/green evidence, but there is no fresh manual rerun note for `/orchestrate-csharp-work` after the markdown-contract update. | Optionally add one short manual validation note after re-running the issue’s original small-scope orchestration scenario. | The implementation surface here is configuration/contract driven, so an end-to-end note would be extra confidence rather than a hard blocker. | `spec.md` manual validation bullets request a rerun of `/orchestrate-csharp-work`; current evidence includes red/green contract tests and QC artifacts only. |
+
+## Typed Python audit
+
+### What changed well
+
+- `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` is fully typed, uses a narrow helper, and avoids `Any` or implicit typing escapes.
+- The test module relies on repository text fixtures only, which keeps the regression seam deterministic and easy to reason about.
+- Mirror parity is enforced directly rather than by loose substring checks, which is the right level of strictness for bundled customization contracts.
+
+### Typing and API notes
+
+- No new `Any`, `# type: ignore`, or `# noqa` suppressions were introduced.
+- The helper `read_repo_text(relative_path: str) -> str` is precisely annotated and keeps file access localized.
+- No new public Python API surface was added; the Python change is test-only.
+
+### Error handling and logging
+
+- The test module does not broad-catch exceptions and lets missing files fail loudly, which is appropriate for contract verification.
+- No ad-hoc logging or print-debugging was introduced.
+
+## Test quality audit
+
+- **Deterministic:** The suite reads checked-in files only and has no network, process, clock, or temp-file dependency.
+- **Isolated:** Each test checks one contract invariant, making failures pinpoint the drift immediately.
+- **Fast:** The targeted green run completed in `0.04s`, and the full repo-root Pytest run completed in `2.99s`.
+- **Good failure messages:** The red artifacts capture the exact missing string or parity mismatch, which makes the regression easy to diagnose.
+
+## Security and correctness checks
+
+- No secrets, credentials, or external endpoints were introduced.
+- No unsafe subprocess usage was added in the reviewed code.
+- Input validation at the test boundary is adequate because the suite consumes repository-relative constant paths only.
+- The large-path C# workflow remains preserved by explicit regression coverage, reducing the risk that the short-path fix accidentally broadens into a routing rewrite.
+
+## Research log
+
+No external research was required for this review. Repository policies, refreshed PR-context artifacts, the feature-folder evidence, and the current working-tree diff were sufficient.
+
+## Verdict
+
+No blocker or major code-quality issues were found in the #101 implementation. The contract updates are coherent, the root/bundled mirrors are synchronized, the regression tests are appropriately strict, and the repo-root verification loop passed cleanly. The only follow-up needed before PR opening is operational: commit the current working-tree changes and refresh `pr_context` so the canonical branch comparison reflects the reviewed scope.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,45 @@
+Timestamp: 2026-03-14T18:32:29.5036760-04:00
+
+Policy Order:
+1. `.github/copilot-instructions.md`
+2. `.github/instructions/general-code-change.instructions.md`
+3. `.github/instructions/general-unit-test.instructions.md`
+4. `.github/instructions/python-code-change.instructions.md`
+5. `.github/instructions/python-unit-test.instructions.md`
+6. `.github/instructions/python-suppressions.instructions.md`
+7. `.github/instructions/self-explanatory-code-commenting.instructions.md`
+
+Files Read:
+- `.github/copilot-instructions.md`
+- `.github/instructions/general-code-change.instructions.md`
+- `.github/instructions/general-unit-test.instructions.md`
+- `.github/instructions/python-code-change.instructions.md`
+- `.github/instructions/python-unit-test.instructions.md`
+- `.github/instructions/python-suppressions.instructions.md`
+- `.github/instructions/self-explanatory-code-commenting.instructions.md`
+- `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/issue.md`
+- `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/spec.md`
+- `artifacts/research/20260314-csharp-orchestrator-small-path-lifecycle-research.md`
+- `.github/agents/orchestrator.agent.md`
+- `.github/agents/csharp-orchestrator.agent.md`
+- `.github/prompts/orchestrate-work.prompt.md`
+- `.github/prompts/orchestrate-csharp-work.prompt.md`
+- `.github/skills/feature-promotion-lifecycle/SKILL.md`
+- `.github/skills/atomic-plan-contract/SKILL.md`
+- `.github/skills/acceptance-criteria-tracking/SKILL.md`
+- `.github/skills/csharp-orchestration-state-machine/SKILL.md`
+- `.github/skills/csharp-change-budget-router/SKILL.md`
+
+Context Package:
+- Requirements Source: `spec.md`
+- User-story Source: `NONE`
+- Supporting Research: `artifacts/research/20260314-csharp-orchestrator-small-path-lifecycle-research.md`
+- Root References: `.github/agents/orchestrator.agent.md`, `.github/agents/csharp-orchestrator.agent.md`, `.github/prompts/orchestrate-work.prompt.md`, `.github/prompts/orchestrate-csharp-work.prompt.md`
+- Shared Skills: `.github/skills/feature-promotion-lifecycle/SKILL.md`, `.github/skills/atomic-plan-contract/SKILL.md`, `.github/skills/acceptance-criteria-tracking/SKILL.md`, `.github/skills/csharp-orchestration-state-machine/SKILL.md`, `.github/skills/csharp-change-budget-router/SKILL.md`
+
+Work Mode: full-bug
+AC Source: spec.md
+Target Plan Path: c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-03-14-orchestrator-not-following-sequential-tasks-101\plan.2026-03-14T18-08.md
+
+Notes:
+- Validation-only preflight for this exact plan path was previously completed with `PREFLIGHT: ALL CLEAR`; execution is proceeding from Phase 0 onward.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-black.2026-03-14T18-33-33.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-black.2026-03-14T18-33-33.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-14T18:33:33-04:00
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary: PASS — Black reported "164 files left unchanged."
+
+Output:
+All done! ✨ 🍰 ✨
+164 files left unchanged.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-pyright.2026-03-14T18-34-04.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-pyright.2026-03-14T18-34-04.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T18:34:04-04:00
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary: PASS — Pyright reported 0 errors, 0 warnings, 0 informations.
+
+Output:
+0 errors, 0 warnings, 0 informations

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-pytest.2026-03-14T18-34-25.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-pytest.2026-03-14T18-34-25.md
@@ -1,0 +1,14 @@
+Timestamp: 2026-03-14T18:34:25-04:00
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: PASS — 873 tests passed in 3.32s; total coverage 83%; scripts/dev_tools coverage 83%; coverage warned that src/lexile_corpus_tuner was not imported.
+
+Coverage Headlines:
+- Total Coverage: 83%
+- scripts/dev_tools Coverage: 83%
+- Tests Passed: 873
+
+Output Excerpt:
+============================= 873 passed in 3.32s =============================
+TOTAL                                                               6618   1153    83%
+CoverageWarning: Module src/lexile_corpus_tuner was never imported. (module-not-imported)

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-ruff.2026-03-14T18-33-45.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/baseline/python-ruff.2026-03-14T18-33-45.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T18:33:45-04:00
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary: PASS — Ruff reported "All checks passed!"
+
+Output:
+All checks passed!

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/other/csharp-orchestration-contracts-green.2026-03-14T18-42-49.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/other/csharp-orchestration-contracts-green.2026-03-14T18-42-49.md
@@ -1,0 +1,15 @@
+Timestamp: 2026-03-14T18:42:49-04:00
+Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py
+EXIT_CODE: 0
+Output Summary: PASS — the targeted C# orchestration contract suite passed 6 tests, covering the small-path lifecycle, prompt contract, state-machine continuity fields, router wording, mirror parity, and large-path preservation.
+
+Covered Tests:
+- test_csharp_orchestrator_small_path_requires_minor_audit_lifecycle
+- test_orchestrate_csharp_work_prompt_requires_minor_audit_lifecycle
+- test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields
+- test_csharp_change_budget_router_requires_orchestrated_small_path_wording
+- test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence
+- test_csharp_orchestrator_large_path_chain_remains_csharp_atomic_pipeline
+
+Pytest Summary:
+6 passed in 0.04s

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/csharp-orchestration-contract-summary.2026-03-14T18-42-49.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/csharp-orchestration-contract-summary.2026-03-14T18-42-49.md
@@ -1,0 +1,25 @@
+Timestamp: 2026-03-14T18:42:49-04:00
+
+Changed Root Files:
+- `.github/agents/csharp-orchestrator.agent.md`
+- `.github/prompts/orchestrate-csharp-work.prompt.md`
+- `.github/skills/csharp-orchestration-state-machine/SKILL.md`
+- `.github/skills/csharp-change-budget-router/SKILL.md`
+
+Changed Mirror Files:
+- `extensions/drm-copilot/resources/customizations/.github/agents/csharp-orchestrator.agent.md`
+- `extensions/drm-copilot/resources/customizations/.github/prompts/orchestrate-csharp-work.prompt.md`
+- `extensions/drm-copilot/resources/customizations/.github/skills/csharp-orchestration-state-machine/SKILL.md`
+- `extensions/drm-copilot/resources/customizations/.github/skills/csharp-change-budget-router/SKILL.md`
+- `extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md`
+- `extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md`
+- `extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md`
+
+Targeted Regression Command:
+- `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+- Result: `6 passed in 0.04s`
+
+Large-Path Preservation:
+- Verified by `test_csharp_orchestrator_large_path_chain_remains_csharp_atomic_pipeline`.
+- Root C# orchestrator still contains `Build C# atomic plan (preflight all clear)`.
+- Root C# orchestrator still contains `Execute approved C# atomic plan`.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-black.2026-03-14T18-45-04.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-black.2026-03-14T18-45-04.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-14T18:45:04-04:00
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary: PASS — Black reported "165 files left unchanged." on the clean final QA pass.
+
+Output:
+All done! ✨ 🍰 ✨
+165 files left unchanged.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-coverage-delta.2026-03-14T18-45-04.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-coverage-delta.2026-03-14T18-45-04.md
@@ -1,0 +1,13 @@
+Timestamp: 2026-03-14T18:45:04-04:00
+Baseline Total Coverage: 83%
+Final Total Coverage: 83%
+Baseline scripts/dev_tools Coverage: 83%
+Final scripts/dev_tools Coverage: 83%
+Coverage Delta (Total): 0 percentage points
+Coverage Delta (scripts/dev_tools): 0 percentage points
+No planned command task skipped: true
+
+Notes:
+- Baseline Pytest artifact: `evidence/baseline/python-pytest.2026-03-14T18-34-25.md`
+- Final Pytest artifact: `evidence/qa-gates/python-pytest.2026-03-14T18-45-04.md`
+- Final targeted regression suite added 6 passing assertions for the C# orchestration contract surface while keeping aggregate repo-root Python coverage stable.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-pyright.2026-03-14T18-45-04.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-pyright.2026-03-14T18-45-04.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T18:45:04-04:00
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary: PASS — Pyright reported 0 errors, 0 warnings, 0 informations on the clean final QA pass.
+
+Output:
+0 errors, 0 warnings, 0 informations

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-pytest.2026-03-14T18-45-04.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-pytest.2026-03-14T18-45-04.md
@@ -1,0 +1,14 @@
+Timestamp: 2026-03-14T18:45:04-04:00
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: PASS — 879 tests passed in 2.90s; total coverage 83%; scripts/dev_tools coverage 83%; coverage warned that src/lexile_corpus_tuner was not imported.
+
+Coverage Headlines:
+- Total Coverage: 83%
+- scripts/dev_tools Coverage: 83%
+- Tests Passed: 879
+
+Output Excerpt:
+============================= 879 passed in 2.90s =============================
+TOTAL                                                               6618   1153    83%
+CoverageWarning: Module src/lexile_corpus_tuner was never imported. (module-not-imported)

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-ruff.2026-03-14T18-45-04.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/qa-gates/python-ruff.2026-03-14T18-45-04.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T18:45:04-04:00
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary: PASS — Ruff reported "All checks passed!" on the clean final QA pass.
+
+Output:
+All checks passed!

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-change-budget-router-red.2026-03-14T18-36-16.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-change-budget-router-red.2026-03-14T18-36-16.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-03-14T18:36:16-04:00
+Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_change_budget_router_requires_orchestrated_small_path_wording
+EXIT_CODE: 1
+Output Summary: EXPECTED RED — the C# change-budget router still describes the small path without the required `--work-mode minor-audit` lifecycle wording.
+
+Failure Excerpt:
+AssertionError: assert '--work-mode minor-audit' in router_text
+
+Pytest Summary:
+1 failed, 3 deselected in 0.06s

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-customization-bundle-red.2026-03-14T18-36-41.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-customization-bundle-red.2026-03-14T18-36-41.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-03-14T18:36:41-04:00
+Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence
+EXIT_CODE: 1
+Output Summary: EXPECTED RED — the bundled C# customization mirror is out of sync with the root contract files, so parity fails before the missing shared-skill assertion is reached.
+
+Failure Excerpt:
+AssertionError: assert mirror_agent_path.read_text(encoding="utf-8") == root_agent
+
+Pytest Summary:
+1 failed, 4 deselected in 0.07s

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-orchestrator-small-path-red.2026-03-14T18-35-17.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-orchestrator-small-path-red.2026-03-14T18-35-17.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-03-14T18:35:17-04:00
+Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_orchestrator_small_path_requires_minor_audit_lifecycle
+EXIT_CODE: 1
+Output Summary: EXPECTED RED — the C# orchestrator contract still omits the required `Build minimal-audit atomic plan (preflight all clear)` small-path lifecycle wording.
+
+Failure Excerpt:
+AssertionError: assert 'Build minimal-audit atomic plan (preflight all clear)' in agent_text
+
+Pytest Summary:
+1 failed in 0.07s

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-state-machine-red.2026-03-14T18-35-58.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/csharp-state-machine-red.2026-03-14T18-35-58.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-03-14T18:35:58-04:00
+Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields
+EXIT_CODE: 1
+Output Summary: EXPECTED RED — the C# orchestration state-machine skill still omits required short-path continuity fields such as `work-mode` and `plan-path`.
+
+Failure Excerpt:
+AssertionError: assert 'work-mode' in state_machine_text
+
+Pytest Summary:
+1 failed, 2 deselected in 0.07s

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/orchestrate-csharp-work-prompt-red.2026-03-14T18-35-39.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/regression-testing/orchestrate-csharp-work-prompt-red.2026-03-14T18-35-39.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-03-14T18:35:39-04:00
+Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_orchestrate_csharp_work_prompt_requires_minor_audit_lifecycle
+EXIT_CODE: 1
+Output Summary: EXPECTED RED — the root C# orchestration prompt still omits the required `minor-audit` short-path lifecycle wording.
+
+Failure Excerpt:
+AssertionError: assert 'minor-audit' in prompt_text
+
+Pytest Summary:
+1 failed, 1 deselected in 0.07s

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/feature-audit.2026-03-14T18-49.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/feature-audit.2026-03-14T18-49.md
@@ -1,0 +1,60 @@
+# Feature Audit: orchestrator-not-following-sequential-tasks (#101)
+
+**Audit Date:** 2026-03-14  
+**Base Branch:** `development`  
+**Feature Folder:** `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101`
+
+## Scope and baseline
+
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/**`
+  - Live working-tree supplement: current `git status` / diff state, because the refreshed PR context reports an empty committed range against `development`
+- **Requirements source:** `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/spec.md`
+- **Work mode:** `full-bug` (resolved from `issue.md`)
+- **Base branch assumption:** none; the user explicitly provided `PRBaseBranch=development`
+- **Note:** The refreshed canonical PR summary uses the correct base and merge-base (`dc0502de6e7b02ea76720fb898c038f01ad13f92` at `2026-03-14T18:06:59-04:00`), but it shows `Range: dc0502de6e7b02ea76720fb898c038f01ad13f92..dc0502de6e7b02ea76720fb898c038f01ad13f92` because the #101 implementation currently lives in the working tree rather than in branch commits. This audit therefore validates the current code and evidence directly.
+
+## Acceptance criteria inventory (authoritative for this run)
+
+From `spec.md`:
+
+1. For the issue #101 repro, the documented C# small path now requires the sequential short-path lifecycle before planning/execution: potential entry resolution, promotion with `--work-mode minor-audit`, branch creation, active feature folder creation, folder-integrity validation, `${plan-path}` resolution, Phase 0-only execution, validation, and reduced audit.
+2. `artifacts/orchestration/csharp-orchestrator-state.json` is documented and validated to carry the lifecycle variables needed for small-path continuity, including non-null `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, `${feature-folder}`, and `${plan-path}` before completion is allowed.
+3. Minor-audit invariants are explicit and testable: a valid short-path folder contains `issue.md` with `- Work Mode: minor-audit`, does not contain `spec.md` or `user-story.md`, and cannot pass completion if Phase 0 evidence or reduced-audit artifacts are missing.
+4. The root C# orchestrator agent, root C# prompt, root C# state/router skills, and their bundled extension mirrors are updated together so the small-path contract is no longer contradictory across root and packaged customization sources.
+5. Regression tests are added or updated in the existing Python test suite to fail on: direct-to-planning/direct-to-engineer shortcut wording, missing `${plan-path}` continuity, missing bundled `acceptance-criteria-tracking` mirror when referenced, or root↔mirror drift.
+6. The fix does not change large-path routing thresholds or large-path lifecycle behavior beyond additive checkpoint compatibility needed to share the updated state contract.
+7. Final validation for the implementation pass includes a clean repo-root toolchain pass (`poetry run black .`, `poetry run ruff check`, `poetry run pyright`, `poetry run pytest`).
+8. Documentation and bundled customization references match the final behavior closely enough that a future reader cannot derive a shortcut small path from the C# agent/prompt/skill set.
+
+## Acceptance criteria evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| 1. Document the full sequential short-path lifecycle before planning/execution. | PASS | `.github/agents/csharp-orchestrator.agent.md` now contains the `S1`–`S8` small-path lifecycle plus `Build minimal-audit atomic plan (preflight all clear)`, `Execute Phase 0 only`, validation, and reduced-audit steps; the prompt mirrors that lifecycle. Red artifacts show the old wording failed before the fix. | `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`; red artifacts under `evidence/regression-testing/` | The implementation is contract-level, so evidence is strongest in the agent/prompt files and fail-before/pass-after test artifacts. |
+| 2. Document and validate the required checkpoint continuity fields, including `${plan-path}`. | PASS | `.github/skills/csharp-orchestration-state-machine/SKILL.md` now documents `work-mode`, `plan-path`, bootstrap metadata, and Phase 0 continuity; `test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields` passed green after failing red. | same targeted Pytest suite | Validation here is documentation-contract validation rather than a fresh live orchestration rerun. |
+| 3. Make minor-audit invariants explicit and testable. | PASS | The root agent, bundled mirrors, and refreshed bundled `feature-promotion-lifecycle` / `atomic-plan-contract` skills now require `issue.md`, reject unexpected `spec.md` / `user-story.md`, and fail closed when Phase 0 evidence or checklist state is inconsistent. | same targeted Pytest suite; static inspection of root and bundled skill files | The invariant language is present in both root and bundled customization sources. |
+| 4. Update root and bundled C# customization sources together. | PASS | `evidence/qa-gates/csharp-orchestration-contract-summary.2026-03-14T18-42-49.md` lists changed root and mirror files; `test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence` enforces mirror parity and presence of bundled `acceptance-criteria-tracking`. | `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` | The bundled mirror now includes `extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md`. |
+| 5. Add regression tests for shortcut wording, continuity, and mirror drift. | PASS | `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` adds six focused tests; five red artifacts capture pre-fix failures; the green artifact records `6 passed in 0.04s`. | `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` | The tests directly lock the issue’s contract drift vectors. |
+| 6. Preserve large-path thresholds and large-path lifecycle behavior. | PASS | `.github/skills/csharp-change-budget-router/SKILL.md` still contains `1-3` and `>3` thresholds; `test_csharp_orchestrator_large_path_chain_remains_csharp_atomic_pipeline` confirms the large-path C# atomic planning chain remains present. | same targeted Pytest suite | The update is additive to checkpoint continuity and small-path lifecycle wording. |
+| 7. Finish with a clean repo-root toolchain pass. | PASS | In-session verification succeeded: Black clean, Ruff clean, Pyright clean, and Pytest `873 passed in 2.99s`; final QA artifacts also exist under `evidence/qa-gates/`. | `poetry run black .`; `poetry run ruff check`; `poetry run pyright`; `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info` | Aggregate coverage stayed stable at `83%`. |
+| 8. Keep documentation and bundled references aligned so a shortcut small path cannot be re-derived. | PASS | Root agent/prompt/router/state-machine files, bundled mirrors, and the added bundled shared skill all reflect the same final behavior; the parity test and summary artifact confirm alignment. | same targeted Pytest suite plus static file inspection | The only remaining caution is operational: commit the changes so PR-context can represent them. |
+
+## Summary
+
+**Overall feature readiness:** PASS
+
+The #101 implementation satisfies the acceptance criteria defined in `spec.md` and is supported by strong red/green regression evidence plus a clean repo-root Python QC pass. The refreshed `pr_context` is correctly targeted at `development` and the requested merge-base, even though the committed branch range is empty because the implementation is still uncommitted. That affects PR packaging, not the acceptance status of the current code.
+
+**Recommended follow-up verification steps:**
+- Commit the current working-tree changes and rerun `poetry run python -m scripts.dev_tools.pr_context.collector --base development` so the canonical PR artifacts describe a real branch diff.
+- Optional but useful: capture one short `/orchestrate-csharp-work` manual rerun note for the original small-scope scenario described in `issue.md`.
+
+## Acceptance Criteria Status
+- Source: `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/spec.md`
+- Total AC items: 8
+- Checked off (delivered): 8
+- Remaining (unchecked): 0
+- Items remaining: None. All eight checkbox criteria were already checked in `spec.md`, and this audit verified that checked state against the current code and evidence; no source-file checkbox update was needed.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/issue.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/issue.md
@@ -1,0 +1,98 @@
+# orchestrator-not-following-sequential-tasks (Issue #101)
+
+- Date captured: 2026-03-14
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/orchestrator-not-following-sequential-tasks/ (Issue #101)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #101
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/101
+- Last Updated: 2026-03-14
+- Work Mode: full-bug
+
+## Summary
+
+When `csharp-orchestrator` classifies a request as the small path, it skips the mandatory short-path promotion/folder lifecycle and delegates straight to `csharp-atomic-planning` (and then execution). This bypass leaves the orchestration variables unset, prevents potential/issue/folder artifacts from being created, and violates the repository’s shared `feature-promotion-lifecycle` contract for short-path work.
+
+## Environment
+
+- OS/version: Windows (user environment on 2026-03-14; exact version not captured in prompt transcript)
+- Python version: N/A — failure occurs in C# orchestration workflow, not Python execution
+- Command/flags used: `/orchestrate-csharp-work In the current add-in, when I click the Sort Email button, it automatically begins the form applying Dark Mode. This add-in should be able to detect whether the system is in Dark Mode or Light Mode and follow the system. Please create this functionality and orchestrate the work to completion`
+- Data source or fixture: `.github/agents/csharp-orchestrator.agent.md`, `.github/prompts/orchestrate-csharp-work.prompt.md`, `.github/skills/feature-promotion-lifecycle/SKILL.md`, and `artifacts/orchestration/csharp-orchestrator-state.json`
+
+## Steps to Reproduce
+
+1. Invoke `csharp-orchestrator` through `.github/prompts/orchestrate-csharp-work.prompt.md` with a small, bounded C# request (for example, the Dark Mode detection request that was estimated at 2 production C# files and 1 test file).
+2. Allow the orchestrator to complete budget estimation and route to the small path.
+3. Observe the next action and the resulting checkpoint state.
+4. Confirm that the orchestrator delegates directly to `csharp-atomic-planning`, then to `csharp-atomic-executor`, without first creating/filling a potential entry, promoting to issue, creating a branch, or creating an active feature folder.
+5. Inspect `artifacts/orchestration/csharp-orchestrator-state.json` and confirm that `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, and `${feature-folder}` all remain `null` even though the workflow is marked complete.
+
+## Expected Behavior
+
+After choosing the small path, the orchestrator should still follow the mandatory short-path sequence defined by the shared lifecycle rules: establish classification variables, create/fill the potential entry, promote with `minor-audit` mode, create the branch and active feature folder, then hand off to planning/execution using the generated artifacts and persisted variables. At minimum, the orchestrator should not report completion while the required orchestration variables and feature artifacts were never created.
+
+## Actual Behavior
+
+The orchestrator routed directly from budget estimation to `csharp-atomic-planning`, followed by `csharp-atomic-executor`, and then marked the mission complete. The checkpoint shows:
+
+- `"path_selected": "small"`
+- `"completed_steps": ["phase-0-intake", "budget-estimate", "delegate-csharp-atomic-planning", "delegate-csharp-atomic-executor"]`
+- all lifecycle variables still `null` (`promotion-type`, `short-name`, `relativeFile`, `long-name`, `issue-num`, `feature-folder`)
+
+This means the orchestrator never performed the mandatory sequential lifecycle steps before planning/execution.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet:
+
+	From `.github/agents/csharp-orchestrator.agent.md` small path:
+	`1. Delegate to csharp-atomic-planning via handoff Build C# atomic plan (preflight all clear).`
+
+	From `.github/skills/feature-promotion-lifecycle/SKILL.md` canonical short path:
+	`When orchestrator routing selects short path, promotion/folder initialization still occurs and MUST use minor-audit mode.`
+
+	From `artifacts/orchestration/csharp-orchestrator-state.json` after the run:
+	`"promotion-type": null,`
+	`"short-name": null,`
+	`"relativeFile": null,`
+	`"long-name": null,`
+	`"issue-num": null,`
+	`"feature-folder": null`
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+There appear to be contradictory orchestration contracts for small-path work:
+
+- `.github/agents/csharp-orchestrator.agent.md` defines the small path as direct planning/execution only.
+- `.github/prompts/orchestrate-csharp-work.prompt.md` defines the small path differently again, as a direct delegation to `csharp-typed-engineer`.
+- `.github/skills/feature-promotion-lifecycle/SKILL.md` explicitly says short-path workflows still require promotion/folder initialization in `minor-audit` mode.
+
+Because the orchestrator agent’s embedded small-path workflow omits those lifecycle steps entirely, the agent followed its local sequence and never set the persisted variables required by its own checkpoint schema. The failure is therefore likely an instruction precedence/design bug rather than a one-off execution mistake.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas
+	- Add workflow-contract coverage for `csharp-orchestrator` small-path routing so a small-scope request must produce non-null lifecycle variables or explicitly documented short-path artifacts.
+	- Add a consistency check that the agent file, orchestration prompt, and shared lifecycle skill do not define conflicting small-path sequences.
+- [x] Integration scenario to retest
+	- Re-run `/orchestrate-csharp-work` with a known small-scope request and verify the resulting flow includes potential entry creation/fill, promotion in `minor-audit` mode, branch creation, active feature folder creation, then planning/execution.
+	- Verify `artifacts/orchestration/csharp-orchestrator-state.json` contains populated values for `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, and `${feature-folder}` before the workflow can complete.
+- [x] Manual verification notes
+	- Inspect the created feature folder and confirm that `issue.md` exists with the persisted work-mode marker before the plan handoff occurs.
+	- Confirm the orchestrator does not mark completion if the lifecycle variables are still `null`.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/plan.2026-03-14T18-08.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/plan.2026-03-14T18-08.md
@@ -1,0 +1,114 @@
+# 2026-03-14-orchestrator-not-following-sequential-tasks (Plan)
+
+- **Issue:** #101
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-03-14T18-08
+- **Status:** Approved
+- **Version:** 0.2
+
+## Implementation Plan (Atomic Tasks)
+
+DIRECTIVE: PREFLIGHT VALIDATION ONLY
+
+- Requirements source: `spec.md` (resolved from `issue.md` work mode `full-bug`)
+- User-story source: `NONE`
+- Feature folder: `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101`
+- Required target plan path: `c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-03-14-orchestrator-not-following-sequential-tasks-101\plan.2026-03-14T18-08.md`
+- Required preflight validator: `atomic_executor`
+- Required final preflight signal: `PREFLIGHT: ALL CLEAR`
+- Revision rule: update this exact plan file in place for every preflight revision; do not create sibling `plan.*.md` files.
+- Execution gate: Phase 0 may begin only after validation-only preflight reports `PREFLIGHT: ALL CLEAR` for this exact plan path.
+
+### Phase 0 — Context & Baseline
+
+- [x] [P0-T1] Read `.github/copilot-instructions.md` and record completion in the Phase 0 evidence artifact
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/copilot-instructions.md` in `Files Read:`.
+- [x] [P0-T2] Read `.github/instructions/general-code-change.instructions.md` and record completion in the Phase 0 evidence artifact
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/general-code-change.instructions.md` in `Files Read:`.
+- [x] [P0-T3] Read `.github/instructions/general-unit-test.instructions.md` and record completion in the Phase 0 evidence artifact
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/general-unit-test.instructions.md` in `Files Read:`.
+- [x] [P0-T4] Read `.github/instructions/python-code-change.instructions.md` and record completion in the Phase 0 evidence artifact
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/python-code-change.instructions.md` in `Files Read:`.
+- [x] [P0-T5] Read `.github/instructions/python-unit-test.instructions.md` and record completion in the Phase 0 evidence artifact
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/python-unit-test.instructions.md` in `Files Read:`.
+- [x] [P0-T6] Read `.github/instructions/python-suppressions.instructions.md` and record completion in the Phase 0 evidence artifact
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/python-suppressions.instructions.md` in `Files Read:`.
+- [x] [P0-T7] Read `.github/instructions/self-explanatory-code-commenting.instructions.md` and record completion in the Phase 0 evidence artifact
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/self-explanatory-code-commenting.instructions.md` in `Files Read:`.
+- [x] [P0-T8] Record the policy-read order, context package, resolved work mode, acceptance-criteria source, and exact target plan path in `evidence/baseline/phase0-instructions-read.md`
+	- Preconditions: `issue.md`, `spec.md`, `artifacts/research/20260314-csharp-orchestrator-small-path-lifecycle-research.md`, `.github/agents/orchestrator.agent.md`, `.github/agents/csharp-orchestrator.agent.md`, `.github/prompts/orchestrate-work.prompt.md`, `.github/prompts/orchestrate-csharp-work.prompt.md`, `.github/skills/feature-promotion-lifecycle/SKILL.md`, `.github/skills/atomic-plan-contract/SKILL.md`, `.github/skills/acceptance-criteria-tracking/SKILL.md`, `.github/skills/csharp-orchestration-state-machine/SKILL.md`, and `.github/skills/csharp-change-budget-router/SKILL.md` exist.
+	- Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and contains `Timestamp:`, `Policy Order:`, `Files Read:`, `Work Mode: full-bug`, `AC Source: spec.md`, and `Target Plan Path: c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-03-14-orchestrator-not-following-sequential-tasks-101\plan.2026-03-14T18-08.md`; its `Files Read:` section explicitly lists `.github/copilot-instructions.md`, `.github/instructions/general-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/python-unit-test.instructions.md`, `.github/instructions/python-suppressions.instructions.md`, and `.github/instructions/self-explanatory-code-commenting.instructions.md`.
+- [x] [P0-T9] Run `poetry run black .` and store the baseline result in `evidence/baseline/python-black.<timestamp>.md`
+	- Acceptance: a file matching `evidence/baseline/python-black.*.md` exists and contains `Timestamp:`, `Command: poetry run black .`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T10] Run `poetry run ruff check` and store the baseline result in `evidence/baseline/python-ruff.<timestamp>.md`
+	- Acceptance: a file matching `evidence/baseline/python-ruff.*.md` exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T11] Run `poetry run pyright` and store the baseline result in `evidence/baseline/python-pyright.<timestamp>.md`
+	- Acceptance: a file matching `evidence/baseline/python-pyright.*.md` exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T12] Run `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and store the baseline result in `evidence/baseline/python-pytest.<timestamp>.md`
+	- Acceptance: a file matching `evidence/baseline/python-pytest.*.md` exists and contains `Timestamp:`, `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`, `EXIT_CODE:`, and `Output Summary:` with numeric total coverage and numeric `scripts/dev_tools` coverage values.
+
+### Phase 1 — Red Regression Coverage
+
+- [x] [P1-T1] [expect-fail] Add pytest case `test_csharp_orchestrator_small_path_requires_minor_audit_lifecycle` to `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+	- Acceptance: `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` contains a test named `test_csharp_orchestrator_small_path_requires_minor_audit_lifecycle`, and `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_orchestrator_small_path_requires_minor_audit_lifecycle` fails while writing `evidence/regression-testing/csharp-orchestrator-small-path-red.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_orchestrator_small_path_requires_minor_audit_lifecycle`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T2] [expect-fail] Add pytest case `test_orchestrate_csharp_work_prompt_requires_minor_audit_lifecycle` to `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+	- Acceptance: `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` contains a test named `test_orchestrate_csharp_work_prompt_requires_minor_audit_lifecycle`, and `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_orchestrate_csharp_work_prompt_requires_minor_audit_lifecycle` fails while writing `evidence/regression-testing/orchestrate-csharp-work-prompt-red.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_orchestrate_csharp_work_prompt_requires_minor_audit_lifecycle`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T3] [expect-fail] Add pytest case `test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields` to `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+	- Acceptance: `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` contains a test named `test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields`, and `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields` fails while writing `evidence/regression-testing/csharp-state-machine-red.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T4] [expect-fail] Add pytest case `test_csharp_change_budget_router_requires_orchestrated_small_path_wording` to `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+	- Acceptance: `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` contains a test named `test_csharp_change_budget_router_requires_orchestrated_small_path_wording`, and `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_change_budget_router_requires_orchestrated_small_path_wording` fails while writing `evidence/regression-testing/csharp-change-budget-router-red.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_change_budget_router_requires_orchestrated_small_path_wording`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T5] [expect-fail] Add pytest case `test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence` to `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+	- Acceptance: `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` contains a test named `test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence`, and `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence` fails while writing `evidence/regression-testing/csharp-customization-bundle-red.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py -k test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence`, and non-zero `EXIT_CODE:`.
+
+### Phase 2 — Root Contract Alignment
+
+- [x] [P2-T1] Update `.github/agents/csharp-orchestrator.agent.md` so the C# small path follows the generic short-path Step S1-S8 lifecycle, persists `${plan-path}`, and keeps the existing large-path C# planning/execution chain intact
+	- Acceptance: `.github/agents/csharp-orchestrator.agent.md` contains `Build minimal-audit atomic plan (preflight all clear)`, `Execute Phase 0 only`, `Small-scope implementation path`, `Validate small-path delivery and post-QC docs`, `Post-implementation small-path audit`, `${plan-path}`, and the large-path enforcement line `The planning route MUST be csharp-atomic-planning -> atomic_planner -> atomic_executor`.
+- [x] [P2-T2] Update `.github/prompts/orchestrate-csharp-work.prompt.md` so the documented small path requires `minor-audit` promotion, folder initialization, minimal-plan preflight, Phase 0-only execution, validation against `issue.md`, and reduced audit
+	- Acceptance: `.github/prompts/orchestrate-csharp-work.prompt.md` contains `minor-audit`, `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`, `PREFLIGHT: ALL CLEAR`, `Phase 0 only`, and `validation against issue.md`, and it does not contain `Delegate directly to csharp-typed-engineer for plan + implementation + QA closure.`
+- [x] [P2-T3] Update `.github/skills/csharp-orchestration-state-machine/SKILL.md` so the checkpoint schema documents `work-mode`, `plan-path`, bootstrap metadata, and Phase 0 continuity for the small path
+	- Acceptance: `.github/skills/csharp-orchestration-state-machine/SKILL.md` contains `work-mode`, `plan-path`, `bootstrap_mode`, `phase0_execution_summary`, and `resume_after_manual_bootstrap` in the required checkpoint-field contract.
+- [x] [P2-T4] Update `.github/skills/csharp-change-budget-router/SKILL.md` so the C# router preserves the `1-3` / `>3` thresholds while requiring orchestrated short-path lifecycle steps instead of plan-and-execute shortcut wording
+	- Acceptance: `.github/skills/csharp-change-budget-router/SKILL.md` still contains `1-3` and `>3`, and also contains `--work-mode minor-audit`, `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`, `PREFLIGHT: ALL CLEAR`, and `Phase 0 only via atomic_executor`.
+
+### Phase 3 — Bundled Mirror Alignment
+
+- [x] [P3-T1] Sync `extensions/drm-copilot/resources/customizations/.github/agents/csharp-orchestrator.agent.md` to the approved root C# orchestrator contract
+	- Acceptance: `extensions/drm-copilot/resources/customizations/.github/agents/csharp-orchestrator.agent.md` exists and matches `.github/agents/csharp-orchestrator.agent.md` exactly.
+- [x] [P3-T2] Sync `extensions/drm-copilot/resources/customizations/.github/prompts/orchestrate-csharp-work.prompt.md` to the approved root C# prompt contract
+	- Acceptance: `extensions/drm-copilot/resources/customizations/.github/prompts/orchestrate-csharp-work.prompt.md` exists and matches `.github/prompts/orchestrate-csharp-work.prompt.md` exactly.
+- [x] [P3-T3] Sync `extensions/drm-copilot/resources/customizations/.github/skills/csharp-orchestration-state-machine/SKILL.md` to the approved root C# state-machine skill
+	- Acceptance: `extensions/drm-copilot/resources/customizations/.github/skills/csharp-orchestration-state-machine/SKILL.md` exists and matches `.github/skills/csharp-orchestration-state-machine/SKILL.md` exactly.
+- [x] [P3-T4] Sync `extensions/drm-copilot/resources/customizations/.github/skills/csharp-change-budget-router/SKILL.md` to the approved root C# change-budget router skill
+	- Acceptance: `extensions/drm-copilot/resources/customizations/.github/skills/csharp-change-budget-router/SKILL.md` exists and matches `.github/skills/csharp-change-budget-router/SKILL.md` exactly.
+- [x] [P3-T5] Refresh `extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md` to the current root lifecycle contract
+	- Acceptance: `extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md` exists and matches `.github/skills/feature-promotion-lifecycle/SKILL.md` exactly.
+- [x] [P3-T6] Refresh `extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md` to the current root atomic-plan contract
+	- Acceptance: `extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md` exists and matches `.github/skills/atomic-plan-contract/SKILL.md` exactly.
+- [x] [P3-T7] Add `extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md` as the bundled mirror of the root shared skill
+	- Acceptance: `extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md` exists and matches `.github/skills/acceptance-criteria-tracking/SKILL.md` exactly.
+
+### Phase 4 — Green Regression & Audit Readiness
+
+- [x] [P4-T1] Add pytest case `test_csharp_orchestrator_large_path_chain_remains_csharp_atomic_pipeline` to `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+	- Acceptance: `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` contains a test named `test_csharp_orchestrator_large_path_chain_remains_csharp_atomic_pipeline` that asserts `.github/agents/csharp-orchestrator.agent.md` still contains `Build C# atomic plan (preflight all clear)` and `Execute approved C# atomic plan` in the large-path workflow.
+- [x] [P4-T2] Run `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` and store the passing targeted regression result in `evidence/other/csharp-orchestration-contracts-green.<timestamp>.md`
+	- Acceptance: a file matching `evidence/other/csharp-orchestration-contracts-green.*.md` exists and contains `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`, `EXIT_CODE: 0`, and `Output Summary:` naming the new C# orchestration contract tests.
+- [x] [P4-T3] Record an audit-readiness summary in `evidence/qa-gates/csharp-orchestration-contract-summary.<timestamp>.md`
+	- Acceptance: a file matching `evidence/qa-gates/csharp-orchestration-contract-summary.*.md` exists and contains the headings `Changed Root Files:`, `Changed Mirror Files:`, `Targeted Regression Command:`, and `Large-Path Preservation:`.
+
+### Phase 5 — Final QA & Audit Closure
+
+If any command in this phase changes files or exits non-zero, restart Phase 5 from [P5-T1].
+
+- [x] [P5-T1] Run `poetry run black .` and store the final QA result in `evidence/qa-gates/python-black.<timestamp>.md`
+	- Acceptance: a file matching `evidence/qa-gates/python-black.*.md` exists and contains `Timestamp:`, `Command: poetry run black .`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T2] Run `poetry run ruff check` and store the final QA result in `evidence/qa-gates/python-ruff.<timestamp>.md`
+	- Acceptance: a file matching `evidence/qa-gates/python-ruff.*.md` exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T3] Run `poetry run pyright` and store the final QA result in `evidence/qa-gates/python-pyright.<timestamp>.md`
+	- Acceptance: a file matching `evidence/qa-gates/python-pyright.*.md` exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T4] Run `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and store the final QA result in `evidence/qa-gates/python-pytest.<timestamp>.md`
+	- Acceptance: a file matching `evidence/qa-gates/python-pytest.*.md` exists and contains `Timestamp:`, `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`, `EXIT_CODE: 0`, and `Output Summary:` with numeric total coverage and numeric `scripts/dev_tools` coverage values.
+- [x] [P5-T5] Record the baseline-versus-final Python coverage delta in `evidence/qa-gates/python-coverage-delta.<timestamp>.md`
+	- Acceptance: a file matching `evidence/qa-gates/python-coverage-delta.*.md` exists and contains `Baseline Total Coverage:`, `Final Total Coverage:`, `Baseline scripts/dev_tools Coverage:`, `Final scripts/dev_tools Coverage:`, and `No planned command task skipped: true`.

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/policy-audit.2026-03-14T18-49.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/policy-audit.2026-03-14T18-49.md
@@ -1,0 +1,236 @@
+# Policy Compliance Audit: orchestrator-not-following-sequential-tasks (#101)
+
+**Audit Date:** 2026-03-14  
+**Feature Folder:** `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101`  
+**Feature Folder Selection Rule:** User-specified active folder for issue `#101`; it already exists, matches the issue suffix `-101`, and required no tie-break against any competing active folder.  
+**Base Branch:** `development`  
+**Code Under Test:** `.github/agents/csharp-orchestrator.agent.md`, `.github/prompts/orchestrate-csharp-work.prompt.md`, `.github/skills/csharp-change-budget-router/SKILL.md`, `.github/skills/csharp-orchestration-state-machine/SKILL.md`, bundled mirrors under `extensions/drm-copilot/resources/customizations/.github/**`, and `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| Python | 1 test file | Pytest suite | [✅] 873 pass, 0 fail | 83% total / 83% `scripts/dev_tools` | 83% total / 83% `scripts/dev_tools` | 100% targeted contract coverage for the new regression module (6/6 assertions exercised) |
+
+## Executive Summary
+
+This review evaluated the current live branch/worktree for issue `#101` against the repo’s general and Python policies, using refreshed PR-context artifacts plus the feature-folder evidence trail. The implementation changes the C# orchestration contract surface by updating root and bundled markdown customizations to require the sequential small-path lifecycle, and it adds a focused Python regression suite that proves the prior shortcut wording failed before the fix and passes after it. The live verification loop run in this session stayed green: `poetry run black .`, `poetry run ruff check`, `poetry run pyright`, and `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info` all passed.
+
+A noteworthy process caveat: the refreshed canonical `pr_context` against `development` reports an empty committed range because the #101 implementation is currently present in the working tree rather than in branch commits. That does not prevent a current-state policy review, but it does mean the branch should be committed and PR context refreshed again before opening a formal PR.
+
+**Policy documents evaluated:**
+- [✅] `.github/instructions/general-code-change.instructions.md`
+- [✅] `.github/instructions/general-unit-test.instructions.md`
+- [✅] `.github/instructions/python-code-change.instructions.md`
+- [✅] `.github/instructions/python-unit-test.instructions.md`
+- [✅] `.github/instructions/python-suppressions.instructions.md`
+
+**Temporary artifacts cleanup:**
+- [✅] No temporary throwaway scripts were introduced by this change.
+- [✅] Supporting evidence is stored inside the feature folder’s canonical `evidence/` tree.
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] PASS | `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` is file-content based and does not share mutable state between tests. |
+| Isolation | [✅] PASS | Each test checks one contract seam: small-path lifecycle wording, prompt wording, checkpoint fields, router wording, mirror parity, or large-path preservation. |
+| Fast Execution | [✅] PASS | Targeted evidence `evidence/other/csharp-orchestration-contracts-green.2026-03-14T18-42-49.md` records `6 passed in 0.04s`. The full in-session Pytest pass completed `873` tests in `2.99s`. |
+| Determinism | [✅] PASS | Tests read checked-in repository files only; they avoid network, time, temp files, and external process dependencies. |
+| Readability & Maintainability | [✅] PASS | Test names are descriptive and align directly to issue/spec acceptance language. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Baseline Coverage Documented | [✅] PASS | `evidence/baseline/python-pytest.2026-03-14T18-34-25.md` records the baseline Pytest run with coverage fields and output summary. |
+| No Coverage Regression | [✅] PASS | `evidence/qa-gates/python-coverage-delta.2026-03-14T18-45-04.md` records `83% → 83%` total coverage and `83% → 83%` `scripts/dev_tools` coverage. |
+| New Code Coverage ≥90% | [✅] PASS | No production Python runtime module was added; the changed Python surface is the new regression module, and the targeted suite exercised all `6/6` contract assertions while aggregate coverage remained stable. |
+| Comprehensive Coverage | [✅] PASS | Red evidence exists for every intended contract gap: `csharp-orchestrator-small-path-red`, `orchestrate-csharp-work-prompt-red`, `csharp-state-machine-red`, `csharp-change-budget-router-red`, and `csharp-customization-bundle-red`; green evidence records the full consolidated suite passing. |
+| Positive Flows | [✅] PASS | The final targeted suite proves the required lifecycle wording, checkpoint-field wording, mirror parity, and large-path preservation all exist post-fix. |
+| Negative Flows | [✅] PASS | The fail-before artifacts capture the missing lifecycle wording and parity failures before the contract updates. |
+| Edge Cases | [✅] PASS | Mirror-parity coverage ensures the bundled customization tree stays aligned with root files, including the newly added bundled `acceptance-criteria-tracking` skill. |
+| Error Handling | [✅] PASS | Contract checks fail fast with direct assertions when required wording or mirrored files are absent. |
+| Concurrency | [N/A] N/A | The reviewed contract tests do not model concurrent behavior. |
+| State Transitions | [N/A] N/A | No runtime state machine implementation changed; the review scope is contract documentation plus tests. |
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clear Failure Messages | [✅] PASS | Each red artifact records the exact missing string or parity assertion that failed. |
+| Arrange-Act-Assert Pattern | [✅] PASS | Tests read the relevant file text, then assert presence/absence of the specific contract signals. |
+| Document Intent | [✅] PASS | The module docstring and test names clearly communicate why each contract matters. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Avoid External Dependencies | [✅] PASS | New tests depend only on checked-in files under the repo root. |
+| Use Mocks/Stubs | [N/A] N/A | No external dependencies needed isolation for this test surface. |
+| Environment Stability | [✅] PASS | No temporary files are created; tests use `Path.read_text()` against committed repository content. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Pre-submission Review | [✅] PASS | This document serves as the required policy audit for the #101 review run. |
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clarify the objective | [✅] PASS | `issue.md` and `spec.md` clearly define the small-path lifecycle regression and the required contract alignment. |
+| Read existing change plans | [✅] PASS | `plan.2026-03-14T18-08.md` exists, is fully checked, and references the approved execution sequence. |
+| Document the plan | [✅] PASS | The feature folder contains `issue.md`, `spec.md`, the approved plan, baseline evidence, regression evidence, and final QA evidence. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Simplicity first | [✅] PASS | The fix updates a small set of canonical markdown contracts and adds one focused regression module instead of broadening into runtime code changes. |
+| Reusability | [✅] PASS | Root-to-bundled mirror parity is treated as a reusable contract and enforced by tests. |
+| Extensibility | [✅] PASS | The updated contracts add `plan-path`, `work-mode`, bootstrap metadata, and reduced-audit language without changing the large-path thresholds. |
+| Separation of concerns | [✅] PASS | Contract definition stays in agent/prompt/skill markdown, while verification is isolated in Python tests and feature-folder evidence. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Cohesive modules | [✅] PASS | Each changed markdown file owns one contract layer: agent, prompt, router skill, or state-machine skill. |
+| Under 500 lines | [✅] PASS | Changed non-document files remain well under the 500-line policy: `.github/agents/csharp-orchestrator.agent.md` `269`, prompt `52`, router skill `34`, state-machine skill `44`, bundled `atomic-plan-contract` mirror `117`, test file `106`. |
+| Public vs internal | [✅] PASS | The change narrows and clarifies orchestration-facing contract text; it does not widen runtime public APIs. |
+| No circular dependencies | [✅] PASS | The update changes content only; no new import graph or runtime dependency cycle is introduced. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Descriptive names | [✅] PASS | New contract labels such as `Build minimal-audit atomic plan (preflight all clear)` and `Validate small-path delivery and post-QC docs` are explicit and scenario-specific. |
+| Docs/docstrings | [✅] PASS | The contract surface is implemented as documentation-first markdown plus a documented Python regression module. |
+| Comment why, not what | [✅] PASS | The updated prompt/skill wording explains the lifecycle intent and fail-closed behavior, not just procedural mechanics. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| 1. Formatting | [✅] PASS | In-session run: `poetry run black .` → `165 files left unchanged.` |
+| 2. Linting | [✅] PASS | In-session run: `poetry run ruff check` → `All checks passed!` |
+| 3. Type checking | [✅] PASS | In-session run: `poetry run pyright` → `0 errors, 0 warnings, 0 informations` |
+| 4. Testing | [✅] PASS | In-session run: `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info` → `873 passed in 2.99s`, total coverage `83%`. |
+| Full toolchain loop | [✅] PASS | The live review pass succeeded in one clean loop with no file mutations after the formatting step. |
+| Explicit reporting | [✅] PASS | Commands and outcomes are recorded in this audit and in feature-folder evidence files. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Summarize changes | [✅] PASS | `spec.md`, `plan.2026-03-14T18-08.md`, and `evidence/qa-gates/csharp-orchestration-contract-summary.2026-03-14T18-42-49.md` summarize the implemented contract changes. |
+| Design choices explained | [✅] PASS | `spec.md` explains why the fix aligns C# behavior to the generic/Python/PowerShell short-path lifecycle rather than inventing a C#-only path. |
+| Update supporting documents | [✅] PASS | The feature folder contains up-to-date issue, spec, plan, baseline, regression, and QA artifacts. |
+| Provide next steps | [✅] PASS | No code remediation is required; operationally, the current working-tree changes should be committed and PR context refreshed before opening a PR. |
+
+## 3. Python-Specific Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting with Black | [✅] PASS | `poetry run black .` passed in-session and baseline/final evidence exists under `evidence/baseline/` and `evidence/qa-gates/`. |
+| Linting with Ruff | [✅] PASS | `poetry run ruff check` passed in-session. |
+| Type checking with Pyright | [✅] PASS | `poetry run pyright` passed in-session with zero diagnostics. |
+| Testing with Pytest | [✅] PASS | `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info` passed in-session with `873` tests. |
+| Strong typing | [✅] PASS | The new regression file uses explicit annotations, `Path`, and no new `Any` or suppression comments. |
+| Dataclasses for value objects | [N/A] N/A | No new value objects were introduced. |
+| Protocols/ABCs for interfaces | [N/A] N/A | No Python interface layer was added in this scope. |
+| Avoid utility classes | [✅] PASS | The change uses plain functions, not static-method-only utility classes. |
+| Specific exceptions | [✅] PASS | The new tests raise no broad exception-handling concerns. |
+| Logging over print | [✅] PASS | No new ad-hoc printing was introduced in Python code. |
+| Invariants at construction | [N/A] N/A | No new class constructors were added. |
+
+## 4. Python Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Pytest | [✅] PASS | The new regression suite is implemented in `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` and executed with Pytest. |
+| Coverage expectation | [✅] PASS | Aggregate coverage stayed stable at `83%`, and the new contract test surface is fully exercised by the targeted suite. |
+| Focused unit tests | [✅] PASS | Each test maps to one acceptance-relevant contract seam. |
+| Mocking sparingly | [✅] PASS | No mocks were needed because the suite inspects checked-in text files only. |
+| Organization | [✅] PASS | The new test file sits under the existing `tests/scripts/dev_tools/` contract-test area. |
+| Naming conventions | [✅] PASS | Test names clearly state the exact contract being enforced. |
+| Docstrings/comments | [✅] PASS | The module and helper function include concise explanatory docstrings. |
+| No alternative test runners | [✅] PASS | Verification used Pytest only. |
+
+## 5. Gaps and Exceptions
+
+### Identified Gaps
+
+**None.** No policy gap in the implementation or verification evidence requires code remediation.
+
+### Approved Exceptions
+
+**None.** No policy exceptions were needed.
+
+### Removed/Skipped Tests
+
+**None.** The planned regression tests were added, captured as red first, and then passed green.
+
+## 6. Summary of Changes
+
+### Commits in This PR/Branch
+
+- The refreshed `pr_context` against `development` reports an empty committed range because the reviewed #101 changes are currently uncommitted in the working tree.
+
+### Files Modified
+
+1. **`.github/agents/csharp-orchestrator.agent.md`** (MODIFIED)
+   - Replaces the old direct small-path shortcut with an explicit sequential short-path lifecycle.
+2. **`.github/prompts/orchestrate-csharp-work.prompt.md`** (MODIFIED)
+   - Aligns prompt instructions with `minor-audit` promotion, Phase 0-only execution, and reduced audit.
+3. **`.github/skills/csharp-change-budget-router/SKILL.md`** and **`.github/skills/csharp-orchestration-state-machine/SKILL.md`** (MODIFIED)
+   - Document the short-path lifecycle requirements and new checkpoint continuity fields.
+4. **`extensions/drm-copilot/resources/customizations/.github/**`** (MODIFIED/ADDED)
+   - Sync bundled mirrors and add the missing bundled `acceptance-criteria-tracking` skill.
+5. **`tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`** (NEW)
+   - Adds focused regression coverage for the updated contract surface.
+6. **`docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/**`** (NEW/UPDATED)
+   - Records issue, spec, plan, baseline evidence, red evidence, green evidence, and QA artifacts.
+
+## 7. Compliance Verdict
+
+### Overall Status: ✅ COMPLIANT
+
+The #101 implementation is policy-compliant as reviewed in the current working tree. The contract updates are cohesive, mirror parity is enforced, the Python regression suite is strongly typed and deterministic, and the full repo-root Python quality loop passed cleanly in this session.
+
+### Recommendation
+
+**Ready for PR review after committing the current working-tree changes and refreshing PR context.** No code or test remediation is required.
+
+## Appendix A: Hard-Requirement Checks
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Feature folder selection documented | [✅] PASS | This audit and the companion code review record the user-specified folder rule. |
+| PR context refreshed against selected base branch | [✅] PASS | Ran `poetry run python -m scripts.dev_tools.pr_context.collector --base development`; summary now reflects `development` and the supplied merge-base `dc0502de6e7b02ea76720fb898c038f01ad13f92`. |
+| Phase 0 policy-read artifact exists | [✅] PASS | `evidence/baseline/phase0-instructions-read.md` exists with policy order, files read, work mode, AC source, and target plan path. |
+| Baseline evidence exists for approved plan | [✅] PASS | Baseline Black/Ruff/Pyright/Pytest artifacts exist under `evidence/baseline/`. |
+| Fail-before evidence exists | [✅] PASS | Five red artifacts exist under `evidence/regression-testing/`. |
+| Green regression evidence exists | [✅] PASS | `evidence/other/csharp-orchestration-contracts-green.2026-03-14T18-42-49.md` records all six targeted tests passing. |
+| Final QA evidence exists | [✅] PASS | `evidence/qa-gates/python-black.2026-03-14T18-45-04.md`, `python-ruff...`, `python-pyright...`, `python-pytest...`, and `python-coverage-delta...` exist. |
+
+## Appendix B: Toolchain Commands Reference
+
+- `git branch --show-current`
+- `git rev-parse HEAD`
+- `git merge-base HEAD development`
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base development`
+- `poetry run black .`
+- `poetry run ruff check`
+- `poetry run pyright`
+- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info`
+- `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
+
+**Audit Completed By:** GitHub Copilot (GPT-5.4)  
+**Policy Version:** Current as of 2026-03-14

--- a/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/spec.md
+++ b/docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/spec.md
@@ -1,0 +1,340 @@
+# 2026-03-14-orchestrator-not-following-sequential-tasks (Spec)
+
+- **Issue:** #101
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-03-14T18-08
+- **Status:** Draft
+- **Version:** 0.1
+
+## Context
+When `csharp-orchestrator` classifies a request as the small path, it skips the mandatory short-path promotion/folder lifecycle and delegates straight to `csharp-atomic-planning` (and then execution). This bypass leaves the orchestration variables unset, prevents potential/issue/folder artifacts from being created, and violates the repository’s shared `feature-promotion-lifecycle` contract for short-path work.
+
+Environment:
+- OS/version: Windows (user environment on 2026-03-14; exact version not captured in prompt transcript)
+- Python version: N/A — failure occurs in C# orchestration workflow, not Python execution
+- Command/flags used: `/orchestrate-csharp-work In the current add-in, when I click the Sort Email button, it automatically begins the form applying Dark Mode. This add-in should be able to detect whether the system is in Dark Mode or Light Mode and follow the system. Please create this functionality and orchestrate the work to completion`
+- Data source or fixture: `.github/agents/csharp-orchestrator.agent.md`, `.github/prompts/orchestrate-csharp-work.prompt.md`, `.github/skills/feature-promotion-lifecycle/SKILL.md`, and `artifacts/orchestration/csharp-orchestrator-state.json`
+
+Impact / Severity:
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+
+## Repro & Evidence
+Steps to Reproduce:
+1. Invoke `csharp-orchestrator` through `.github/prompts/orchestrate-csharp-work.prompt.md` with a small, bounded C# request (for example, the Dark Mode detection request that was estimated at 2 production C# files and 1 test file).
+2. Allow the orchestrator to complete budget estimation and route to the small path.
+3. Observe the next action and the resulting checkpoint state.
+4. Confirm that the orchestrator delegates directly to `csharp-atomic-planning`, then to `csharp-atomic-executor`, without first creating/filling a potential entry, promoting to issue, creating a branch, or creating an active feature folder.
+5. Inspect `artifacts/orchestration/csharp-orchestrator-state.json` and confirm that `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, and `${feature-folder}` all remain `null` even though the workflow is marked complete.
+
+Expected:
+After choosing the small path, the orchestrator should still follow the mandatory short-path sequence defined by the shared lifecycle rules: establish classification variables, create/fill the potential entry, promote with `minor-audit` mode, create the branch and active feature folder, then hand off to planning/execution using the generated artifacts and persisted variables. At minimum, the orchestrator should not report completion while the required orchestration variables and feature artifacts were never created.
+
+Actual:
+The orchestrator routed directly from budget estimation to `csharp-atomic-planning`, followed by `csharp-atomic-executor`, and then marked the mission complete. The checkpoint shows:
+
+- `"path_selected": "small"`
+- `"completed_steps": ["phase-0-intake", "budget-estimate", "delegate-csharp-atomic-planning", "delegate-csharp-atomic-executor"]`
+- all lifecycle variables still `null` (`promotion-type`, `short-name`, `relativeFile`, `long-name`, `issue-num`, `feature-folder`)
+
+This means the orchestrator never performed the mandatory sequential lifecycle steps before planning/execution.
+
+Logs / Screenshots:
+- [ ] Attached minimal logs or screenshot
+- Snippet:
+
+	From `.github/agents/csharp-orchestrator.agent.md` small path:
+	`1. Delegate to csharp-atomic-planning via handoff Build C# atomic plan (preflight all clear).`
+
+	From `.github/skills/feature-promotion-lifecycle/SKILL.md` canonical short path:
+	`When orchestrator routing selects short path, promotion/folder initialization still occurs and MUST use minor-audit mode.`
+
+	From `artifacts/orchestration/csharp-orchestrator-state.json` after the run:
+	`"promotion-type": null,`
+	`"short-name": null,`
+	`"relativeFile": null,`
+	`"long-name": null,`
+	`"issue-num": null,`
+	`"feature-folder": null`
+
+
+## Scope & Non-Goals
+- In scope:
+	- Align the root C# small-path orchestration contract with the repository’s canonical short-path lifecycle already used by the generic, Python, and PowerShell orchestrators.
+	- Require the C# small path to perform promotion and active-folder initialization in `minor-audit` mode before any planning or execution handoff.
+	- Extend the documented C# checkpoint/state contract so short-path runs persist `${plan-path}`, `work-mode`, and enough Phase 0 / bootstrap continuity to resume deterministically.
+	- Restore root-to-bundled customization parity for every changed C# agent/prompt/skill file under `extensions/drm-copilot/resources/customizations/.github/...`.
+	- Add deterministic regression coverage that fails if the C# small-path sequence, minor-audit invariants, or bundled-mirror parity regress.
+- Out of scope / non-goals:
+	- Redesigning the large-path C# orchestration flow; large-path promotion, research, spec, planning, execution, and review remain as currently defined unless directly needed for shared checkpoint compatibility.
+	- Changing the change-budget thresholds (`1-3` production files = small path, `>3` = large path).
+	- Broadly remediating similar prompt drift in Python or PowerShell orchestration files during this fix; those are follow-up candidates, not part of issue #101.
+	- Introducing new runtime services, network calls, telemetry backends, or feature flags.
+- Explicitly excluded systems, integrations, or datasets:
+	- GitHub issue content beyond the already-promoted local feature docs for issue #101.
+	- Unrelated extension command surfaces or VS Code activation behavior.
+	- Any repository data migration unrelated to the C# orchestration checkpoint JSON and markdown customization contracts.
+
+## Root Cause Analysis
+There appear to be contradictory orchestration contracts for small-path work:
+
+- `.github/agents/csharp-orchestrator.agent.md` defines the small path as direct planning/execution only.
+- `.github/prompts/orchestrate-csharp-work.prompt.md` defines the small path differently again, as a direct delegation to `csharp-typed-engineer`.
+- `.github/skills/feature-promotion-lifecycle/SKILL.md` explicitly says short-path workflows still require promotion/folder initialization in `minor-audit` mode.
+
+Because the orchestrator agent’s embedded small-path workflow omits those lifecycle steps entirely, the agent followed its local sequence and never set the persisted variables required by its own checkpoint schema. The failure is therefore an instruction-precedence and contract-drift bug rather than a one-off execution mistake.
+
+Additional evidence from the research makes the defect broader than a single paragraph mismatch:
+
+- `.github/skills/csharp-orchestration-state-machine/SKILL.md` still documents the pre-`minor-audit` checkpoint shape and does not include `${plan-path}` or short-path resume metadata, so the persisted-state contract cannot fully represent the required small-path lifecycle.
+- `.github/skills/csharp-change-budget-router/SKILL.md` still summarizes small path as “atomic plan + execution route,” which reinforces the incorrect shortcut after budget selection.
+- `extensions/drm-copilot/resources/customizations/.github/agents/csharp-orchestrator.agent.md` and `extensions/drm-copilot/resources/customizations/.github/prompts/orchestrate-csharp-work.prompt.md` mirror the stale root behavior, so packaged customizations would continue to distribute the broken contract even if only the root copy were updated.
+- The bundled customization mirror also lacks `extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/`, even though the root C# orchestrator already references that shared skill.
+- No existing deterministic regression test currently pins the required C# small-path sequence or root↔mirror parity, so the drift was free to persist across root files, bundled copies, and state-machine documentation.
+
+
+## Proposed Fix
+
+### Design summary (what changes where):
+- Update the root C# orchestrator contract so the `small` route follows the canonical short-path sequence instead of jumping directly to planning or engineering. The required sequence is: classify and persist `${promotion-type}` / `${short-name}` / `${relativeFile}` → promote with `--work-mode minor-audit` → create the active feature folder with `--work-mode minor-audit` → verify `issue.md` integrity and absence of `spec.md` / `user-story.md` → resolve and persist `${plan-path}` → delegate minimal-audit planning until `PREFLIGHT: ALL CLEAR` → execute Phase 0 only → branch by bootstrap mode → continue constrained small-path implementation → validate against `issue.md` → run reduced audit/remediation.
+- Bring the root C# prompt, C# router skill, and C# state-machine skill into the same contract so the agent, prompt, and shared skills all describe one small-path lifecycle.
+- Mirror every changed root customization file into `extensions/drm-copilot/resources/customizations/.github/...`, and add the missing bundled `acceptance-criteria-tracking` skill if the mirrored C# orchestrator continues to reference it.
+- Add deterministic content-based tests over the markdown customization files and publisher helpers so future drift is caught without relying on live orchestration runs or temporary files.
+
+### Boundaries and invariants to preserve:
+- The large path remains the full promotion → research → spec/story → atomic planning → atomic execution → feature review workflow; this bug fix must not collapse the distinction between large and small path.
+- The small-path budget threshold remains `1-3` production C# files plus corresponding tests.
+- Short-path work must use `minor-audit` mode and therefore treat `issue.md` as the sole authoritative requirements file. `spec.md` and `user-story.md` must not appear in a valid minor-audit folder.
+- `${plan-path}` continuity is mandatory: once a plan file is chosen for a short-path run, planning and preflight must update that same file in place rather than creating sibling `plan.*.md` variants opportunistically.
+- Completion must fail closed if required orchestration variables remain `null`, if `issue.md` lacks `- Work Mode: minor-audit`, if Phase 0 evidence is missing, or if reduced-audit inputs contradict artifact state.
+- Existing branch/folder reuse behavior must be preserved: if the branch or feature folder already exists, the workflow should reuse and record that fact instead of treating it as a new-path failure.
+
+### Dependencies or blocked work:
+- Primary references already exist in `.github/agents/orchestrator.agent.md`, `.github/agents/python-orchestrator.agent.md`, and `.github/agents/powershell-orchestrator.agent.md`; the C# fix should mirror those established contracts instead of inventing a new C#-only flow.
+- The downstream C# delegates (`csharp-atomic-planning`, `csharp-atomic-executor`, and `csharp-typed-engineer`) already exist, so this bug is primarily orchestration wiring/documentation/state continuity rather than missing implementation infrastructure.
+- Existing regression seams already exist in `tests/scripts/dev_tools/test_push_down_copilot_customizations.py`, `tests/scripts/dev_tools/test_push_down_copilot_customizations_helpers.py`, and the `minor-audit` feature-doc tests. No additional research is required to complete this spec.
+
+### Implementation strategy (what changes, not sequencing):
+	- Normalize the C# small-path contract across root agent, root prompt, root router skill, and root state-machine skill.
+	- Add the missing short-path lifecycle details: `minor-audit` promotion, active-folder creation, folder-integrity checks, `${plan-path}` resolution/reuse, Phase 0 only execution, bootstrap branching, and reduced audit gates.
+	- Update the bundled extension customization mirror to match the root copies for all changed files and supply any mirrored shared skill dependency that becomes required by the mirrored C# orchestrator.
+	- Add regression tests that assert required lifecycle strings, required checkpoint fields, and root↔mirror parity for the changed customization set.
+	
+#### Files/modules to change:
+- Root C# customization contracts:
+	- `.github/agents/csharp-orchestrator.agent.md`
+	- `.github/prompts/orchestrate-csharp-work.prompt.md`
+	- `.github/skills/csharp-orchestration-state-machine/SKILL.md`
+	- `.github/skills/csharp-change-budget-router/SKILL.md`
+- Bundled extension customization mirror:
+	- `extensions/drm-copilot/resources/customizations/.github/agents/csharp-orchestrator.agent.md`
+	- `extensions/drm-copilot/resources/customizations/.github/prompts/orchestrate-csharp-work.prompt.md`
+	- `extensions/drm-copilot/resources/customizations/.github/skills/csharp-orchestration-state-machine/SKILL.md`
+	- `extensions/drm-copilot/resources/customizations/.github/skills/csharp-change-budget-router/SKILL.md`
+	- `extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md` (refresh to current root parity if referenced lifecycle language is stale)
+	- `extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md` (refresh to current root parity if referenced minimal-plan language is stale)
+	- `extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md` (add bundled mirror because the C# orchestrator references the shared skill and the mirror currently lacks it)
+- Likely regression test touch points:
+	- `tests/scripts/dev_tools/test_push_down_copilot_customizations.py`
+	- `tests/scripts/dev_tools/test_push_down_copilot_customizations_helpers.py`
+	- `tests/scripts/dev_tools/test_feature_docs.py` only if plan-path / minor-audit parsing assertions need an additional deterministic guard.
+
+#### Functions/classes/CLI commands impacted:
+- Prompt/agent entrypoints and contracts:
+	- `/orchestrate-csharp-work`
+	- `csharp-orchestrator`
+	- `csharp-atomic-planning`
+	- `csharp-atomic-executor`
+	- `csharp-typed-engineer` (small-path implementation delegate after Phase 0, not direct initial route)
+- Lifecycle-related CLI/tooling surfaces that must remain consistently referenced by the C# orchestrator contract:
+	- `scripts/dev-tools/new-potential-entry.ps1`
+	- `scripts.dev_tools.new_potential_bug_entry`
+	- `scripts.dev_tools.potential_to_issue --work-mode minor-audit`
+	- `scripts.dev_tools.new_active_feature_folder --work-mode minor-audit`
+- Checkpoint/state schema described by `artifacts/orchestration/csharp-orchestrator-state.json`.
+
+#### Data flow and validation changes:
+- Small-path data flow must no longer be `budget-estimate -> planning -> execution -> done`. It must become:
+	1. budget estimate selects `small`
+	2. lifecycle variables are derived and persisted
+	3. potential item is promoted with `minor-audit`
+	4. active feature folder is created/reused and validated
+	5. `${plan-path}` is resolved and persisted before planning
+	6. minimal-audit planning updates the single chosen plan file in place until `PREFLIGHT: ALL CLEAR`
+	7. Phase 0 only execution writes evidence-backed checklist state
+	8. bootstrap branching determines whether to stop for manual resume or continue to constrained implementation
+	9. validation and reduced audit gate completion
+- Validation must explicitly check:
+	- non-null `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, `${feature-folder}`, and `${plan-path}` before completion;
+	- `issue.md` contains `- Work Mode: minor-audit`;
+	- `spec.md` and `user-story.md` are absent from the minor-audit folder;
+	- Phase 0 artifacts and checklist state are evidence-backed;
+	- reduced-audit outputs exist before final completion is recorded.
+
+#### Error handling and logging updates:
+- The C# state-machine contract should document fail-closed behavior when required fields are missing for the next step. In particular, a run marked `small` must not be allowed to set `next_step` to planning/execution completion while lifecycle variables remain unset.
+- Checkpoint `completed_steps` and `next_step` values should reflect the sequential short-path lifecycle rather than the current coarse shortcut, so interruptions can resume after promotion, after folder creation, after Phase 0, or at bootstrap branching without recomputing earlier state.
+- Logging/output should make the selected short-path stage visible enough to diagnose contract drift: promotion in `minor-audit`, `${plan-path}` reuse/selection, Phase 0-only execution, and reduced-audit gating should all be evident in delegated outputs or checkpoint summaries.
+- No separate telemetry pipeline is required; the checkpoint JSON and generated markdown artifacts are the observability surface for this fix.
+
+#### Rollback/feature-flag considerations (if applicable):
+- No feature flag is warranted because this is a correctness fix for a broken orchestration contract.
+- Rollback is a straight reversion of the changed markdown customization files and associated regression tests if the new contract proves incompatible.
+- Checkpoint schema expansion should remain additive/backward-compatible where possible so older in-progress state files can still be resumed or safely re-derived rather than discarded.
+
+### Technical specifications (interfaces/contracts):
+- The authoritative short-path contract for C# must match the shared repository lifecycle, not a C#-local shortcut. Specifically, the C# small path should mirror the generic short-path steps S1-S8 already documented in `.github/agents/orchestrator.agent.md`.
+- The authoritative acceptance-criteria source for this bug fix remains `spec.md` only because issue #101 is `full-bug`; however, the resulting orchestrator behavior must create `minor-audit` feature folders whose downstream execution and validation use `issue.md` as the only short-path requirements source.
+- Root and bundled copies of any changed `.github` customization file are a parity contract. If the root file changes, the bundled mirror must change in the same patch unless there is an explicit packaging exception documented in the file content or tests.
+
+#### Inputs/outputs and formats:
+- Inputs:
+	- natural-language C# objective provided through `/orchestrate-csharp-work`
+	- optional file hints and classification hints already supported by the prompt
+	- existing checkpoint state from `artifacts/orchestration/csharp-orchestrator-state.json`
+	- existing feature-folder artifacts if the workflow is resuming or reusing a previously created branch/folder
+- Outputs:
+	- updated checkpoint JSON with populated lifecycle variables and short-path continuity fields
+	- promoted `minor-audit` feature folder containing `issue.md`, a single canonical `plan*.md`, Phase 0 evidence artifacts, and reduced-audit artifacts
+	- no `spec.md` or `user-story.md` in a valid minor-audit folder
+	- synchronized bundled customization markdown under `extensions/drm-copilot/resources/customizations/.github/...`
+- Formats:
+	- checkpoint remains JSON
+	- orchestration contracts remain markdown agent/prompt/skill files
+	- tests remain deterministic Python `pytest` suites with no temp-file dependency beyond existing in-memory or committed fixture patterns
+
+#### Required configuration keys and defaults:
+- Existing required checkpoint keys remain required: `objective`, `change_budget_estimate`, `path_selected`, `promotion-type`, `short-name`, `relativeFile`, `long-name`, `issue-num`, `feature-folder`, `completed_steps`, `next_step`, `last_updated`.
+- The C# checkpoint contract must be extended to include at minimum:
+	- `${plan-path}` / `plan-path`: the single plan file reused across planning and preflight iterations
+	- `work-mode`: expected to be `minor-audit` for the small path after promotion
+	- bootstrap/resume metadata sufficient to distinguish “manual bootstrap stop after Phase 0” from “continue to implementation”
+	- Phase 0 evidence summary fields or equivalent documented state needed to prove Phase 0 was actually executed before resume
+- Defaulting behavior should be fail-closed for small-path completion: missing new fields may be tolerated only before the lifecycle reaches the step where that field must exist.
+
+#### Backward-compatibility expectations:
+- Existing large-path behavior and command surfaces remain unchanged.
+- Existing small-path invocations continue to use the same prompt entrypoint and budget threshold, but the resulting behavior changes from shortcut routing to full short-path lifecycle compliance.
+- Resume logic should tolerate older checkpoint files that lack newly documented fields by deriving or initializing them before advancing; it must not silently skip required lifecycle steps just because an older checkpoint omitted those fields.
+- Bundled extension customizations must remain consumable by the extension packaging flow; parity updates should not introduce repo-only paths that cannot exist in the bundled tree.
+
+#### Performance constraints (latency/throughput/memory):
+- The fix is documentation/contract/test heavy, so runtime cost should remain dominated by the existing orchestration commands rather than the added checks.
+- Additional validation is limited to markdown contract checks and checkpoint field presence checks; no material latency or memory regression is expected beyond negligible text parsing overhead.
+- Regression coverage should remain deterministic and fast by operating on in-memory or checked-in text fixtures rather than invoking live orchestration delegates.
+
+## Assumptions, Constraints, Dependencies
+- Assumptions (environment, data, access):
+	- The provided issue and research artifacts are sufficient to complete this spec; no additional task research is required before planning.
+	- The generic, Python, and PowerShell orchestrator files are the authoritative references for the intended small-path lifecycle.
+	- The extension’s `resources/customizations/.github` tree is a deliberate bundled mirror of root `.github` customizations and must be kept aligned when root contracts change.
+	- This fix is implemented in repository markdown customization files and Python regression tests rather than in C# runtime code.
+- Constraints (budget, performance, compatibility):
+	- Only files explicitly grounded in the issue/research should be changed.
+	- The fix must preserve small-vs-large routing thresholds and avoid widening into a cross-language orchestration refactor.
+	- Tests must remain deterministic and comply with the repository ban on ad hoc temporary-file workflows for new regression coverage.
+- External dependencies (services, libraries, releases):
+	- No new external libraries or services are required.
+	- Existing repository tooling for promotion, feature-folder creation, and customization publishing remains the dependency surface.
+
+## Data / API / Config Impact
+- User-facing or API changes:
+	- Users invoking `/orchestrate-csharp-work` for a small-scope request will no longer see a direct planner/engineer shortcut. They should see the same promoted short-path lifecycle artifacts that other orchestrators already require: issue promotion, branch creation, active feature folder, single plan file, Phase 0 artifacts, and reduced audit.
+	- No new end-user flags are introduced; the change is behavioral alignment of existing command contracts.
+- Data or migration considerations:
+	- `artifacts/orchestration/csharp-orchestrator-state.json` gains additional documented continuity fields. This is an additive schema evolution, not a repository-wide data migration.
+	- Existing incomplete checkpoints may need normalization on resume so missing `${plan-path}` / `work-mode` fields are backfilled before advancing.
+- Logging/telemetry updates (if any):
+	- Expected updates are limited to checkpoint step names / persisted fields and more explicit markdown contract language around short-path gating.
+	- No centralized telemetry system is added; validation relies on checkpoint content, created artifact paths, and regression tests.
+- Compatibility notes (CLI flags, config schemas, versioning):
+	- The spec requires explicit use of `--work-mode minor-audit` for short-path promotion and feature-folder creation.
+	- Root and bundled copies of the changed customization files must stay version-compatible and textually aligned enough for push-down publishing and extension packaging.
+
+## Test Strategy
+Seeded from issue:
+
+- [x] Unit coverage areas
+	- Add workflow-contract coverage for `csharp-orchestrator` small-path routing so a small-scope request must produce non-null lifecycle variables or explicitly documented short-path artifacts.
+	- Add a consistency check that the agent file, orchestration prompt, and shared lifecycle skill do not define conflicting small-path sequences.
+- [x] Integration scenario to retest
+	- Re-run `/orchestrate-csharp-work` with a known small-scope request and verify the resulting flow includes potential entry creation/fill, promotion in `minor-audit` mode, branch creation, active feature folder creation, then planning/execution.
+	- Verify `artifacts/orchestration/csharp-orchestrator-state.json` contains populated values for `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, and `${feature-folder}` before the workflow can complete.
+- [x] Manual verification notes
+	- Inspect the created feature folder and confirm that `issue.md` exists with the persisted work-mode marker before the plan handoff occurs.
+	- Confirm the orchestrator does not mark completion if the lifecycle variables are still `null`.
+
+- Regression tests to add or update:
+	- Extend `tests/scripts/dev_tools/test_push_down_copilot_customizations.py` and/or `tests/scripts/dev_tools/test_push_down_copilot_customizations_helpers.py` with content-based assertions that the root and bundled C# orchestrator/prompt/skill files contain the required small-path signals (`minor-audit`, `${plan-path}`, Phase 0-only execution, reduced audit, and mirror parity).
+	- Add a deterministic regression that fails if the bundled mirror omits `acceptance-criteria-tracking` after the mirrored C# orchestrator references it.
+	- Reuse `tests/scripts/dev_tools/test_feature_docs.py` only if an additional guard is needed for `minor-audit` issue-only semantics or canonical `plan*.md` continuity.
+- Unit tests (pytest) for the fixed behavior and boundaries:
+	- Assert the C# orchestrator agent no longer describes `small` as direct planning/execution completion.
+	- Assert the C# prompt no longer describes `small` as direct delegation to `csharp-typed-engineer`.
+	- Assert the C# state-machine skill documents `${plan-path}` and short-path resume metadata.
+	- Assert the C# change-budget router still uses the same thresholds but now preserves the short-path lifecycle rather than bypassing it.
+	- Assert each changed root file matches its bundled mirror counterpart or the specific rewritten output expected by the customization publisher.
+- Edge cases and negative scenarios (invalid inputs, missing data, boundary values):
+	- Resume from a checkpoint created after promotion but before plan generation.
+	- Resume when the feature folder already exists and must be reused.
+	- Resume when an existing `plan*.md` already exists and must become `${plan-path}` rather than generating a new sibling.
+	- Fail validation when `issue.md` lacks `- Work Mode: minor-audit`.
+	- Fail validation when `spec.md` or `user-story.md` exists in a supposed minor-audit folder.
+	- Fail completion when lifecycle variables remain `null` or when Phase 0 evidence is missing.
+- Error handling and logging verification:
+	- Verify tests or fixture assertions cover the required checkpoint fields and step names for short-path continuity.
+	- Verify the documented contract forbids marking completion without reduced-audit artifacts and evidence-backed checklist state.
+- Coverage impact and targets for changed lines/modules:
+	- Changed Python regression tests should cover the new text-contract assertions for every changed customization class (agent, prompt, skill, mirror parity).
+	- Coverage should remain within the existing repo-root Python coverage workflow; no separate C# runtime coverage is expected because the fix is not changing compiled C# sources.
+- Toolchain commands to run (format → lint → type-check → test):
+	- `poetry run black .`
+	- `poetry run ruff check`
+	- `poetry run pyright`
+	- `poetry run pytest`
+- Manual validation steps (if required):
+	- Re-run `/orchestrate-csharp-work` with the documented small-scope Dark Mode request and inspect the resulting checkpoint plus created feature folder.
+	- Confirm the checkpoint includes populated lifecycle variables and `${plan-path}` before planning/execution is reported complete.
+	- Confirm the resulting feature folder is `minor-audit` shaped: `issue.md` present with work-mode marker, no `spec.md`, no `user-story.md`, single canonical plan path reused, and reduced-audit artifacts present before completion.
+
+
+## Acceptance Criteria
+- [x] For the issue #101 repro, the documented C# small path now requires the sequential short-path lifecycle before planning/execution: potential entry resolution, promotion with `--work-mode minor-audit`, branch creation, active feature folder creation, folder-integrity validation, `${plan-path}` resolution, Phase 0-only execution, validation, and reduced audit.
+- [x] `artifacts/orchestration/csharp-orchestrator-state.json` is documented and validated to carry the lifecycle variables needed for small-path continuity, including non-null `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, `${feature-folder}`, and `${plan-path}` before completion is allowed.
+- [x] Minor-audit invariants are explicit and testable: a valid short-path folder contains `issue.md` with `- Work Mode: minor-audit`, does not contain `spec.md` or `user-story.md`, and cannot pass completion if Phase 0 evidence or reduced-audit artifacts are missing.
+- [x] The root C# orchestrator agent, root C# prompt, root C# state/router skills, and their bundled extension mirrors are updated together so the small-path contract is no longer contradictory across root and packaged customization sources.
+- [x] Regression tests are added or updated in the existing Python test suite to fail on: direct-to-planning/direct-to-engineer shortcut wording, missing `${plan-path}` continuity, missing bundled `acceptance-criteria-tracking` mirror when referenced, or root↔mirror drift.
+- [x] The fix does not change large-path routing thresholds or large-path lifecycle behavior beyond additive checkpoint compatibility needed to share the updated state contract.
+- [x] Final validation for the implementation pass includes a clean repo-root toolchain pass (`poetry run black .`, `poetry run ruff check`, `poetry run pyright`, `poetry run pytest`).
+- [x] Documentation and bundled customization references match the final behavior closely enough that a future reader cannot derive a shortcut small path from the C# agent/prompt/skill set.
+
+## Risks & Mitigations
+- Technical or operational risks:
+	- Updating only the root `.github` files would leave the extension-bundled customization pack stale and reintroduce the bug for downstream consumers.
+	- Updating only the agent without the prompt/router/state-machine skills would leave contradictory instructions in place and make future drift likely.
+	- Older incomplete checkpoint files may not contain `${plan-path}` or `work-mode`, creating resume ambiguity unless the implementation defines how to backfill them.
+	- There is a broader repository pattern of prompt drift in other language orchestrators; that increases the risk of copy/paste regressions if tests are too C#-specific or too narrow.
+- Mitigations and rollbacks:
+	- Require same-change parity for root and bundled C# customizations and add regression tests that compare or otherwise validate both sides.
+	- Make the generic/Python/PowerShell short-path flow the source template for the C# fix so only one lifecycle model is being copied.
+	- Treat new checkpoint fields as additive and fail closed only once the workflow reaches the step where the field is mandatory.
+	- If the contract update creates unexpected downstream packaging issues, revert the markdown/test changes as a unit rather than partially rolling back one layer.
+
+## Rollout & Follow-up
+- Release/rollout steps:
+	- Land the root customization updates, bundled mirror updates, and regression tests in the same change.
+	- Run the repo-root Python quality loop and verify the changed markdown contracts are exercised by the added tests.
+	- Re-run the documented small-path repro through `/orchestrate-csharp-work` to confirm the lifecycle now produces the expected artifacts.
+- Post-fix monitoring or clean-up tasks:
+	- Watch for any follow-up defects involving resume from pre-fix checkpoints that lack `${plan-path}` or `work-mode`.
+	- Open separate follow-up work, if desired, to audit Python and PowerShell orchestration prompts for the same prompt-drift pattern identified in research; that work is intentionally not bundled into issue #101.
+	- If the implementation relies on the push-down publisher to refresh the bundled mirror, verify the published extension resources remain in sync after the update.
+- Links: issue, PRs, related docs
+	- Issue: `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/issue.md`
+	- Spec: `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/spec.md`
+	- Research: `artifacts/research/20260314-csharp-orchestrator-small-path-lifecycle-research.md`
+	- Canonical short-path reference: `.github/agents/orchestrator.agent.md`

--- a/extensions/drm-copilot/resources/customizations/.github/agents/csharp-orchestrator.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/csharp-orchestrator.agent.md
@@ -1,10 +1,30 @@
 ---
 name: csharp-orchestrator
 model: GPT-5.4 (copilot)
-description: Orchestrate end-to-end C# feature/bug delivery by estimating change budget and routing through atomic planning/execution and feature review until complete.
+description: Orchestrate end-to-end C# feature/bug delivery by estimating change budget, routing small changes through promotion -> folder -> minimal-plan -> development -> QC -> small-audit, and routing larger efforts through scope -> promotion -> research -> spec -> atomic planning -> atomic execution -> feature review until complete.
 argument-hint: "Provide objective, affected files (if known), and whether this is likely bug or feature. The orchestrator will estimate change budget, choose workflow path, delegate to specialist agents, and persist until completion."
 tools: ['execute/getTerminalOutput', 'execute/runTask', 'execute/createAndRunTask', 'execute/runInTerminal', 'read/terminalSelection', 'read/terminalLastCommand', 'read/getTaskOutput', 'read/problems', 'read/readFile', 'agent', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web', 'todo']
 handoffs:
+  - label: Build minimal-audit atomic plan (preflight all clear)
+    agent: atomic_planner
+    prompt: "Generate a minimal-audit atomic plan for `${feature-folder}` using `${feature-folder}/issue.md` as the only requirements source (no spec/user-story/research). Use directive `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`. Target plan file path is `${plan-path}` and MUST be updated in place. Do NOT create additional `plan.*.md` siblings during drafting or preflight revision loops. The plan MUST include exactly 3 phases: Phase 0 baseline capture, Phase 1 placeholder for constrained small-path implementation work, Phase 2 final QC loop. Final-QC command tasks MUST be unconditional when present in the plan: do not add IN_SCOPE/OUT_OF_SCOPE branching and do not allow SKIPPED as a valid completion state for those tasks. Require validation-only preflight through `atomic_executor` and iterate until final `PREFLIGHT: ALL CLEAR` while preserving the same target path. Return `plan-path` and final preflight signal."
+    send: true
+  - label: Execute Phase 0 only
+    agent: atomic_executor
+    prompt: "Execute the approved plan in `${feature-folder}` with strict phase scoping: run Phase 0 only and stop. Return execution summary and updated checklist state. Do not execute Phase 1 or Phase 2."
+    send: true
+  - label: Small-scope implementation path
+    agent: csharp-typed-engineer
+    prompt: "Estimate and confirm scope (1-3 production C# files + corresponding tests). If confirmed, execute the constrained short-path implementation phase from the approved minimal-audit plan and return analyzer/type/test/coverage deltas."
+    send: true
+  - label: Validate small-path delivery and post-QC docs
+    agent: atomic_executor
+    prompt: "Validate small-path delivery for `${feature-folder}` against `${feature-folder}/issue.md`, check off completed plan tasks, check off delivered acceptance criteria in AC source files per `acceptance-criteria-tracking`, and produce post-QC validation documentation deltas. Validation MUST fail if minor-audit integrity is broken (`spec.md` or `user-story.md` exists, required Phase 0 artifacts are missing, or checklist state contradicts artifact evidence). If validation fails, return precise remediation deltas."
+    send: true
+  - label: Post-implementation small-path audit
+    agent: feature_code_review_agent
+    prompt: "Use `.github/agents/feature-review.agent.md` as the governing agent contract together with `.github/prompts/review-feature.prompt.md` for `${feature-folder}` in short-path/minor-audit mode. Generate the reduced audit artifacts required for short path (policy + feature acceptance focus) and trigger remediation planning only if required by that reduced gate. The orchestrator MUST treat the delegated review artifacts as authoritative and MUST NOT author replacement audit files directly."
+    send: true
   - label: Fill potential entry details
     agent: prd_feature
     prompt: "Populate the generated potential entry docs without changing headings/template scaffolding. Add detail only, based on user objective and repository context."
@@ -23,11 +43,11 @@ handoffs:
     send: true
   - label: Execute approved C# atomic plan
     agent: csharp-atomic-executor
-    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce C# quality gates from agent policy.\n4) Complete final QA loop (format → analyze/lint → type-check → test) and report analyzer/type/test/coverage deltas.\n\nOutput requirements:\n- execution summary\n- QA summary\n- analyzer/type/test/coverage deltas\n- updated plan checklist state"
+    prompt: "Execute the approved atomic plan exactly as written (no replanning, no task reordering).\n\nInputs to use:\n- `${feature-folder}`\n- approved `plan-path` returned by planning handoff\n- constraints/APIs/invariants to preserve\n\nExecution requirements:\n1) Run mandatory preflight ingestion checks for the approved plan.\n2) Execute tasks in order with binary acceptance checks.\n3) Enforce C# quality gates from agent policy.\n4) Complete final QA loop (format → analyze/lint → type-check → test) and report analyzer/type/test/coverage deltas.\n5) Track and check off acceptance criteria in AC source files per `acceptance-criteria-tracking` as tasks deliver verified work. Include AC Status Summary at completion.\n\nOutput requirements:\n- execution summary\n- QA summary\n- analyzer/type/test/coverage deltas\n- AC Status Summary\n- updated plan checklist state"
     send: true
   - label: Post-implementation feature review
     agent: feature_code_review_agent
-    prompt: "Use `.github/prompts/review-feature.prompt.md` for this feature folder and generate policy/code/feature audits. Pass `PRBaseBranch` from orchestration context (default to `main` if missing). If remediation is required, trigger atomic planner remediation flow automatically."
+    prompt: "Use `.github/prompts/review-feature.prompt.md` for this feature folder and generate policy/code/feature audits. Resolve `PRBaseBranch` via `pr-base-branch-merge-base` and pass that resolved branch from orchestration context (do not default to `main` unless merge-base resolution fails for all candidates). If remediation is required, trigger atomic planner remediation flow automatically."
     send: true
 ---
 
@@ -42,9 +62,12 @@ You do not perform deep implementation yourself when delegated specialists exist
 Use these reusable skills to avoid duplicating shared operations:
 - `policy-compliance-order`
 - `pr-context-artifacts`
+- `pr-base-branch-merge-base`
 - `csharp-change-budget-router`
 - `csharp-orchestration-state-machine`
 - `feature-promotion-lifecycle`
+- `atomic-plan-contract`
+- `acceptance-criteria-tracking`
 
 # Non-negotiable mission behavior
 
@@ -59,7 +82,7 @@ Use these reusable skills to avoid duplicating shared operations:
   - `objective`
   - `change_budget_estimate`
   - `path_selected` (`small` or `large`)
-  - variables (`promotion-type`, `short-name`, `relativeFile`, `long-name`, `issue-num`, `feature-folder`)
+  - variables (`promotion-type`, `short-name`, `relativeFile`, `long-name`, `issue-num`, `feature-folder`, `plan-path`)
   - `completed_steps`
   - `next_step`
   - `last_updated`
@@ -78,6 +101,7 @@ Use these reusable skills to avoid duplicating shared operations:
   - `${long-name}`: `${relativeFile}` filename without `.md`
   - `${issue-num}`: promoted GitHub issue number
   - `${feature-folder}`: created active feature folder path
+  - `${plan-path}`: workspace-relative path to the single plan file that must be updated in-place across all planning/preflight iterations
 
 # Workflow router
 
@@ -94,14 +118,117 @@ Use these reusable skills to avoid duplicating shared operations:
 
 ## Small path (budget 1-3 production C# files and 1-3 test C# files)
 
-Use this exact sequence:
+Follow this exact sequence.
 
-1. Delegate to `csharp-atomic-planning` via handoff **Build C# atomic plan (preflight all clear)**.
-2. Require return of concrete `plan-path` and `PREFLIGHT: ALL CLEAR`.
-3. Delegate to `csharp-atomic-executor` via handoff **Execute approved C# atomic plan** using the approved `plan-path`.
-4. Require execution summary, QA summary, and analyzer/type/test/coverage deltas.
-5. Delegate to `feature_code_review_agent` via handoff **Post-implementation feature review**; use the delegated artifacts as authoritative and do NOT create `policy-audit.*.md`, `feature-audit.*.md`, or `code-review.*.md` directly from orchestration.
-6. Do not record completion in checkpoint or respond as done until the delegated review artifacts exist on disk under `${feature-folder}`.
+### Step S1 — Scope potential feature/bug
+
+S1.1 Determine type and set `${promotion-type}`:
+- `feature` or `bug`
+
+S1.2 Generate `${short-name}`:
+- lowercase slug, hyphen-separated
+
+S1.3 Ensure potential entry exists using exact command by type when missing:
+- If `${promotion-type}` is `feature`:
+  - `${workspaceFolder}/scripts/dev-tools/new-potential-entry.ps1 -ShortName ${short-name}`
+- If `${promotion-type}` is `bug`:
+  - `${workspaceFolder}/scripts/dev_tools/new_potential_bug_entry.py --short-name ${short-name}`
+
+S1.4 Detect created/existing potential markdown file path and save as `${relativeFile}`.
+
+### Step S2 — Promote with short-path flag
+
+S2.1 Promote to issue using existing tooling with short-path flag set:
+- `poetry run python -m scripts.dev_tools.potential_to_issue --potential-path ${relativeFile} --promotion-type ${promotion-type} --work-mode minor-audit`
+
+S2.2 Set `${long-name}` from `${relativeFile}` filename without `.md`.
+
+S2.3 Parse promoted document to capture `${issue-num}`.
+
+S2.4 Create branch with exact name:
+- `${promotion-type}/${short-name}-${issue-num}`
+
+S2.5 Create active feature folder with short-path flag set:
+- `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name ${long-name} --type ${promotion-type} --issue-number ${issue-num} --work-mode minor-audit`
+
+S2.6 Capture created folder path as `${feature-folder}`.
+
+S2.7 Verify short-path folder integrity before proceeding:
+- `${feature-folder}/issue.md` MUST exist and contain `- Work Mode: minor-audit`.
+- `${feature-folder}/spec.md` MUST NOT exist.
+- `${feature-folder}/user-story.md` MUST NOT exist.
+- If any integrity check fails, stop and remediate before planning.
+
+### Step S3 — Build minimal-audit atomic plan with preflight
+
+S3.0 Resolve `${plan-path}` before delegating:
+- If one or more `plan*.md` files already exist in `${feature-folder}`, set `${plan-path}` to the earliest existing template file and reuse it.
+- If none exist, create exactly one canonical plan file path and persist it as `${plan-path}`.
+
+S3.1 Delegate handoff **Build minimal-audit atomic plan (preflight all clear)**.
+
+Hard enforcement for S3:
+- Handoff MUST include directive `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`.
+- Handoff MUST include `${plan-path}` and require in-place updates to that single file.
+- Generated plan MUST include exactly 3 phases:
+  - Phase 0 baseline capture,
+  - Phase 1 placeholder for constrained small-path implementation work,
+  - Phase 2 final QC loop.
+- Plan MUST treat `${feature-folder}/issue.md` as sole requirements source (no `spec.md`).
+- Final-QC command tasks in the generated plan MUST be unconditional when present; no IN_SCOPE/OUT_OF_SCOPE branches and no SKIPPED completion path unless explicitly required by the user.
+- Do not mark S3 complete until delegate returns `plan-path` and `PREFLIGHT: ALL CLEAR`.
+
+### Step S4 — Execute baseline phase only
+
+S4.1 Delegate handoff **Execute Phase 0 only** using approved `plan-path`.
+
+Hard enforcement for S4:
+- Execute only Phase 0.
+- Persist checkpoint with Phase 0 completion evidence.
+- Do not mark S4 complete unless `phase0-instructions-read.md` and the baseline command-step artifacts referenced by the plan exist on disk, and the corresponding Phase 0 checklist items are checked from execution evidence rather than inferred summary text.
+
+### Step S5 — Branch by bootstrap mode
+
+S5.1 If request is `manual bootstrap`:
+- Save checkpoint with `next_step` at Phase 1 resume point.
+- Stop execution and return resume instructions.
+
+S5.2 If request is small development (not manual bootstrap):
+- Continue to Step S6.
+
+### Step S6 — Delegate constrained small-path development
+
+Delegate to `csharp-typed-engineer` using handoff **Small-scope implementation path**.
+
+Required delegation expectations:
+- implement only Phase 1 placeholder scope,
+- strict QA gates,
+- final analyzer/type/test/coverage deltas,
+- completion report referencing `${feature-folder}` and approved `plan-path`.
+
+### Step S7 — Validate delivery and post-QC documentation
+
+S7.1 Delegate handoff **Validate small-path delivery and post-QC docs**.
+
+Hard enforcement for S7:
+- Validation MUST be against `${feature-folder}/issue.md`.
+- Plan checklist updates MUST be persisted before audit.
+- Validation MUST fail if minor-audit integrity is broken (`spec.md` or `user-story.md` exists, required Phase 0 artifacts are missing, or checklist state contradicts artifact evidence).
+
+### Step S8 — Run reduced audit and remediation loop
+
+S8.1 Delegate handoff **Post-implementation small-path audit**.
+
+S8.2 If audit triggers remediation:
+- generate remediation inputs + remediation plan,
+- execute remediation,
+- re-run reduced audit,
+- repeat until ready-to-merge gate passes.
+
+Hard enforcement for S8:
+- Orchestrator MUST delegate the short-path audit to `feature_code_review_agent` as defined in `.github/agents/feature-review.agent.md`; direct creation or replacement of `policy-audit.*.md`, `feature-audit.*.md`, or `code-review.*.md` by the orchestrator is prohibited.
+- Do not mark small path complete until reduced audit artifacts are present in `${feature-folder}` and remediation loop (if any) is closed.
+- Do not accept PASS reduced-audit outcomes when required baseline evidence is missing, when plan checklist state is not evidence-backed, or when minor-audit folders contain `spec.md`/`user-story.md`.
 
 ---
 
@@ -199,7 +326,13 @@ On each invocation:
 4. If user explicitly asks to restart:
    - reset checkpoint and start at Phase 0.
 
-Checkpoint writes are mandatory after each completed sub-step in the large path sequence and after final completion in the small path.
+Checkpoint writes are mandatory after each completed sub-step in the large and small path sequences and after final completion.
+
+Artifact verification gate before mission completion (small path):
+- At least one short-path `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
+- At least one short-path `feature-audit.<timestamp>.md` exists under `${feature-folder}`.
+- `phase0-instructions-read.md` and baseline command-step artifacts required by the approved plan exist under `${feature-folder}`.
+- If remediation triggered, `remediation-inputs.<timestamp>.md` and `remediation-plan.<timestamp>.md` must exist and the latest re-audit must pass.
 
 Artifact verification gate before mission completion (large path):
 - At least one `policy-audit.<timestamp>.md` exists under `${feature-folder}`.
@@ -212,7 +345,7 @@ Artifact verification gate before mission completion (large path):
 You are complete only when:
 - selected path has run end-to-end,
 - all required delegations completed,
-- feature review completed for the selected path,
+- feature review completed (large path) or reduced small-path audit completed (small path),
 - checkpoint indicates completed mission,
 - user receives concise summary with produced paths/artifacts and branch info.
 

--- a/extensions/drm-copilot/resources/customizations/.github/prompts/orchestrate-csharp-work.prompt.md
+++ b/extensions/drm-copilot/resources/customizations/.github/prompts/orchestrate-csharp-work.prompt.md
@@ -22,7 +22,17 @@ Coordinate the user request from intake to completion using the correct path bas
 
 1. Estimate rough change budget first (production C# files and test C# files).
 2. If budget is **1–3 production C# files** (+ corresponding tests):
-   - Delegate directly to `csharp-typed-engineer` for plan + implementation + QA closure.
+   - Execute enforced small-path lifecycle:
+     1) Scope/create potential entry and promote with `--work-mode minor-audit`
+     2) Create branch and active feature folder with `--work-mode minor-audit`
+     3) Delegate plan creation to `atomic_planner` with directive `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
+     4) Require `atomic_executor` preflight until `PREFLIGHT: ALL CLEAR`
+     5) Delegate to `atomic_executor` to execute **Phase 0 only**
+     6) Branch behavior:
+        - manual bootstrap: save state and stop for manual resume
+        - non-bootstrap small development: delegate constrained implementation to `csharp-typed-engineer`
+     7) Delegate post-delivery validation to `atomic_executor` for validation against issue.md and persist checklist/doc updates
+     8) Run reduced small-path audit and remediation loop until ready-to-merge
 3. If budget is **>3 production C# files** or **>3 test C# files**:
    - Execute full large-path lifecycle:
      1) Scope and create potential entry (`feature` vs `bug`, short-name creation)
@@ -48,3 +58,9 @@ On completion, report:
 - Key captured variables (`promotion-type`, `short-name`, `issue-num`, `feature-folder` when applicable)
 - Created/updated artifact paths
 - Final readiness summary and any remaining action items
+
+For small path also report:
+- approved `plan-path`
+- preflight result (`PREFLIGHT: ALL CLEAR`)
+- whether `manual bootstrap` branch was taken
+- Phase 0 execution evidence and stored `next_step` for resume

--- a/extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: acceptance-criteria-tracking
+description: 'Track and check off acceptance criteria in requirement source files (issue.md, spec.md, user-story.md) as they are delivered. Use when executing plans, reviewing features, or validating delivery to keep AC checkboxes current.'
+---
+
+# Acceptance Criteria Tracking
+
+Shared protocol for identifying, tracking, and checking off acceptance criteria (AC) in their source requirement files as work is delivered and verified.
+
+## When to Use This Skill
+
+Use this skill when:
+- Executing an atomic plan that delivers work satisfying acceptance criteria.
+- Reviewing a feature branch and verifying acceptance criteria.
+- Validating small-path or large-path delivery against requirement files.
+- Any agent completes work that satisfies one or more acceptance criteria from `issue.md`, `spec.md`, or `user-story.md`.
+
+## AC Source Resolution (by Work Mode)
+
+Resolve the authoritative acceptance-criteria source file(s) using the work-mode marker from `issue.md`, per the mode rules in `feature-promotion-lifecycle` and `atomic-plan-contract`:
+
+| Work Mode | AC Source File(s) |
+|---|---|
+| `minor-audit` | `issue.md` only |
+| `full-feature` | `spec.md` and `user-story.md` |
+| `full-bug` | `spec.md` only |
+| legacy `full` | normalize to `full-feature` for compatibility |
+| missing / malformed | fail closed to `full-feature` (`spec.md` + `user-story.md`) |
+
+Deterministic mode rule: use the persisted `- Work Mode: ...` marker from `issue.md` as the single source of truth. `full-feature` always means `spec.md` **and** `user-story.md`; `full-bug` always means `spec.md` **only**; legacy `full` always normalizes to `full-feature`.
+
+When multiple AC source files exist, track checkboxes in **each** applicable file independently.
+
+## AC Identification
+
+Acceptance criteria are markdown checkbox items within AC source files, typically under headings such as:
+- `## Acceptance Criteria`
+- `### Acceptance Criteria`
+- `## Done When` or similar
+
+AC items use the standard markdown checkbox format:
+- `- [ ] <criterion text>` (not yet delivered)
+- `- [x] <criterion text>` (delivered and verified)
+
+If AC items are not in checkbox format (e.g., numbered lists or prose), do NOT reformat them. Instead, note their status in the agent's own tracking artifacts (plan checklist, feature-audit, etc.) and document that the source file uses a non-checkbox format.
+
+## Check-Off Protocol
+
+### Rules (non-negotiable)
+
+1. **Evidence before check-off**: Only mark an AC item `[x]` after the work satisfying it has been **implemented and verified** (e.g., tests pass, toolchain clean, code reviewed).
+2. **One-at-a-time**: Check off each AC item individually as the corresponding work is verified. Do not batch-check items without individual verification.
+3. **Preserve text**: When checking off, change only `- [ ]` to `- [x]`. Do not modify the criterion text.
+4. **Leave unmet items unchecked**: If an AC item cannot be fully delivered or verified, leave it as `- [ ]` and document the gap in the appropriate artifact (plan checklist, remediation inputs, or feature-audit).
+5. **No phantom criteria**: Do not add new AC items to source files. AC items are authored by planning/scoping agents, not by executors or reviewers.
+
+### When Executors Check Off AC
+
+During plan execution, after completing a task whose work satisfies an acceptance criterion:
+
+1. Identify which AC item(s) in the resolved source file(s) are satisfied by the completed task.
+2. Verify the work meets the criterion (task acceptance criteria passed, tests pass, etc.).
+3. Update the AC source file(s): change `- [ ]` to `- [x]` for the satisfied criterion.
+4. Report the check-off in the task's progress output (e.g., "Checked off AC: `<criterion text>` in `issue.md`").
+
+Timing: Check off AC items as soon as the corresponding plan task passes verification — do not defer all AC updates to the end of plan execution.
+
+### When Reviewers Check Off AC
+
+During feature review (feature-audit phase):
+
+1. For each AC item evaluated as **PASS** in the feature-audit evaluation table, check it off in the source file(s) if not already checked.
+2. For items evaluated as **PARTIAL**, **FAIL**, or **UNVERIFIED**, leave them unchecked and document the gap.
+3. Report any newly checked-off items in the feature-audit artifact.
+
+### When Orchestrators Enforce AC Tracking
+
+Orchestrators do not directly check off AC items. Instead:
+
+1. Ensure delegated executors and reviewers reference this skill.
+2. After executor or reviewer completion, verify that AC source files reflect delivered work (spot-check; do not re-execute verification).
+3. If AC items remain unchecked after all delegated work completes, flag them in the orchestration summary as outstanding acceptance criteria.
+
+## AC Status Summary (Required at Completion)
+
+At the end of plan execution or feature review, report an AC summary:
+
+```
+### Acceptance Criteria Status
+- Source: <file path(s)>
+- Total AC items: <N>
+- Checked off (delivered): <M>
+- Remaining (unchecked): <N - M>
+- Items remaining: <list of unchecked criterion texts, if any>
+```
+
+This summary must appear in:
+- The executor's final completion report (after last plan task).
+- The reviewer's feature-audit artifact (Phase F or equivalent).

--- a/extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/atomic-plan-contract/SKILL.md
@@ -61,6 +61,7 @@ Required planner outputs for this directive:
 	- Phase 0 baseline capture,
 	- Phase 1 placeholder for constrained small-path implementation,
 	- Phase 2 final QC loop,
+- final-QC command tasks in the generated plan MUST be unconditional when present; no IN_SCOPE/OUT_OF_SCOPE branches and no SKIPPED completion path unless the task text explicitly authorizes a skip branch,
 - planner MUST return `plan-path` and final preflight signal.
 
 ## Phase-0-Only Execution Contract (Small Path)
@@ -82,6 +83,7 @@ Phase 0 must also capture baseline toolchain results for the languages touched. 
 For short-path/minimal-audit plans, Phase 0 evidence is incomplete unless both artifacts exist:
 - `phase0-instructions-read.md` with at least: `Timestamp:`, `Policy Order:`, and explicit list of files read.
 - baseline command-step artifacts with at least: `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` for each baseline check executed.
+- approved-plan checklist state MUST remain unchecked for any Phase 0 task whose artifact is absent or whose artifact fields are incomplete.
 
 `Output Summary:` is mandatory for each command-step artifact and must concisely summarize the essential result signal (for example: pass/fail status, key counts, coverage headline, or primary diagnostic).
 
@@ -155,5 +157,6 @@ When a plan is generated or validated from a feature folder, resolve selected mo
 
 - `minor-audit` plans MUST include baseline evidence tasks, targeted verification evidence tasks, and end-state evidence tasks.
 - `minor-audit` plans MUST NOT treat missing `spec.md` or `user-story.md` as automatic blockers.
+- `minor-audit` execution/validation/audit MUST fail closed when `spec.md` or `user-story.md` exists unexpectedly in the active folder, when required Phase 0 artifacts are missing, or when checklist state contradicts evidence on disk.
 - `full-feature` plans MUST enforce full-document expectations (`spec.md` + `user-story.md`) and full QA loop obligations.
 - `full-bug` plans MUST enforce spec-driven expectations (`spec.md` required, `user-story.md` optional/absent by default) and full QA loop obligations.

--- a/extensions/drm-copilot/resources/customizations/.github/skills/csharp-change-budget-router/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/csharp-change-budget-router/SKILL.md
@@ -18,14 +18,26 @@ Use this skill when:
 
 1) Estimate rough change budget first based on likely **production C# files** touched.
 2) Route:
-- `1-3` production files (+ corresponding tests) → **small path** (atomic plan + execution route).
+- `1-3` production files (+ corresponding tests) → **small path** (`csharp-typed-engineer` direct mode).
 - `>3` production files or `>3` test files → **large path** (orchestration workflow with promotion/research/spec/planning/execution/review).
+
+## Orchestrated Small-Path Requirements
+
+When routed through `csharp-orchestrator`, small path still requires lifecycle scaffolding before implementation:
+- promote potential item to GitHub issue with `--work-mode minor-audit`,
+- create active feature folder with `--work-mode minor-audit`,
+- delegate minimal-audit plan creation to `atomic_planner` with `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`,
+- require `atomic_executor` preflight until `PREFLIGHT: ALL CLEAR`,
+- execute Phase 0 only via atomic_executor before branching,
+- run reduced small-audit after implementation and QC.
+
+Direct invocation of `csharp-typed-engineer` remains implementation-focused and does not replace orchestrator lifecycle steps.
 
 ## Direct-Mode Rejection Rule
 
 If direct implementation is requested but estimated scope is `>3` production files:
 - Stop before implementation.
-- Return explicit routing instruction to invoke `csharp-orchestrator`.
+- Return explicit routing instruction to invoke `csharp-orchestrator` (or `.github/prompts/orchestrate-csharp-work.prompt.md`).
 
 ## Documentation Expectations
 

--- a/extensions/drm-copilot/resources/customizations/.github/skills/csharp-orchestration-state-machine/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/csharp-orchestration-state-machine/SKILL.md
@@ -29,9 +29,18 @@ Use this skill when:
 - `long-name`
 - `issue-num`
 - `feature-folder`
+- `work-mode` (`minor-audit`, `full-feature`, or `full-bug`; normalize legacy `full` to `full-feature` before persistence)
+- `plan-path` (minimal or full plan path)
 - `completed_steps`
 - `next_step`
 - `last_updated`
+
+For short-path runs, also persist:
+- `small_path_qc_summary`
+- `small_path_audit_artifacts`
+- `bootstrap_mode` (`manual-bootstrap` or `auto-small-dev`)
+- `phase0_execution_summary`
+- `resume_after_manual_bootstrap` (next step token)
 
 ## Update Protocol
 

--- a/extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md
+++ b/extensions/drm-copilot/resources/customizations/.github/skills/feature-promotion-lifecycle/SKILL.md
@@ -23,6 +23,7 @@ Use this skill when:
 - `${long-name}`: `${relativeFile}` filename without `.md`
 - `${issue-num}`: promoted GitHub issue number
 - `${feature-folder}`: active feature folder path
+- `${plan-path}`: single canonical plan file path reused across planning and preflight revisions
 - `${work-mode}`: `minor-audit`, `full-feature`, or `full-bug` (legacy `full` is accepted only as an alias for `full-feature`)
 - `${short-path-flag}`: `--work-mode minor-audit` (mandatory for short-path promotion/folder creation)
 
@@ -54,8 +55,18 @@ When orchestrator routing selects short path, promotion/folder initialization st
 3) Create active feature folder with short-path flag:
 - `poetry run python -m scripts.dev_tools.new_active_feature_folder --feature-name ${long-name} --type ${promotion-type} --issue-number ${issue-num} --work-mode minor-audit`
 
+3a) Verify minor-audit folder integrity before proceeding:
+- `${feature-folder}/issue.md` exists and contains `- Work Mode: minor-audit`
+- `${feature-folder}/spec.md` does not exist
+- `${feature-folder}/user-story.md` does not exist
+- if any check fails, stop and remediate before planning
+
 4) Delegate minimal-audit plan creation to `atomic_planner` with directive:
 - `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
+
+4a) Resolve and persist `${plan-path}` before delegation:
+- reuse the earliest existing `plan*.md` in `${feature-folder}` when present
+- otherwise create exactly one canonical plan file path and reuse it for all revisions
 
 5) Require preflight validation via `atomic_executor` until:
 - `PREFLIGHT: ALL CLEAR`
@@ -79,6 +90,7 @@ Before delegating research/spec/planning, provide:
 
 Mode-aware expectations:
 - For `minor-audit`, `issue.md` is the primary acceptance-criteria source and `spec.md`/`user-story.md` may be intentionally absent by design.
+- For `minor-audit`, `spec.md`/`user-story.md` must be treated as integrity failures when they appear unexpectedly in the active folder.
 - For `full-feature`, `spec.md` and `user-story.md` are expected alongside `issue.md`.
 - For `full-bug`, `spec.md` is expected alongside `issue.md`; `user-story.md` should be absent unless the requirements explicitly justify it.
 

--- a/tests/scripts/dev_tools/test_csharp_orchestration_contracts.py
+++ b/tests/scripts/dev_tools/test_csharp_orchestration_contracts.py
@@ -1,0 +1,138 @@
+"""Regression tests for the C# orchestration markdown contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def read_repo_text(relative_path: str) -> str:
+    """
+    Return repository text content for a checked-in contract file.
+
+    Purpose:
+        Let markdown contract tests assert required lifecycle language without
+        depending on temporary files or external processes.
+
+    Args:
+        relative_path (str): Repository-relative path to the text file.
+
+    Returns:
+        str: UTF-8 text content for the requested repository file.
+
+    Raises:
+        FileNotFoundError: When the requested file does not exist.
+
+    Side Effects:
+        Reads a checked-in repository file from disk.
+    """
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_csharp_orchestrator_small_path_requires_minor_audit_lifecycle() -> None:
+    """Require the C# small path to mirror the enforced short-path lifecycle."""
+    agent_text = read_repo_text(".github/agents/csharp-orchestrator.agent.md")
+
+    assert "Build minimal-audit atomic plan (preflight all clear)" in agent_text
+    assert "Execute Phase 0 only" in agent_text
+    assert "Small-scope implementation path" in agent_text
+    assert "Validate small-path delivery and post-QC docs" in agent_text
+    assert "Post-implementation small-path audit" in agent_text
+    assert "${plan-path}" in agent_text
+
+
+def test_orchestrate_csharp_work_prompt_requires_minor_audit_lifecycle() -> None:
+    """Require the C# prompt to document the enforced short-path lifecycle."""
+    prompt_text = read_repo_text(".github/prompts/orchestrate-csharp-work.prompt.md")
+    direct_delegate_text = (
+        "Delegate directly to `csharp-typed-engineer` for plan + "
+        "implementation + QA closure."
+    )
+
+    assert "minor-audit" in prompt_text
+    assert "DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED" in prompt_text
+    assert "PREFLIGHT: ALL CLEAR" in prompt_text
+    assert "Phase 0 only" in prompt_text
+    assert "validation against issue.md" in prompt_text
+    assert direct_delegate_text not in prompt_text
+
+
+def _assert_state_machine_contract() -> None:
+    """Require the C# checkpoint contract to include short-path continuity fields."""
+    state_machine_text = read_repo_text(
+        ".github/skills/csharp-orchestration-state-machine/SKILL.md"
+    )
+
+    assert "work-mode" in state_machine_text
+    assert "plan-path" in state_machine_text
+    assert "bootstrap_mode" in state_machine_text
+    assert "phase0_execution_summary" in state_machine_text
+    assert "resume_after_manual_bootstrap" in state_machine_text
+
+
+test_csharp_orchestration_state_machine_requires_plan_path_and_bootstrap_fields = (
+    _assert_state_machine_contract
+)
+
+
+def test_csharp_change_budget_router_requires_orchestrated_small_path_wording() -> None:
+    """Require the C# router to describe the enforced short-path lifecycle."""
+    router_text = read_repo_text(".github/skills/csharp-change-budget-router/SKILL.md")
+
+    assert "1-3" in router_text
+    assert ">3" in router_text
+    assert "--work-mode minor-audit" in router_text
+    assert "DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED" in router_text
+    assert "PREFLIGHT: ALL CLEAR" in router_text
+    assert "Phase 0 only via atomic_executor" in router_text
+
+
+def _assert_bundle_mirror_contract() -> None:
+    """Require bundled C# customizations to mirror root contracts and shared skills."""
+    root_agent = read_repo_text(".github/agents/csharp-orchestrator.agent.md")
+    mirror_agent_path = REPO_ROOT / (
+        "extensions/drm-copilot/resources/customizations/.github/agents/"
+        "csharp-orchestrator.agent.md"
+    )
+    mirror_prompt_path = REPO_ROOT / (
+        "extensions/drm-copilot/resources/customizations/.github/prompts/"
+        "orchestrate-csharp-work.prompt.md"
+    )
+    mirror_state_machine_path = REPO_ROOT / (
+        "extensions/drm-copilot/resources/customizations/.github/skills/"
+        "csharp-orchestration-state-machine/SKILL.md"
+    )
+    mirror_router_path = REPO_ROOT / (
+        "extensions/drm-copilot/resources/customizations/.github/skills/"
+        "csharp-change-budget-router/SKILL.md"
+    )
+    mirror_acceptance_skill_path = REPO_ROOT / (
+        "extensions/drm-copilot/resources/customizations/.github/skills/"
+        "acceptance-criteria-tracking/SKILL.md"
+    )
+
+    assert mirror_agent_path.read_text(encoding="utf-8") == root_agent
+    assert mirror_prompt_path.read_text(encoding="utf-8") == read_repo_text(
+        ".github/prompts/orchestrate-csharp-work.prompt.md"
+    )
+    assert mirror_state_machine_path.read_text(encoding="utf-8") == read_repo_text(
+        ".github/skills/csharp-orchestration-state-machine/SKILL.md"
+    )
+    assert mirror_router_path.read_text(encoding="utf-8") == read_repo_text(
+        ".github/skills/csharp-change-budget-router/SKILL.md"
+    )
+    assert mirror_acceptance_skill_path.exists()
+
+
+test_csharp_customization_bundle_requires_contract_mirror_and_shared_skill_presence = (
+    _assert_bundle_mirror_contract
+)
+
+
+def test_csharp_orchestrator_large_path_chain_remains_csharp_atomic_pipeline() -> None:
+    """Keep the large-path C# workflow on the existing C# atomic planning chain."""
+    agent_text = read_repo_text(".github/agents/csharp-orchestrator.agent.md")
+
+    assert "Build C# atomic plan (preflight all clear)" in agent_text
+    assert "Execute approved C# atomic plan" in agent_text


### PR DESCRIPTION
Enforce the sequential minor-audit lifecycle for C# orchestrator small-path work

## Summary

- Replace the C# orchestrator small-path shortcut with the full sequential minor-audit lifecycle, so small-scope requests no longer jump straight to planning/execution with unset orchestration variables.
- Align the root C# agent, prompt, router skill, and state-machine skill around one shared short-path contract, including `${plan-path}` continuity, Phase 0-only execution, validation against `issue.md`, and reduced audit gates.
- Sync the packaged customization mirrors under `extensions/drm-copilot/resources/customizations/.github/...` with the root contract and add the missing bundled `acceptance-criteria-tracking` skill required by that mirrored flow.
- Add targeted regression coverage that locks the repaired contract surface, including small-path lifecycle wording, checkpoint continuity fields, root↔mirror parity, and large-path preservation.
- Capture the feature’s implementation evidence, QA-gate outputs, and review artifacts in the active feature folder for issue `#101`.

## Why

- The recorded bug was that `csharp-orchestrator` classified some requests as small-path work and then skipped the mandatory promotion/folder lifecycle, delegating straight to `csharp-atomic-planning` and execution.
- The spec states this bypass left `${promotion-type}`, `${short-name}`, `${relativeFile}`, `${long-name}`, `${issue-num}`, and `${feature-folder}` unset, prevented feature artifacts from being created, and violated the repository’s shared `feature-promotion-lifecycle` contract.
- The fix is constrained to preserve the existing large-path workflow and the `1-3` production-file small-path threshold while making short-path work use `minor-audit`, treat `issue.md` as the authoritative requirements source, and reuse a single `${plan-path}` through planning/preflight.
- The acceptance criteria also require the contract change to be reflected consistently across root and bundled customization sources, with deterministic regression coverage that fails on shortcut wording, missing continuity fields, missing bundled dependencies, or root↔mirror drift.

## What Changed

- **Core behavior / architecture**
  - Reworked `.github/agents/csharp-orchestrator.agent.md` so small-path work follows the documented S1-S8 lifecycle: promotion, active-folder initialization, `${plan-path}` resolution, minimal-audit preflight, Phase 0 execution, validation, and reduced audit.
  - Updated `.github/prompts/orchestrate-csharp-work.prompt.md` to describe the same enforced short-path lifecycle instead of a direct handoff shortcut.
  - Expanded `.github/skills/csharp-change-budget-router/SKILL.md` and `.github/skills/csharp-orchestration-state-machine/SKILL.md` to document orchestration-first short-path routing, `work-mode`, `${plan-path}`, bootstrap metadata, and continuity requirements.

- **Tooling / automation / DevEx**
  - Refreshed the bundled mirror files under `extensions/drm-copilot/resources/customizations/.github/...` to match the repaired root contract.
  - Added `extensions/drm-copilot/resources/customizations/.github/skills/acceptance-criteria-tracking/SKILL.md` so the packaged customization set includes the shared skill referenced by the mirrored C# orchestrator.
  - Captured a contract summary artifact listing changed root files, changed mirror files, and explicit large-path preservation evidence.

- **Tests**
  - Added `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` with six focused checks covering:
    - small-path lifecycle wording,
    - prompt contract wording,
    - state-machine continuity fields,
    - router wording,
    - root↔mirror parity plus bundled shared-skill presence,
    - large-path atomic pipeline preservation.
  - Preserved fail-before evidence for the pre-fix contract drift and recorded the passing targeted regression run after the update.

- **Docs / templates / agents**
  - Added the issue, spec, plan, feature audit, policy audit, code review, and evidence artifacts under `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/` to document the bug, scope, acceptance criteria, and verification trail.

## Architecture / How It Fits Together

- The repaired flow starts in `/orchestrate-csharp-work`, whose prompt now routes small-scope C# work through the same minor-audit lifecycle described by `csharp-orchestrator`.
- `csharp-orchestrator` persists the short-path variables, promotes the work item in `minor-audit` mode, creates or reuses the active feature folder, resolves a single `${plan-path}`, and then hands off to planning/execution in a staged sequence.
- The router skill determines whether the request stays on the small path or enters the existing large-path flow; the state-machine skill documents which continuity fields must exist before the orchestrator can advance or complete.
- The bundled customization mirror under `extensions/drm-copilot/resources/customizations/.github/...` now reflects the same contract, so packaged resources do not reintroduce the stale shortcut behavior.
- The regression test module verifies the contract surface end to end at the documentation/customization layer, including the explicit guarantee that the large-path C# atomic planning/execution chain remains intact.

## Verification

### Completed

- Targeted regression suite passed:
  - `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
  - Recorded result: `6 passed in 0.04s`
- Repo-root formatting passed:
  - `poetry run black .`
  - Recorded result: pass
- Repo-root linting passed:
  - `poetry run ruff check`
  - Recorded result: pass
- Repo-root type-checking passed:
  - `poetry run pyright`
  - Recorded result: pass
- Repo-root test suite passed:
  - `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
  - Recorded result: `879 passed in 2.90s`, total coverage `83%`, `scripts/dev_tools` coverage `83%`
- Coverage delta remained stable:
  - baseline total coverage `83%` → final total coverage `83%`
  - baseline `scripts/dev_tools` coverage `83%` → final `scripts/dev_tools` coverage `83%`

### Recommended

- `poetry run pytest tests/scripts/dev_tools/test_csharp_orchestration_contracts.py`
- `poetry run black .`
- `poetry run ruff check`
- `poetry run pyright`
- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
- Refresh canonical PR artifacts after any additional commits:
  - `poetry run python -m scripts.dev_tools.pr_context.collector --base development`

## Backward Compatibility / Migration Notes

- Large-path routing thresholds are intentionally unchanged: `1-3` production C# files remain the small path, and larger scopes remain on the full promotion/research/spec/atomic-planning/atomic-execution/review path.
- The large-path C# atomic pipeline is explicitly preserved; the targeted regression suite verifies that `Build C# atomic plan (preflight all clear)` and `Execute approved C# atomic plan` still exist in the root C# orchestrator.
- Small-path behavior is intentionally different after this change: callers now get the full minor-audit promotion/folder/plan lifecycle instead of the previous direct shortcut.
- The C# checkpoint contract gains additive continuity expectations such as `work-mode`, `${plan-path}`, and bootstrap metadata; the spec calls for older incomplete checkpoints to be normalized on resume rather than silently skipping required lifecycle steps.

## Risks and Mitigations

- **Risk:** Root and bundled customization files could drift again and reintroduce contradictory behavior.
  - **Mitigation:** Root↔mirror parity and bundled shared-skill presence are now covered by targeted regression tests.
- **Risk:** Future edits could simplify small-path wording back into a shortcut and break required orchestration continuity.
  - **Mitigation:** The targeted suite explicitly checks lifecycle wording in the agent, prompt, router, and state-machine contract.
- **Risk:** Older incomplete checkpoints may be missing `${plan-path}` or `work-mode`, creating resume ambiguity.
  - **Mitigation:** The spec defines these additions as additive, fail-closed only when the workflow reaches the point where those fields are mandatory.
- **Risk:** The contract fix could accidentally blur the difference between small and large C# paths.
  - **Mitigation:** Large-path preservation is explicitly verified by `test_csharp_orchestrator_large_path_chain_remains_csharp_atomic_pipeline`.

## Review Guide

- Start with `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/spec.md` for the bug statement, constraints, and acceptance criteria.
- Review `.github/agents/csharp-orchestrator.agent.md` for the core behavior change from shortcut routing to the S1-S8 minor-audit lifecycle.
- Review `.github/prompts/orchestrate-csharp-work.prompt.md`, `.github/skills/csharp-change-budget-router/SKILL.md`, and `.github/skills/csharp-orchestration-state-machine/SKILL.md` to confirm the contract is consistent across the prompt/router/state layers.
- Review `tests/scripts/dev_tools/test_csharp_orchestration_contracts.py` next; it captures the intended contract surface in executable form.
- Review `extensions/drm-copilot/resources/customizations/.github/...` after that to confirm the packaged mirrors match the repaired root contract.
- Treat the files under `docs/features/active/2026-03-14-orchestrator-not-following-sequential-tasks-101/evidence/` as supporting evidence rather than primary logic changes.

## Follow-ups

- Re-run the documented `/orchestrate-csharp-work` small-scope scenario and capture a manual validation note for the original repro path, as recommended in the feature audit.
- Monitor resume behavior for pre-fix checkpoints that do not already contain `${plan-path}` or `work-mode`.
- Consider a separate follow-up audit for similar prompt-drift patterns in Python and PowerShell orchestrator customization files.

## GitHub Auto-close

- Closes #101

## Related issues / PRs

- None