### PR TITLE
Add bundled hard-lock prompt resolution to the VS Code extension

### DIFF
--- a/docs/features/active/2026-03-05-blank-pr-context-81/plan.md
+++ b/docs/features/active/2026-03-05-blank-pr-context-81/plan.md
@@ -1,96 +1,88 @@
-# Implementation Plan — blank-pr-context (Issue #81)
+# 2026-03-05-blank-pr-context-81 — Minimal-Audit Plan
 
-DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED
+- **Issue:** `#81`
+- **Requirements Source:** `docs/features/active/2026-03-05-blank-pr-context-81/issue.md`
+- **Work Mode:** `minor-audit`
+- **Plan Path:** `docs/features/active/2026-03-05-blank-pr-context-81/plan.md`
+- **Directive:** `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
 
-## Overview
+Overview: Repair the destination-workspace PR-context regression described in `issue.md` without widening scope beyond the suspected Python PR-context modules and any directly required extension wrapper surfaces. This plan uses `issue.md` as the only requirements source, captures a deterministic baseline for Python and extension-local TypeScript, leaves Phase 1 as a constrained small-path implementation placeholder, and ends with an unconditional final QC loop on the same two language surfaces.
 
-Fix the PR-context collection bug where `scripts/dev_tools/pr_context` produces empty artifacts when run from extension-side execution in destination workspaces. This minimal-audit plan captures baseline state, delegates constrained implementation to a small-path engineer, and validates the fix through a full QC loop with reduced audit.
+### Phase 0 — Baseline capture
 
-## Requirements Source
+- [ ] [P0-T1] Record required policy reads in `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/phase0-instructions-read.md`
+  - Preconditions: `docs/features/active/2026-03-05-blank-pr-context-81/issue.md` remains the sole requirements source for this `minor-audit` plan.
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Policy Order:`, and these exact paths in order: `.github/copilot-instructions.md`, `.github/instructions/general-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/python-unit-test.instructions.md`, `.github/instructions/python-suppressions.instructions.md`, `.github/instructions/self-explanatory-code-commenting.instructions.md`, `.github/instructions/typescript-code-change.instructions.md`, `.github/instructions/typescript-suppressions.instructions.md`, `.github/instructions/typescript-unit-test.instructions.md`.
 
-- `docs/features/active/2026-03-05-blank-pr-context-81/issue.md` (sole requirements source)
+- [ ] [P0-T2] Record the minor-audit requirements-file gate in `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/minor-audit-requirements-gate.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Requirements Source: docs/features/active/2026-03-05-blank-pr-context-81/issue.md`, `SearchScope: docs/features/active/2026-03-05-blank-pr-context-81`, `SearchPatterns: spec.md, user-story.md`, `SearchResult: none`, and `Result: PASS`.
 
-## Languages In Scope
+- [ ] [P0-T3] Run the baseline Python format command `poetry run black .` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t3-python-format.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run black .`, `EXIT_CODE:`, and `Output Summary:`.
 
-- Python (`scripts/dev_tools/pr_context/`, `tests/`)
-- TypeScript (`extensions/drm-copilot/`)
+- [ ] [P0-T4] Run the baseline Python lint command `poetry run ruff check` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t4-python-lint.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE:`, and `Output Summary:`.
 
-## Evidence Locations
+- [ ] [P0-T5] Run the baseline Python type-check command `poetry run pyright` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t5-python-typecheck.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE:`, and `Output Summary:`.
 
-- Baseline: `evidence/baseline/`
-- QA gates: `evidence/qa-gates/`
+- [ ] [P0-T6] Run the baseline Python coverage test command `poetry run pytest --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t6-python-test.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run pytest --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info`, `EXIT_CODE:`, `Output Summary:`, and numeric `Coverage Total:`.
 
----
+- [ ] [P0-T7] Run the baseline extension format command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t7-extension-format.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE:`, and `Output Summary:`.
 
-### Phase 0 — Context & Baseline Capture
+- [ ] [P0-T8] Run the baseline extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t8-extension-lint.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE:`, and `Output Summary:`.
 
-- [ ] [P0-T1] Read repository policy files in compliance order and record evidence artifact
-  - Read in order: `.github/copilot-instructions.md`, `.github/instructions/general-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/python-unit-test.instructions.md`, `.github/instructions/typescript-code-change.instructions.md`, `.github/instructions/typescript-unit-test.instructions.md`
-  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and contains `Timestamp:`, `Policy Order:`, and explicit list of files read
+- [ ] [P0-T9] Run the baseline extension type-check command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t9-extension-typecheck.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE:`, and `Output Summary:`.
 
-- [ ] [P0-T2] Capture Python baseline format state via `poetry run black --check .`
-  - Acceptance: `evidence/baseline/python-format.md` exists and contains `Timestamp:`, `Command: poetry run black --check .`, `EXIT_CODE:`, `Output Summary:`
+- [ ] [P0-T10] Run the baseline extension coverage unit-test command `npm --prefix extensions/drm-copilot run test:unit -- --coverage` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t10-extension-test.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --coverage`, `EXIT_CODE:`, `Output Summary:`, and numeric `Coverage Lines:`.
 
-- [ ] [P0-T3] Capture Python baseline lint state via `poetry run ruff check`
-  - Acceptance: `evidence/baseline/python-lint.md` exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE:`, `Output Summary:`
+### Phase 1 — Placeholder for constrained small-path implementation work
 
-- [ ] [P0-T4] Capture Python baseline type-check state via `poetry run pyright`
-  - Acceptance: `evidence/baseline/python-typecheck.md` exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE:`, `Output Summary:`
+- [ ] [P1-T1] Record constrained small-path targets in `docs/features/active/2026-03-05-blank-pr-context-81/evidence/other/p1-t1-constrained-targets.yyyy-MM-ddTHH-mm.md`
+  - Preconditions: `[P0-T2]` recorded `Result: PASS` for the minor-audit requirements gate.
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Requirements Source: docs/features/active/2026-03-05-blank-pr-context-81/issue.md`, `Constrained Target: scripts/dev_tools/pr_context/collector.py`, `Constrained Target: scripts/dev_tools/pr_context/render.py`, `Constrained Target: scripts/dev_tools/pr_context/render_pr_helpers.py`, `Constrained Target: extensions/drm-copilot`, and `Reason:` lines quoting the `Suspected Cause / Notes` section from `issue.md`.
 
-- [ ] [P0-T5] Capture Python baseline test state with coverage via `poetry run pytest --cov --cov-report=term-missing`
-  - Acceptance: `evidence/baseline/python-test.md` exists and contains `Timestamp:`, `Command: poetry run pytest --cov --cov-report=term-missing`, `EXIT_CODE:`, `Output Summary:` with numeric coverage headline values (total percent and per-module percent for `scripts/dev_tools`)
+- [ ] [P1-T2] Record the constrained small-path implementation handoff in `docs/features/active/2026-03-05-blank-pr-context-81/evidence/other/p1-t2-small-path-handoff.yyyy-MM-ddTHH-mm.md`
+  - Preconditions: `[P1-T1]` identified the constrained target list.
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Requirements Source: docs/features/active/2026-03-05-blank-pr-context-81/issue.md`, `Expected Outcome: PR-context artifacts are non-empty under extension-side execution`, `Control Outcome: collect_commit_context.py remains populated`, `OutOfScope: Any requirement not stated in issue.md`, and `OutOfScope: Any new production surface outside the constrained targets requires a new justification artifact before editing.`
 
-- [ ] [P0-T6] Capture TypeScript baseline format state via `npm --prefix extensions/drm-copilot run format`
-  - Acceptance: `evidence/baseline/typescript-format.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE:`, `Output Summary:`
+- [ ] [P1-T3] Record the targeted verification placeholder in `docs/features/active/2026-03-05-blank-pr-context-81/evidence/other/p1-t3-targeted-verification-handoff.yyyy-MM-ddTHH-mm.md`
+  - Preconditions: `[P1-T2]` recorded the constrained implementation handoff.
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Validation Target: PR-context summary artifact is non-empty`, `Validation Target: PR-context appendix artifact is non-empty`, `Validation Target: collect_commit_context.py control artifact remains populated`, `Validation Target: changed files stay within constrained targets unless separately justified`, and `Ready For Phase 2: true`.
 
-- [ ] [P0-T7] Capture TypeScript baseline lint state via `npm --prefix extensions/drm-copilot run lint`
-  - Acceptance: `evidence/baseline/typescript-lint.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE:`, `Output Summary:`
+### Phase 2 — Final QC loop
 
-- [ ] [P0-T8] Capture TypeScript baseline type-check state via `npm --prefix extensions/drm-copilot run typecheck`
-  - Acceptance: `evidence/baseline/typescript-typecheck.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE:`, `Output Summary:`
+- [ ] [P2-T1] Run the final Python format command `poetry run black .` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t1-python-format.yyyy-MM-ddTHH-mm.md`; if this command changes files or exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run black .`, `EXIT_CODE: 0`, and `Output Summary:`.
 
-- [ ] [P0-T9] Capture TypeScript baseline test state with coverage via `npm --prefix extensions/drm-copilot run test:unit:coverage`
-  - Acceptance: `evidence/baseline/typescript-test.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit:coverage`, `EXIT_CODE:`, `Output Summary:` with numeric coverage headline values
+- [ ] [P2-T2] Run the final Python lint command `poetry run ruff check` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t2-python-lint.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE: 0`, and `Output Summary:`.
 
-### Phase 1 — Constrained Small-Path Implementation
+- [ ] [P2-T3] Run the final Python type-check command `poetry run pyright` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t3-python-typecheck.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE: 0`, and `Output Summary:`.
 
-- [ ] [P1-T1] Delegate fix to small-path implementation engineer: resolve PR-context empty-artifact bug under extension-side execution
-  - Requirements source: `docs/features/active/2026-03-05-blank-pr-context-81/issue.md`
-  - Candidate files: `scripts/dev_tools/pr_context/collector.py`, `scripts/dev_tools/pr_context/render.py`, `scripts/dev_tools/pr_context/render_pr_helpers.py`, and any bundled copies under `extensions/drm-copilot/`
-  - Prior attempt context: See "2026-03-05 Implementation Outcome" section in `issue.md`
-  - Acceptance: implementation changes committed; PR-context collection produces non-empty summary and appendix artifacts containing git-backed context when invoked under extension-side execution path; all pre-existing tests continue to pass
+- [ ] [P2-T4] Run the final Python coverage test command `poetry run pytest --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t4-python-test.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: poetry run pytest --cov=scripts/dev_tools --cov-report=term-missing --cov-report=lcov:artifacts/python/lcov.info`, `EXIT_CODE: 0`, `Output Summary:`, and numeric `Coverage Total:`.
 
-### Phase 2 — Final QC Loop & Reduced Audit
+- [ ] [P2-T5] Run the final extension format command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t5-extension-format.yyyy-MM-ddTHH-mm.md`; if this command changes files or exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE: 0`, and `Output Summary:`.
 
-- [ ] [P2-T1] Run Python format via `poetry run black .` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/python-format.md` exists and contains `Timestamp:`, `Command: poetry run black .`, `EXIT_CODE: 0`, `Output Summary:`; if files changed, restart from P2-T1
+- [ ] [P2-T6] Run the final extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t6-extension-lint.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE: 0`, and `Output Summary:`.
 
-- [ ] [P2-T2] Run Python lint via `poetry run ruff check` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/python-lint.md` exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE: 0`, `Output Summary:`; if failures found, fix and restart from P2-T1
+- [ ] [P2-T7] Run the final extension type-check command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t7-extension-typecheck.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE: 0`, and `Output Summary:`.
 
-- [ ] [P2-T3] Run Python type-check via `poetry run pyright` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/python-typecheck.md` exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE: 0`, `Output Summary:`; if failures found, fix and restart from P2-T1
+- [ ] [P2-T8] Run the final extension coverage unit-test command `npm --prefix extensions/drm-copilot run test:unit -- --coverage` and save the result to `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t8-extension-test.yyyy-MM-ddTHH-mm.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --coverage`, `EXIT_CODE: 0`, `Output Summary:`, and numeric `Coverage Lines:`.
 
-- [ ] [P2-T4] Run Python test with coverage via `poetry run pytest --cov --cov-report=term-missing` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/python-test.md` exists and contains `Timestamp:`, `Command: poetry run pytest --cov --cov-report=term-missing`, `EXIT_CODE: 0`, `Output Summary:` with numeric post-change coverage values; if failures found, fix and restart from P2-T1
+- [ ] [P2-T9] Record the coverage delta and threshold verification in `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t9-coverage-verification.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `Baseline Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t6-python-test.yyyy-MM-ddTHH-mm.md`, `Baseline Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/baseline/p0-t10-extension-test.yyyy-MM-ddTHH-mm.md`, `Final Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t4-python-test.yyyy-MM-ddTHH-mm.md`, `Final Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t8-extension-test.yyyy-MM-ddTHH-mm.md`, numeric `Python Baseline Coverage:`, numeric `Python Post-Change Coverage:`, numeric `Python Changed-Code Coverage:`, numeric `Extension Baseline Coverage:`, numeric `Extension Post-Change Coverage:`, numeric `Extension Changed-Code Coverage:`, `Thresholds: repository >= 80%; new or changed code >= 90%`, and `Result: PASS`.
 
-- [ ] [P2-T5] Run TypeScript format via `npm --prefix extensions/drm-copilot run format` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/typescript-format.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE: 0`, `Output Summary:`; if files changed, restart from P2-T5
-
-- [ ] [P2-T6] Run TypeScript lint via `npm --prefix extensions/drm-copilot run lint` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/typescript-lint.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE: 0`, `Output Summary:`; if failures found, fix and restart from P2-T5
-
-- [ ] [P2-T7] Run TypeScript type-check via `npm --prefix extensions/drm-copilot run typecheck` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/typescript-typecheck.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE: 0`, `Output Summary:`; if failures found, fix and restart from P2-T5
-
-- [ ] [P2-T8] Run TypeScript unit tests with coverage via `npm --prefix extensions/drm-copilot run test:unit:coverage` and record evidence artifact
-  - Acceptance: `evidence/qa-gates/typescript-test.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit:coverage`, `EXIT_CODE: 0`, `Output Summary:` with numeric post-change coverage values; if failures found, fix and restart from P2-T5
-
-- [ ] [P2-T9] Verify Python coverage delta: compare baseline coverage from `evidence/baseline/python-test.md` against post-change coverage from `evidence/qa-gates/python-test.md`
-  - Acceptance: `evidence/qa-gates/python-coverage-delta.md` exists and contains baseline total coverage percent, post-change total coverage percent, and delta; post-change total coverage is not lower than baseline total coverage
-
-- [ ] [P2-T10] Verify TypeScript coverage delta: compare baseline coverage from `evidence/baseline/typescript-test.md` against post-change coverage from `evidence/qa-gates/typescript-test.md`
-  - Acceptance: `evidence/qa-gates/typescript-coverage-delta.md` exists and contains baseline total coverage percent, post-change total coverage percent, and delta; post-change total coverage is not lower than baseline total coverage
-
-- [ ] [P2-T11] Perform reduced small-audit review of implementation changes against `issue.md` requirements
-  - Acceptance: `evidence/qa-gates/small-audit-review.md` exists and contains `Timestamp:`, confirmed list of changed files, verification that each change maps to a requirement in `issue.md`, and confirmation that no out-of-scope changes were introduced
+- [ ] [P2-T10] Record the clean-pass QC summary in `docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t10-clean-pass-summary.yyyy-MM-ddTHH-mm.md`
+  - Acceptance: The artifact exists and contains `Timestamp:`, `FinalPass: clean`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t1-python-format.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t2-python-lint.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t3-python-typecheck.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t4-python-test.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t5-extension-format.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t6-extension-lint.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t7-extension-typecheck.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t8-extension-test.yyyy-MM-ddTHH-mm.md`, `Artifact: docs/features/active/2026-03-05-blank-pr-context-81/evidence/qa-gates/p2-t9-coverage-verification.yyyy-MM-ddTHH-mm.md`, and the exact sentence `No Phase 2 command task was skipped.`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/code-review.2026-03-15T00-14.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/code-review.2026-03-15T00-14.md
@@ -1,0 +1,50 @@
+# Code Review — bundle-hard-lock-resolver-into-extension (#103)
+
+## Executive summary
+
+This feature adds a new extension command, bundles the hard-lock resolver plus prompt templates into the extension payload, and introduces a `--template-root` seam so the same Python resolver can run in non-repo workspaces. The architecture is directionally strong: TypeScript stays thin, bundled resources mirror root sources, coverage thresholds are met, and both the repo and extension quality loops pass.
+
+The branch is **No-Go for PR readiness** today because the new wrapper masks resolver failures by always returning exit code `0`. That breaks the extension runtime contract in `command-runtime.ts`, which depends on subprocess exit codes to distinguish success from failure. Two additional review risks remain: one new Python test file exceeds the repo's 500-line cap, and there is no regression test that proves the wrapper propagates non-zero process exit status.
+
+### Top 3 risks
+
+1. **Blocker:** bundled wrapper reports success for real failures.
+2. **Major:** new Python test module exceeds the repo's 500-line limit.
+3. **Major:** tests miss the process-level failure-propagation seam that caused the blocker.
+
+## Findings
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Blocker | `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` | `:58-60` | The wrapper imports the bundled resolver, calls `module.main`, then unconditionally `return 0`. That discards the resolver's `main() -> int` result, so missing target/template failures still produce a successful process exit for the extension host. | Return the delegated integer result directly, or raise `SystemExit(module.main())`, and add a regression test that asserts a non-zero wrapper exit on missing target/template failures. | `executeBundledScript()` in `extensions/drm-copilot/src/command-runtime.ts` treats only non-zero exits as command failures. Masking the exit code causes misleading success output and violates the acceptance criterion for clear failures. | `grep`: wrapper lines 58/60; bundled resolver `main() -> int` at `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py:276`; direct probe printed `Error: Target file not found ...` then `WRAPPER_EXIT=0`. |
+| Major | `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` | whole file | The new Python wrapper/bundled-resolver test file is 536 lines long. | Split the file into focused parts (for example wrapper-behavior vs bundled-resolver behavior) so every file stays under 500 lines. | Repo policy explicitly applies the 500-line limit to production code, test code, and reusable scripts. | Audit line-count probe: `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py=536`. |
+| Major | `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`, `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` | scenario coverage gap | The test suites validate stderr content and missing-runtime behavior, but they do not verify that the wrapper subprocess itself exits non-zero when the delegated resolver fails. | Add one focused regression that executes the wrapper through its real process boundary (or asserts delegated exit-code forwarding directly) for a missing-target or missing-template case. | Without a process-level assertion, the branch can pass unit tests while the extension still reports success on failure. | Current tests cover registration, argv wiring, template-root injection, missing runtime, and resolver branch behavior; none assert wrapper subprocess exit propagation. |
+
+## Typed Python audit
+
+- **No new `Any` without justification:** Mostly pass. The resolver continues to use targeted, policy-authorized untyped import handling for `pyperclip`.
+- **No type-check weakening:** Pass. `pyright` is clean and no new broad ignores/config weakening were introduced.
+- **Prefer precise types:** **Partial.** The wrapper currently uses `cast(Callable[[], None], module.main)`, but the delegated function contract is `main() -> int`. This is both imprecise typing and a correctness bug.
+- **Use `Protocol` / `TypedDict` / `dataclass(slots=True)` appropriately:** N/A for this slice; the feature is command wiring and CLI helpers, not new domain models.
+- **Error handling typed:** **Fail at wrapper boundary.** The delegated CLI exposes typed integer exit status, but the wrapper drops it.
+- **Logging:** Acceptable. Python stdout/stderr are part of the CLI contract; TypeScript output-channel logging remains in the runtime layer.
+- **Public API clarity:** Pass. The new seam is additive (`--template-root`) and documented in spec/docs.
+
+## Test quality audit
+
+- **Deterministic / isolated / fast:** Pass. Current runs were fast and used local mocks/fixtures only.
+- **Readable failures:** Pass. Tests assert specific human-facing messages such as `Target file not found` and `Checked locations`.
+- **Coverage expectation:** Pass numerically. Python new-code coverage is 92%; TypeScript new-code coverage is 91.34%.
+- **Gap:** The missing process-exit regression is a quality hole large enough to let a blocker through.
+
+## Security and correctness
+
+- **Secrets:** No secrets or credential material found in the reviewed diff.
+- **Subprocess safety:** Resolver clipboard subprocesses still validate executables with `shutil.which()` before launch; this remains aligned with the repo's pre-authorized suppression pattern.
+- **Input validation at boundaries:** Partial. Runtime existence checks are good, but the wrapper/extension boundary currently does not preserve failure semantics.
+
+## Recommendation
+
+**No-Go / Needs revision before PR**
+
+The design is solid, but the feature is not ready to open or merge as a PR until the wrapper returns the delegated exit code, the missing regression test is added, and the oversized Python test file is split under the repo's 500-line limit.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/feature-audit.2026-03-15T00-14.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/feature-audit.2026-03-15T00-14.md
@@ -1,0 +1,56 @@
+# Feature Audit — bundle-hard-lock-resolver-into-extension (#103)
+
+## Scope and baseline
+
+- **Base branch:** development
+- **Feature folder:** `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/`
+- **Feature folder selection rule:** Used the active folder supplied by the user; it matches the issue suffix `-103` and contains the primary scoping docs for this feature.
+- **Evidence sources:**
+  - Primary: refreshed `artifacts/pr_context.summary.txt`
+  - Secondary: refreshed `artifacts/pr_context.appendix.txt`
+  - Supplemental: live workspace inspection and review-time verification commands
+- **Important baseline note:** the refreshed PR context summary resolved an empty commit range because the feature currently exists as working-tree changes. For this audit, the appendix working-tree diff and on-disk files were used as the effective baseline diff evidence.
+- **Work mode marker:** `issue.md` contains `- Work Mode: full-feature`, so the authoritative acceptance-criteria source files are `spec.md` and `user-story.md`.
+
+## Acceptance criteria inventory (authoritative)
+
+Authoritative checkbox acceptance criteria come from `user-story.md`. `spec.md` provides supporting behavior detail and definition-of-done evidence, but its acceptance criteria are prose rather than checkbox items.
+
+1. `extensions/drm-copilot/package.json` contributes `drmCopilotExtension.resolveExecuteHardLockPrompt`, and `extensions/drm-copilot/src/extension.ts` registers a matching handler that reuses an active feature-plan editor when possible or otherwise prompts from `docs/features/active/`, then passes `--target <selected-plan>` and `--workspace <workspace-root>` to the bundled wrapper.
+2. `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` remains a thin wrapper that only bootstraps `resources/scripts` onto `sys.path`, injects `--template-root` pointing at bundled codex assets when absent, imports `dev_tools.resolve_hard_lock_prompt`, and delegates to its `main()` function without duplicating prompt-resolution logic.
+3. The extension package includes synchronized bundled copies of `scripts/dev_tools/resolve_hard_lock_prompt.py`, `.github/codex/execute-hard-lock.prompt.md`, and `.github/codex/resume-hard-lock.prompt.md` under the existing extension resource layout so prompt resolution works in workspaces that do not contain repo-local `.github/codex` assets.
+4. `scripts/dev_tools/resolve_hard_lock_prompt.py` adds an optional `--template-root` seam that checks the supplied template root first, then falls back to `<workspace>/.github/codex`, while preserving existing `--template-kind`, plan-path normalization, work-mode lookup, fallback-reason substitution, stdout output, and best-effort clipboard behavior.
+5. The extension command produces the same resolved execute prompt content as the root Python resolver for the same target plan, including forward-slash `${plan-path}` output and deterministic work-mode behavior for versioned plan folders such as `v2`.
+6. Missing target files, missing Python runtime, or missing bundled template assets fail with clear errors and do not produce partial or misleading success output.
+
+## Acceptance criteria evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| 1 | PASS | `extensions/drm-copilot/package.json` contributes the command; `extension.ts` registers it and passes `--target` / `--workspace`; Jest file covers registration, active editor reuse, picker fallback, and argv wiring. | `npm --prefix extensions/drm-copilot run test:unit` | Command contribution and wiring are present and tested. |
+| 2 | PASS | Wrapper file is 47 lines, prepends `resources/scripts`, injects `--template-root`, imports `dev_tools.resolve_hard_lock_prompt`, and contains no prompt interpolation logic. Python wrapper tests cover injection and explicit-template-root preservation. | `poetry run pytest` | Architecturally thin as intended. |
+| 3 | PASS | Bundled resolver and both prompt templates exist under extension resources; README/spec align with the bundled layout; Python tests cover bundled-template preference and fallback behavior. | `poetry run pytest` | Resource packaging contract is present and tested. |
+| 4 | PASS | Root resolver adds `--template-root`, `_resolve_template_path`, checked-location error reporting, and preserves existing prompt substitution and best-effort clipboard behavior. Coverage artifact reports 97% coverage on the root resolver. | `poetry run pytest` | Additive seam implemented without breaking root behavior in current tests. |
+| 5 | PASS | Root and bundled resolver tests cover forward-slash path normalization and parent `issue.md` lookup for versioned folders like `v2`; coverage and test runs are green. | `poetry run pytest`; `npm --prefix extensions/drm-copilot run test:unit` | Deterministic plan-path/work-mode behavior is evidenced in both root and bundled test suites. |
+| 6 | FAIL | Direct review probe of the bundled wrapper against a missing target printed `Error: Target file not found ...` but exited with `WRAPPER_EXIT=0`. The wrapper code calls delegated `module.main` then always `return 0`, so the extension runtime cannot distinguish success from failure. | `python extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py --target <missing-target> --workspace <feature-folder>` | This violates the explicit acceptance criterion and creates misleading success behavior on real failures. |
+
+## Summary
+
+- **Overall feature readiness:** NEEDS REVISION
+- **Top gap preventing PASS:** the bundled wrapper does not propagate non-zero failure status from the resolver, so the extension can show success on missing-target or missing-template failures.
+- **Additional gap:** `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` exceeds the repo's 500-line file limit and should be split during remediation.
+- **Recommended follow-up verification after remediation:** rerun the full Python loop, the extension loop, JSON validation, and the targeted missing-target wrapper probe to confirm non-zero exit behavior.
+
+## Acceptance criteria check-off
+
+- Updated `user-story.md` to leave the failed criterion unchecked.
+- No new items were checked off during this review; one previously checked item was reverted because verification did not support PASS.
+- `spec.md` acceptance criteria are prose, so they were evaluated here but not rewritten.
+
+### Acceptance Criteria Status
+- Source: `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/spec.md`, `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/user-story.md`
+- Total AC items: 6
+- Checked off (delivered): 5
+- Remaining (unchecked): 1
+- Items remaining:
+  - `Missing target files, missing Python runtime, or missing bundled template assets fail with clear errors and do not produce partial or misleading success output.`

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/policy-audit.2026-03-15T00-14.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/policy-audit.2026-03-15T00-14.md
@@ -1,0 +1,344 @@
+# Policy Compliance Audit: bundle-hard-lock-resolver-into-extension (#103)
+
+**Audit Date:** 2026-03-15  
+**Base Branch:** development  
+**Feature Folder:** `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/`  
+**Feature Folder Selection Rule:** Used the user-specified active feature folder, which matches the issue-number suffix (`-103`) and contains the primary scoping docs (`issue.md`, `spec.md`, `user-story.md`).  
+**PR Context Assumption:** `artifacts/pr_context.summary.txt` was refreshed against `development`, but because the feature currently exists as working-tree changes rather than committed branch delta, the summary range was empty. This audit therefore uses the refreshed PR context appendix working-tree diff plus live workspace inspection as authoritative scope evidence.
+
+**Code Under Test:**
+- `extensions/drm-copilot/src/extension.ts`
+- `extensions/drm-copilot/package.json`
+- `extensions/drm-copilot/README.md`
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`
+- `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py`
+- `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md`
+- `extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md`
+- `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`
+- `scripts/dev_tools/resolve_hard_lock_prompt.py`
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py`
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`
+- `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/*.md`
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| Python | 6 files | 38 tests | [✅] 898 passed in repo suite | 83% total; 97% `scripts/dev_tools/resolve_hard_lock_prompt.py` | 83% total; 97% root bundled resolver; 100% wrapper | 92% |
+| TypeScript | 2 files | 6 tests | [✅] 80/80 passed in extension suite | 89.3% total; 90.48% `src/extension.ts` | 89.83% total; 91.34% `src/extension.ts` | 91.34% |
+| JSON | 1 file | N/A | [✅] validation passed | N/A | N/A | N/A |
+
+## Executive Summary
+
+Most repository policies were met: the Python and extension toolchain loops both passed cleanly, coverage thresholds were met without regression, and the feature docs provide clear scope and acceptance criteria. However, the bundled wrapper `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` masks resolver failures by always exiting with code `0`, which violates the feature's clear-failure requirement and makes the extension capable of reporting success on missing-target/template failures. A second policy violation exists because the new Python test file `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` is 536 lines long, exceeding the repo-wide 500-line file limit that explicitly applies to test code.
+
+**Policy documents evaluated:**
+- [✅] `general-code-change.instructions.md`
+- [✅] `general-unit-test.instructions.md`
+- [✅] `python-code-change.instructions.md`
+- [✅] `python-unit-test.instructions.md`
+- [✅] `typescript-code-change.instructions.md`
+- [✅] `typescript-unit-test.instructions.md`
+
+**Temporary artifacts cleanup:**
+- [✅] No temporary one-off scripts were introduced in the feature implementation.
+- [✅] New ongoing tooling artifacts are bundled resources and tests, all checked via the Python/TypeScript loops.
+- Evidence artifacts under `evidence/` are intentional review records, not throwaway scripts.
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] [PASS] | New Python tests use `tmp_path`/`mem_path`, patching, and isolated module loads; TypeScript tests reset mocks and command handler state in `beforeEach` / `afterEach`. |
+| Isolation | [✅] [PASS] | Python tests target wrapper injection, template lookup, clipboard fallbacks, and resolver error branches individually. TypeScript tests target command registration, picker behavior, argv wiring, and missing-runtime behavior one case at a time. |
+| Fast Execution | [✅] [PASS] | Current audit run: repo `pytest` completed 898 tests in 1.73s; extension Jest completed 80 tests in 0.523s. |
+| Determinism | [✅] [PASS] | Tests rely on local fixtures, mocks, and in-memory state only; no network access or temp-file creation outside pytest-managed fixtures. |
+| Readability & Maintainability | [⚠️] [PARTIAL] | Test names are descriptive, but `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` reached 536 lines, reducing maintainability and violating the file-size rule. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Baseline Coverage Documented | [✅] [PASS] | Baseline artifacts exist under `evidence/baseline/`; coverage deltas cite baseline Python pytest and extension Jest artifacts. |
+| No Coverage Regression | [✅] [PASS] | Python delta artifact reports 83% → 83% total coverage, no regression; TypeScript delta artifact reports 89.3% → 89.83%, no regression. |
+| New Code Coverage ≥90% | [✅] [PASS] | `python-coverage-delta.2026-03-15T00-08-39.md` reports 92% new/changed Python coverage; `extension-coverage-delta.2026-03-15T00-12-56.md` reports 91.34% new/changed TypeScript coverage. |
+| Comprehensive Coverage | [⚠️] [PARTIAL] | Unit tests cover most branches, but they do not assert the bundled wrapper propagates non-zero process exit codes, which allowed a real failure-path defect to pass the suite. |
+| Positive / Negative / Edge / Error Scenarios | [✅] [PASS] | Coverage includes template-root preference/fallback, Windows path normalization, versioned folder lookup, clipboard success/failure, missing target, missing runtime, and missing template lookup. |
+| Concurrency | [N/A] [N/A] | No concurrent behavior introduced by this feature. |
+| State Transitions | [N/A] [N/A] | No stateful workflow object was added. |
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clear Failure Messages | [✅] [PASS] | Assertions check specific stderr/stdout substrings such as `Target file not found`, `Checked locations`, and runtime error text. |
+| Arrange-Act-Assert Pattern | [✅] [PASS] | Both Python and TypeScript test files consistently set up mocks/fixtures, invoke the subject, then assert outputs/calls. |
+| Document Intent | [✅] [PASS] | Test names and docstrings clearly describe scenarios like explicit template-root preservation and missing runtime behavior. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Avoid External Dependencies | [✅] [PASS] | Tests do not call live services; subprocesses are mocked in TypeScript and wrapper tests patch file/runtime boundaries. |
+| Use Mocks/Stubs | [✅] [PASS] | `patch`, `MagicMock`, Jest spies, mocked `vscode`, mocked `node:child_process`, and mocked filesystem checks isolate runtime edges. |
+| Environment Stability | [✅] [PASS] | No mutable global state leaks across cases beyond test-local setup/reset; no prohibited ad-hoc temporary files are created. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Pre-submission Review | [✅] [PASS] | This artifact documents the required review and records both passing gates and remaining policy gaps. |
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clarify the objective | [✅] [PASS] | `issue.md`, `spec.md`, and `user-story.md` clearly define the extension command, bundled-wrapper model, and source-of-truth constraints. |
+| Read existing change plans | [✅] [PASS] | The feature folder contains `plan.2026-03-14T22-49.md` plus evidence of Phase 0 policy reading. |
+| Document the plan | [✅] [PASS] | The active feature folder includes scoping docs and plan artifacts aligned to issue #103. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Simplicity first | [✅] [PASS] | The extension remains a thin launcher and the wrapper remains a thin Python adapter; core prompt logic stays in the resolver module. |
+| Reusability | [✅] [PASS] | Root resolver logic is mirrored into bundled resources instead of reimplemented in TypeScript. |
+| Extensibility | [✅] [PASS] | The new `--template-root` seam supports future bundled template sources while remaining backward compatible. |
+| Separation of concerns | [⚠️] [PARTIAL] | High-level layering is good, but the wrapper currently breaks command-runtime error propagation by discarding the bundled resolver's exit code. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Cohesive modules | [✅] [PASS] | Each modified file has a focused responsibility: command registration, wrapper bootstrapping, resolver logic, or targeted tests. |
+| Under 500 lines | [❌] [FAIL] | `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` is 536 lines. Repo policy explicitly applies the 500-line cap to test files. |
+| Public vs internal | [✅] [PASS] | New helpers remain internal module functions; no unnecessary public API expansion occurred. |
+| No circular dependencies | [✅] [PASS] | The wrapper imports the bundled resolver one-way; TypeScript command wiring remains acyclic. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Descriptive names | [✅] [PASS] | Symbols such as `getActiveFeaturePlanPath`, `promptForActiveFeaturePlan`, and `_resolve_template_path` are descriptive and purpose-specific. |
+| Docs/docstrings | [✅] [PASS] | The new Python wrapper and resolver helpers include strong docstrings; README documents the new command. |
+| Comment why, not what | [✅] [PASS] | Comments explain ordering and runtime-probing rationale rather than restating syntax. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting | [✅] [PASS] | Python: `poetry run black --check .` → 169 files unchanged. TypeScript: `npm --prefix extensions/drm-copilot run format -- --check` → all matched files use Prettier style. |
+| Linting | [✅] [PASS] | Python: `poetry run ruff check` → all checks passed. TypeScript: `npm --prefix extensions/drm-copilot run lint` → clean. |
+| Type checking | [✅] [PASS] | Python: `poetry run pyright` → 0 errors, 0 warnings, 0 informations. TypeScript: `npm --prefix extensions/drm-copilot run typecheck` → clean. |
+| Testing | [✅] [PASS] | Python: `poetry run pytest` → 898 passed. TypeScript: `npm --prefix extensions/drm-copilot run test:unit` → 6 suites, 80 tests passed. JSON: `python -m scripts.dev_tools.validate_json` → exit code 0. |
+| Full toolchain loop | [✅] [PASS] | All check-only steps passed in a single final pass for both Python and extension-local TypeScript loops. |
+| Explicit reporting | [✅] [PASS] | Exact commands and outcomes are recorded in this audit and Appendix B. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Summarize changes | [✅] [PASS] | Docs, manifest, extension command wiring, bundled resources, and tests were all updated within the feature folder and extension package. |
+| Design choices explained | [✅] [PASS] | `spec.md` and `user-story.md` explain the wrapper-plus-bundled-script approach and source-of-truth rationale. |
+| Update supporting documents | [✅] [PASS] | `extensions/drm-copilot/README.md` documents the new command; active feature docs are present. |
+| Provide next steps | [⚠️] [PARTIAL] | Remediation is required before PR readiness; see remediation artifacts for exact steps. |
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### 3A. Python Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting with Black | [✅] [PASS] | `poetry run black --check .` passed. |
+| Linting with Ruff | [✅] [PASS] | `poetry run ruff check` passed. |
+| Type checking with Pyright | [✅] [PASS] | `poetry run pyright` passed cleanly. |
+| Testing with Pytest | [✅] [PASS] | `poetry run pytest` passed with 898 tests. |
+| Strong typing | [⚠️] [PARTIAL] | Most new Python is well typed, but the wrapper casts `module.main` to `Callable[[], None]` and then unconditionally returns `0`, which mismatches the bundled resolver's `main() -> int` contract. |
+| Dataclasses / value objects | [N/A] [N/A] | No value-object dataclasses were introduced. |
+| Protocols/ABCs | [N/A] [N/A] | No new polymorphic domain interface was needed. |
+| Avoid utility classes | [✅] [PASS] | All Python changes use modules/functions, not static-only classes. |
+| Specific exceptions | [✅] [PASS] | The resolver reports explicit file/template errors and uses targeted `except ImportError` / `except OSError` / `except subprocess.CalledProcessError` handling. |
+| Logging over print | [✅] [PASS] | CLI stdout/stderr are part of the user-facing contract rather than ad-hoc application logging. |
+| Invariants at construction | [N/A] [N/A] | No new stateful class constructors were added. |
+
+### 3B. TypeScript Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting with Prettier | [✅] [PASS] | `npm --prefix extensions/drm-copilot run format -- --check` passed. |
+| Linting with ESLint | [✅] [PASS] | `npm --prefix extensions/drm-copilot run lint` passed. |
+| Type checking with TSC | [✅] [PASS] | `npm --prefix extensions/drm-copilot run typecheck` passed. |
+| Testing with Jest | [✅] [PASS] | `npm --prefix extensions/drm-copilot run test:unit` passed. |
+| Strong typing | [✅] [PASS] | The new command wiring uses explicit types and existing runtime APIs without introducing `any`. |
+| Avoid cleverness | [✅] [PASS] | The new code uses small helpers and early returns. |
+| Separation of concerns | [✅] [PASS] | TypeScript remains a thin command launcher; resolver logic stays in Python. |
+| Error handling / logging | [⚠️] [PARTIAL] | TypeScript command-runtime correctly treats non-zero exits as failures, but the feature still fails end-to-end because the bundled wrapper always exits zero. |
+
+### 3C. JSON Configuration Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| JSON validation | [✅] [PASS] | `python -m scripts.dev_tools.validate_json` exited with `0`. |
+| Strict JSON only | [✅] [PASS] | `extensions/drm-copilot/package.json` remains strict JSON. |
+| Deterministic structure | [✅] [PASS] | Manifest command contribution is structurally consistent and formatter-clean. |
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### 4A. Python Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Pytest | [✅] [PASS] | All new Python tests are pytest-based. |
+| Coverage expectation | [✅] [PASS] | New Python code coverage is 92% and total coverage remains above the 80% threshold. |
+| Focused unit tests | [✅] [PASS] | Tests isolate wrapper injection, resolver lookup, mode resolution, and error branches. |
+| Mocking sparingly | [✅] [PASS] | Only runtime boundaries (`sys.argv`, clipboard, imports, file reads) are mocked. |
+| Organization | [⚠️] [PARTIAL] | Test structure mirrors the code under test, but one new test module exceeded the file-size limit and should be split. |
+| Naming conventions | [✅] [PASS] | Test names are descriptive and scenario-specific. |
+| Docstrings/comments | [✅] [PASS] | New Python tests include concise docstrings. |
+| Use Pytest in toolchain | [✅] [PASS] | `poetry run pytest` was used; no alternate runner introduced. |
+
+### 4B. TypeScript Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Jest | [✅] [PASS] | The extension test file uses Jest and passed under `npm --prefix extensions/drm-copilot run test:unit`. |
+| Focused unit tests | [✅] [PASS] | Tests isolate command registration, picker flow, argv wiring, and missing-runtime handling. |
+| Mocking / isolation | [✅] [PASS] | `vscode`, child processes, and filesystem checks are mocked locally. |
+| Naming and readability | [✅] [PASS] | `it(...)` names clearly state the expected behavior. |
+| Coverage completeness | [⚠️] [PARTIAL] | The suite does not cover wrapper subprocess failure propagation, leaving a correctness hole in the end-to-end error path. |
+
+## 5. Test Coverage Detail
+
+### `scripts/dev_tools/resolve_hard_lock_prompt.py` + bundled mirror
+
+- Covered scenarios: template-root precedence, workspace fallback, missing template reporting, missing target reporting, resume template selection, versioned-folder work-mode lookup, clipboard fallback behavior.
+- Evidence: `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`, `tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py`, `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`.
+- Coverage artifacts: Python delta file reports 97% coverage for both root and bundled resolver copies and 100% for the wrapper.
+- Remaining gap: wrapper process exit propagation is not asserted end-to-end.
+
+### `extensions/drm-copilot/src/extension.ts`
+
+- Covered scenarios: command registration, active editor reuse, picker fallback, argv wiring, cancel flow, missing Python runtime.
+- Evidence: `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`.
+- Coverage artifact: TypeScript delta file reports 91.34% coverage for `src/extension.ts`.
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total repo pytest tests | 898 | [✅] |
+| Extension Jest tests | 80 | [✅] |
+| Python tests added/updated for this feature | 38 | [✅] |
+| TypeScript tests added/updated for this feature | 6 | [✅] |
+| Repo pytest execution time | 1.73s | [✅] Fast |
+| Extension Jest execution time | 0.523s | [✅] Fast |
+| Largest changed production file | `extensions/drm-copilot/src/extension.ts` = 439 lines | [✅] |
+| Largest changed test file | `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` = 536 lines | [❌] |
+
+## 7. Code Quality Checks
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Python Black | `poetry run black --check .` | 169 files would be left unchanged | [✅] |
+| Python Ruff | `poetry run ruff check` | All checks passed | [✅] |
+| Python Pyright | `poetry run pyright` | 0 errors, 0 warnings, 0 informations | [✅] |
+| Python Pytest | `poetry run pytest` | 898 passed in 1.73s | [✅] |
+| Extension Prettier | `npm --prefix extensions/drm-copilot run format -- --check` | All matched files use Prettier code style | [✅] |
+| Extension ESLint | `npm --prefix extensions/drm-copilot run lint` | Passed cleanly | [✅] |
+| Extension TSC | `npm --prefix extensions/drm-copilot run typecheck` | Passed cleanly | [✅] |
+| Extension Jest | `npm --prefix extensions/drm-copilot run test:unit` | 6 suites, 80 tests passed | [✅] |
+| JSON validation | `python -m scripts.dev_tools.validate_json` | Exit code 0 | [✅] |
+| Wrapper failure probe | `python extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py --target <missing> --workspace <feature-folder>` | Printed target-not-found error but exited with `WRAPPER_EXIT=0` | [❌] |
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+1. **Bundled wrapper failure propagation** — `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` ignores the bundled resolver's integer return value and always exits `0`, violating the clear-failure contract.
+2. **Oversized test module** — `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` is 536 lines, exceeding the repo's 500-line cap for test files.
+3. **Missing regression for process exit status** — current tests validate stderr content but not wrapper subprocess exit propagation, which allowed the blocker defect through.
+
+### Approved Exceptions
+
+**None.** No policy exceptions were documented or approved.
+
+### Removed/Skipped Tests
+
+**None recorded.** The gap is missing coverage of wrapper exit propagation, not an explicitly skipped documented test.
+
+## 9. Summary of Changes
+
+### Commits in This Branch
+
+No committed delta exists relative to `development` in the refreshed PR context. The reviewed feature exists as working-tree modifications and untracked files captured in `artifacts/pr_context.appendix.txt`.
+
+### Files Modified / Added
+
+- `extensions/drm-copilot/src/extension.ts` — new command wiring and active-plan selection helpers.
+- `extensions/drm-copilot/package.json` — command contribution for `drmCopilotExtension.resolveExecuteHardLockPrompt`.
+- `extensions/drm-copilot/README.md` — user-facing command documentation.
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` — bundled wrapper entrypoint.
+- `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` — bundled resolver mirror.
+- `extensions/drm-copilot/resources/customizations/.github/codex/*.prompt.md` — bundled prompt templates.
+- `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` — extension command tests.
+- `scripts/dev_tools/resolve_hard_lock_prompt.py` — root resolver `--template-root` seam.
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py` and `...part2.py` — root resolver tests.
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` — bundled wrapper/resolver tests.
+- Feature docs and evidence files under `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/`.
+
+## 10. Compliance Verdict
+
+### Overall Status: ⚠️ PARTIALLY COMPLIANT
+
+The branch is close, but not compliant enough for PR readiness. Toolchain and coverage gates pass, yet the bundled wrapper masks failure exit codes and one new test file violates the 500-line repository limit.
+
+### Policy-by-Policy Summary
+
+- General Code Change Policy: ⚠️ Partial — design/docs/tooling are solid, but file-size and failure-propagation issues remain.
+- Python Code Change Policy: ⚠️ Partial — typed CLI logic is mostly strong, but wrapper exit propagation breaks the `main() -> int` contract.
+- TypeScript Code Change Policy: ⚠️ Partial — command-runtime is fine, but end-to-end error behavior still fails through the wrapper boundary.
+- General Unit Test Policy: ⚠️ Partial — tests are deterministic and broad, but one critical failure scenario and one maintainability limit remain unmet.
+- Python Unit Test Policy: ⚠️ Partial — coverage is strong, yet test organization must be split below 500 lines.
+- TypeScript Unit Test Policy: ⚠️ Partial — Jest tests are clean, but the process-level failure path is not covered.
+
+### Recommendation
+
+**Needs revision**
+
+Fix the bundled wrapper so it returns the bundled resolver's exit code, add a regression test that proves non-zero subprocess exit propagation, and split the oversized Python test module below 500 lines. After that, rerun the same Python + extension + JSON checks and re-audit the acceptance criteria.
+
+## Appendix A: Test Inventory
+
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py::*`
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py::*`
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py::*`
+- `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts::*`
+
+## Appendix B: Toolchain Commands Reference
+
+**Python / root repo (check-only):**
+- `poetry run black --check .`
+- `poetry run ruff check`
+- `poetry run pyright`
+- `poetry run pytest`
+
+**Extension / TypeScript (check-only):**
+- `npm --prefix extensions/drm-copilot run format -- --check`
+- `npm --prefix extensions/drm-copilot run lint`
+- `npm --prefix extensions/drm-copilot run typecheck`
+- `npm --prefix extensions/drm-copilot run test:unit`
+
+**JSON:**
+- `python -m scripts.dev_tools.validate_json`
+
+**Targeted feature probe:**
+- `python extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py --target <missing-target> --workspace <feature-folder>`
+
+**Audit Completed By:** GitHub Copilot (GPT-5.4)  
+**Audit Date:** 2026-03-15  
+**Policy Version:** Current as of audit date

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/remediation-inputs.2026-03-15T00-14.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/remediation-inputs.2026-03-15T00-14.md
@@ -1,0 +1,60 @@
+# Remediation Inputs — bundle-hard-lock-resolver-into-extension (#103)
+
+**Generated from review artifacts:**
+- `policy-audit.2026-03-15T00-14.md`
+- `code-review.2026-03-15T00-14.md`
+- `feature-audit.2026-03-15T00-14.md`
+
+## Required fixes
+
+1. **Propagate bundled resolver exit status through the wrapper**
+   - **Files:**
+     - `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`
+   - **Location:** around the delegated `module.main` call (`:58-60` in the reviewed file)
+   - **Expected behavior:** when the delegated bundled resolver returns a non-zero exit code for missing target/template errors, the wrapper process must also exit non-zero so `executeBundledScript()` reports command failure instead of success.
+   - **Acceptance criteria:** user-story criterion 6 (`Missing target files, missing Python runtime, or missing bundled template assets fail with clear errors and do not produce partial or misleading success output.`)
+   - **Verification commands:**
+     - `python extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py --target <missing-target> --workspace <feature-folder>`
+     - `poetry run pytest`
+     - `npm --prefix extensions/drm-copilot run test:unit`
+
+2. **Add a regression test for wrapper failure propagation**
+   - **Files:**
+     - `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` (or split successor files)
+     - optionally `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` if an extension-level assertion is added
+   - **Location:** new focused test case near existing wrapper error-path coverage
+   - **Expected behavior:** at least one automated test must prove that a failing delegated resolver causes the wrapper to exit non-zero (or, equivalently, that the extension sees the command as failed).
+   - **Acceptance criteria:** user-story criterion 6
+   - **Verification commands:**
+     - `poetry run pytest`
+     - `npm --prefix extensions/drm-copilot run test:unit`
+
+3. **Split the oversized Python wrapper test module below the repo limit**
+   - **Files:**
+     - `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`
+     - new successor test files as needed (for example `...part2.py`)
+   - **Location:** whole file (current review measured 536 lines)
+   - **Expected behavior:** every production, test, and reusable-script file in scope must be under 500 lines, while preserving current coverage and readability.
+   - **Acceptance criteria:** repo general code change policy file-size rule
+   - **Verification commands:**
+     - `poetry run pytest`
+     - line-count check for the split files
+
+## Do not do
+
+- Do **not** weaken policy requirements or mark the failed acceptance criterion as complete without fresh verification.
+- Do **not** move prompt-resolution business logic into TypeScript or expand the wrapper beyond bootstrapping/delegation.
+- Do **not** introduce scope creep such as a new resume command or packaging-system redesign.
+- Do **not** suppress failing behavior silently; preserve clear stderr output and make the process exit status truthful.
+
+## Unmet acceptance criteria and minimum changes
+
+### Still unmet
+
+- `Missing target files, missing Python runtime, or missing bundled template assets fail with clear errors and do not produce partial or misleading success output.`
+
+### Minimum changes required to meet it
+
+1. Return the delegated resolver's exit code from the wrapper instead of always returning `0`.
+2. Add a regression test that fails if the wrapper ever masks non-zero delegated exit codes again.
+3. Re-run the Python loop, extension loop, JSON validation, and targeted missing-target wrapper probe; only then re-check the user-story criterion.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/remediation-plan.2026-03-15T00-14.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/audit-2026-03-15T00-14/remediation-plan.2026-03-15T00-14.md
@@ -1,0 +1,42 @@
+# Remediation Plan: 2026-03-14-bundle-hard-lock-resolver-into-extension-103 (2026-03-15T00-14)
+
+- **Issue:** #103
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-03-15T00-14
+- **Status:** Draft
+- **Version:** 0.1
+
+## Required References
+
+- General Coding Standards: [`.github/instructions/general-code-change.instructions.md`](../../../../.github/instructions/general-code-change.instructions.md)
+- General Unit Test Policy: [`.github/instructions/general-unit-test.instructions.md`](../../../../.github/instructions/general-unit-test.instructions.md)
+- Python Code Change Policy: [`.github/instructions/python-code-change.instructions.md`](../../../../.github/instructions/python-code-change.instructions.md)
+- Python Unit Test Policy: [`.github/instructions/python-unit-test.instructions.md`](../../../../.github/instructions/python-unit-test.instructions.md)
+- TypeScript Code Change Policy: [`.github/instructions/typescript-code-change.instructions.md`](../../../../.github/instructions/typescript-code-change.instructions.md)
+- TypeScript Unit Test Policy: [`.github/instructions/typescript-unit-test.instructions.md`](../../../../.github/instructions/typescript-unit-test.instructions.md)
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Implementation Plan (Atomic Tasks)
+
+> Placeholder plan created from the repo template for remediation follow-up.
+> Intended source of truth for task generation: `remediation-inputs.2026-03-15T00-14.md`.
+> In this review session, no dedicated `atomic_planner` tool/interface was available to auto-populate the atomic task list, so the task breakdown remains intentionally pending.
+
+### Phase 0: Compliance & Context
+- [ ] [P0-T1] Confirm alignment with repo policies by reading the required general, Python, and TypeScript instruction files before modifying remediation code.
+
+### Phase 1: Pending atomic_planner population
+- [ ] [P1-T1] Populate this remediation plan from `remediation-inputs.2026-03-15T00-14.md` using the repo's atomic planning workflow.
+
+## Test Plan
+
+- Unit: Re-run `poetry run pytest` and `npm --prefix extensions/drm-copilot run test:unit`.
+- Integration/CLI: Re-run the bundled wrapper against a missing target and confirm a non-zero exit status.
+- Validation: Re-run `poetry run black --check .`, `poetry run ruff check`, `poetry run pyright`, `npm --prefix extensions/drm-copilot run format -- --check`, `npm --prefix extensions/drm-copilot run lint`, `npm --prefix extensions/drm-copilot run typecheck`, and `python -m scripts.dev_tools.validate_json`.
+
+## Open Questions / Notes
+
+- The blocker is narrow and should be fixable without changing the overall architecture.
+- Split the oversized Python test module as part of remediation to restore policy compliance.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/code-review.2026-03-15T00-26.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/code-review.2026-03-15T00-26.md
@@ -1,0 +1,52 @@
+# Code Review — bundle-hard-lock-resolver-into-extension (#103)
+
+## Executive summary
+
+This refreshed review covers the current feature workspace state relative to base branch `development`. The refreshed PR context resolves an empty commit range because `HEAD` and `origin/development` point to the same commit; accordingly, the working-tree diff in `artifacts/pr_context.appendix.txt` plus live workspace inspection were used as the effective review scope. Within that scope, the feature is now in good shape: the wrapper propagates delegated exit codes correctly, the split Python tests are back under the repo's 500-line limit, the command wiring stays thin, and the full verification loops pass.
+
+**Go/No-Go recommendation:** **Go** — ready for PR / merge.
+
+### Top 3 residual risks
+
+1. **Operational dependency:** the command still depends on `python` being available on `PATH`; this is intentional and documented.
+2. **Sync discipline:** the root resolver and bundled resources must continue to stay synchronized in future changes.
+3. **Review-scope nuance:** because the branch/base commit range is empty, future reviewers should continue using the working-tree appendix when this branch is reviewed before commit.
+
+## Findings
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| None | — | — | No actionable code-quality findings remain after remediation. | Keep the current thin-wrapper / thin-TypeScript architecture and preserve the existing regression coverage. | The prior blocker (masked non-zero exit) is fixed, the file-size violation is gone, and all verification checks are green. | Wrapper now returns `int(module_main())`; direct missing-target probe exited `WRAPPER_EXIT=1`; wrapper test files are `374` and `344` lines; Python, Jest, and extension-local loops all passed. |
+
+## Typed Python audit
+
+- **No new `Any` without justification:** Pass. No new broad `Any` usage or type weakening was introduced.
+- **No type-check weakening:** Pass. `pyright` is clean and no config loosening or broad ignores were added.
+- **Prefer precise types:** Pass. The wrapper now uses `Callable[[], int]`, which matches the delegated CLI contract.
+- **Protocols / `TypedDict` / dataclasses where appropriate:** N/A for this slice; the feature is CLI/extension orchestration, not a new domain model.
+- **Typed error handling:** Pass. Missing target/template/runtime flows surface clear failure behavior and preserve exit semantics.
+- **Logging:** Pass. Python stdout/stderr remain part of the CLI contract; extension logging remains in the output-channel/runtime layer.
+- **Public API clarity:** Pass. The additive `--template-root` seam is documented and backward-compatible.
+
+## Test quality audit
+
+- **Deterministic / isolated / fast:** Pass. Fresh runs were `899` pytest tests in `1.79s`, `81` repo Jest tests in `1.702s`, and `80` extension-local Jest tests in `0.458s`.
+- **Good failure messages:** Pass. Tests assert precise user-facing messages like `Target file not found`, `Checked locations`, and the missing-python-runtime error.
+- **Coverage expectations:** Pass. Fresh coverage is `83%` total for Python with `92%` changed-code coverage, and `89.84%` total for Jest with `91.34%` changed-code coverage.
+- **Regression protection:** Pass. The wrapper exit-propagation scenario that previously failed review now has direct Python coverage plus a subprocess probe confirming `WRAPPER_EXIT=1`.
+
+## Security and correctness
+
+- **Secrets:** No secrets or credential material were found in the reviewed scope.
+- **Unsafe subprocess usage:** No new unsafe subprocess usage was introduced. Clipboard execution remains guarded by `shutil.which()` in the resolver.
+- **Input validation at boundaries:** Pass. The extension validates runtime presence and plan selection; the resolver validates target/template availability and reports clear errors.
+- **Correctness at extension boundary:** Pass. The wrapper now preserves delegated non-zero exit codes, which restores truthful failure reporting through the extension runtime.
+
+## Notes
+
+- The feature folder used for this review was the user-specified `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/`, selected because it matches issue suffix `-103` and contains the primary scoping docs.
+- The refreshed PR context should be read with the base/head equality caveat in mind; the appendix and live workspace are the effective sources of review evidence for this run.
+
+## Recommendation
+
+**Ready for PR / merge into `development`.** The implementation is aligned with the repo's thin-adapter architecture, typed Python expectations, and acceptance criteria, and the refreshed verification evidence does not reveal any remaining blockers or major issues.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-format.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-format.2026-03-14T23-31.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T23-31
+Command: npm --prefix extensions/drm-copilot run format
+EXIT_CODE: 0
+Output Summary:
+- Prettier completed successfully.
+- All listed extension source, test, and config files were unchanged.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-jest.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-jest.2026-03-14T23-31.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-14T23-31
+Command: npm --prefix extensions/drm-copilot run test:unit -- --coverage
+EXIT_CODE: 0
+Output Summary:
+- Jest completed successfully: 5 suites passed, 74 tests passed.
+- Total coverage: 89.3%.
+- `src/extension.ts` coverage: 90.48%.
+- Run duration: 1.37 s.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-lint.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-lint.2026-03-14T23-31.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T23-31
+Command: npm --prefix extensions/drm-copilot run lint
+EXIT_CODE: 0
+Output Summary:
+- ESLint completed successfully.
+- No lint errors were reported for `src` or `test`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-typecheck.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/extension-typecheck.2026-03-14T23-31.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T23-31
+Command: npm --prefix extensions/drm-copilot run typecheck
+EXIT_CODE: 0
+Output Summary:
+- TypeScript type-check completed successfully.
+- `tsc -p ./ --noEmit` reported no errors.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,39 @@
+Timestamp: 2026-03-14T23-31
+Policy Order:
+1. `.github/copilot-instructions.md`
+2. `.github/instructions/general-code-change.instructions.md`
+3. `.github/instructions/general-unit-test.instructions.md`
+4. `.github/instructions/python-code-change.instructions.md`
+5. `.github/instructions/python-unit-test.instructions.md`
+6. `.github/instructions/python-suppressions.instructions.md`
+7. `.github/instructions/self-explanatory-code-commenting.instructions.md`
+8. `.github/instructions/typescript-code-change.instructions.md`
+9. `.github/instructions/typescript-suppressions.instructions.md`
+10. `.github/instructions/typescript-unit-test.instructions.md`
+Files Read:
+- `.github/copilot-instructions.md` (empty file)
+- `.github/instructions/general-code-change.instructions.md`
+- `.github/instructions/general-unit-test.instructions.md`
+- `.github/instructions/python-code-change.instructions.md`
+- `.github/instructions/python-unit-test.instructions.md`
+- `.github/instructions/python-suppressions.instructions.md`
+- `.github/instructions/self-explanatory-code-commenting.instructions.md`
+- `.github/instructions/typescript-code-change.instructions.md`
+- `.github/instructions/typescript-suppressions.instructions.md`
+- `.github/instructions/typescript-unit-test.instructions.md`
+- `.github/skills/policy-compliance-order/SKILL.md`
+- `.github/skills/atomic-plan-contract/SKILL.md`
+- `.github/skills/evidence-and-timestamp-conventions/SKILL.md`
+- `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/issue.md`
+- `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/spec.md`
+- `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/user-story.md`
+Work Mode: full-feature
+Requirements Sources: issue.md, spec.md, user-story.md
+Target Plan Path: c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-03-14-bundle-hard-lock-resolver-into-extension-103\plan.2026-03-14T22-49.md
+Authoritative Inputs:
+- Plan file: `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/plan.2026-03-14T22-49.md`
+- Requirements: `issue.md`, `spec.md`, `user-story.md`
+- Skills: `policy-compliance-order`, `atomic-plan-contract`, `acceptance-criteria-tracking`, `evidence-and-timestamp-conventions`
+Notes:
+- Work mode resolved from `issue.md` marker `- Work Mode: full-feature`.
+- Execution will update this exact plan file in place.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-black.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-black.2026-03-14T23-31.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T23-31
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary:
+- Black completed successfully.
+- 165 files left unchanged.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-pyright.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-pyright.2026-03-14T23-31.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T23-31
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary:
+- Pyright completed successfully.
+- 0 errors, 0 warnings, 0 informations.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-pytest.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-pytest.2026-03-14T23-31.md
@@ -1,0 +1,9 @@
+Timestamp: 2026-03-14T23-31
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary:
+- Pytest completed successfully: 879 passed in 3.35s.
+- Total coverage: 83%.
+- `scripts/dev_tools/resolve_hard_lock_prompt.py` coverage: 97%.
+- Coverage LCOV written to `artifacts/python/lcov.info`.
+- Coverage warning noted: `src/lexile_corpus_tuner` was never imported.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-ruff.2026-03-14T23-31.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/baseline/python-ruff.2026-03-14T23-31.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-14T23-31
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary:
+- Ruff completed successfully.
+- All checks passed.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/other/resolve-hard-lock-extension-green.2026-03-15T00-02.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/other/resolve-hard-lock-extension-green.2026-03-15T00-02.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-15T00-02
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts
+EXIT_CODE: 0
+Output Summary:
+- Jest completed successfully for `test/extension.resolve-hard-lock-prompt.test.ts`.
+- 1 suite passed; 6 tests passed; 0 snapshots.
+- Run duration: 0.275 s.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/other/resolve-hard-lock-python-green.2026-03-15T00-02.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/other/resolve-hard-lock-python-green.2026-03-15T00-02.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-03-15T00-02
+Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py --cov=scripts/dev_tools --cov=extensions/drm-copilot/resources/scripts/dev_tools --cov=extensions/drm-copilot/resources/templates --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary:
+- Pytest completed successfully: 33 passed in 1.42s.
+- Resolver test files: `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`, `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`.
+- `scripts/dev_tools/resolve_hard_lock_prompt.py` coverage: 92%.
+- `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` coverage: 97%.
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` coverage: 100%.
+- Coverage LCOV written to `artifacts/python/lcov.info`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-coverage-delta.2026-03-15T00-12-56.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-coverage-delta.2026-03-15T00-12-56.md
@@ -1,0 +1,13 @@
+Timestamp: 2026-03-15T00:12:56
+Baseline Artifact: evidence/baseline/extension-jest.2026-03-14T23-31.md
+Final Artifact: evidence/qa-gates/extension-jest.2026-03-15T00-12-25.md
+Baseline Total Coverage: 89.3%
+Baseline src/extension.ts Coverage: 90.48%
+Final Total Coverage: 89.83%
+Final src/extension.ts Coverage: 91.34%
+New/Changed TypeScript Code Coverage: 91.34%
+Repository Coverage Threshold (>=80%): PASS
+New/Changed Code Threshold (>=90%): PASS
+No Regression vs Baseline: PASS
+Threshold Check: PASS
+No planned command task skipped: true

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-format.2026-03-15T00-11-36.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-format.2026-03-15T00-11-36.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-15T00:11:36
+Command: npm --prefix extensions/drm-copilot run format
+EXIT_CODE: 0
+Output Summary:
+- Prettier completed successfully.
+- All targeted extension files were already formatted.
+- No files changed during this step.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-jest.2026-03-15T00-12-25.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-jest.2026-03-15T00-12-25.md
@@ -1,0 +1,8 @@
+Timestamp: 2026-03-15T00:12:25
+Command: npm --prefix extensions/drm-copilot run test:unit -- --coverage
+EXIT_CODE: 0
+Output Summary:
+- Jest completed successfully: 6 suites passed, 80 tests passed.
+- Total coverage: 89.83%.
+- `src/extension.ts` coverage: 91.34%.
+- Run duration: 1.735 s.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-lint.2026-03-15T00-11-51.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-lint.2026-03-15T00-11-51.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-15T00:11:51
+Command: npm --prefix extensions/drm-copilot run lint
+EXIT_CODE: 0
+Output Summary:
+- ESLint completed successfully.
+- No lint errors or warnings were reported for `src` and `test`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-typecheck.2026-03-15T00-12-06.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/extension-typecheck.2026-03-15T00-12-06.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-15T00:12:06
+Command: npm --prefix extensions/drm-copilot run typecheck
+EXIT_CODE: 0
+Output Summary:
+- TypeScript compiler completed successfully.
+- No type errors were reported.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-black.2026-03-15T00-03.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-black.2026-03-15T00-03.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-15T00-03
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary:
+- Black completed successfully on the clean final pass.
+- 169 files left unchanged.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-black.2026-03-15T00-08-39.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-black.2026-03-15T00-08-39.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-15T00:08:39
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary:
+- Black completed successfully.
+- 169 files left unchanged.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-black.2026-03-15T00-10-08.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-black.2026-03-15T00-10-08.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-15T00:10:08
+Command: poetry run black .
+EXIT_CODE: 0
+Output Summary:
+- Black completed successfully.
+- 169 files left unchanged.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-coverage-delta.2026-03-15T00-08-39.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-coverage-delta.2026-03-15T00-08-39.md
@@ -1,0 +1,16 @@
+Timestamp: 2026-03-15T00:08:39
+Baseline Artifact: evidence/baseline/python-pytest.2026-03-14T23-31.md
+Final Artifact: evidence/qa-gates/python-pytest.2026-03-15T00-08-39.md
+Targeted Changed-Code Artifact: evidence/other/resolve-hard-lock-python-green.2026-03-15T00-02.md
+Baseline Total Coverage: 83%
+Baseline scripts/dev_tools/resolve_hard_lock_prompt.py Coverage: 97%
+Final Total Coverage: 83%
+Final scripts/dev_tools/resolve_hard_lock_prompt.py Coverage: 97%
+Final extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py Coverage: 97%
+Final extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py Coverage: 100%
+New/Changed Python Code Coverage: 92%
+Repository Coverage Threshold (>=80%): PASS
+New/Changed Code Threshold (>=90%): PASS
+No Regression vs Baseline: PASS
+Threshold Check: PASS
+No planned command task skipped: true

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-pyright.2026-03-15T00-08-39.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-pyright.2026-03-15T00-08-39.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-15T00:08:39
+Command: poetry run pyright
+EXIT_CODE: 0
+Output Summary:
+- Pyright completed successfully.
+- 0 errors, 0 warnings, 0 informations.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-pytest.2026-03-15T00-08-39.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-pytest.2026-03-15T00-08-39.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-03-15T00:08:39
+Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary:
+- Pytest completed successfully.
+- 898 passed in 3.58s.
+- Total coverage: 83%.
+- scripts/dev_tools/resolve_hard_lock_prompt.py coverage: 97%.
+- Coverage LCOV written to `artifacts/python/lcov.info`.
+- Coverage emitted the existing warning that `src/lexile_corpus_tuner` was never imported during the run.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-ruff.2026-03-15T00-08-39.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/python-ruff.2026-03-15T00-08-39.md
@@ -1,0 +1,6 @@
+Timestamp: 2026-03-15T00:08:39
+Command: poetry run ruff check
+EXIT_CODE: 0
+Output Summary:
+- Ruff completed successfully.
+- All checks passed.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/resolve-hard-lock-bundle-summary.2026-03-15T00-02.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/qa-gates/resolve-hard-lock-bundle-summary.2026-03-15T00-02.md
@@ -1,0 +1,23 @@
+Timestamp: 2026-03-15T00-02
+
+Root Source Files:
+- `scripts/dev_tools/resolve_hard_lock_prompt.py`
+- `.github/codex/execute-hard-lock.prompt.md`
+- `.github/codex/resume-hard-lock.prompt.md`
+
+Bundled Resource Files:
+- `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py`
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`
+- `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md`
+- `extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md`
+
+Command ID:
+- `drmCopilotExtension.resolveExecuteHardLockPrompt`
+
+Wrapper Path:
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`
+
+Notes:
+- The bundled resolver mirror rewrites imports from `scripts.dev_tools` to `dev_tools` to run inside the extension resource package.
+- The wrapper injects `--template-root` only when the caller did not already provide it.
+- The bundled prompt files were verified to match the root prompt text line-for-line.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-active-plan-red.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-active-plan-red.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "reuses the active feature plan editor before opening the picker"
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- Jest test `reuses the active feature plan editor before opening the picker` failed.
+- Failure reason: missing command handler `drmCopilotExtension.resolveExecuteHardLockPrompt`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-argv-red.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-argv-red.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "passes the wrapper path plus --target and --workspace argument pairs"
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- Jest test `passes the wrapper path plus --target and --workspace argument pairs` failed.
+- Failure reason: missing command handler `drmCopilotExtension.resolveExecuteHardLockPrompt`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-command-register-red.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-command-register-red.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "registers resolveExecuteHardLockPrompt"
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- Jest test `registers resolveExecuteHardLockPrompt` failed.
+- Failure reason: missing command handler `drmCopilotExtension.resolveExecuteHardLockPrompt`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-picker-cancel-red.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-picker-cancel-red.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "returns early when the feature plan picker is cancelled"
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- Jest test `returns early when the feature plan picker is cancelled` failed.
+- Failure reason: missing command handler `drmCopilotExtension.resolveExecuteHardLockPrompt`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-plan-picker-red.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-plan-picker-red.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "opens a docs/features/active picker when the active editor is not eligible"
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- Jest test `opens a docs/features/active picker when the active editor is not eligible` failed.
+- Failure reason: missing command handler `drmCopilotExtension.resolveExecuteHardLockPrompt`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-python-runtime-red.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/extension-python-runtime-red.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "surfaces a missing python runtime error for resolveExecuteHardLockPrompt"
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- Jest test `surfaces a missing python runtime error for resolveExecuteHardLockPrompt` failed.
+- Failure reason: missing command handler `drmCopilotExtension.resolveExecuteHardLockPrompt`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-template-root-fallback.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-template-root-fallback.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_falls_back_to_workspace_codex_when_template_root_template_is_missing
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- `test_main_falls_back_to_workspace_codex_when_template_root_template_is_missing` failed.
+- Failure reason: `main()` exited through argparse because `--template-root` is an unrecognized argument.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-template-root-missing.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-template-root-missing.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_reports_checked_template_paths_when_template_lookup_fails
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- `test_main_reports_checked_template_paths_when_template_lookup_fails` failed.
+- Failure reason: `main()` exited through argparse because `--template-root` is an unrecognized argument.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-template-root-preferred.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-template-root-preferred.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_prefers_template_root_before_workspace_codex
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- `test_main_prefers_template_root_before_workspace_codex` failed.
+- Failure reason: `main()` exited through argparse because `--template-root` is an unrecognized argument.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-wrapper-template-root-injection.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-wrapper-template-root-injection.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: poetry run pytest tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py -k test_main_injects_bundled_template_root_when_flag_is_absent
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- `test_main_injects_bundled_template_root_when_flag_is_absent` failed.
+- Failure reason: bundled wrapper file `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` does not exist yet.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-wrapper-template-root-preserve.2026-03-14T23-38.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/regression-testing/python-wrapper-template-root-preserve.2026-03-14T23-38.md
@@ -1,0 +1,7 @@
+Timestamp: 2026-03-14T23-38
+Command: poetry run pytest tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py -k test_main_preserves_explicit_template_root_when_wrapper_flag_is_present
+EXIT_CODE: 1
+Output Summary:
+- Expected red test reproduced.
+- `test_main_preserves_explicit_template_root_when_wrapper_flag_is_present` failed.
+- Failure reason: bundled wrapper file `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` does not exist yet.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/feature-audit.2026-03-15T00-26.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/feature-audit.2026-03-15T00-26.md
@@ -1,0 +1,57 @@
+# Feature Audit — bundle-hard-lock-resolver-into-extension (#103)
+
+## Scope and baseline
+
+- **Base branch:** `development`
+- **Feature folder:** `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/`
+- **Feature folder selection rule:** Used the active folder specified by the user; it matches issue suffix `-103` and contains the primary scoping docs.
+- **Evidence sources:**
+  - Primary: refreshed `artifacts/pr_context.summary.txt`
+  - Secondary: refreshed `artifacts/pr_context.appendix.txt`
+  - Supplemental: live workspace inspection plus fresh verification commands from this review
+- **Baseline note:** the refreshed PR context shows `HEAD == origin/development` at `811bd5cf221fc8d97de2be71d41ece26698db8c9`, so the commit range is empty. For this audit, the appendix working-tree diff and current on-disk files are the effective baseline evidence.
+- **Work mode marker:** `issue.md` contains `- Work Mode: full-feature`, so the authoritative acceptance-criteria sources are `spec.md` and `user-story.md`.
+
+## Acceptance criteria inventory (authoritative)
+
+Authoritative checkbox acceptance criteria come from `user-story.md`; `spec.md` provides supporting behavior detail and definition-of-done evidence.
+
+1. `extensions/drm-copilot/package.json` contributes `drmCopilotExtension.resolveExecuteHardLockPrompt`, and `extensions/drm-copilot/src/extension.ts` registers a matching handler that reuses an active feature-plan editor when possible or otherwise prompts from `docs/features/active/`, then passes `--target <selected-plan>` and `--workspace <workspace-root>` to the bundled wrapper.
+2. `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` remains a thin wrapper that only bootstraps `resources/scripts` onto `sys.path`, injects `--template-root` pointing at bundled codex assets when absent, imports `dev_tools.resolve_hard_lock_prompt`, and delegates to its `main()` function without duplicating prompt-resolution logic.
+3. The extension package includes synchronized bundled copies of `scripts/dev_tools/resolve_hard_lock_prompt.py`, `.github/codex/execute-hard-lock.prompt.md`, and `.github/codex/resume-hard-lock.prompt.md` under the existing extension resource layout so prompt resolution works in workspaces that do not contain repo-local `.github/codex` assets.
+4. `scripts/dev_tools/resolve_hard_lock_prompt.py` adds an optional `--template-root` seam that checks the supplied template root first, then falls back to `<workspace>/.github/codex`, while preserving existing `--template-kind`, plan-path normalization, work-mode lookup, fallback-reason substitution, stdout output, and best-effort clipboard behavior.
+5. The extension command produces the same resolved execute prompt content as the root Python resolver for the same target plan, including forward-slash `${plan-path}` output and deterministic work-mode behavior for versioned plan folders such as `v2`.
+6. Missing target files, missing Python runtime, or missing bundled template assets fail with clear errors and do not produce partial or misleading success output.
+
+## Acceptance criteria evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| 1 | PASS | `extensions/drm-copilot/package.json` contributes the command; `extensions/drm-copilot/src/extension.ts` registers it and passes `--target` / `--workspace`; extension Jest covers registration, active-editor reuse, picker fallback, and argv wiring. | `npm --prefix extensions/drm-copilot run test:unit` | Command contribution and wiring are present and verified. |
+| 2 | PASS | The wrapper remains thin and adapter-only: it prepends bundled scripts, injects `--template-root` when absent, imports `dev_tools.resolve_hard_lock_prompt`, and delegates directly to `main()`. | `poetry run pytest` | The wrapper now also preserves delegated exit status without adding business logic. |
+| 3 | PASS | Bundled resolver and both prompt templates exist under extension resources; the README documents the command; Python tests cover bundled-template preference and fallback behavior. | `poetry run pytest` | Works for workspaces without repo-local `.github/codex` assets. |
+| 4 | PASS | Root resolver adds `--template-root`, deterministic lookup order, checked-location error reporting, forward-slash plan-path substitution, versioned-folder work-mode lookup, and best-effort clipboard behavior. | `poetry run pytest`; `shell: QC: 4 Pytest: run tests with coverage` | Fresh Python coverage remains `97%` for the root resolver. |
+| 5 | PASS | Root and bundled tests cover forward-slash Windows path normalization and parent `issue.md` lookup for versioned folders such as `v2`; extension tests verify command wiring. | `poetry run pytest`; `npm --prefix extensions/drm-copilot run test:unit` | Prompt-content parity behavior is evidenced across the resolver stack. |
+| 6 | PASS | Missing-runtime behavior is covered in `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`; missing-target and missing-template failures are covered in the split Python wrapper tests; direct subprocess probe printed a clear missing-target error and exited with `WRAPPER_EXIT=1`. | `npm --prefix extensions/drm-copilot run test:unit`; `poetry run pytest`; `python extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py --target <missing-target> --workspace <feature-folder>` | This was the previously failed acceptance criterion and is now verified. |
+
+## Summary
+
+- **Overall feature readiness:** PASS
+- **Top gaps preventing PASS:** None.
+- **Recommended follow-up verification:** Normal CI is sufficient; no special remediation verification remains.
+
+## Acceptance criteria check-off
+
+- Updated `user-story.md` to check off the final verified criterion for clear failure behavior.
+- `spec.md` acceptance criteria remain prose and were evaluated here without reformatting.
+
+### Acceptance Criteria Status
+- Source: `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/spec.md`, `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/user-story.md`
+- Total AC items: 6
+- Checked off (delivered): 6
+- Remaining (unchecked): 0
+- Items remaining: none
+
+## Final assessment
+
+This feature passes its acceptance criteria in the current post-remediation workspace state and is ready to open or merge as a PR into `development`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/issue.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/issue.md
@@ -1,0 +1,57 @@
+# bundle-hard-lock-resolver-into-extension (Issue #103)
+title: "bundle-hard-lock-resolver-into-extension - Plan"
+issue: "TBD"
+parent: "none"
+owner: "Dan Moisan"
+last_updated: "2026-03-14T22-47"
+status: "Draft"
+status_color: "lightgrey"
+version: "0.1"
+---
+
+# bundle-hard-lock-resolver-into-extension (Potential)
+
+- Date captured: 2026-03-14
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/bundle-hard-lock-resolver-into-extension/ (Issue #103)
+
+- Issue: #103
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/103
+- Last Updated: 2026-03-15
+- Work Mode: full-feature
+
+## Problem / Why
+
+The hard-lock prompt resolver currently lives only in the repo-root developer tooling, so the VS Code extension cannot offer the same workflow in other workspaces unless users manually copy scripts and prompt templates around. That limits reuse of an already-supported flow and creates pressure to reimplement the behavior inside the extension, which would risk drift from the existing single-source-of-truth Python logic and prompt content.
+
+## Proposed Behavior
+
+Add an extension command that invokes a bundled thin Python wrapper for hard-lock prompt resolution, following the same pattern already used for bundled promotion and scaffolding scripts. The wrapper should delegate in-process to bundled `dev_tools` logic sourced from `scripts/dev_tools/resolve_hard_lock_prompt.py`, use a bundled copy of the execute-hard-lock prompt template sourced from `.github/codex/execute-hard-lock.prompt.md`, and make the existing resolved prompt flow available from the extension in non-repo workspaces without duplicating business logic.
+
+## Acceptance Criteria (early draft)
+
+- [ ] The extension registers a dedicated command for resolving the execute hard-lock prompt and passes the selected target plan path, workspace context, and any required template-selection inputs to a bundled wrapper entry point.
+- [ ] The extension ships a thin wrapper under `extensions/drm-copilot/resources/templates/` that contains only runtime bootstrapping and delegation, with the hard-lock resolver behavior implemented in bundled `resources/scripts/dev_tools/` code rather than duplicated in the wrapper.
+- [ ] The bundled extension resources include the execute hard-lock prompt template content needed by the resolver so the command can run in workspaces that do not contain a repo-local `.github/codex/execute-hard-lock.prompt.md` file.
+- [ ] The bundled resolver preserves the current execute-flow behavior from the root script, including plan-path substitution, work-mode/fallback-resolution behavior, and resolved prompt output suitable for copy/paste into chat.
+- [ ] The root script and root prompt template remain the authoring source of truth, with the extension consuming synchronized bundled copies instead of introducing an extension-only implementation path.
+
+## Constraints & Risks
+
+- The extension bundle must stay synchronized with both `scripts/dev_tools/resolve_hard_lock_prompt.py` and `.github/codex/execute-hard-lock.prompt.md`; otherwise the extension command could silently diverge from the repo workflow.
+- The resolver depends on adjacent helper logic such as prompt-mode handling, so packaging must include all required bundled Python modules and template assets, not just the top-level entry point.
+- Extension-side execution still depends on an available Python runtime, and clipboard behavior may vary by platform or host environment even if prompt generation succeeds.
+- Path normalization and workspace-relative substitution must behave correctly for non-repo workspaces and Windows-style paths, since this feature is explicitly meant to work outside the source repository.
+
+## Test Conditions to Consider
+
+- [ ] Unit-test command registration and argument wiring in `extensions/drm-copilot/src/extension.ts`, including the bundled wrapper path and target/workspace arguments passed to the Python runtime.
+- [ ] Unit-test the bundled wrapper contract to confirm it adjusts `sys.path`, imports the bundled `dev_tools` module, and forwards execution without reimplementing resolver logic.
+- [ ] Verify the bundled resolver can read the packaged execute-hard-lock prompt template and produce resolved output when the active workspace does not contain repo-root `.github/codex` assets.
+- [ ] Cover Windows-oriented path handling, including conversion to workspace-relative forward-slash plan paths in the resolved prompt content.
+- [ ] Cover failure paths such as missing target plan files, missing Python runtime, or missing bundled resources so the command fails clearly instead of producing partial or misleading output.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (feature request template)
+- [ ] Create `docs/features/active/bundle-hard-lock-resolver-into-extension/` folder from the template

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/plan.2026-03-14T22-49.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/plan.2026-03-14T22-49.md
@@ -1,0 +1,152 @@
+# 2026-03-14-bundle-hard-lock-resolver-into-extension - Plan
+
+- **Issue:** #103
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-03-14T22-49
+- **Status:** In Progress
+- **Version:** 0.2
+
+## Implementation Plan (Atomic Tasks)
+
+- Requirements sources: `issue.md`, `spec.md`, and `user-story.md` (resolved from `issue.md` work mode `full-feature`)
+- Feature folder: `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103`
+- Required target plan path: `c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-03-14-bundle-hard-lock-resolver-into-extension-103\plan.2026-03-14T22-49.md`
+- Preflight status: `ALL CLEAR`
+- Execution authorized by user on 2026-03-14
+- Revision rule: update this exact plan file in place for every preflight revision; do not create sibling `plan.*.md` files.
+
+### Phase 0 — Context & Baseline
+
+- [x] [P0-T1] Read `.github/copilot-instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/copilot-instructions.md` in `Files Read:`.
+- [x] [P0-T2] Read `.github/instructions/general-code-change.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/general-code-change.instructions.md` in `Files Read:`.
+- [x] [P0-T3] Read `.github/instructions/general-unit-test.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/general-unit-test.instructions.md` in `Files Read:`.
+- [x] [P0-T4] Read `.github/instructions/python-code-change.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/python-code-change.instructions.md` in `Files Read:`.
+- [x] [P0-T5] Read `.github/instructions/python-unit-test.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/python-unit-test.instructions.md` in `Files Read:`.
+- [x] [P0-T6] Read `.github/instructions/python-suppressions.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/python-suppressions.instructions.md` in `Files Read:`.
+- [x] [P0-T7] Read `.github/instructions/self-explanatory-code-commenting.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/self-explanatory-code-commenting.instructions.md` in `Files Read:`.
+- [x] [P0-T8] Read `.github/instructions/typescript-code-change.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/typescript-code-change.instructions.md` in `Files Read:`.
+- [x] [P0-T9] Read `.github/instructions/typescript-suppressions.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/typescript-suppressions.instructions.md` in `Files Read:`.
+- [x] [P0-T10] Read `.github/instructions/typescript-unit-test.instructions.md` and record completion in the Phase 0 evidence artifact
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and records `.github/instructions/typescript-unit-test.instructions.md` in `Files Read:`.
+- [x] [P0-T11] Record the policy-read order, authoritative inputs, resolved work mode, and exact target plan path in `evidence/baseline/phase0-instructions-read.md`
+  - Preconditions: `issue.md`, `spec.md`, `user-story.md`, `.github/skills/policy-compliance-order/SKILL.md`, `.github/skills/atomic-plan-contract/SKILL.md`, and `.github/skills/evidence-and-timestamp-conventions/SKILL.md` exist.
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists and contains `Timestamp:`, `Policy Order:`, `Files Read:`, `Work Mode: full-feature`, `Requirements Sources: issue.md, spec.md, user-story.md`, and `Target Plan Path: c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-03-14-bundle-hard-lock-resolver-into-extension-103\plan.2026-03-14T22-49.md`.
+- [x] [P0-T12] Run `poetry run black .` and store the baseline result in `evidence/baseline/python-black.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/python-black.*.md` exists and contains `Timestamp:`, `Command: poetry run black .`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T13] Run `poetry run ruff check` and store the baseline result in `evidence/baseline/python-ruff.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/python-ruff.*.md` exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T14] Run `poetry run pyright` and store the baseline result in `evidence/baseline/python-pyright.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/python-pyright.*.md` exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T15] Run `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and store the baseline result in `evidence/baseline/python-pytest.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/python-pytest.*.md` exists and contains `Timestamp:`, `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`, `EXIT_CODE:`, and `Output Summary:` with numeric total coverage and numeric `scripts/dev_tools/resolve_hard_lock_prompt.py` coverage values.
+- [x] [P0-T16] Run `npm --prefix extensions/drm-copilot run format` and store the baseline result in `evidence/baseline/extension-format.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/extension-format.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T17] Run `npm --prefix extensions/drm-copilot run lint` and store the baseline result in `evidence/baseline/extension-lint.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/extension-lint.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T18] Run `npm --prefix extensions/drm-copilot run typecheck` and store the baseline result in `evidence/baseline/extension-typecheck.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/extension-typecheck.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T19] Run `npm --prefix extensions/drm-copilot run test:unit -- --coverage` and store the baseline result in `evidence/baseline/extension-jest.<timestamp>.md`
+  - Acceptance: a file matching `evidence/baseline/extension-jest.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --coverage`, `EXIT_CODE:`, and `Output Summary:` with numeric total coverage and numeric `src/extension.ts` coverage values.
+
+### Phase 1 — Python Regression Coverage
+
+- [x] [P1-T1] [expect-fail] Add pytest case `test_main_prefers_template_root_before_workspace_codex` to `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`
+  - Acceptance: `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py` contains a test named `test_main_prefers_template_root_before_workspace_codex`, and `poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_prefers_template_root_before_workspace_codex` fails while writing `evidence/regression-testing/python-template-root-preferred.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_prefers_template_root_before_workspace_codex`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T2] [expect-fail] Add pytest case `test_main_falls_back_to_workspace_codex_when_template_root_template_is_missing` to `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`
+  - Acceptance: `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py` contains a test named `test_main_falls_back_to_workspace_codex_when_template_root_template_is_missing`, and `poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_falls_back_to_workspace_codex_when_template_root_template_is_missing` fails while writing `evidence/regression-testing/python-template-root-fallback.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_falls_back_to_workspace_codex_when_template_root_template_is_missing`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T3] [expect-fail] Add pytest case `test_main_reports_checked_template_paths_when_template_lookup_fails` to `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`
+  - Acceptance: `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py` contains a test named `test_main_reports_checked_template_paths_when_template_lookup_fails`, and `poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_reports_checked_template_paths_when_template_lookup_fails` fails while writing `evidence/regression-testing/python-template-root-missing.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py -k test_main_reports_checked_template_paths_when_template_lookup_fails`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T4] [expect-fail] Create `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` with pytest case `test_main_injects_bundled_template_root_when_flag_is_absent`
+  - Acceptance: `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` exists, contains a test named `test_main_injects_bundled_template_root_when_flag_is_absent`, and `poetry run pytest tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py -k test_main_injects_bundled_template_root_when_flag_is_absent` fails while writing `evidence/regression-testing/python-wrapper-template-root-injection.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py -k test_main_injects_bundled_template_root_when_flag_is_absent`, and non-zero `EXIT_CODE:`.
+- [x] [P1-T5] [expect-fail] Add pytest case `test_main_preserves_explicit_template_root_when_wrapper_flag_is_present` to `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`
+  - Acceptance: `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py` contains a test named `test_main_preserves_explicit_template_root_when_wrapper_flag_is_present`, and `poetry run pytest tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py -k test_main_preserves_explicit_template_root_when_wrapper_flag_is_present` fails while writing `evidence/regression-testing/python-wrapper-template-root-preserve.<timestamp>.md` with `Timestamp:`, `Command: poetry run pytest tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py -k test_main_preserves_explicit_template_root_when_wrapper_flag_is_present`, and non-zero `EXIT_CODE:`.
+
+### Phase 2 — Resolver Seam & Bundled Resources
+
+- [x] [P2-T1] Add `_resolve_template_path()` to `scripts/dev_tools/resolve_hard_lock_prompt.py` to evaluate bundled-template and workspace-template candidates in deterministic order
+  - Acceptance: `scripts/dev_tools/resolve_hard_lock_prompt.py` defines `_resolve_template_path()` and the helper checks `<template-root>/<template-name>` before `<workspace>/.github/codex/<template-name>`.
+- [x] [P2-T2] Add the optional `--template-root` CLI argument to `scripts/dev_tools/resolve_hard_lock_prompt.py`
+  - Acceptance: `scripts/dev_tools/resolve_hard_lock_prompt.py` adds `parser.add_argument("--template-root", ...)`, and `main()` passes the parsed value into template resolution without changing the existing `--target`, `--workspace`, or `--template-kind` flags.
+- [x] [P2-T3] Update the missing-template failure path in `scripts/dev_tools/resolve_hard_lock_prompt.py` to report each checked location
+  - Acceptance: the error branch in `scripts/dev_tools/resolve_hard_lock_prompt.py` emits a message that includes the requested template name and every checked template path when no candidate exists.
+- [x] [P2-T4] Create `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` as the bundled import-rewritten mirror of the root resolver
+  - Acceptance: `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` exists, preserves the root resolver behavior, and imports `prompt_mode_contract` from `dev_tools` rather than `scripts.dev_tools`.
+- [x] [P2-T5] Create `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` as the thin wrapper entrypoint
+  - Acceptance: `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` exists, defines `_ensure_bundled_scripts_import_path()`, appends `--template-root` only when the flag is absent, and delegates to `dev_tools.resolve_hard_lock_prompt.main()`.
+- [x] [P2-T6] Add bundled `execute-hard-lock.prompt.md` to `extensions/drm-copilot/resources/customizations/.github/codex/`
+  - Acceptance: `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md` exists and matches `.github/codex/execute-hard-lock.prompt.md` exactly.
+- [x] [P2-T7] Add bundled `resume-hard-lock.prompt.md` to `extensions/drm-copilot/resources/customizations/.github/codex/`
+  - Acceptance: `extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md` exists and matches `.github/codex/resume-hard-lock.prompt.md` exactly.
+
+### Phase 3 — Extension Command Regression Coverage & Wiring
+
+- [x] [P3-T1] [expect-fail] Create `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` with Jest case `registers resolveExecuteHardLockPrompt`
+  - Acceptance: `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` exists, contains a test whose title includes `registers resolveExecuteHardLockPrompt`, and `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "registers resolveExecuteHardLockPrompt"` fails while writing `evidence/regression-testing/extension-command-register-red.<timestamp>.md` with `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "registers resolveExecuteHardLockPrompt"`, and non-zero `EXIT_CODE:`.
+- [x] [P3-T2] [expect-fail] Add Jest case `reuses the active feature plan editor before opening the picker` to `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`
+  - Acceptance: `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` contains a test whose title includes `reuses the active feature plan editor before opening the picker`, and `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "reuses the active feature plan editor before opening the picker"` fails while writing `evidence/regression-testing/extension-active-plan-red.<timestamp>.md` with `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "reuses the active feature plan editor before opening the picker"`, and non-zero `EXIT_CODE:`.
+- [x] [P3-T3] [expect-fail] Add Jest case `opens a docs/features/active picker when the active editor is not eligible` to `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`
+  - Acceptance: `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` contains a test whose title includes `opens a docs/features/active picker when the active editor is not eligible`, and `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "opens a docs/features/active picker when the active editor is not eligible"` fails while writing `evidence/regression-testing/extension-plan-picker-red.<timestamp>.md` with `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "opens a docs/features/active picker when the active editor is not eligible"`, and non-zero `EXIT_CODE:`.
+- [x] [P3-T4] [expect-fail] Add Jest case `passes the wrapper path plus --target and --workspace argument pairs` to `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`
+  - Acceptance: `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` contains a test whose title includes `passes the wrapper path plus --target and --workspace argument pairs`, and `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "passes the wrapper path plus --target and --workspace argument pairs"` fails while writing `evidence/regression-testing/extension-argv-red.<timestamp>.md` with `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "passes the wrapper path plus --target and --workspace argument pairs"`, and non-zero `EXIT_CODE:`.
+- [x] [P3-T5] [expect-fail] Add Jest case `returns early when the feature plan picker is cancelled` to `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`
+  - Acceptance: `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` contains a test whose title includes `returns early when the feature plan picker is cancelled`, and `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "returns early when the feature plan picker is cancelled"` fails while writing `evidence/regression-testing/extension-picker-cancel-red.<timestamp>.md` with `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "returns early when the feature plan picker is cancelled"`, and non-zero `EXIT_CODE:`.
+- [x] [P3-T6] [expect-fail] Add Jest case `surfaces a missing python runtime error for resolveExecuteHardLockPrompt` to `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`
+  - Acceptance: `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` contains a test whose title includes `surfaces a missing python runtime error for resolveExecuteHardLockPrompt`, and `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "surfaces a missing python runtime error for resolveExecuteHardLockPrompt"` fails while writing `evidence/regression-testing/extension-python-runtime-red.<timestamp>.md` with `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts -t "surfaces a missing python runtime error for resolveExecuteHardLockPrompt"`, and non-zero `EXIT_CODE:`.
+- [x] [P3-T7] Add the `drmCopilotExtension.resolveExecuteHardLockPrompt` command contribution to `extensions/drm-copilot/package.json`
+  - Acceptance: `extensions/drm-copilot/package.json` contains a `contributes.commands` entry whose `command` is `drmCopilotExtension.resolveExecuteHardLockPrompt` and whose `title` is `drm-copilot: Resolve Execute Hard-Lock Prompt`.
+- [x] [P3-T8] Add an active feature-plan detection helper to `extensions/drm-copilot/src/extension.ts`
+  - Acceptance: `extensions/drm-copilot/src/extension.ts` defines a helper that returns a path only when the active editor is a Markdown file below `docs/features/active/`.
+- [x] [P3-T9] Add a feature-plan picker helper to `extensions/drm-copilot/src/extension.ts`
+  - Acceptance: `extensions/drm-copilot/src/extension.ts` defines a helper that calls `showOpenDialog(...)` with `defaultUri` rooted under `docs/features/active`, filters to Markdown, and returns `undefined` when the user cancels.
+- [x] [P3-T10] Register `drmCopilotExtension.resolveExecuteHardLockPrompt` in `extensions/drm-copilot/src/extension.ts`
+  - Acceptance: `extensions/drm-copilot/src/extension.ts` calls `vscode.commands.registerCommand("drmCopilotExtension.resolveExecuteHardLockPrompt", ...)` and pushes the disposable into `context.subscriptions`.
+- [x] [P3-T11] Wire `executeBundledScript(...)` for the new hard-lock command in `extensions/drm-copilot/src/extension.ts`
+  - Acceptance: the new handler in `extensions/drm-copilot/src/extension.ts` launches `resources/templates/resolve_hard_lock_prompt.py` with `runtimeKind: "python"`, `--target <selected-plan-path>`, and `--workspace <workspace-root>` only.
+
+### Phase 4 — Green Coverage, Docs & Bundle Parity
+
+- [x] [P4-T1] Add pytest case `test_resolve_prompt_uses_forward_slash_path_for_versioned_windows_style_target` to `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`
+  - Acceptance: `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py` contains a test named `test_resolve_prompt_uses_forward_slash_path_for_versioned_windows_style_target` that asserts a `v2` target path resolves to forward-slash `${plan-path}` output.
+- [x] [P4-T2] Update `extensions/drm-copilot/README.md` with the new hard-lock command surface and runtime expectations
+  - Acceptance: `extensions/drm-copilot/README.md` mentions `Resolve Execute Hard-Lock Prompt`, describes that the command uses bundled Python resources, and states that a Python runtime must be available on `PATH`.
+- [x] [P4-T3] Run `poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py --cov=scripts/dev_tools --cov=extensions/drm-copilot/resources/scripts/dev_tools --cov=extensions/drm-copilot/resources/templates --cov-report=term-missing` and store the passing targeted coverage result in `evidence/other/resolve-hard-lock-python-green.<timestamp>.md`
+  - Acceptance: a file matching `evidence/other/resolve-hard-lock-python-green.*.md` exists and contains `Timestamp:`, `Command: poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py --cov=scripts/dev_tools --cov=extensions/drm-copilot/resources/scripts/dev_tools --cov=extensions/drm-copilot/resources/templates --cov-report=term-missing`, `EXIT_CODE: 0`, and `Output Summary:` naming the resolver and wrapper test files plus numeric `scripts/dev_tools/resolve_hard_lock_prompt.py` coverage, numeric `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` coverage, and numeric `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` coverage values.
+- [x] [P4-T4] Run `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts` and store the passing targeted result in `evidence/other/resolve-hard-lock-extension-green.<timestamp>.md`
+  - Acceptance: a file matching `evidence/other/resolve-hard-lock-extension-green.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts`, `EXIT_CODE: 0`, and `Output Summary:` naming `extension.resolve-hard-lock-prompt.test.ts`.
+- [x] [P4-T5] Record bundle parity details in `evidence/qa-gates/resolve-hard-lock-bundle-summary.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/resolve-hard-lock-bundle-summary.*.md` exists and contains the headings `Root Source Files:`, `Bundled Resource Files:`, `Command ID:`, and `Wrapper Path:`.
+
+### Phase 5 — Final QA & Coverage Closure
+
+If any command in this phase changes files or exits non-zero, restart Phase 5 from [P5-T1].
+
+- [x] [P5-T1] Run `poetry run black .` and store the final QA result in `evidence/qa-gates/python-black.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/python-black.*.md` exists and contains `Timestamp:`, `Command: poetry run black .`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T2] Run `poetry run ruff check` and store the final QA result in `evidence/qa-gates/python-ruff.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/python-ruff.*.md` exists and contains `Timestamp:`, `Command: poetry run ruff check`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T3] Run `poetry run pyright` and store the final QA result in `evidence/qa-gates/python-pyright.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/python-pyright.*.md` exists and contains `Timestamp:`, `Command: poetry run pyright`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T4] Run `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` and store the final QA result in `evidence/qa-gates/python-pytest.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/python-pytest.*.md` exists and contains `Timestamp:`, `Command: poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`, `EXIT_CODE: 0`, and `Output Summary:` with numeric total coverage and numeric `scripts/dev_tools/resolve_hard_lock_prompt.py` coverage values.
+- [x] [P5-T5] Record the baseline-versus-final Python coverage delta and threshold verification in `evidence/qa-gates/python-coverage-delta.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/python-coverage-delta.*.md` exists and uses the revised `[P0-T15]` artifact generated by `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` for `Baseline Total Coverage:` and `Baseline scripts/dev_tools/resolve_hard_lock_prompt.py Coverage:`, uses the revised `[P5-T4]` artifact generated by `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` for `Final Total Coverage:` and `Final scripts/dev_tools/resolve_hard_lock_prompt.py Coverage:`, evaluates `Repository Coverage Threshold (>=80%):` against those `Baseline Total Coverage:` and `Final Total Coverage:` values, uses the `[P4-T3]` targeted coverage artifact for `Final extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py Coverage:`, `Final extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py Coverage:`, and `New/Changed Python Code Coverage:`, and contains `New/Changed Code Threshold (>=90%):`, `No Regression vs Baseline:`, `Threshold Check: PASS or FAIL`, and `No planned command task skipped: true`.
+- [x] [P5-T6] Run `npm --prefix extensions/drm-copilot run format` and store the final QA result in `evidence/qa-gates/extension-format.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/extension-format.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run format`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T7] Run `npm --prefix extensions/drm-copilot run lint` and store the final QA result in `evidence/qa-gates/extension-lint.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/extension-lint.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run lint`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T8] Run `npm --prefix extensions/drm-copilot run typecheck` and store the final QA result in `evidence/qa-gates/extension-typecheck.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/extension-typecheck.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run typecheck`, `EXIT_CODE: 0`, and `Output Summary:`.
+- [x] [P5-T9] Run `npm --prefix extensions/drm-copilot run test:unit -- --coverage` and store the final QA result in `evidence/qa-gates/extension-jest.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/extension-jest.*.md` exists and contains `Timestamp:`, `Command: npm --prefix extensions/drm-copilot run test:unit -- --coverage`, `EXIT_CODE: 0`, and `Output Summary:` with numeric total coverage and numeric `src/extension.ts` coverage values.
+- [x] [P5-T10] Record the baseline-versus-final extension coverage delta and threshold verification in `evidence/qa-gates/extension-coverage-delta.<timestamp>.md`
+  - Acceptance: a file matching `evidence/qa-gates/extension-coverage-delta.*.md` exists and uses the `[P0-T19]` baseline artifact for `Baseline Total Coverage:` and `Baseline src/extension.ts Coverage:`, uses the `[P5-T9]` final QA artifact for `Final Total Coverage:`, `Final src/extension.ts Coverage:`, and `New/Changed TypeScript Code Coverage:` (because `src/extension.ts` is the only planned changed production TypeScript file), and contains `Repository Coverage Threshold (>=80%):`, `New/Changed Code Threshold (>=90%):`, `No Regression vs Baseline:`, `Threshold Check: PASS or FAIL`, and `No planned command task skipped: true`.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/policy-audit.2026-03-15T00-26.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/policy-audit.2026-03-15T00-26.md
@@ -1,0 +1,365 @@
+# Policy Compliance Audit: bundle-hard-lock-resolver-into-extension (#103)
+
+**Audit Date:** 2026-03-15  
+**Base Branch:** `development`  
+**Feature Folder:** `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/`  
+**Feature Folder Selection Rule:** Used the user-specified active feature folder, which matches issue suffix `-103` and contains the primary scoping docs (`issue.md`, `spec.md`, `user-story.md`).  
+**PR Context Assumption:** `artifacts/pr_context.summary.txt` was refreshed against `development`. Because `HEAD` and `origin/development` currently resolve to the same commit (`811bd5cf221fc8d97de2be71d41ece26698db8c9`), the summary range is empty. For this rerun, the refreshed appendix working-tree diff plus live workspace inspection are the authoritative scope evidence.
+
+**Code Under Test:**
+- `extensions/drm-copilot/src/extension.ts`
+- `extensions/drm-copilot/package.json`
+- `extensions/drm-copilot/README.md`
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`
+- `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py`
+- `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md`
+- `extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md`
+- `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`
+- `scripts/dev_tools/resolve_hard_lock_prompt.py`
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py`
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt_part2.py`
+- `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/*.md`
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| Python | 7 files | 899 repo pytest tests | [✅] 899 passed | 83% total; 97% `scripts/dev_tools/resolve_hard_lock_prompt.py` | 83% total; 97% root resolver; 97% bundled resolver; 100% wrapper | 92% |
+| TypeScript | 2 files | 81 repo Jest tests / 80 extension-local Jest tests | [✅] all passed | 89.3% total; 90.48% `extensions/drm-copilot/src/extension.ts` | 89.84% total; 91.34% `extensions/drm-copilot/src/extension.ts` | 91.34% |
+| JSON | 1 file | N/A | [✅] validation passed | N/A | N/A | N/A |
+
+## Executive Summary
+
+This post-remediation review is now fully compliant. The previously identified wrapper exit-code defect is fixed: the extension-bundled wrapper returns the delegated resolver exit status, the direct missing-target probe exits non-zero, the missing-runtime and missing-template failure paths remain covered, and the oversized Python test module has been split into two files under the repo's 500-line limit. The refreshed Python, TypeScript, extension-local, and JSON checks all passed.
+
+**Policy documents evaluated:**
+- [✅] `general-code-change.instructions.md`
+- [✅] `general-unit-test.instructions.md`
+- [✅] `python-code-change.instructions.md`
+- [✅] `python-unit-test.instructions.md`
+- [✅] `typescript-code-change.instructions.md`
+- [✅] `typescript-unit-test.instructions.md`
+
+**Temporary artifacts cleanup:**
+- [✅] No temporary one-off scripts were introduced by the feature.
+- [✅] Bundled resources and tests are intentional long-lived artifacts and passed the applicable checks.
+- [✅] Review evidence under `evidence/` remains intentional audit output, not throwaway tooling.
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] [PASS] | Python tests use isolated `tmp_path`/`mem_path`, targeted patching, and fresh module loading. TypeScript/Jest tests reset mocks and handler state in `beforeEach`/`afterEach`. |
+| Isolation | [✅] [PASS] | Each test targets a single behavior: command registration, picker reuse, wrapper injection, template lookup, missing target/runtime/template failures, or path normalization. |
+| Fast Execution | [✅] [PASS] | Fresh runs: `pytest` 899 passed in 1.79s; repo Jest coverage run 81 passed in 1.702s; extension-local Jest run 80 passed in 0.458s. |
+| Determinism | [✅] [PASS] | Tests rely on fixtures, mocks, and local file trees only; no network calls or live external services. |
+| Readability & Maintainability | [✅] [PASS] | The previously oversized wrapper test module is now split into `374` and `344` line files; names and docstrings remain descriptive. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Baseline Coverage Documented | [✅] [PASS] | Baseline artifacts cited in `evidence/baseline/python-pytest.2026-03-14T23-31.md` and `evidence/baseline/extension-jest.2026-03-14T23-31.md`. |
+| No Coverage Regression | [✅] [PASS] | Python delta: `83% -> 83%` total, no regression. TypeScript delta: `89.3% -> 89.84%` total, no regression. |
+| New Code Coverage ≥90% | [✅] [PASS] | Python changed-code coverage: `92%`. TypeScript changed-code coverage: `91.34%`. Both exceed the repo threshold. |
+| Comprehensive Coverage | [✅] [PASS] | Tests cover success paths plus missing target, missing runtime, missing template, explicit-template preservation, workspace fallback, Windows path normalization, and versioned-folder work-mode lookup. |
+| Positive Flows | [✅] [PASS] | Covered by prompt resolution, command registration, active-editor reuse, picker fallback, and successful resolver execution tests. |
+| Negative Flows | [✅] [PASS] | Covered by missing runtime, missing target, and missing template lookup tests. |
+| Edge Cases | [✅] [PASS] | Covered by Windows-style path normalization and versioned `v2` issue lookup scenarios. |
+| Error Handling | [✅] [PASS] | Covered by wrapper non-zero exit propagation, template read failure, missing runtime, and clipboard fallback warnings. |
+| Concurrency | [N/A] [N/A] | No concurrent behavior is introduced by this feature. |
+| State Transitions | [N/A] [N/A] | No stateful workflow object is introduced. |
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clear Failure Messages | [✅] [PASS] | Assertions target precise messages such as `Target file not found`, `Python runtime 'python' not found on PATH.`, and `Checked locations:`. |
+| Arrange-Act-Assert Pattern | [✅] [PASS] | Both Python and Jest tests follow clear setup/invoke/assert structure. |
+| Document Intent | [✅] [PASS] | Test names and docstrings clearly describe the scenarios under test. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Avoid External Dependencies | [✅] [PASS] | No live network/database/API dependencies are used in unit tests. |
+| Use Mocks/Stubs | [✅] [PASS] | `patch`, `MagicMock`, mocked `vscode`, mocked child-process boundaries, and mocked filesystem/runtime checks isolate external seams. |
+| Environment Stability | [✅] [PASS] | Tests manage `sys.argv`, `sys.path`, and mock state locally, restoring them after each case. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Pre-submission Review | [✅] [PASS] | This artifact records the refreshed post-remediation policy review and the final passing evidence. |
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clarify the objective | [✅] [PASS] | `issue.md`, `spec.md`, and `user-story.md` clearly define the bundled hard-lock prompt goal and acceptance criteria. |
+| Read existing change plans | [✅] [PASS] | The active feature folder contains scoping docs, `plan.2026-03-14T22-49.md`, and prior review/remediation history. |
+| Document the plan | [✅] [PASS] | The feature folder documents scope, behavior, risks, definition of done, and acceptance criteria. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Simplicity first | [✅] [PASS] | TypeScript remains a thin launcher; Python resolver logic stays centralized in the resolver module. |
+| Reusability | [✅] [PASS] | The feature bundles synchronized copies instead of introducing a separate extension-only implementation path. |
+| Extensibility | [✅] [PASS] | The additive `--template-root` seam supports bundled or workspace-local template sources without breaking existing CLI usage. |
+| Separation of concerns | [✅] [PASS] | Command selection, wrapper bootstrapping, and prompt-resolution logic remain separated cleanly. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Cohesive modules | [✅] [PASS] | Modified files each have a single clear responsibility: command wiring, wrapper bootstrapping, resolver behavior, or focused tests. |
+| Under 500 lines | [✅] [PASS] | Fresh line counts: `test_resolve_hard_lock_prompt.py=374`, `test_resolve_hard_lock_prompt_part2.py=344`, wrapper `=58`. |
+| Public vs internal | [✅] [PASS] | New helpers remain internal; no unnecessary public API expansion occurred. |
+| No circular dependencies | [✅] [PASS] | Imports remain one-way between the wrapper, bundled scripts, and extension runtime. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Descriptive names | [✅] [PASS] | Symbols such as `getActiveFeaturePlanPath`, `_resolve_template_path`, and `test_main_propagates_bundled_non_zero_exit_code` are explicit and scenario-focused. |
+| Docs/docstrings | [✅] [PASS] | Python wrapper/resolver helpers include docstrings; `extensions/drm-copilot/README.md` documents the command. |
+| Comment why, not what | [✅] [PASS] | Existing comments explain ordering and resource-selection rationale rather than restating syntax. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| 1. Formatting | [✅] [PASS] | Python task `poetry run black .` reported `170 files left unchanged`. Extension-local `npm --prefix extensions/drm-copilot run format -- --check` reported all matched files already use Prettier style. |
+| 2. Linting | [✅] [PASS] | `poetry run ruff check` passed. Root `npm run lint` and extension-local `npm --prefix extensions/drm-copilot run lint` both passed. |
+| 3. Type checking | [✅] [PASS] | `poetry run pyright` reported `0 errors, 0 warnings, 0 informations`; root `npm run typecheck` and extension-local `npm --prefix extensions/drm-copilot run typecheck` passed. |
+| 4. Testing | [✅] [PASS] | `pytest` passed `899` tests; repo Jest passed `81` tests with coverage; extension-local Jest passed `80` tests. JSON validation also passed. |
+| Full toolchain loop | [✅] [PASS] | All required Python and TypeScript/extension checks completed green in the final pass. |
+| Explicit reporting | [✅] [PASS] | Exact commands and outcomes are recorded in this artifact and Appendix B. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Summarize changes | [✅] [PASS] | Feature docs, extension command wiring, bundled resources, tests, and README updates are captured in the active feature folder and reviewed here. |
+| Design choices explained | [✅] [PASS] | `spec.md` and `user-story.md` explain the wrapper-plus-bundled-resolver pattern and source-of-truth strategy. |
+| Update supporting documents | [✅] [PASS] | `extensions/drm-copilot/README.md` documents the command surface and runtime expectations. |
+| Provide next steps | [✅] [PASS] | No remediation remains; the refreshed recommendation is ready for merge / safe PR opening. |
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### 3A. Python Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting with Black | [✅] [PASS] | `poetry run black .` completed with `170 files left unchanged`. |
+| Linting with Ruff | [✅] [PASS] | `poetry run ruff check` passed cleanly. |
+| Type checking with Pyright | [✅] [PASS] | `poetry run pyright` passed cleanly. |
+| Testing with Pytest | [✅] [PASS] | `poetry run pytest` passed `899` tests; coverage run reported `83%` total and `97%` for the resolver module. |
+| Strong typing | [✅] [PASS] | The wrapper now casts `module.main` to `Callable[[], int]` and returns the delegated integer result, matching the resolver contract. |
+| Dataclasses for value objects | [N/A] [N/A] | No new dataclass/value-object layer was needed for this feature. |
+| Protocols/ABCs for interfaces | [N/A] [N/A] | No new multi-implementation domain interface was introduced. |
+| Avoid utility classes | [✅] [PASS] | Python changes remain module/function based. |
+| Specific exceptions | [✅] [PASS] | Error handling remains targeted and explicit for missing files, unreadable templates, clipboard fallback, and import/runtime boundaries. |
+| Logging over print | [✅] [PASS] | CLI stdout/stderr remain intentional command output rather than ad-hoc debugging. |
+| Invariants at construction | [N/A] [N/A] | No new stateful class constructors were added. |
+
+### 3B. TypeScript Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting with Prettier | [✅] [PASS] | Root and extension-local formatting checks passed without modifications. |
+| Linting with ESLint | [✅] [PASS] | Root and extension-local lint runs passed. |
+| Type checking with TSC | [✅] [PASS] | Root and extension-local type checks passed. |
+| Testing with Jest | [✅] [PASS] | Root Jest passed `81` tests and extension-local Jest passed `80` tests. |
+| Strong typing | [✅] [PASS] | New TypeScript command wiring uses explicit types and existing runtime contracts without `any`. |
+| Avoid cleverness | [✅] [PASS] | The implementation uses small helpers, straightforward guards, and early returns. |
+| Separation of concerns | [✅] [PASS] | TypeScript remains a thin command layer; prompt resolution stays in Python. |
+| Error handling / logging | [✅] [PASS] | The extension runtime preserves subprocess failure semantics now that the wrapper returns non-zero exit codes correctly. |
+
+### 3C. JSON Configuration Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| JSON validation | [✅] [PASS] | `python -m scripts.dev_tools.validate_json` completed successfully. |
+| Strict JSON only | [✅] [PASS] | `extensions/drm-copilot/package.json` remains strict JSON. |
+| Deterministic structure | [✅] [PASS] | Manifest contribution structure is formatter-clean and consistent. |
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### 4A. Python Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Pytest | [✅] [PASS] | All Python tests are written and run with Pytest. |
+| Coverage expectation | [✅] [PASS] | Current changed-code coverage is `92%`, above the repo's `>=90%` threshold. |
+| Focused unit tests | [✅] [PASS] | Tests isolate wrapper injection, exit propagation, template lookup, prompt resolution, and error cases. |
+| Mocking sparingly | [✅] [PASS] | Only runtime seams (`sys.argv`, import boundaries, clipboard helpers, file reads) are mocked. |
+| Organization | [✅] [PASS] | The root and extension wrapper tests mirror the code under test and the split files remain maintainable. |
+| Naming conventions | [✅] [PASS] | Function names are descriptive and scenario specific. |
+| Docstrings/comments | [✅] [PASS] | Tests include concise docstrings where helpful. |
+| Use Pytest in toolchain | [✅] [PASS] | Both the standard and coverage verification steps used `pytest`. |
+
+### 4B. TypeScript Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Jest | [✅] [PASS] | TypeScript tests run under Jest in both the root and extension-local loops. |
+| Focused unit tests | [✅] [PASS] | The extension test file isolates registration, active editor reuse, picker fallback, argv wiring, cancel flow, and missing runtime behavior. |
+| Mocking / isolation | [✅] [PASS] | `vscode`, child process boundaries, and filesystem/runtime checks are mocked locally. |
+| Naming and readability | [✅] [PASS] | `it(...)` descriptions clearly state the scenario and expectation. |
+| Coverage completeness | [✅] [PASS] | Current coverage for `extension.ts` is `91.34%`, and the failure-path behavior is now covered by Python-side wrapper tests plus the direct subprocess probe. |
+
+## 5. Test Coverage Detail
+
+### Python resolver stack
+
+- `scripts/dev_tools/resolve_hard_lock_prompt.py`: `97%` coverage in the fresh coverage run.
+- `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py`: `97%` coverage per feature coverage delta.
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`: `100%` coverage per feature coverage delta.
+- Covered scenarios include template-root precedence/fallback, versioned-folder work-mode lookup, missing target/template handling, template read failures, clipboard fallback, and non-zero exit propagation.
+
+### TypeScript command wiring
+
+- `extensions/drm-copilot/src/extension.ts`: `91.34%` line coverage in the fresh Jest coverage run.
+- Covered scenarios include command registration, active editor reuse, picker fallback, argv wiring, cancellation, and missing Python runtime.
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total repo pytest tests | 899 | [✅] |
+| Total repo Jest tests | 81 | [✅] |
+| Extension-local Jest tests | 80 | [✅] |
+| Repo pytest execution time | 1.79s | [✅] Fast |
+| Repo Jest coverage execution time | 1.702s | [✅] Fast |
+| Extension-local Jest execution time | 0.458s | [✅] Fast |
+| Largest changed production file | `extensions/drm-copilot/src/extension.ts` (under 500 lines) | [✅] |
+| Largest changed wrapper test file | `374` lines | [✅] |
+
+## 7. Code Quality Checks
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Python formatting | `poetry run black .` | `170 files left unchanged` | [✅] |
+| Python linting | `poetry run ruff check` | `All checks passed!` | [✅] |
+| Python type checking | `poetry run pyright` | `0 errors, 0 warnings, 0 informations` | [✅] |
+| Python tests | `poetry run pytest` | `899 passed in 1.79s` | [✅] |
+| Python tests with coverage | `shell: QC: 4 Pytest: run tests with coverage` | `TOTAL 83%`; resolver `97%`; `899 passed in 3.86s` | [✅] |
+| Repo Jest with coverage | `npm run test:unit:coverage` | `81 passed`; total `89.84%`; `extension.ts` `91.34%` | [✅] |
+| Extension-local formatting | `npm --prefix extensions/drm-copilot run format -- --check` | `All matched files use Prettier code style!` | [✅] |
+| Extension-local linting | `npm --prefix extensions/drm-copilot run lint` | Passed cleanly | [✅] |
+| Extension-local type checking | `npm --prefix extensions/drm-copilot run typecheck` | Passed cleanly | [✅] |
+| Extension-local tests | `npm --prefix extensions/drm-copilot run test:unit` | `80 passed in 0.458s` | [✅] |
+| JSON validation | `python -m scripts.dev_tools.validate_json` | Passed | [✅] |
+| Wrapper missing-target probe | `python extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py --target <missing> --workspace <feature-folder>` | Printed clear missing-target error and exited with `WRAPPER_EXIT=1` | [✅] |
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+**None.** All policy requirements reviewed in this rerun are satisfied.
+
+### Approved Exceptions
+
+**None.** No policy exceptions were needed.
+
+### Removed/Skipped Tests
+
+**None.** The previously missing wrapper exit-propagation scenario is now covered.
+
+## 9. Summary of Changes
+
+### Commits in This Branch
+
+The refreshed PR context shows no committed delta relative to `development`; the reviewed feature exists as working-tree changes captured in the refreshed appendix and current workspace files.
+
+### Files Modified / Added
+
+- `extensions/drm-copilot/src/extension.ts` — registers the execute hard-lock command and plan-selection helpers.
+- `extensions/drm-copilot/package.json` — contributes `drmCopilotExtension.resolveExecuteHardLockPrompt`.
+- `extensions/drm-copilot/README.md` — documents the new command and runtime expectations.
+- `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` — thin wrapper that now correctly propagates delegated exit codes.
+- `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` — bundled synchronized resolver copy.
+- `extensions/drm-copilot/resources/customizations/.github/codex/*.prompt.md` — bundled prompt templates.
+- `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` — extension command tests.
+- `scripts/dev_tools/resolve_hard_lock_prompt.py` — additive `--template-root` seam.
+- Python tests under `tests/scripts/dev_tools/` and `tests/extensions/drm_copilot/resources/templates/` — resolver, wrapper, and failure-path coverage.
+- Feature docs and review artifacts under the active feature folder.
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+The post-remediation workspace state now satisfies the reviewed general, Python, TypeScript, and unit-test policies for this feature.
+
+### Policy-by-Policy Summary
+
+- General Code Change Policy: ✅ Pass
+- Python Code Change Policy: ✅ Pass
+- TypeScript Code Change Policy: ✅ Pass
+- General Unit Test Policy: ✅ Pass
+- Python Unit Test Policy: ✅ Pass
+- TypeScript Unit Test Policy: ✅ Pass
+
+### Metrics Summary
+
+- [✅] `899/899` pytest tests passing
+- [✅] `81/81` repo Jest tests passing
+- [✅] `80/80` extension-local Jest tests passing
+- [✅] Python total coverage `83%`, no regression; changed Python code `92%`
+- [✅] TypeScript total coverage `89.84%`, no regression; changed TypeScript code `91.34%`
+- [✅] Wrapper failure probe exits non-zero as required
+- [✅] All reviewed files remain within the repo's 500-line limit
+
+### Recommendation
+
+**Ready for merge**
+
+On the evidence collected in this rerun, the feature is safe to open or merge as a PR into `development` after CI.
+
+## Appendix A: Test Inventory
+
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py::*`
+- `tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py::*`
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py::*`
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt_part2.py::*`
+- `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts::*`
+
+## Appendix B: Toolchain Commands Reference
+
+**PR context refresh**
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base development`
+
+**Python / root repo**
+- `poetry run black .`
+- `poetry run ruff check`
+- `poetry run pyright`
+- `poetry run pytest`
+- `shell: QC: 4 Pytest: run tests with coverage`
+
+**Repo Jest / TypeScript coverage**
+- `npm run format`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:unit:coverage`
+
+**Extension-local loop**
+- `npm --prefix extensions/drm-copilot run format -- --check`
+- `npm --prefix extensions/drm-copilot run lint`
+- `npm --prefix extensions/drm-copilot run typecheck`
+- `npm --prefix extensions/drm-copilot run test:unit`
+
+**Other verification**
+- `python -m scripts.dev_tools.validate_json`
+- `python extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py --target <missing-target> --workspace <feature-folder>`
+
+**Audit Completed By:** GitHub Copilot (GPT-5.4)  
+**Policy Version:** Current as of 2026-03-15

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/spec.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/spec.md
@@ -1,0 +1,192 @@
+# 2026-03-14-bundle-hard-lock-resolver-into-extension — Spec
+
+- **Issue:** #103
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-03-14T22-49
+- **Status:** Draft
+- **Version:** 0.1
+
+## Overview
+
+This feature makes execute hard-lock prompt resolution available from the VS Code extension without creating an extension-only implementation path. The design keeps `scripts/dev_tools/resolve_hard_lock_prompt.py` and the root `.github/codex/*.prompt.md` files as the canonical authoring sources, while the extension ships synchronized bundled copies using the same wrapper-plus-bundled-script pattern already used for other extension commands.
+
+The only new behavior seam in the root Python resolver is an optional `--template-root` argument so bundled extension assets can be supplied explicitly for non-repo workspaces. All existing prompt substitution, work-mode resolution, fallback handling, and best-effort clipboard behavior stay in the Python resolver rather than moving into TypeScript or wrapper code.
+
+
+## Behavior
+
+Add a new user-facing command contribution in `extensions/drm-copilot/package.json` and a matching handler in `extensions/drm-copilot/src/extension.ts` for execute hard-lock prompt resolution. The command should follow the existing extension execution model: gather inputs in TypeScript, call `executeBundledScript(...)`, and run a thin Python wrapper from `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` in the active workspace.
+
+The TypeScript handler should resolve a target plan path using the same ergonomic pattern already used elsewhere in the extension:
+- Prefer the active editor when it is a Markdown file under `docs/features/active/`.
+- Otherwise open a file picker rooted under `docs/features/active/` and allow the user to choose a target plan file.
+- If the user cancels selection, return early without spawning Python.
+
+The handler should pass only the runtime inputs owned by the extension surface: `--target <selected-plan-path>` and `--workspace <workspace-root>`. It should not implement prompt resolution or template lookup itself.
+
+The wrapper in `resources/templates/resolve_hard_lock_prompt.py` should remain adapter-only:
+- prepend `extensions/drm-copilot/resources/scripts/` to `sys.path`
+- compute the bundled codex root at `extensions/drm-copilot/resources/customizations/.github/codex`
+- inject `--template-root <bundled-codex-root>` when the caller did not already supply it
+- import `dev_tools.resolve_hard_lock_prompt`
+- delegate to the bundled module's `main()` entry point in-process
+
+The bundled Python module at `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` should be a synchronized import-rewritten copy of the root resolver, not a separate implementation. The root resolver must accept `--template-root` and resolve templates in this order:
+1. `<template-root>/<template-name>` when `--template-root` is supplied
+2. `<workspace>/.github/codex/<template-name>`
+3. fail with a clear error that identifies the checked path(s)
+
+Once a template is found, the resolver should preserve current behavior:
+- normalize the selected target plan path relative to the workspace when possible
+- emit forward-slash plan paths in `${plan-path}` substitutions
+- resolve `${work-mode}` and `${fallback-reason}` from the nearest deterministic `issue.md`, including parent-folder lookup for versioned plan folders such as `v2`
+- print the fully resolved prompt to stdout
+- attempt best-effort clipboard copy without turning clipboard failure into command failure
+
+The extension should bundle `execute-hard-lock.prompt.md` and `resume-hard-lock.prompt.md` under `extensions/drm-copilot/resources/customizations/.github/codex/` so the bundled resolver contract stays aligned with the root script's existing `--template-kind execute|resume` behavior, even though this feature only registers an execute command initially.
+
+
+## Inputs / Outputs
+
+- Inputs (CLI flags, files, env vars)
+	- Extension command input:
+		- active Markdown editor path under `docs/features/active/`, or
+		- a file chosen from `showOpenDialog(...)` rooted under `docs/features/active/`
+	- Root and bundled Python CLI flags:
+		- `--target <path>`: required path to the selected plan file
+		- `--workspace <path>`: optional workspace root; defaults to `Path.cwd()` when omitted
+		- `--template-kind execute|resume`: existing selector, default `execute`
+		- `--template-root <path>`: new optional directory containing bundled or repo-local hard-lock prompt templates
+	- Files read at runtime:
+		- selected target plan file passed through `--target`
+		- nearest `issue.md` beside the plan file, or parent-folder `issue.md` when the target lives in a version folder like `v2`
+		- root authoring sources: `scripts/dev_tools/resolve_hard_lock_prompt.py`, `.github/codex/execute-hard-lock.prompt.md`, `.github/codex/resume-hard-lock.prompt.md`
+		- bundled extension copies: `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py`, `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md`, `extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md`
+	- Environment/runtime dependencies:
+		- Python runtime discoverable on `PATH`
+		- platform clipboard mechanism discovered through `pyperclip` or validated native commands (`pbcopy`, `wl-copy`, `xclip`, `xsel`, `clip`, `clip.exe`)
+- Outputs (artifacts, logs, telemetry)
+	- stdout: the fully resolved prompt text suitable for copy/paste into chat
+	- stderr: clipboard success/failure notice and clear runtime errors for missing target/template resources
+	- VS Code output channel: command start/failure details emitted by existing extension runtime plumbing
+	- Persistent artifacts: none; this command generates prompt text only and should not write feature files or cache state
+	- Telemetry: none added by this feature
+- Config keys and defaults:
+	- `--workspace` defaults to the current working directory in Python when not supplied
+	- `--template-kind` defaults to `execute`
+	- `--template-root` defaults to unset; template lookup then falls back to `<workspace>/.github/codex`
+	- the extension command should inject `--template-root` in the wrapper, not by expanding the public TypeScript command surface
+- Versioning or backward-compatibility constraints:
+	- `--template-root` must be additive and backward-compatible for existing repo-root CLI usage
+	- existing `--target`, `--workspace`, and `--template-kind` behavior must remain unchanged for current callers and tests
+	- no new `activationEvents` entry is required because contributed commands activate automatically for the extension's supported VS Code engine range (`^1.108.0`)
+
+## API / CLI Surface
+
+List commands, flags, request/response shapes, and examples.
+- Extension command contribution:
+	- Command ID: `drmCopilotExtension.resolveExecuteHardLockPrompt`
+	- Title: `drm-copilot: Resolve Execute Hard-Lock Prompt`
+	- Handler location: `extensions/drm-copilot/src/extension.ts`
+	- Runtime entrypoint: `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`
+- Python CLI surface owned by the resolver module:
+	- `--target <path>`
+	- `--workspace <path>`
+	- `--template-kind execute|resume`
+	- `--template-root <path>`
+- Request/response shape:
+	- Request from TypeScript to Python: argv list passed to `executeBundledScript(...)`
+	- Response from Python to the extension host: process exit code plus stdout/stderr streams
+	- Success contract: exit code `0`, resolved prompt written to stdout, clipboard warning allowed on stderr
+	- Failure contract: exit code `1` for missing target, missing template, or template read failure, with human-readable stderr text
+- Example invocations with expected outputs (concise):
+	- Extension-spawned execute flow: `python resources/templates/resolve_hard_lock_prompt.py --target C:/workspace/docs/features/active/feature-1/plan.md --workspace C:/workspace` resolves `${plan-path}` to `docs/features/active/feature-1/plan.md` and writes the completed execute prompt to stdout.
+	- Repo-root CLI flow with workspace templates: `python scripts/dev_tools/resolve_hard_lock_prompt.py --target docs/features/active/feature-1/plan.md --workspace .` keeps current behavior and uses `.github/codex/execute-hard-lock.prompt.md` when `--template-root` is omitted.
+	- Explicit bundled-template flow: `python scripts/dev_tools/resolve_hard_lock_prompt.py --target docs/features/active/feature-1/plan.md --workspace C:/workspace --template-root C:/extension/resources/customizations/.github/codex` resolves the same prompt without requiring repo-local codex files.
+- Contracts and validation rules:
+	- `--target` is required and must point to an existing file
+	- `--template-kind` must remain restricted to `execute` or `resume`
+	- when `--template-root` is supplied, the resolver must still fall back to workspace `.github/codex` if the requested template file is not present there
+	- plan-path substitution must always emit forward slashes, including on Windows
+	- wrapper code must not contain prompt business rules beyond import bootstrapping and `--template-root` injection
+
+## Data & State
+
+Data flow, storage, or state changes introduced by this feature.
+- Data flow:
+	- `extension.ts` selects the target plan file and workspace root
+	- `executeBundledScript(...)` launches the wrapper in the active workspace
+	- the wrapper adjusts `sys.path` and injects the bundled codex directory via `--template-root`
+	- the bundled resolver reads the requested prompt template, target plan path, and nearest deterministic `issue.md`
+	- `resolve_prompt(...)` substitutes `${plan-path}`, `${work-mode}`, and `${fallback-reason}` into the raw template content
+	- the resolver prints the final prompt and attempts clipboard copy
+- Data transformations and invariants:
+	- target plan paths are made workspace-relative when possible and always converted to forward slashes before template substitution
+	- work-mode resolution remains fail-closed to `full-feature` when `issue.md` is missing, unreadable, or malformed
+	- root Python logic and root prompt files remain canonical authoring sources; extension resources are synchronized copies only
+	- the wrapper is an adapter layer only and must not become a second logic fork
+- Caching or persistence details:
+	- no cache is introduced in the extension or Python resolver
+	- no workspace files are created, modified, or rewritten by this command
+	- clipboard writes remain best-effort and ephemeral
+- Migration or backfill requirements (if any):
+	- no user data migration is required
+	- existing repo-root workflows continue to work unchanged because `--template-root` is optional
+	- bundling requires keeping mirrored extension copies synchronized during future changes to the root resolver or root hard-lock templates
+
+## Constraints & Risks
+
+- The extension bundle must stay synchronized with both `scripts/dev_tools/resolve_hard_lock_prompt.py` and `.github/codex/execute-hard-lock.prompt.md`; otherwise the extension command could silently diverge from the repo workflow.
+- The resolver depends on adjacent helper logic such as prompt-mode handling, so packaging must include all required bundled Python modules and template assets, not just the top-level entry point.
+- Extension-side execution still depends on an available Python runtime, and clipboard behavior may vary by platform or host environment even if prompt generation succeeds.
+- Path normalization and workspace-relative substitution must behave correctly for non-repo workspaces and Windows-style paths, since this feature is explicitly meant to work outside the source repository.
+- The extension should bundle both hard-lock templates even though only execute is exposed initially; shipping only one template would leave the bundled resolver contract out of sync with the root script's supported `--template-kind` values.
+- The TypeScript command surface must stay thin; moving prompt resolution, work-mode selection, or template interpolation into `extension.ts` would violate the single-source-of-truth requirement and increase long-term drift risk.
+- Because this command is intended for arbitrary workspaces, file-selection behavior must fail clearly when no workspace is open or when the user selects a non-existent target, rather than assuming repo-relative structure is always available.
+
+
+## Implementation Strategy
+
+- Implementation scope (what changes, not sequencing):
+	- Update `scripts/dev_tools/resolve_hard_lock_prompt.py` to accept `--template-root` and perform template lookup with bundled-root-first, workspace-second behavior.
+	- Mirror that resolver into `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` using the existing bundled-script import rewrite pattern.
+	- Add `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` as a thin wrapper that injects the bundled codex root.
+	- Bundle synchronized prompt assets under `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md` and `extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md`.
+	- Register a new extension command in `extensions/drm-copilot/src/extension.ts` and add its manifest entry in `extensions/drm-copilot/package.json`.
+	- Add or update tests in both the root Python suite and the extension Jest suite to cover the new seam and the new command wiring.
+- New classes/functions/commands to add or update:
+	- Add command registration for `drmCopilotExtension.resolveExecuteHardLockPrompt` in `extensions/drm-copilot/src/extension.ts` and `extensions/drm-copilot/package.json`.
+	- Add a plan-path selection helper in `extensions/drm-copilot/src/extension.ts` adjacent to the existing active-file helpers so active feature plans can be reused before opening a picker.
+	- Extend the resolver CLI in `scripts/dev_tools/resolve_hard_lock_prompt.py` and the bundled mirror under `extensions/drm-copilot/resources/scripts/dev_tools/`.
+	- Add the thin wrapper entrypoint in `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`.
+	- Add extension Jest coverage in a new test file such as `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` and extend Python coverage in `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`.
+- Dependency changes (new/removed packages) and rationale:
+	- No new runtime or dev dependency is required.
+	- Reuse the existing extension-side Python execution contract, the existing bundled `prompt_mode_contract.py`, and the already-packaged `resources/**` asset behavior.
+- Logging/telemetry additions and locations:
+	- No new telemetry is required.
+	- Continue using the extension output channel created in `extensions/drm-copilot/src/command-runtime.ts` for command-level diagnostics.
+	- Continue emitting Python stderr messages for missing templates, missing targets, and clipboard outcomes so failures remain understandable when subprocess execution fails.
+- Rollout plan (feature flags, staged deploys, fallback path):
+	- Ship as a standard extension command with no feature flag.
+	- Keep the root CLI usable outside the extension; the new flag is additive rather than a replacement.
+	- Use the wrapper-injected bundled codex root for non-repo workspaces while preserving workspace `.github/codex` fallback inside the resolver.
+	- Treat synchronized bundled copies as part of normal extension packaging rather than introducing a new synchronization subsystem.
+
+## Definition of Done
+
+- [x] Acceptance criteria in `user-story.md` are mapped to Python coverage in `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py` and extension coverage in `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts`.
+- [x] Behavior is verified in both repo-like and non-repo workspaces, including a workspace that lacks `.github/codex/execute-hard-lock.prompt.md` but succeeds through bundled extension assets.
+- [x] Tests are updated or added in `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py` and the extension Jest suite to cover command registration, argv wiring, template-root resolution, and bundled-template execution.
+- [x] Edge cases and error handling are covered by tests for Windows-style paths, versioned feature folders, missing target files, missing Python runtime, and missing bundled template assets.
+- [x] Docs are updated in `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/` and, if the command is user-facing in the packaged extension, `extensions/drm-copilot/README.md` reflects the new command surface.
+- [x] No new telemetry is introduced; existing output-channel and stderr diagnostics are preserved and verified, or any intentional logging changes are documented in the affected extension/Python files.
+- [x] Final verification completes the repo-standard Python loop (`poetry run black .`, `poetry run ruff check`, `poetry run pyright`, `poetry run pytest`) and the extension loop (`npm --prefix extensions/drm-copilot run format`, `npm --prefix extensions/drm-copilot run lint`, `npm --prefix extensions/drm-copilot run typecheck`, `npm --prefix extensions/drm-copilot run test:unit`) with all steps passing in a single final pass.
+
+## Seeded Test Conditions (from potential)
+- [x] Unit-test command registration and argument wiring in `extensions/drm-copilot/src/extension.ts`, including active-editor reuse, picker fallback rooted under `docs/features/active`, the bundled wrapper path, and the `--target` / `--workspace` args passed to the Python runtime.
+- [x] Unit-test the bundled wrapper contract to confirm it prepends `resources/scripts` to `sys.path`, injects `--template-root` pointing at `resources/customizations/.github/codex`, imports `dev_tools.resolve_hard_lock_prompt`, and forwards execution without reimplementing resolver logic.
+- [x] Verify the bundled resolver can read the packaged `execute-hard-lock.prompt.md` template and produce resolved output when the active workspace does not contain repo-root `.github/codex` assets, while keeping `resume-hard-lock.prompt.md` bundled for contract parity.
+- [x] Cover Windows-oriented path handling, including conversion to workspace-relative forward-slash plan paths in the resolved prompt content and parent `issue.md` lookup for versioned folders such as `v2`.
+- [x] Cover failure paths such as missing target plan files, missing Python runtime, no open workspace, or missing bundled template resources so the command fails clearly instead of producing partial or misleading output.

--- a/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/user-story.md
+++ b/docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/user-story.md
@@ -1,0 +1,63 @@
+# `2026-03-14-bundle-hard-lock-resolver-into-extension` — User Story
+
+- Issue: #103
+- Owner: drmoisan
+- Status: Draft
+- Last Updated: 2026-03-14T22-49
+
+## Story Statement
+
+- As a developer using the `drm-copilot` extension in a workspace that is not this repository, I want to run an extension command that resolves the execute hard-lock prompt for a selected feature plan, so that I can use the same guided execution flow without manually copying Python scripts or prompt templates into the workspace.
+- As a maintainer of the repo-root developer tooling, I want the extension command to delegate to synchronized bundled copies of the existing Python resolver and hard-lock prompt templates, so that the root script and root prompt files remain the single source of truth and extension behavior does not drift into a second implementation.
+
+## Problem / Why
+
+The hard-lock prompt workflow already exists, but today it is trapped in repo-root tooling that assumes local `.github/codex` assets are present. That makes the extension less useful in other workspaces and nudges future work toward reimplementing the resolver in TypeScript or wrapper code.
+
+This feature removes that gap by packaging synchronized extension-side copies of the canonical Python resolver and hard-lock prompt templates. The goal is reuse, not reinvention: the extension should expose the same resolved execute prompt flow while the root Python and root templates remain the authoring sources.
+
+
+## Personas & Scenarios
+
+- Persona: Extension-driven feature implementer
+  - A developer working in VS Code who uses the `drm-copilot` extension to follow the repo's feature execution workflows.
+  - Cares about getting a ready-to-paste execute prompt quickly from the current plan file without leaving the editor.
+  - Often works in a workspace that does not contain this repository's root `.github/codex` directory or Python helper scripts.
+  - Wants the extension command to behave predictably on Windows paths and feature-folder layouts such as `docs/features/active/<feature>/v2/plan.md`.
+  - Gets frustrated when an extension command depends on hidden repo-local files that are not packaged with the extension.
+- Persona: Tooling maintainer
+  - A maintainer responsible for the Python developer tooling and the VS Code extension packaging contract.
+  - Cares about keeping one canonical resolver implementation and one canonical set of prompt templates.
+  - Must avoid logic drift between repo-root scripts, bundled extension copies, and wrapper entrypoints.
+  - Wants any extension adaptation to be limited to bootstrapping concerns such as resource lookup and runtime argument injection.
+- Scenario: Resolve execute hard-lock prompt from the extension in a non-repo workspace
+  - A developer opens a feature plan in VS Code and decides to use the hard-lock execute workflow from the command palette.
+  - The extension first checks whether the active editor is already a Markdown file under `docs/features/active/`; if so, it reuses that path. Otherwise it prompts the user to choose a plan file from `docs/features/active/`.
+  - After the user confirms a target plan, the extension launches the bundled wrapper, passing only `--target` and `--workspace`.
+  - The wrapper injects the bundled codex template root and delegates to the bundled Python resolver.
+  - The resolver reads the synchronized hard-lock prompt template, resolves `${plan-path}`, `${work-mode}`, and `${fallback-reason}`, prints the completed prompt, and attempts clipboard copy.
+  - The developer receives a prompt suitable for immediate paste into chat even though the workspace itself does not contain repo-root `.github/codex` assets.
+- Scenario: Maintain canonical sources while adding extension support
+  - A maintainer updates the root resolver or one of the root hard-lock templates.
+  - The extension packaging flow mirrors those files into bundled resources instead of adding a custom extension-only resolver branch.
+  - Tests fail if the command wiring, template-root seam, or bundled resource contract no longer matches the root implementation.
+  - The maintainer can evolve the resolver in one place while keeping the extension bundle synchronized and testable.
+
+
+## Acceptance Criteria
+
+- [x] `extensions/drm-copilot/package.json` contributes `drmCopilotExtension.resolveExecuteHardLockPrompt`, and `extensions/drm-copilot/src/extension.ts` registers a matching handler that reuses an active feature-plan editor when possible or otherwise prompts from `docs/features/active/`, then passes `--target <selected-plan>` and `--workspace <workspace-root>` to the bundled wrapper.
+- [x] `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` remains a thin wrapper that only bootstraps `resources/scripts` onto `sys.path`, injects `--template-root` pointing at bundled codex assets when absent, imports `dev_tools.resolve_hard_lock_prompt`, and delegates to its `main()` function without duplicating prompt-resolution logic.
+- [x] The extension package includes synchronized bundled copies of `scripts/dev_tools/resolve_hard_lock_prompt.py`, `.github/codex/execute-hard-lock.prompt.md`, and `.github/codex/resume-hard-lock.prompt.md` under the existing extension resource layout so prompt resolution works in workspaces that do not contain repo-local `.github/codex` assets.
+- [x] `scripts/dev_tools/resolve_hard_lock_prompt.py` adds an optional `--template-root` seam that checks the supplied template root first, then falls back to `<workspace>/.github/codex`, while preserving existing `--template-kind`, plan-path normalization, work-mode lookup, fallback-reason substitution, stdout output, and best-effort clipboard behavior.
+- [x] The extension command produces the same resolved execute prompt content as the root Python resolver for the same target plan, including forward-slash `${plan-path}` output and deterministic work-mode behavior for versioned plan folders such as `v2`.
+- [x] Missing target files, missing Python runtime, or missing bundled template assets fail with clear errors and do not produce partial or misleading success output.
+
+
+## Non-Goals
+
+- Rewriting hard-lock prompt resolution in TypeScript, Node.js, or wrapper-specific Python logic.
+- Replacing or deprecating the repo-root CLI workflow in `scripts/dev_tools/resolve_hard_lock_prompt.py`.
+- Removing the Python runtime requirement for extension-side execution.
+- Adding a separate user-facing resume hard-lock command in this change; the bundled resume template is included to preserve resolver contract parity, not to expand the command surface yet.
+- Introducing a new packaging system, live sync daemon, or extension-managed authoring source for hard-lock templates.

--- a/extensions/drm-copilot/README.md
+++ b/extensions/drm-copilot/README.md
@@ -13,6 +13,16 @@ This extension executes bundled scripts directly from extension resources while 
 - `drmCopilotExtension.newPotentialEntry`
 - `drmCopilotExtension.potentialToIssue`
 - `drmCopilotExtension.newActiveFeatureFolder`
+- `drmCopilotExtension.resolveExecuteHardLockPrompt`
+
+### Resolve Execute Hard-Lock Prompt
+
+- Command Palette title: `drm-copilot: Resolve Execute Hard-Lock Prompt`
+- Requires an open workspace folder.
+- Reuses the active Markdown feature plan under `docs/features/active/` when possible; otherwise prompts for a Markdown plan file under that folder.
+- Executes bundled Python wrapper: `resources/templates/resolve_hard_lock_prompt.py`
+- The wrapper injects bundled hard-lock prompt templates from `resources/customizations/.github/codex/` so the command works even when the active workspace does not contain repo-local `.github/codex` assets.
+- Passes only `--target <selected-plan-path>` and `--workspace <workspace-root>` to the bundled resolver entrypoint.
 
 ### Push Down Copilot Customizations
 
@@ -35,6 +45,8 @@ This extension executes bundled scripts directly from extension resources while 
 
 - Python command: `python`
 - PowerShell commands: `pwsh` (preferred), then `powershell`
+
+`Resolve Execute Hard-Lock Prompt` depends on a Python runtime being available on `PATH` because the command delegates to bundled Python resources at execution time.
 
 If runtime detection fails, handlers throw actionable runtime-named errors.
 

--- a/extensions/drm-copilot/package.json
+++ b/extensions/drm-copilot/package.json
@@ -44,6 +44,10 @@
       {
         "command": "drmCopilotExtension.pushDownCopilotCustomizations",
         "title": "drm-copilot: Push Down Copilot Customizations"
+      },
+      {
+        "command": "drmCopilotExtension.resolveExecuteHardLockPrompt",
+        "title": "drm-copilot: Resolve Execute Hard-Lock Prompt"
       }
     ]
   },

--- a/extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md
+++ b/extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md
@@ -1,0 +1,105 @@
+YOU ARE OPERATING IN ATOMIC EXECUTION MODE (atomic_executor).
+
+IDENTITY & SCOPE
+- Execution-only persona. No planning, no redesign, no reordering.
+- Execute an atomic_planner plan exactly as written.
+- Preserve Phase headings, task IDs ([P#-T#]), checkbox format, and task order.
+- Complete tasks strictly one-by-one.
+- Verify acceptance criteria before checking off any task.
+
+SUPREMACY & PRECONDITIONS (NON-NEGOTIABLE)
+- Repository policy files override these instructions.
+- BEFORE executing any task, you must confirm compliance with:
+  1) .github/copilot-instructions.md
+  2) .github/instructions/general-code-change.instructions.md
+  3) .github/instructions/general-unit-test.instructions.md
+  4) Any applicable language-specific policies
+- If Phase 0 does not include:
+  - Repo-policy reading tasks, AND
+  - Baseline toolchain capture for each language touched by the plan,
+  the plan is INVALID and execution must not begin.
+
+PLAN AUTHORITY (THE CONTRACT)
+- The plan text is the sole source of truth and the only todo list.
+- Task IDs must remain unchanged and referenced exactly.
+- Tasks must be executed in exact written order.
+- You MUST NOT:
+  - Add phases or tasks
+  - Reorder tasks
+  - Replace the plan with an alternative approach
+  - Perform work not explicitly described in the plan
+
+PREFLIGHT VALIDATION GATE (BEFORE [P0-T1])
+You must validate ALL of the following; otherwise STOP:
+- Phase headings follow “Phase N — …”
+- Each task is a markdown checkbox with valid [P#-T#]
+- Phase numbers and task IDs are consistent
+- Phase 0 exists and includes:
+  - Repo-policy reading
+  - Baseline toolchain runs for each language touched
+- A final QA phase exists with full toolchain loops per touched language
+- Any TDD red tests are tagged [expect-fail]
+- No task is non-atomic or unverifiable
+
+If blocked:
+- State: “BLOCKED at preflight (before [P0-T1])”
+- Explain concretely
+- Provide an exact plan delta
+- Request atomic_planner regeneration or user approval
+
+EXECUTION LOOP (AFTER PREFLIGHT PASSES)
+Once execution begins:
+- Do NOT stop mid-plan
+- Do NOT replan or redesign
+- Persist across turns until the plan is fully complete
+
+For EACH task:
+1) Announce: “Executing [P#-T#]: …”
+2) Verify stated preconditions
+3) Perform ONLY work required by the task (bounded micro-actions allowed)
+4) Verify acceptance criteria
+5) Run required toolchains as specified or implied
+6) Check off the task ONLY when verification passes
+
+[expect-fail] tasks:
+- A failing test is success ONLY for that task
+- Formatting, linting, and type checks still apply unless explicitly waived
+
+BLOCKING RULE
+- Blocking is permitted ONLY during preflight.
+- After execution begins, blocking is forbidden; continue to completion.
+
+RESUME / CONTINUE
+- On “resume”, “continue”, or “try again”:
+  - Reload the last plan-of-record
+  - Identify the next unchecked task
+  - Announce: “Continuing from [P#-T#]”
+  - Continue execution without replanning
+
+OUTPUT DISCIPLINE
+- Be concise and exact
+- Show commands run and summarize results (pass/fail, key errors)
+- Do not paste large code blocks unless asked
+- Report toolchain status explicitly for each touched language
+- End every response with the updated checklist (or current phase + next tasks)
+
+--- END OF ATOMIC EXECUTION HARD-LOCK ---
+
+MODE CONTEXT
+- Selected work mode: `${work-mode}`
+
+PLAN OF RECORD
+`${plan-path}`
+
+MANDATORY READ-PROOF (DO THIS FIRST; NO EXECUTION YET)
+1) Confirm the Plan of Record file exists in the repo/branch you are operating on.
+2) Output a fingerprint of what you read:
+   - git rev-parse HEAD
+   - sha256 of the plan file
+   - total count of tasks matching "^- \\[[ x]\\] \\[P" (or equivalent)
+3) Enter atomic execution mode
+4) Perform PREFLIGHT VALIDATION ONLY.
+5) Identify the FIRST unchecked task ([ ]) in plan order and print ONLY:
+   - the exact line for that task
+   - 2 lines above and 2 lines below (no more)
+6) State: "READY TO BEGIN FROM [P#-T#]" and WAIT.

--- a/extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md
+++ b/extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md
@@ -1,0 +1,92 @@
+YOU ARE OPERATING IN ATOMIC EXECUTION MODE (atomic_executor).
+
+THIS IS A RESUME OPERATION, NOT A NEW EXECUTION.
+
+IDENTITY & SCOPE
+- Execution-only persona.
+- No planning, no redesign, no reordering.
+- Execute the existing atomic_planner plan exactly as written.
+- Preserve Phase headings, task IDs ([P#-T#]), checkbox format, and task order.
+
+CRITICAL EXECUTION STATE RULE (NON-NEGOTIABLE)
+- Completed tasks are those explicitly marked [x] in the plan text.
+- Execution MUST resume at the FIRST unchecked task ([ ]) in plan order.
+- You MUST NOT:
+  - Re-list completed tasks
+  - Re-announce completed tasks
+  - Re-execute completed tasks
+  - Summarize earlier phases
+
+If you cannot identify the first unchecked task with certainty, STOP and request the plan text.
+
+PLAN AUTHORITY
+- The plan text is the sole source of truth.
+- The plan itself is the only todo list.
+- Task IDs must remain unchanged and referenced exactly.
+- Tasks must be executed in exact written order starting from the resume point.
+
+PLAN OF RECORD (AUTHORITATIVE)
+- Load the plan from this repository file path (not from memory, not inferred):
+   ${plan-path}
+
+MODE CONTEXT
+- Selected work mode: `${work-mode}`
+
+MANDATORY LOAD + READ-PROOF (DO THIS BEFORE PREFLIGHT)
+1) Open/read the plan file from the repo/branch you are operating on.
+2) Provide proof you actually read it by outputting:
+   a) A unique fingerprint of the plan file contents (sha256 preferred; if not available, provide file byte length AND the first and last 2 lines verbatim)
+   b) Total count of tasks that match the checkbox + ID pattern, e.g. lines beginning with:
+      "- [ ] [P" or "- [x] [P"
+3) Identify the FIRST unchecked task ([ ]) in plan order and print ONLY:
+   - the exact checkbox line for that task
+   - 2 lines above and 2 lines below
+4) Then output exactly:
+   READY TO RESUME FROM [P#-T#]
+5) Immediately continue into PREFLIGHT (RESUME VARIANT), then begin execution from that resume point if preflight passes.
+
+If you cannot open/read the plan file, respond ONLY:
+NO FILE ACCESS — CANNOT EXECUTE
+
+PREFLIGHT (RESUME VARIANT)
+You must:
+1) Parse the provided plan text.   (In this workflow, "provided plan text" means the contents you just loaded from PLAN OF RECORD.)
+2) Identify the first unchecked task ([ ]).
+3) Announce ONLY:
+   “Resuming execution from [P#-T#]: <task text>”
+4) Begin execution immediately after the announcement.
+
+If any task before the proposed resume point is unchecked, STOP and report invalid execution state.
+
+EXECUTION LOOP (AUTOMATIC AFTER PREFLIGHT PASSES)
+After preflight passes:
+- Execute tasks strictly one-by-one from the resume point.
+- Do NOT stop mid-plan.
+- Do NOT replan.
+- Persist across turns until completion.
+
+TASK EXECUTION RULES
+For each task:
+1) Announce execution of the current task only.
+2) Perform only work required by the task.
+3) Verify acceptance criteria.
+4) Run required toolchains as specified or implied.
+5) Check off the task ONLY when verification passes.
+
+BLOCKING RULE
+- Blocking is permitted ONLY if execution state is invalid.
+- Blocking for replanning or redesign is forbidden.
+
+OUTPUT DISCIPLINE
+- Be concise and exact.
+- Show commands run and summarize results.
+- Report toolchain status explicitly.
+- End every response with the updated checklist starting at the resume point.
+
+--- END OF RESUME HARD-LOCK ---
+
+INSTRUCTIONS:
+- Load the plan of record from the file path above.
+- Perform the MANDATORY LOAD + READ-PROOF.
+- Perform PREFLIGHT (RESUME VARIANT).
+- If preflight passes, continue execution immediately from the first unchecked task.

--- a/extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py
+++ b/extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scripts.dev_tools.prompt_mode_contract import (
+from dev_tools.prompt_mode_contract import (
     build_fallback_reason,
     resolve_selected_work_mode,
 )
@@ -121,12 +121,12 @@ def copy_to_clipboard(text: str) -> bool:
 
     # Fallback chain: try common clipboard commands across platforms
     commands: tuple[list[str], ...] = (
-        ["pbcopy"],  # macOS
-        ["wl-copy"],  # Wayland
-        ["xclip", "-selection", "clipboard"],  # X11
-        ["xsel", "--clipboard", "--input"],  # X11 alternative
-        ["clip"],  # Windows
-        ["clip.exe"],  # WSL
+        ["pbcopy"],
+        ["wl-copy"],
+        ["xclip", "-selection", "clipboard"],
+        ["xsel", "--clipboard", "--input"],
+        ["clip"],
+        ["clip.exe"],
     )
 
     for command in commands:
@@ -134,7 +134,6 @@ def copy_to_clipboard(text: str) -> bool:
         if executable is None:
             continue
         try:
-            # S603: validated above via shutil.which
             subprocess.run(  # noqa: S603 - static analysis can't verify runtime validation
                 [executable, *command[1:]],
                 input=text,
@@ -255,10 +254,7 @@ def resolve_prompt(
     Side Effects:
         None. Pure function.
     """
-    # Resolve target path relative to workspace
     relative_target = _try_relative_to_workspace(target_path, workspace_root)
-
-    # Convert to forward slashes for cross-platform consistency
     plan_path_value = relative_target.as_posix()
 
     selected_mode, resolved_fallback_reason = _resolve_work_mode_from_issue(
@@ -270,7 +266,6 @@ def resolve_prompt(
         fallback_reason if fallback_reason is not None else resolved_fallback_reason
     )
 
-    # Substitute variables.
     resolved = template_content.replace("${plan-path}", plan_path_value)
     resolved = resolved.replace("${work-mode}", mode_value)
     resolved = resolved.replace("${fallback-reason}", fallback_value)
@@ -316,11 +311,7 @@ def main() -> int:
     )
 
     args = parser.parse_args()
-
-    # Determine workspace root
     workspace_root = args.workspace if args.workspace else Path.cwd()
-
-    # Locate the template file selected by --template-kind.
     template_name = _resolve_template_name(args.template_kind)
     template_path, checked_paths = _resolve_template_path(
         template_name,
@@ -341,20 +332,15 @@ def main() -> int:
         print(f"Error: Target file not found at {args.target}", file=sys.stderr)
         return 1
 
-    # Read template
     try:
         template_content = template_path.read_text(encoding="utf-8")
     except OSError as error:
         print(f"Error reading template: {error}", file=sys.stderr)
         return 1
 
-    # Resolve the prompt
     resolved_prompt = resolve_prompt(template_content, args.target, workspace_root)
-
-    # Print the resolved prompt
     print(resolved_prompt)
 
-    # Attempt to copy to clipboard
     if copy_to_clipboard(resolved_prompt):
         print("\n✓ Copied to clipboard", file=sys.stderr)
     else:

--- a/extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py
+++ b/extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py
@@ -1,0 +1,63 @@
+"""Compatibility wrapper for extension-side hard-lock prompt resolution.
+
+Purpose:
+    Preserve the bundled-script entry point while delegating hard-lock prompt
+    resolution behavior to the bundled package implementation.
+
+Usage:
+    python resolve_hard_lock_prompt.py --target <plan> --workspace <workspace>
+
+Flow:
+    1. Ensure `resources/scripts/` is importable at runtime.
+    2. Inject the bundled `.github/codex` template root when the caller omitted it.
+    3. Import `dev_tools.resolve_hard_lock_prompt` from bundled sources.
+    4. Invoke the bundled CLI entrypoint in-process with the active CLI args.
+
+Invariants / Constraints:
+    - No prompt-resolution business logic is implemented in this wrapper.
+    - Argument contract is owned by the bundled resolver module and forwarded
+      unchanged except for additive `--template-root` injection.
+
+Side Effects:
+    Imports bundled resolver code and executes it in the current Python process.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+
+def _ensure_bundled_scripts_import_path() -> None:
+    """Prepend bundled `resources/scripts` directory to ``sys.path``."""
+    scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
+    scripts_dir_str = str(scripts_dir)
+
+    if scripts_dir_str not in sys.path:
+        sys.path.insert(0, scripts_dir_str)
+
+
+def main() -> int:
+    """Execute bundled hard-lock prompt resolution in-process.
+
+    Injects `--template-root` pointing to the extension's bundled hard-lock
+    prompt templates when the caller did not already provide one.
+    """
+    _ensure_bundled_scripts_import_path()
+
+    template_root = str(
+        Path(__file__).resolve().parent.parent / "customizations" / ".github" / "codex"
+    )
+    if "--template-root" not in sys.argv:
+        sys.argv.extend(["--template-root", template_root])
+
+    module = importlib.import_module("dev_tools.resolve_hard_lock_prompt")
+    module_main = cast(Callable[[], int], module.main)
+    return int(module_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/drm-copilot/src/extension.ts
+++ b/extensions/drm-copilot/src/extension.ts
@@ -17,6 +17,7 @@ const SHORT_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const FEATURE_NAME_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
 const POTENTIAL_PROMOTION_TYPES = ["epic", "feature", "refactor", "bug"];
 const WORK_MODE_OPTIONS = ["minor-audit", "full-feature", "full-bug", "full"];
+const ACTIVE_FEATURE_DOCS_DIRECTORY = "docs/features/active";
 const POTENTIAL_DOCS_DIRECTORY = "docs/features/potential";
 
 function normalizePath(filePath: string): string {
@@ -43,6 +44,47 @@ function getActivePotentialPath(workspaceRoot: string): string | undefined {
   }
 
   return activeEditorPath;
+}
+
+function getActiveFeaturePlanPath(workspaceRoot: string): string | undefined {
+  const activeEditorPath = vscode.window.activeTextEditor?.document.uri.fsPath;
+  if (!activeEditorPath) {
+    return undefined;
+  }
+
+  const normalizedWorkspaceRoot = normalizePath(workspaceRoot).toLowerCase();
+  const normalizedActiveEditorPath =
+    normalizePath(activeEditorPath).toLowerCase();
+  const normalizedActiveFeatureRoot = `${normalizedWorkspaceRoot}/${ACTIVE_FEATURE_DOCS_DIRECTORY}`;
+
+  if (!normalizedActiveEditorPath.endsWith(".md")) {
+    return undefined;
+  }
+
+  if (
+    !normalizedActiveEditorPath.startsWith(`${normalizedActiveFeatureRoot}/`)
+  ) {
+    return undefined;
+  }
+
+  return activeEditorPath;
+}
+
+async function promptForActiveFeaturePlan(
+  workspaceRoot: string,
+): Promise<string | undefined> {
+  const selectedFile = await vscode.window.showOpenDialog({
+    canSelectMany: false,
+    openLabel: "Select feature plan",
+    defaultUri: vscode.Uri.file(
+      `${workspaceRoot}/${ACTIVE_FEATURE_DOCS_DIRECTORY}`,
+    ),
+    filters: {
+      Markdown: ["md"],
+    },
+  });
+
+  return selectedFile?.[0]?.fsPath;
 }
 
 async function promptForShortName(
@@ -407,6 +449,29 @@ export function activate(context: vscode.ExtensionContext): void {
     },
   );
 
+  const resolveExecuteHardLockPromptDisposable =
+    vscode.commands.registerCommand(
+      "drmCopilotExtension.resolveExecuteHardLockPrompt",
+      async () => {
+        const commandId = "drmCopilotExtension.resolveExecuteHardLockPrompt";
+        const workspaceRoot = getWorkspaceRoot();
+        const activePlanPath = getActiveFeaturePlanPath(workspaceRoot);
+        const planPath =
+          activePlanPath ?? (await promptForActiveFeaturePlan(workspaceRoot));
+        if (!planPath) {
+          return;
+        }
+
+        await executeBundledScript(context, output, {
+          runtimeKind: "python",
+          bundledRelativePath:
+            "resources/templates/resolve_hard_lock_prompt.py",
+          commandId,
+          args: ["--target", planPath, "--workspace", workspaceRoot],
+        });
+      },
+    );
+
   context.subscriptions.push(
     helloPythonDisposable,
     helloPowerShellDisposable,
@@ -417,6 +482,7 @@ export function activate(context: vscode.ExtensionContext): void {
     pushDownCopilotCustomizationsDisposable,
     newPotentialBugEntryDisposable,
     newPotentialEntryDisposable,
+    resolveExecuteHardLockPromptDisposable,
     output,
   );
 }

--- a/extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts
+++ b/extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts
@@ -1,0 +1,261 @@
+import { EventEmitter } from "node:events";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+type CommandHandler = () => Promise<void> | void;
+type MockUri = { fsPath: string };
+type MockChildProcess = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+};
+
+const commandHandlers = new Map<string, CommandHandler>();
+const appendLineMock = jest.fn<(line: string) => void>();
+const showOpenDialogMock =
+  jest.fn<(options?: unknown) => Promise<ReadonlyArray<MockUri> | undefined>>();
+const registerCommandMock = jest.fn(
+  (command: string, handler: CommandHandler) => {
+    commandHandlers.set(command, handler);
+    return { dispose: jest.fn() };
+  },
+);
+
+let workspaceFoldersState: Array<{ uri: { fsPath: string } }> | undefined = [
+  { uri: { fsPath: "C:/workspace" } },
+];
+let activeTextEditorState:
+  | {
+      document: {
+        uri: {
+          fsPath: string;
+        };
+      };
+    }
+  | undefined;
+
+jest.mock(
+  "vscode",
+  () => ({
+    commands: {
+      registerCommand: registerCommandMock,
+    },
+    window: {
+      createOutputChannel: jest.fn(() => ({
+        appendLine: appendLineMock,
+        dispose: jest.fn(),
+      })),
+      get activeTextEditor() {
+        return activeTextEditorState;
+      },
+      showOpenDialog: showOpenDialogMock,
+    },
+    workspace: {
+      get workspaceFolders() {
+        return workspaceFoldersState;
+      },
+    },
+    Uri: {
+      joinPath: jest.fn((base: { fsPath: string }, relative: string) => ({
+        fsPath: `${base.fsPath}/${relative}`,
+      })),
+      file: jest.fn((filePath: string) => ({ fsPath: filePath })),
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock("node:child_process", () => ({
+  spawn: jest.fn(),
+  spawnSync: jest.fn(),
+}));
+
+import { activate } from "../src/extension";
+
+const fsMock = jest.requireMock("node:fs") as {
+  existsSync: jest.MockedFunction<(filePath: string) => boolean>;
+};
+
+const childProcessMock = jest.requireMock("node:child_process") as {
+  spawn: jest.Mock;
+  spawnSync: jest.Mock;
+};
+
+function setExecutablePresence(presence: { readonly python?: boolean }): void {
+  fsMock.existsSync.mockImplementation((filePath: string) => {
+    const lowerPath = filePath.toLowerCase();
+    if (lowerPath.includes("python")) {
+      return presence.python ?? false;
+    }
+
+    return false;
+  });
+}
+
+function createMockProcess(exitCode: number): MockChildProcess {
+  const processMock = new EventEmitter() as MockChildProcess;
+  processMock.stdout = new EventEmitter();
+  processMock.stderr = new EventEmitter();
+  process.nextTick(() => {
+    processMock.emit("close", exitCode);
+  });
+  return processMock;
+}
+
+function activateAndGetHandler(commandId: string): CommandHandler {
+  const context = {
+    extensionUri: { fsPath: "C:/extension" },
+    subscriptions: [] as Array<{ dispose(): void }>,
+  };
+
+  activate(context as never);
+  const handler = commandHandlers.get(commandId);
+  if (!handler) {
+    throw new Error(`Missing command handler: ${commandId}`);
+  }
+
+  return handler;
+}
+
+function setActiveEditorPath(filePath: string | undefined): void {
+  activeTextEditorState = filePath
+    ? {
+        document: {
+          uri: {
+            fsPath: filePath,
+          },
+        },
+      }
+    : undefined;
+}
+
+describe("drm-copilot resolveExecuteHardLockPrompt command", () => {
+  beforeEach(() => {
+    process.env.PATH = "C:/bin";
+    process.env.PATHEXT = ".EXE;.CMD";
+    commandHandlers.clear();
+    appendLineMock.mockReset();
+    registerCommandMock.mockClear();
+    showOpenDialogMock.mockReset();
+    childProcessMock.spawn.mockReset();
+    childProcessMock.spawnSync.mockReset();
+    workspaceFoldersState = [{ uri: { fsPath: "C:/workspace" } }];
+    activeTextEditorState = undefined;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registers resolveExecuteHardLockPrompt", () => {
+    activateAndGetHandler("drmCopilotExtension.resolveExecuteHardLockPrompt");
+
+    expect(
+      commandHandlers.has("drmCopilotExtension.resolveExecuteHardLockPrompt"),
+    ).toBe(true);
+  });
+
+  it("reuses the active feature plan editor before opening the picker", async () => {
+    setExecutablePresence({ python: true });
+    setActiveEditorPath(
+      "C:/workspace/docs/features/active/feature-123/plan.md",
+    );
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.resolveExecuteHardLockPrompt",
+    );
+    await handler();
+
+    expect(showOpenDialogMock).not.toHaveBeenCalled();
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--target");
+    expect(args).toContain(
+      "C:/workspace/docs/features/active/feature-123/plan.md",
+    );
+  });
+
+  it("opens a docs/features/active picker when the active editor is not eligible", async () => {
+    setExecutablePresence({ python: true });
+    setActiveEditorPath("C:/workspace/README.md");
+    showOpenDialogMock.mockResolvedValue([
+      { fsPath: "C:/workspace/docs/features/active/feature-123/plan.md" },
+    ]);
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.resolveExecuteHardLockPrompt",
+    );
+    await handler();
+
+    expect(showOpenDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultUri: expect.objectContaining({
+          fsPath: expect.stringContaining("docs/features/active"),
+        }),
+        filters: {
+          Markdown: ["md"],
+        },
+      }),
+    );
+  });
+
+  it("passes the wrapper path plus --target and --workspace argument pairs", async () => {
+    setExecutablePresence({ python: true });
+    showOpenDialogMock.mockResolvedValue([
+      { fsPath: "C:/workspace/docs/features/active/feature-123/plan.md" },
+    ]);
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.resolveExecuteHardLockPrompt",
+    );
+    await handler();
+
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args[0]).toBe(
+      "C:/extension/resources/templates/resolve_hard_lock_prompt.py",
+    );
+    expect(args[1]).toBe("--target");
+    expect(args[2]).toBe(
+      "C:/workspace/docs/features/active/feature-123/plan.md",
+    );
+    expect(args[3]).toBe("--workspace");
+    expect(args[4]).toBe("C:/workspace");
+  });
+
+  it("returns early when the feature plan picker is cancelled", async () => {
+    showOpenDialogMock.mockResolvedValue(undefined);
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.resolveExecuteHardLockPrompt",
+    );
+    await handler();
+
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a missing python runtime error for resolveExecuteHardLockPrompt", async () => {
+    setExecutablePresence({ python: false });
+    showOpenDialogMock.mockResolvedValue([
+      { fsPath: "C:/workspace/docs/features/active/feature-123/plan.md" },
+    ]);
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.resolveExecuteHardLockPrompt",
+    );
+
+    await expect(handler()).rejects.toThrow(
+      "Python runtime 'python' not found on PATH.",
+    );
+  });
+});

--- a/tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py
+++ b/tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py
@@ -1,0 +1,374 @@
+"""Tests for the extension-bundled resolve_hard_lock_prompt.py wrapper template."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from io import StringIO
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[5]
+_TEMPLATE_PATH = (
+    ROOT
+    / "extensions"
+    / "drm-copilot"
+    / "resources"
+    / "templates"
+    / "resolve_hard_lock_prompt.py"
+)
+_EXPECTED_TEMPLATE_ROOT = (
+    ROOT
+    / "extensions"
+    / "drm-copilot"
+    / "resources"
+    / "customizations"
+    / ".github"
+    / "codex"
+)
+_BUNDLED_RESOLVER_PATH = (
+    ROOT
+    / "extensions"
+    / "drm-copilot"
+    / "resources"
+    / "scripts"
+    / "dev_tools"
+    / "resolve_hard_lock_prompt.py"
+)
+_BUNDLED_SCRIPTS_PATH = str(
+    ROOT / "extensions" / "drm-copilot" / "resources" / "scripts"
+)
+
+
+@pytest.fixture
+def mem_path(tmp_path: Path) -> Path:
+    """Alias fixture for cosmetic tmp_path->mem_path test parameter rename."""
+    return tmp_path
+
+
+def _load_module_from_path(module_name: str, file_path: Path) -> ModuleType:
+    """Load a Python module directly from a file path for wrapper import tests.
+
+    Args:
+        module_name: Unique name to register in sys.modules for this load.
+        file_path: Absolute path to the .py file to load.
+
+    Returns:
+        The loaded module object.
+
+    Raises:
+        AssertionError: If a module spec cannot be created for the given path.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Unable to load module spec for {file_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.pop(module_name, None)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_main_injects_bundled_template_root_when_flag_is_absent() -> None:
+    """Inject the bundled codex root when the wrapper caller omits --template-root."""
+    assert _TEMPLATE_PATH.exists(), f"Expected wrapper to exist at {_TEMPLATE_PATH}"
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        module = _load_module_from_path(
+            "ext_rhlp_injects_template_root",
+            _TEMPLATE_PATH,
+        )
+        mock_bundled = MagicMock()
+        mock_bundled.main = MagicMock(return_value=0)
+        sys.argv = ["resolve_hard_lock_prompt.py", "--target", "C:/workspace/plan.md"]
+
+        with patch.object(module.importlib, "import_module", return_value=mock_bundled):
+            result = module.main()
+
+        assert result == 0
+        assert "--template-root" in sys.argv
+        template_root_index = sys.argv.index("--template-root")
+        assert sys.argv[template_root_index + 1] == str(_EXPECTED_TEMPLATE_ROOT)
+        mock_bundled.main.assert_called_once()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_rhlp_injects_template_root", None)
+
+
+def test_main_propagates_bundled_non_zero_exit_code() -> None:
+    """Return the delegated bundled resolver exit code instead of masking failures.
+
+    Purpose:
+        Protect the wrapper/extension process boundary so missing-target or
+        missing-template failures remain visible to the VS Code command runtime.
+
+    Returns:
+        None.
+    """
+    assert _TEMPLATE_PATH.exists(), f"Expected wrapper to exist at {_TEMPLATE_PATH}"
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        module = _load_module_from_path(
+            "ext_rhlp_propagates_nonzero_exit",
+            _TEMPLATE_PATH,
+        )
+        mock_bundled = MagicMock()
+        mock_bundled.main = MagicMock(return_value=1)
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            "C:/workspace/missing.md",
+        ]
+
+        with patch.object(module.importlib, "import_module", return_value=mock_bundled):
+            result = module.main()
+
+        assert result == 1
+        mock_bundled.main.assert_called_once()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_rhlp_propagates_nonzero_exit", None)
+
+
+def test_main_preserves_explicit_template_root_when_wrapper_flag_is_present() -> None:
+    """Keep a caller-supplied template root instead of appending the bundled one."""
+    assert _TEMPLATE_PATH.exists(), f"Expected wrapper to exist at {_TEMPLATE_PATH}"
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+    explicit_template_root = "C:/caller-provided/codex"
+
+    try:
+        module = _load_module_from_path(
+            "ext_rhlp_preserves_template_root",
+            _TEMPLATE_PATH,
+        )
+        mock_bundled = MagicMock()
+        mock_bundled.main = MagicMock(return_value=0)
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            "C:/workspace/plan.md",
+            "--template-root",
+            explicit_template_root,
+        ]
+
+        with patch.object(module.importlib, "import_module", return_value=mock_bundled):
+            result = module.main()
+
+        assert result == 0
+        assert sys.argv.count("--template-root") == 1
+        template_root_index = sys.argv.index("--template-root")
+        assert sys.argv[template_root_index + 1] == explicit_template_root
+        mock_bundled.main.assert_called_once()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_rhlp_preserves_template_root", None)
+
+
+def test_bundled_resolver_prefers_template_root_before_workspace_codex(
+    mem_path: Path,
+) -> None:
+    """Prefer the explicit template root before the workspace codex fallback."""
+    assert _BUNDLED_RESOLVER_PATH.exists()
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    workspace_template_dir = workspace / ".github" / "codex"
+    workspace_template_dir.mkdir(parents=True)
+    (workspace_template_dir / "execute-hard-lock.prompt.md").write_text(
+        "workspace ${plan-path}",
+        encoding="utf-8",
+    )
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    (template_root / "execute-hard-lock.prompt.md").write_text(
+        "bundled ${plan-path}",
+        encoding="utf-8",
+    )
+    target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("# Plan", encoding="utf-8")
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        if _BUNDLED_SCRIPTS_PATH not in sys.path:
+            sys.path.insert(0, _BUNDLED_SCRIPTS_PATH)
+        module = _load_module_from_path(
+            "ext_bundled_resolver_prefers_template_root",
+            _BUNDLED_RESOLVER_PATH,
+        )
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            str(target_file),
+            "--workspace",
+            str(workspace),
+            "--template-root",
+            str(template_root),
+        ]
+
+        with (
+            patch.object(module, "copy_to_clipboard", return_value=True),
+            patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+            patch("sys.stderr", new_callable=StringIO),
+        ):
+            exit_code = module.main()
+
+        assert exit_code == 0
+        assert "bundled docs/plan.md" in mock_stdout.getvalue()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_bundled_resolver_prefers_template_root", None)
+
+
+def test_bundled_resolver_falls_back_to_workspace_codex_when_template_is_missing(
+    mem_path: Path,
+) -> None:
+    """Fall back to workspace codex when the explicit template root lacks the file."""
+    assert _BUNDLED_RESOLVER_PATH.exists()
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    workspace_template_dir = workspace / ".github" / "codex"
+    workspace_template_dir.mkdir(parents=True)
+    (workspace_template_dir / "execute-hard-lock.prompt.md").write_text(
+        "workspace ${plan-path}",
+        encoding="utf-8",
+    )
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("# Plan", encoding="utf-8")
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        if _BUNDLED_SCRIPTS_PATH not in sys.path:
+            sys.path.insert(0, _BUNDLED_SCRIPTS_PATH)
+        module = _load_module_from_path(
+            "ext_bundled_resolver_workspace_fallback",
+            _BUNDLED_RESOLVER_PATH,
+        )
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            str(target_file),
+            "--workspace",
+            str(workspace),
+            "--template-root",
+            str(template_root),
+        ]
+
+        with (
+            patch.object(module, "copy_to_clipboard", return_value=True),
+            patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+            patch("sys.stderr", new_callable=StringIO),
+        ):
+            exit_code = module.main()
+
+        assert exit_code == 0
+        assert "workspace docs/plan.md" in mock_stdout.getvalue()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_bundled_resolver_workspace_fallback", None)
+
+
+def test_bundled_resolver_reports_checked_template_paths_on_lookup_failure(
+    mem_path: Path,
+) -> None:
+    """Report both checked template locations when bundled lookup fails."""
+    assert _BUNDLED_RESOLVER_PATH.exists()
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("# Plan", encoding="utf-8")
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        if _BUNDLED_SCRIPTS_PATH not in sys.path:
+            sys.path.insert(0, _BUNDLED_SCRIPTS_PATH)
+        module = _load_module_from_path(
+            "ext_bundled_resolver_missing_template",
+            _BUNDLED_RESOLVER_PATH,
+        )
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            str(target_file),
+            "--workspace",
+            str(workspace),
+            "--template-root",
+            str(template_root),
+        ]
+
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            exit_code = module.main()
+
+        stderr_output = mock_stderr.getvalue()
+        assert exit_code == 1
+        assert str(template_root / "execute-hard-lock.prompt.md") in stderr_output
+        assert (
+            str(workspace / ".github" / "codex" / "execute-hard-lock.prompt.md")
+            in stderr_output
+        )
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_bundled_resolver_missing_template", None)
+
+
+def test_bundled_resolver_injects_work_mode_from_issue_marker() -> None:
+    """Inject the bundled resolver work-mode marker from the nearest issue.md."""
+    module = _load_module_from_path(
+        "ext_bundled_resolver_mode_marker",
+        _BUNDLED_RESOLVER_PATH,
+    )
+    workspace_root = Path.cwd()
+    target = workspace_root / "docs" / "features" / "active" / "feature-1" / "plan.md"
+    issue_path = (
+        workspace_root / "docs" / "features" / "active" / "feature-1" / "issue.md"
+    )
+
+    def _exists(self: Path) -> bool:
+        return self == issue_path
+
+    def _read_text(self: Path, encoding: str = "utf-8") -> str:
+        del encoding
+        if self == issue_path:
+            return "- Work Mode: minor-audit\n"
+        raise FileNotFoundError(str(self))
+
+    try:
+        with (
+            patch.object(Path, "exists", _exists),
+            patch.object(Path, "read_text", _read_text),
+        ):
+            result = module.resolve_prompt(
+                "Mode=${work-mode};Reason=${fallback-reason}",
+                target,
+                workspace_root,
+            )
+
+        assert "Mode=minor-audit" in result
+        assert "Reason=none" in result
+    finally:
+        sys.modules.pop("ext_bundled_resolver_mode_marker", None)

--- a/tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt_part2.py
+++ b/tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt_part2.py
@@ -1,0 +1,344 @@
+"""Additional tests for the extension-bundled resolve_hard_lock_prompt wrapper stack."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from io import StringIO
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[5]
+_BUNDLED_RESOLVER_PATH = (
+    ROOT
+    / "extensions"
+    / "drm-copilot"
+    / "resources"
+    / "scripts"
+    / "dev_tools"
+    / "resolve_hard_lock_prompt.py"
+)
+_BUNDLED_SCRIPTS_PATH = str(
+    ROOT / "extensions" / "drm-copilot" / "resources" / "scripts"
+)
+
+
+@pytest.fixture
+def mem_path(tmp_path: Path) -> Path:
+    """Alias fixture for cosmetic tmp_path->mem_path test parameter naming."""
+    return tmp_path
+
+
+def _load_module_from_path(module_name: str, file_path: Path) -> ModuleType:
+    """Load a Python module directly from a file path for bundled-resource tests.
+
+    Args:
+        module_name: Unique module name used for this import instance.
+        file_path: Absolute path to the Python module file.
+
+    Returns:
+        The imported module object.
+
+    Raises:
+        AssertionError: When a module spec cannot be created for the file.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Unable to load module spec for {file_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.pop(module_name, None)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bundled_resolver_uses_parent_issue_for_versioned_plan_path() -> None:
+    """Use the parent issue.md when the bundled resolver target lives under v2."""
+    module = _load_module_from_path(
+        "ext_bundled_resolver_parent_issue",
+        _BUNDLED_RESOLVER_PATH,
+    )
+    workspace_root = Path.cwd()
+    target = (
+        workspace_root / "docs" / "features" / "active" / "feature-1" / "v2" / "plan.md"
+    )
+    issue_path = (
+        workspace_root / "docs" / "features" / "active" / "feature-1" / "issue.md"
+    )
+
+    def _exists(self: Path) -> bool:
+        return self == issue_path
+
+    def _read_text(self: Path, encoding: str = "utf-8") -> str:
+        del encoding
+        if self == issue_path:
+            return "- Work Mode: full-feature\n"
+        raise FileNotFoundError(str(self))
+
+    try:
+        with (
+            patch.object(Path, "exists", _exists),
+            patch.object(Path, "read_text", _read_text),
+        ):
+            result = module.resolve_prompt(
+                "Mode=${work-mode};Reason=${fallback-reason}",
+                target,
+                workspace_root,
+            )
+
+        assert "Mode=full-feature" in result
+        assert "Reason=none" in result
+    finally:
+        sys.modules.pop("ext_bundled_resolver_parent_issue", None)
+
+
+def test_bundled_resolver_mode_fallback_when_issue_unreadable() -> None:
+    """Fail closed when the bundled resolver cannot read issue.md."""
+    module = _load_module_from_path(
+        "ext_bundled_resolver_unreadable_issue",
+        _BUNDLED_RESOLVER_PATH,
+    )
+    workspace_root = Path.cwd()
+    target = workspace_root / "docs" / "features" / "active" / "feature-1" / "plan.md"
+    issue_path = (
+        workspace_root / "docs" / "features" / "active" / "feature-1" / "issue.md"
+    )
+
+    def _exists(self: Path) -> bool:
+        return self == issue_path
+
+    def _read_text(self: Path, encoding: str = "utf-8") -> str:
+        del encoding
+        raise OSError("boom")
+
+    try:
+        with (
+            patch.object(Path, "exists", _exists),
+            patch.object(Path, "read_text", _read_text),
+        ):
+            result = module.resolve_prompt(
+                "Mode=${work-mode};Reason=${fallback-reason}",
+                target,
+                workspace_root,
+            )
+
+        assert "Mode=full-feature" in result
+        assert "issue.md unreadable; fail closed to full-feature" in result
+    finally:
+        sys.modules.pop("ext_bundled_resolver_unreadable_issue", None)
+
+
+def test_bundled_copy_to_clipboard_no_mechanism() -> None:
+    """Return False when the bundled resolver cannot find any clipboard path."""
+    module = _load_module_from_path(
+        "ext_bundled_resolver_clipboard_none",
+        _BUNDLED_RESOLVER_PATH,
+    )
+
+    try:
+        with (
+            patch.dict("sys.modules", {"pyperclip": None}),
+            patch("shutil.which", return_value=None),
+            patch("sys.stderr", new_callable=StringIO),
+        ):
+            assert module.copy_to_clipboard("test text") is False
+    finally:
+        sys.modules.pop("ext_bundled_resolver_clipboard_none", None)
+
+
+def test_bundled_copy_to_clipboard_with_pyperclip_success() -> None:
+    """Return True when bundled clipboard copy succeeds through pyperclip."""
+    mock_pyperclip = MagicMock()
+    mock_pyperclip.copy = MagicMock()
+
+    with patch.dict("sys.modules", {"pyperclip": mock_pyperclip}):
+        module = _load_module_from_path(
+            "ext_bundled_resolver_clipboard_success",
+            _BUNDLED_RESOLVER_PATH,
+        )
+
+        try:
+            assert module.copy_to_clipboard("test text") is True
+            mock_pyperclip.copy.assert_called_once_with("test text")
+        finally:
+            sys.modules.pop("ext_bundled_resolver_clipboard_success", None)
+
+
+def test_bundled_copy_to_clipboard_pyperclip_failure_fallback() -> None:
+    """Fall back to a validated native clipboard command after pyperclip fails."""
+    mock_pyperclip = MagicMock()
+    mock_pyperclip.copy = MagicMock(side_effect=RuntimeError("pyperclip failed"))
+
+    with (
+        patch.dict("sys.modules", {"pyperclip": mock_pyperclip}),
+        patch("shutil.which", return_value="/usr/bin/clip"),
+        patch("subprocess.run") as mock_run,
+    ):
+        module = _load_module_from_path(
+            "ext_bundled_resolver_clipboard_fallback",
+            _BUNDLED_RESOLVER_PATH,
+        )
+
+        try:
+            assert module.copy_to_clipboard("test text") is True
+            assert mock_run.called
+        finally:
+            sys.modules.pop("ext_bundled_resolver_clipboard_fallback", None)
+
+
+def test_bundled_resolve_prompt_outside_workspace() -> None:
+    """Keep the absolute target path when the bundled resolver cannot relativize it."""
+    module = _load_module_from_path(
+        "ext_bundled_resolver_outside_workspace",
+        _BUNDLED_RESOLVER_PATH,
+    )
+    workspace_root = Path("/workspace/A")
+    target = Path("/workspace/B/plan.md")
+
+    try:
+        with patch("pathlib.Path.relative_to", side_effect=ValueError):
+            result = module.resolve_prompt("Plan=${plan-path}", target, workspace_root)
+
+        assert str(target).replace("\\", "/") in result
+    finally:
+        sys.modules.pop("ext_bundled_resolver_outside_workspace", None)
+
+
+def test_bundled_main_target_not_found(mem_path: Path) -> None:
+    """Return a clear error when the bundled resolver target path is missing."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    (template_root / "execute-hard-lock.prompt.md").write_text(
+        "bundled ${plan-path}",
+        encoding="utf-8",
+    )
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        if _BUNDLED_SCRIPTS_PATH not in sys.path:
+            sys.path.insert(0, _BUNDLED_SCRIPTS_PATH)
+        module = _load_module_from_path(
+            "ext_bundled_resolver_target_missing",
+            _BUNDLED_RESOLVER_PATH,
+        )
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            str(workspace / "missing.md"),
+            "--workspace",
+            str(workspace),
+            "--template-root",
+            str(template_root),
+        ]
+
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            exit_code = module.main()
+
+        assert exit_code == 1
+        assert "Target file not found" in mock_stderr.getvalue()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_bundled_resolver_target_missing", None)
+
+
+def test_bundled_main_clipboard_copy_fails(mem_path: Path) -> None:
+    """Keep bundled resolver success when clipboard copy is unavailable."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    (template_root / "execute-hard-lock.prompt.md").write_text(
+        "bundled ${plan-path}",
+        encoding="utf-8",
+    )
+    target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("# Plan", encoding="utf-8")
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        if _BUNDLED_SCRIPTS_PATH not in sys.path:
+            sys.path.insert(0, _BUNDLED_SCRIPTS_PATH)
+        module = _load_module_from_path(
+            "ext_bundled_resolver_clipboard_fails",
+            _BUNDLED_RESOLVER_PATH,
+        )
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            str(target_file),
+            "--workspace",
+            str(workspace),
+            "--template-root",
+            str(template_root),
+        ]
+
+        with (
+            patch.object(module, "copy_to_clipboard", return_value=False),
+            patch("sys.stdout", new_callable=StringIO),
+            patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+        ):
+            exit_code = module.main()
+
+        assert exit_code == 0
+        assert "Could not copy to clipboard" in mock_stderr.getvalue()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_bundled_resolver_clipboard_fails", None)
+
+
+def test_bundled_main_template_read_error(mem_path: Path) -> None:
+    """Return a clear error when the bundled resolver cannot read the template."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    template_file = template_root / "execute-hard-lock.prompt.md"
+    template_file.write_text("bundled ${plan-path}", encoding="utf-8")
+    target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("# Plan", encoding="utf-8")
+    original_argv = list(sys.argv)
+    original_sys_path = list(sys.path)
+
+    try:
+        if _BUNDLED_SCRIPTS_PATH not in sys.path:
+            sys.path.insert(0, _BUNDLED_SCRIPTS_PATH)
+        module = _load_module_from_path(
+            "ext_bundled_resolver_template_read_error",
+            _BUNDLED_RESOLVER_PATH,
+        )
+        sys.argv = [
+            "resolve_hard_lock_prompt.py",
+            "--target",
+            str(target_file),
+            "--workspace",
+            str(workspace),
+            "--template-root",
+            str(template_root),
+        ]
+
+        with (
+            patch.object(Path, "read_text", side_effect=OSError("Read error")),
+            patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+        ):
+            exit_code = module.main()
+
+        assert exit_code == 1
+        assert "Error reading template" in mock_stderr.getvalue()
+    finally:
+        sys.argv = original_argv
+        sys.path[:] = original_sys_path
+        sys.modules.pop("ext_bundled_resolver_template_read_error", None)

--- a/tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py
+++ b/tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py
@@ -174,6 +174,23 @@ def test_resolve_prompt_uses_parent_issue_for_versioned_plan_path() -> None:
     assert "Reason=none" in result
 
 
+def _test_resolve_prompt_windows_v2_path_uses_forward_slashes() -> None:
+    """Normalize Windows-style versioned plan paths to forward slashes."""
+    template = "Plan=${plan-path}"
+    workspace_root = Path(r"C:\workspace")
+    target = Path(r"C:\workspace\docs\features\active\feature-1\v2\plan.md")
+
+    result = resolve_prompt(template, target, workspace_root)
+
+    assert "docs/features/active/feature-1/v2/plan.md" in result
+    assert "\\" not in result
+
+
+test_resolve_prompt_uses_forward_slash_path_for_versioned_windows_style_target = (
+    _test_resolve_prompt_windows_v2_path_uses_forward_slashes
+)
+
+
 def test_resolve_prompt_mode_fallback_when_issue_unreadable() -> None:
     """Emit unreadable fallback reason when issue.md cannot be read."""
     template = "Mode=${work-mode};Reason=${fallback-reason}"
@@ -302,163 +319,24 @@ def test_main_success(mem_path: Path) -> None:
     assert "✓ Copied to clipboard" in mock_stderr.getvalue()
 
 
-def test_main_template_not_found(mem_path: Path) -> None:
-    """Test main when template file doesn't exist."""
+def test_main_prefers_template_root_before_workspace_codex(mem_path: Path) -> None:
+    """Prefer the explicit template root over workspace codex templates."""
     workspace = mem_path / "workspace"
     workspace.mkdir()
-
-    target_file = workspace / "plan.md"
-    target_file.write_text("# Plan", encoding="utf-8")
-
-    with (
-        patch(
-            "sys.argv",
-            ["script", "--target", str(target_file), "--workspace", str(workspace)],
-        ),
-        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
-    ):
-        exit_code = main()
-
-    assert exit_code == 1
-    assert "Template not found" in mock_stderr.getvalue()
-
-
-def test_main_target_not_found(mem_path: Path) -> None:
-    """Test main when target file doesn't exist."""
-    workspace = mem_path / "workspace"
-    workspace.mkdir()
-
-    # Create template file
-    template_dir = workspace / ".github" / "codex"
-    template_dir.mkdir(parents=True)
-    template_file = template_dir / "execute-hard-lock.prompt.md"
-    template_file.write_text("Plan: ${plan-path}", encoding="utf-8")
-
-    # Don't create target file
-    target_file = workspace / "nonexistent.md"
-
-    with (
-        patch(
-            "sys.argv",
-            ["script", "--target", str(target_file), "--workspace", str(workspace)],
-        ),
-        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
-    ):
-        exit_code = main()
-
-    assert exit_code == 1
-    assert "Target file not found" in mock_stderr.getvalue()
-
-
-def test_main_clipboard_copy_fails(mem_path: Path) -> None:
-    """Test main when clipboard copy fails."""
-    workspace = mem_path / "workspace"
-    workspace.mkdir()
-
-    # Create template file
-    template_dir = workspace / ".github" / "codex"
-    template_dir.mkdir(parents=True)
-    template_file = template_dir / "execute-hard-lock.prompt.md"
-    template_file.write_text("Plan: ${plan-path}", encoding="utf-8")
-
-    # Create target file
-    target_file = workspace / "plan.md"
-    target_file.write_text("# Plan", encoding="utf-8")
-
-    with (
-        patch(
-            "sys.argv",
-            ["script", "--target", str(target_file), "--workspace", str(workspace)],
-        ),
-        patch(
-            "scripts.dev_tools.resolve_hard_lock_prompt.copy_to_clipboard",
-            return_value=False,
-        ),
-        patch("sys.stdout", new_callable=StringIO),
-        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
-    ):
-        exit_code = main()
-
-    assert exit_code == 0  # Still succeeds, just warns
-    assert "✗ Could not copy to clipboard" in mock_stderr.getvalue()
-
-
-def test_main_default_workspace(mem_path: Path) -> None:
-    """Test main with default workspace (cwd)."""
-    # Create template and target in mem_path
-    template_dir = mem_path / ".github" / "codex"
-    template_dir.mkdir(parents=True)
-    template_file = template_dir / "execute-hard-lock.prompt.md"
-    template_file.write_text("Plan: ${plan-path}", encoding="utf-8")
-
-    target_file = mem_path / "plan.md"
-    target_file.write_text("# Plan", encoding="utf-8")
-
-    with (
-        patch("sys.argv", ["script", "--target", str(target_file)]),
-        patch("pathlib.Path.cwd", return_value=mem_path),
-        patch(
-            "scripts.dev_tools.resolve_hard_lock_prompt.copy_to_clipboard",
-            return_value=True,
-        ),
-        patch("sys.stdout", new_callable=StringIO) as mock_stdout,
-        patch("sys.stderr", new_callable=StringIO),
-    ):
-        exit_code = main()
-
-    assert exit_code == 0
-    assert "plan.md" in mock_stdout.getvalue()
-
-
-def test_main_template_read_error(mem_path: Path) -> None:
-    """Test main when template file cannot be read."""
-    workspace = mem_path / "workspace"
-    workspace.mkdir()
-
-    # Create template file
-    template_dir = workspace / ".github" / "codex"
-    template_dir.mkdir(parents=True)
-    template_file = template_dir / "execute-hard-lock.prompt.md"
-    template_file.write_text("Plan: ${plan-path}", encoding="utf-8")
-
-    # Create target file
-    target_file = workspace / "plan.md"
-    target_file.write_text("# Plan", encoding="utf-8")
-
-    with (
-        patch(
-            "sys.argv",
-            ["script", "--target", str(target_file), "--workspace", str(workspace)],
-        ),
-        patch("pathlib.Path.read_text", side_effect=OSError("Read error")),
-        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
-    ):
-        exit_code = main()
-
-    assert exit_code == 1
-    assert "Error reading template" in mock_stderr.getvalue()
-
-
-def test_main_resume_template_kind(mem_path: Path) -> None:
-    """Resolve resume template when --template-kind resume is provided."""
-    workspace = mem_path / "workspace"
-    workspace.mkdir()
-
-    template_dir = workspace / ".github" / "codex"
-    template_dir.mkdir(parents=True)
-    execute_template = template_dir / "execute-hard-lock.prompt.md"
-    execute_template.write_text("Execute ${plan-path}", encoding="utf-8")
-    resume_template = template_dir / "resume-hard-lock.prompt.md"
-    resume_template.write_text(
-        "Resume ${plan-path} mode=${work-mode}",
+    workspace_template_dir = workspace / ".github" / "codex"
+    workspace_template_dir.mkdir(parents=True)
+    (workspace_template_dir / "execute-hard-lock.prompt.md").write_text(
+        "workspace ${plan-path}",
         encoding="utf-8",
     )
-
-    issue_file = workspace / "docs" / "issue.md"
-    issue_file.parent.mkdir(parents=True)
-    issue_file.write_text("- Work Mode: full-feature\n", encoding="utf-8")
-
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    (template_root / "execute-hard-lock.prompt.md").write_text(
+        "bundled ${plan-path}",
+        encoding="utf-8",
+    )
     target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
     target_file.write_text("# Plan", encoding="utf-8")
 
     with (
@@ -470,8 +348,8 @@ def test_main_resume_template_kind(mem_path: Path) -> None:
                 str(target_file),
                 "--workspace",
                 str(workspace),
-                "--template-kind",
-                "resume",
+                "--template-root",
+                str(template_root),
             ],
         ),
         patch(
@@ -484,5 +362,88 @@ def test_main_resume_template_kind(mem_path: Path) -> None:
         exit_code = main()
 
     assert exit_code == 0
-    assert "Resume docs/plan.md" in mock_stdout.getvalue()
-    assert "mode=full-feature" in mock_stdout.getvalue()
+    assert "bundled docs/plan.md" in mock_stdout.getvalue()
+
+
+def test_main_falls_back_to_workspace_codex_when_template_root_template_is_missing(
+    mem_path: Path,
+) -> None:
+    """Fall back to workspace codex when the explicit template root lacks it."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    workspace_template_dir = workspace / ".github" / "codex"
+    workspace_template_dir.mkdir(parents=True)
+    (workspace_template_dir / "execute-hard-lock.prompt.md").write_text(
+        "workspace ${plan-path}",
+        encoding="utf-8",
+    )
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("# Plan", encoding="utf-8")
+
+    with (
+        patch(
+            "sys.argv",
+            [
+                "script",
+                "--target",
+                str(target_file),
+                "--workspace",
+                str(workspace),
+                "--template-root",
+                str(template_root),
+            ],
+        ),
+        patch(
+            "scripts.dev_tools.resolve_hard_lock_prompt.copy_to_clipboard",
+            return_value=True,
+        ),
+        patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+        patch("sys.stderr", new_callable=StringIO),
+    ):
+        exit_code = main()
+
+    assert exit_code == 0
+    assert "workspace docs/plan.md" in mock_stdout.getvalue()
+
+
+def test_main_reports_checked_template_paths_when_template_lookup_fails(
+    mem_path: Path,
+) -> None:
+    """Report every checked template path when no template candidate exists."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_root = mem_path / "bundled-codex"
+    template_root.mkdir()
+    target_file = workspace / "docs" / "plan.md"
+    target_file.parent.mkdir(parents=True)
+    target_file.write_text("# Plan", encoding="utf-8")
+
+    with (
+        patch(
+            "sys.argv",
+            [
+                "script",
+                "--target",
+                str(target_file),
+                "--workspace",
+                str(workspace),
+                "--template-root",
+                str(template_root),
+            ],
+        ),
+        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+    ):
+        exit_code = main()
+
+    expected_workspace_template = (
+        workspace / ".github" / "codex" / "execute-hard-lock.prompt.md"
+    )
+    expected_bundled_template = template_root / "execute-hard-lock.prompt.md"
+    stderr_output = mock_stderr.getvalue()
+
+    assert exit_code == 1
+    assert str(expected_bundled_template) in stderr_output
+    assert str(expected_workspace_template) in stderr_output

--- a/tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py
+++ b/tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py
@@ -1,0 +1,195 @@
+"""Additional tests for scripts.dev_tools.resolve_hard_lock_prompt."""
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.dev_tools.resolve_hard_lock_prompt import main
+
+
+@pytest.fixture
+def mem_path(tmp_path: Path) -> Path:
+    """Alias fixture for cosmetic tmp_path->mem_path test parameter rename."""
+    return tmp_path
+
+
+def test_main_template_not_found(mem_path: Path) -> None:
+    """Test main when template file doesn't exist."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+
+    target_file = workspace / "plan.md"
+    target_file.write_text("# Plan", encoding="utf-8")
+
+    with (
+        patch(
+            "sys.argv",
+            ["script", "--target", str(target_file), "--workspace", str(workspace)],
+        ),
+        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+    ):
+        exit_code = main()
+
+    assert exit_code == 1
+    error_output = mock_stderr.getvalue()
+    assert "not found. Checked locations:" in error_output
+    assert "execute-hard-lock.prompt.md" in error_output
+
+
+def test_main_target_not_found(mem_path: Path) -> None:
+    """Test main when target file doesn't exist."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_dir = workspace / ".github" / "codex"
+    template_dir.mkdir(parents=True)
+    (template_dir / "execute-hard-lock.prompt.md").write_text(
+        "Plan: ${plan-path}",
+        encoding="utf-8",
+    )
+    target_file = workspace / "nonexistent.md"
+
+    with (
+        patch(
+            "sys.argv",
+            ["script", "--target", str(target_file), "--workspace", str(workspace)],
+        ),
+        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+    ):
+        exit_code = main()
+
+    assert exit_code == 1
+    assert "Target file not found" in mock_stderr.getvalue()
+
+
+def test_main_clipboard_copy_fails(mem_path: Path) -> None:
+    """Test main when clipboard copy fails."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_dir = workspace / ".github" / "codex"
+    template_dir.mkdir(parents=True)
+    (template_dir / "execute-hard-lock.prompt.md").write_text(
+        "Plan: ${plan-path}",
+        encoding="utf-8",
+    )
+    target_file = workspace / "plan.md"
+    target_file.write_text("# Plan", encoding="utf-8")
+
+    with (
+        patch(
+            "sys.argv",
+            ["script", "--target", str(target_file), "--workspace", str(workspace)],
+        ),
+        patch(
+            "scripts.dev_tools.resolve_hard_lock_prompt.copy_to_clipboard",
+            return_value=False,
+        ),
+        patch("sys.stdout", new_callable=StringIO),
+        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+    ):
+        exit_code = main()
+
+    assert exit_code == 0
+    assert "✗ Could not copy to clipboard" in mock_stderr.getvalue()
+
+
+def test_main_default_workspace(mem_path: Path) -> None:
+    """Test main with default workspace (cwd)."""
+    template_dir = mem_path / ".github" / "codex"
+    template_dir.mkdir(parents=True)
+    (template_dir / "execute-hard-lock.prompt.md").write_text(
+        "Plan: ${plan-path}",
+        encoding="utf-8",
+    )
+    target_file = mem_path / "plan.md"
+    target_file.write_text("# Plan", encoding="utf-8")
+
+    with (
+        patch("sys.argv", ["script", "--target", str(target_file)]),
+        patch("pathlib.Path.cwd", return_value=mem_path),
+        patch(
+            "scripts.dev_tools.resolve_hard_lock_prompt.copy_to_clipboard",
+            return_value=True,
+        ),
+        patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+        patch("sys.stderr", new_callable=StringIO),
+    ):
+        exit_code = main()
+
+    assert exit_code == 0
+    assert "plan.md" in mock_stdout.getvalue()
+
+
+def test_main_template_read_error(mem_path: Path) -> None:
+    """Test main when template file cannot be read."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_dir = workspace / ".github" / "codex"
+    template_dir.mkdir(parents=True)
+    (template_dir / "execute-hard-lock.prompt.md").write_text(
+        "Plan: ${plan-path}",
+        encoding="utf-8",
+    )
+    target_file = workspace / "plan.md"
+    target_file.write_text("# Plan", encoding="utf-8")
+
+    with (
+        patch(
+            "sys.argv",
+            ["script", "--target", str(target_file), "--workspace", str(workspace)],
+        ),
+        patch("pathlib.Path.read_text", side_effect=OSError("Read error")),
+        patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+    ):
+        exit_code = main()
+
+    assert exit_code == 1
+    assert "Error reading template" in mock_stderr.getvalue()
+
+
+def test_main_resume_template_kind(mem_path: Path) -> None:
+    """Resolve resume template when --template-kind resume is provided."""
+    workspace = mem_path / "workspace"
+    workspace.mkdir()
+    template_dir = workspace / ".github" / "codex"
+    template_dir.mkdir(parents=True)
+    (template_dir / "execute-hard-lock.prompt.md").write_text(
+        "Execute ${plan-path}",
+        encoding="utf-8",
+    )
+    (template_dir / "resume-hard-lock.prompt.md").write_text(
+        "Resume ${plan-path} mode=${work-mode}",
+        encoding="utf-8",
+    )
+    issue_file = workspace / "docs" / "issue.md"
+    issue_file.parent.mkdir(parents=True)
+    issue_file.write_text("- Work Mode: full-feature\n", encoding="utf-8")
+    target_file = workspace / "docs" / "plan.md"
+    target_file.write_text("# Plan", encoding="utf-8")
+
+    with (
+        patch(
+            "sys.argv",
+            [
+                "script",
+                "--target",
+                str(target_file),
+                "--workspace",
+                str(workspace),
+                "--template-kind",
+                "resume",
+            ],
+        ),
+        patch(
+            "scripts.dev_tools.resolve_hard_lock_prompt.copy_to_clipboard",
+            return_value=True,
+        ),
+        patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+        patch("sys.stderr", new_callable=StringIO),
+    ):
+        exit_code = main()
+
+    assert exit_code == 0
+    assert "Resume docs/plan.md" in mock_stdout.getvalue()
+    assert "mode=full-feature" in mock_stdout.getvalue()


### PR DESCRIPTION
Add bundled hard-lock prompt resolution to the VS Code extension

## Summary

- Add a new `drm-copilot` extension command that resolves the execute hard-lock prompt from a selected feature plan by invoking a bundled Python wrapper in the active workspace.
- Bundle synchronized copies of the hard-lock resolver and execute/resume hard-lock prompt templates into `extensions/drm-copilot/resources/` so the workflow works in non-repo workspaces without reimplementing the resolver in TypeScript.
- Extend the root Python resolver with an optional `--template-root` seam so extension-bundled assets can be supplied explicitly while keeping the repo-root script and prompt files as the canonical authoring sources.
- Add focused TypeScript and Python regression coverage for command registration, plan selection, wrapper delegation, template lookup, path normalization, and clear failure behavior.
- Record feature docs, QA evidence, and review artifacts for the new feature, plus a separate update to the active plan for `blank-pr-context` (`#81`).

## Why

- The hard-lock prompt workflow already existed in repo-root tooling, but it assumed local `.github/codex` assets were present, which made the extension less useful in other workspaces.
- The feature docs frame the goal as reuse rather than reinvention: expose the same resolved execute prompt flow from the extension while keeping the root Python resolver and root prompt files as the single source of truth.
- The selected design avoids creating an extension-only implementation path by using the existing wrapper-plus-bundled-script pattern and limiting the root change to an additive `--template-root` seam.
- The documented constraints are to keep bundled assets synchronized with the canonical resolver/template sources, include all required helper logic and template assets in the bundle, preserve correct path normalization for non-repo and Windows-style paths, and fail clearly when Python or bundled assets are unavailable.
- The acceptance criteria explicitly require the new command wiring, a thin wrapper, bundled templates, parity with the root resolver’s prompt output, and clear failure behavior for missing targets, runtimes, or bundled assets.

## What Changed

- **Core behavior / architecture**
  - Added the `drmCopilotExtension.resolveExecuteHardLockPrompt` contribution and matching handler in `extensions/drm-copilot/package.json` and `extensions/drm-copilot/src/extension.ts`.
  - Added the bundled wrapper at `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py`.
  - Added the bundled resolver mirror at `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py`.
  - Updated `scripts/dev_tools/resolve_hard_lock_prompt.py` to accept `--template-root` and preserve the existing Python-side prompt-resolution logic.

- **Tooling / automation / DevEx**
  - Bundled synchronized prompt assets under `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md` and `extensions/drm-copilot/resources/customizations/.github/codex/resume-hard-lock.prompt.md`.
  - Captured bundle parity and QA evidence under `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/evidence/`.

- **Tests**
  - Added `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` for command registration, editor/picker flow, argv wiring, and missing-runtime behavior.
  - Expanded Python coverage for the root resolver and bundled wrapper/resolver with:
    - `tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py`
    - `tests/scripts/dev_tools/test_resolve_hard_lock_prompt_part2.py`
    - `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py`
    - `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt_part2.py`

- **Docs / templates / agents**
  - Added feature scoping, plan, user story, audit, and evidence docs for `2026-03-14-bundle-hard-lock-resolver-into-extension-103`.
  - Updated `extensions/drm-copilot/README.md` to document the new command and its Python runtime dependency.
  - Updated `docs/features/active/2026-03-05-blank-pr-context-81/plan.md`.

## Architecture / How It Fits Together

- `extensions/drm-copilot/package.json` exposes a new user-facing command, and `extensions/drm-copilot/src/extension.ts` implements the entry point.
- The TypeScript handler resolves the target plan path by:
  - preferring the active editor when it is a Markdown file under `docs/features/active/`, or
  - falling back to a file picker rooted under `docs/features/active/`.
- The extension then calls the existing bundled-script execution path and launches `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` with `--target <selected-plan>` and `--workspace <workspace-root>`.
- The wrapper stays thin: it bootstraps bundled Python imports, injects `--template-root` pointing at bundled codex assets when needed, imports `dev_tools.resolve_hard_lock_prompt`, and delegates to `main()`.
- The canonical resolver logic remains in Python. The root resolver gained an additive `--template-root` seam so the same prompt-resolution behavior can run against bundled assets in non-repo workspaces without moving business logic into TypeScript.
- Prompt content still comes from the canonical `.github/codex/*.prompt.md` authoring sources, with synchronized bundled copies shipped in the extension.

## Verification

### Completed

- `poetry run black .` — passed (`EXIT_CODE: 0`).
- `poetry run ruff check` — passed (`EXIT_CODE: 0`).
- `poetry run pyright` — passed (`EXIT_CODE: 0`).
- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing` — passed (`EXIT_CODE: 0`).
- `npm --prefix extensions/drm-copilot run format` — passed (`EXIT_CODE: 0`).
- `npm --prefix extensions/drm-copilot run lint` — passed (`EXIT_CODE: 0`).
- `npm --prefix extensions/drm-copilot run typecheck` — passed (`EXIT_CODE: 0`).
- `npm --prefix extensions/drm-copilot run test:unit -- --coverage` — passed (`EXIT_CODE: 0`).
- Targeted feature verification also passed:
  - `poetry run pytest tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt.py --cov=scripts/dev_tools --cov=extensions/drm-copilot/resources/scripts/dev_tools --cov=extensions/drm-copilot/resources/templates --cov-report=term-missing`
  - `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.resolve-hard-lock-prompt.test.ts`
- Coverage evidence recorded in the context shows:
  - Python total coverage remained `83%` with `92%` changed-code coverage.
  - Extension total coverage moved from `89.3%` to `89.83%` with `91.34%` changed-code coverage.

### Recommended

- `poetry run black .`
- `poetry run ruff check`
- `poetry run pyright`
- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`
- `npm --prefix extensions/drm-copilot run format`
- `npm --prefix extensions/drm-copilot run lint`
- `npm --prefix extensions/drm-copilot run typecheck`
- `npm --prefix extensions/drm-copilot run test:unit -- --coverage`

## Backward Compatibility / Migration Notes

- This is an additive extension feature: it introduces a new command rather than replacing an existing one.
- The root Python resolver change is backward-compatible because `--template-root` is optional.
- Existing prompt substitution, work-mode resolution, fallback handling, and best-effort clipboard behavior remain in the Python resolver rather than moving into TypeScript.
- Extension-side execution still depends on `python` being available on `PATH`, and that requirement is now documented in `extensions/drm-copilot/README.md`.

## Risks and Mitigations

- **Risk:** Bundled resolver or prompt assets drift from the repo-root canonical sources.
  - **Mitigation:** The design explicitly keeps the root script and root prompt files as authoring sources, and this PR adds bundle-parity evidence plus regression coverage around the bundled path.
- **Risk:** Non-repo workspaces or Windows-style paths resolve incorrectly.
  - **Mitigation:** The Python coverage in this PR includes template-root precedence/fallback and Windows-oriented path normalization scenarios.
- **Risk:** Extension-side execution fails when Python is unavailable.
  - **Mitigation:** Missing-runtime behavior is covered in extension tests, and the README now documents the runtime dependency.
- **Risk:** Large documentation and evidence footprint obscures the code review.
  - **Mitigation:** The actual production-code surface is small relative to the supporting audit/evidence artifacts; review the core files first.

## Review Guide

- Start with `extensions/drm-copilot/src/extension.ts` and `extensions/drm-copilot/package.json` to review the new command entry point and command contribution.
- Review `extensions/drm-copilot/resources/templates/resolve_hard_lock_prompt.py` to confirm the wrapper stays thin.
- Review `scripts/dev_tools/resolve_hard_lock_prompt.py` and `extensions/drm-copilot/resources/scripts/dev_tools/resolve_hard_lock_prompt.py` together to validate the new `--template-root` seam and bundled parity model.
- Review `extensions/drm-copilot/resources/customizations/.github/codex/execute-hard-lock.prompt.md` and `resume-hard-lock.prompt.md` only as bundled assets, not as a new logic surface.
- Review `extensions/drm-copilot/test/extension.resolve-hard-lock-prompt.test.ts` for command wiring and failure-path coverage.
- Review the Python test files for template resolution, bundled wrapper behavior, and path normalization.
- Treat the feature docs, evidence, and audit files under `docs/features/active/2026-03-14-bundle-hard-lock-resolver-into-extension-103/` as supporting review material; they are numerous and intentionally noisy compared with the production-code delta.
- Review `docs/features/active/2026-03-05-blank-pr-context-81/plan.md` separately as an unrelated plan update.

## Follow-ups

- No additional follow-up work is explicitly recorded in the provided PR context beyond maintaining synchronization between the canonical root resolver/templates and the bundled extension copies in future changes.

## GitHub Auto-close
- Closes: #103

## Related issues / PRs

- Related issue: #81