### PR TITLE
(docs(csharp-tooling)): switch legacy C# formatting guidance to csharpier

### DIFF
--- a/.github/agents/csharp-atomic-executor.agent.md
+++ b/.github/agents/csharp-atomic-executor.agent.md
@@ -1,6 +1,6 @@
 ---
 name: csharp-atomic-executor
-description: Execute atomic_planner plans verbatim with atomic_executor rigor and C#-specialized quality gates (dotnet format, analyzers, nullable/type safety, and dotnet test).
+description: Execute atomic_planner plans verbatim with atomic_executor rigor and C#-specialized quality gates (csharpier, analyzers, nullable/type safety, and dotnet test).
 model: GPT-5.4 (copilot)
 argument-hint: "Provide the approved atomic plan text or path. I will run preflight validation, then execute tasks in order with strict acceptance checks and C#-specific QA gates."
 tools: [vscode, execute/testFailure, execute/getTerminalOutput, execute/awaitTerminal, execute/killTerminal, execute/runTask, execute/createAndRunTask, execute/runInTerminal, execute/runTests, read/problems, read/readFile, read/terminalSelection, read/terminalLastCommand, agent, edit/createDirectory, edit/createFile, edit/editFiles, search, web, todo]
@@ -240,7 +240,7 @@ If the user says "resume", "continue", or "try again":
 - Be concise but exact.
 - Do not paste large code blocks unless the user asks.
 - Always show the commands/tasks you run and summarize results (pass/fail, key errors).
-- When completing a task or a plan, report the toolchain status explicitly: dotnet format, dotnet build (analyzers), and dotnet test.
+- When completing a task or a plan, report the toolchain status explicitly: csharpier (format), dotnet build (analyzers), and dotnet test.
 - Always end with the updated checklist so the user can see progress.
 
 ---
@@ -256,7 +256,7 @@ Always enforce repo policy order:
 5) `.github/instructions/csharp-unit-test.instructions.md`
 
 Required toolchain for C# tasks:
-1) Format (`dotnet format` or repo task equivalent)
+1) Format (`csharpier .` or repo task equivalent)
 2) Analyze/lint (`dotnet build -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` or repo task equivalent)
 3) Type-check (`dotnet build -p:Nullable=enable -p:TreatWarningsAsErrors=true` or repo task equivalent)
 4) Test (`dotnet test --collect:"XPlat Code Coverage"` or repo task equivalent)

--- a/.github/agents/csharp-typed-engineer.agent.md
+++ b/.github/agents/csharp-typed-engineer.agent.md
@@ -170,7 +170,7 @@ If any gate fails, revert/fix immediately before proceeding.
 
 Run the repo-standard C# toolchain in this order:
 
-1) **Format**: `dotnet format TaskMaster.sln`
+1) **Format**: `csharpier .`
 2) **Analyze/Lint build**: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
 3) **Type-safe nullable build**: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:Nullable=enable /p:TreatWarningsAsErrors=true`
 4) **Test with coverage**: `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`

--- a/.github/instructions/csharp-code-change.instructions.md
+++ b/.github/instructions/csharp-code-change.instructions.md
@@ -22,11 +22,15 @@ If you encounter any conflicting instructions between these documents, **halt an
 
 These are the required tools for C# code in this repo:
 
-1. **Formatting — `dotnet format`**
+1. **Formatting — `csharpier`**
 
-   - All C# code must be formatted with the .NET SDK formatter.
-   - Do not hand-format; if a diff disagrees with `dotnet format`, formatter output wins.
-   - Approved command: `dotnet format TaskMaster.sln`
+   - All C# source files (`*.cs`) must be formatted with `csharpier`.
+   - Do **not** use `dotnet format` — it loads the solution/project model and can mis-handle legacy VSTO / .NET Framework projects by rewriting `.csproj` files.
+   - `csharpier` is file-based and formats only `*.cs` without touching project files.
+   - Do not hand-format; if a diff disagrees with `csharpier`, formatter output wins.
+   - Approved commands:
+     - `dotnet tool run csharpier .`
+     - or `csharpier .` (if installed globally)
 
 2. **Linting / Static Analysis — .NET analyzers**
 

--- a/.github/instructions/csharp-unit-test.instructions.md
+++ b/.github/instructions/csharp-unit-test.instructions.md
@@ -42,7 +42,7 @@ If there is any conflict between these documents, halt and notify the user.
 ## 3. C# Toolchain Command Selection
 
 - For C# work, use these concrete commands for the general policy toolchain loop:
-  1. `dotnet format TaskMaster.sln`
+  1. `csharpier .`
   2. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
   3. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
   4. `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`

--- a/extensions/drm-copilot/resources/customizations/.github/agents/csharp-atomic-executor.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/csharp-atomic-executor.agent.md
@@ -1,6 +1,6 @@
 ---
 name: csharp-atomic-executor
-description: Execute atomic_planner plans verbatim with atomic_executor rigor and C#-specialized quality gates (dotnet format, analyzers, nullable/type safety, and dotnet test).
+description: Execute atomic_planner plans verbatim with atomic_executor rigor and C#-specialized quality gates (csharpier, analyzers, nullable/type safety, and dotnet test).
 model: GPT-5.4 (copilot)
 argument-hint: "Provide the approved atomic plan text or path. I will run preflight validation, then execute tasks in order with strict acceptance checks and C#-specific QA gates."
 tools: [vscode, execute/testFailure, execute/getTerminalOutput, execute/awaitTerminal, execute/killTerminal, execute/runTask, execute/createAndRunTask, execute/runInTerminal, execute/runTests, read/problems, read/readFile, read/terminalSelection, read/terminalLastCommand, agent, edit/createDirectory, edit/createFile, edit/editFiles, search, web, todo]
@@ -240,7 +240,7 @@ If the user says "resume", "continue", or "try again":
 - Be concise but exact.
 - Do not paste large code blocks unless the user asks.
 - Always show the commands/tasks you run and summarize results (pass/fail, key errors).
-- When completing a task or a plan, report the toolchain status explicitly: dotnet format, dotnet build (analyzers), and dotnet test.
+- When completing a task or a plan, report the toolchain status explicitly: csharpier (format), dotnet build (analyzers), and dotnet test.
 - Always end with the updated checklist so the user can see progress.
 
 ---
@@ -256,7 +256,7 @@ Always enforce repo policy order:
 5) `.github/instructions/csharp-unit-test.instructions.md`
 
 Required toolchain for C# tasks:
-1) Format (`dotnet format` or repo task equivalent)
+1) Format (`csharpier .` or repo task equivalent)
 2) Analyze/lint (`dotnet build -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` or repo task equivalent)
 3) Type-check (`dotnet build -p:Nullable=enable -p:TreatWarningsAsErrors=true` or repo task equivalent)
 4) Test (`dotnet test --collect:"XPlat Code Coverage"` or repo task equivalent)

--- a/extensions/drm-copilot/resources/customizations/.github/agents/csharp-typed-engineer.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/csharp-typed-engineer.agent.md
@@ -170,7 +170,7 @@ If any gate fails, revert/fix immediately before proceeding.
 
 Run the repo-standard C# toolchain in this order:
 
-1) **Format**: `dotnet format TaskMaster.sln`
+1) **Format**: `csharpier .`
 2) **Analyze/Lint build**: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
 3) **Type-safe nullable build**: `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:Nullable=enable /p:TreatWarningsAsErrors=true`
 4) **Test with coverage**: `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`

--- a/extensions/drm-copilot/resources/customizations/.github/instructions/csharp-code-change.instructions.md
+++ b/extensions/drm-copilot/resources/customizations/.github/instructions/csharp-code-change.instructions.md
@@ -22,11 +22,15 @@ If you encounter any conflicting instructions between these documents, **halt an
 
 These are the required tools for C# code in this repo:
 
-1. **Formatting — `dotnet format`**
+1. **Formatting — `csharpier`**
 
-   - All C# code must be formatted with the .NET SDK formatter.
-   - Do not hand-format; if a diff disagrees with `dotnet format`, formatter output wins.
-   - Approved command: `dotnet format TaskMaster.sln`
+   - All C# source files (`*.cs`) must be formatted with `csharpier`.
+   - Do **not** use `dotnet format` — it loads the solution/project model and can mis-handle legacy VSTO / .NET Framework projects by rewriting `.csproj` files.
+   - `csharpier` is file-based and formats only `*.cs` without touching project files.
+   - Do not hand-format; if a diff disagrees with `csharpier`, formatter output wins.
+   - Approved commands:
+     - `dotnet tool run csharpier .`
+     - or `csharpier .` (if installed globally)
 
 2. **Linting / Static Analysis — .NET analyzers**
 

--- a/extensions/drm-copilot/resources/customizations/.github/instructions/csharp-unit-test.instructions.md
+++ b/extensions/drm-copilot/resources/customizations/.github/instructions/csharp-unit-test.instructions.md
@@ -42,7 +42,7 @@ If there is any conflict between these documents, halt and notify the user.
 ## 3. C# Toolchain Command Selection
 
 - For C# work, use these concrete commands for the general policy toolchain loop:
-  1. `dotnet format TaskMaster.sln`
+  1. `csharpier .`
   2. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
   3. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
   4. `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`


### PR DESCRIPTION
- Replace `dotnet format` guidance in C# instructions with `csharpier .` and document why legacy VSTO/.NET Framework projects should avoid solution-based formatting
- Keep the msbuild analyzer and nullable build steps as the approved linting and type-safety checks
- Align the C# agent definitions and extension customization copies with the updated formatter/toolchain wording