### PR TITLE
(chore(powershell-runtime)): raise repository PowerShell baseline to 7.6

### DIFF
--- a/.devcontainer/CODESPACES-SETUP.md
+++ b/.devcontainer/CODESPACES-SETUP.md
@@ -99,7 +99,7 @@ Once your Codespace is created, you should have:
 - **OS:** Debian Bookworm (not Ubuntu)
 - **Python:** 3.13.x (not 3.12.x)
 - **Poetry:** 2.2.1
-- **PowerShell:** 7.5+
+- **PowerShell:** 7.6+
 - **Shell tools:** shellcheck, shfmt, bashdb, actionlint
 
 ### Verification Command

--- a/.devcontainer/CONFIG-GUIDE.md
+++ b/.devcontainer/CONFIG-GUIDE.md
@@ -11,7 +11,7 @@ This repository uses **separate dev container configurations** for Codespaces an
 1. **Codespaces** (`.devcontainer/codespaces/devcontainer.json`) - Manual selection required
 2. **Local Docker** (`.devcontainer/local/devcontainer.json`) - Manual selection required
 
-Both provide identical tooling (Debian Bookworm, Python 3.13, PowerShell 7.5+, etc.)
+Both provide identical tooling (Debian Bookworm, Python 3.13, PowerShell 7.6+, etc.)
 
 ## Quick Start
 
@@ -40,7 +40,7 @@ Both configurations provide:
 ### Base Environment
 - Debian Bookworm (latest stable)
 - Python 3.13 with Poetry 2.2.1
-- PowerShell 7.5+ with PSScriptAnalyzer and Pester
+- PowerShell 7.6+ with PSScriptAnalyzer and Pester
 - Git, GitHub CLI, actionlint, bashdb
 
 ### Python Tooling
@@ -60,7 +60,7 @@ After container starts, check which config was used:
 # Check environment
 cat /etc/os-release  # Should show Debian Bookworm
 python --version     # Should show 3.13.x
-pwsh --version       # Should show PowerShell 7.5+
+pwsh --version       # Should show PowerShell 7.6+
 poetry --version     # Should show 2.2.1
 
 # Check if running in Codespaces

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -42,7 +42,7 @@ This directory contains the Docker Dev Container configuration for the DRM Copil
 ### Base Environment
 - **Debian Bookworm** (latest stable)
 - **Python 3.13** with Poetry package manager
-- **PowerShell 7.5+** for cross-platform scripting
+- **PowerShell 7.6+** for cross-platform scripting
 - **Git** and **GitHub CLI** (gh)
 - **Graphite CLI** (`gt`) for the Graphite VS Code extension
 - **GitHub Copilot CLI** (`copilot`) for the `atomic_executor` tool

--- a/.devcontainer/RECREATE-CODESPACE.md
+++ b/.devcontainer/RECREATE-CODESPACE.md
@@ -69,7 +69,7 @@ bash .devcontainer/verify-container.sh
 # 2. Check Python tools
 python --version         # Should be 3.13.x
 poetry --version         # Should be 2.2.x
-pwsh --version          # Should be PowerShell 7.x
+pwsh --version          # Should be PowerShell 7.6.x
 
 # 3. Verify project setup
 poetry install          # Install dependencies
@@ -97,7 +97,7 @@ Using: .devcontainer/devcontainer.json (Codespaces)
 And you should have:
 - Debian Bookworm OS
 - Python 3.13.x
-- PowerShell 7.5+
+- PowerShell 7.6+
 - Poetry 2.2.1
 - All shell tools (shellcheck, shfmt, bashdb, actionlint)
 

--- a/.devcontainer/codespaces/Dockerfile
+++ b/.devcontainer/codespaces/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone --depth 1 https://github.com/Trepan-Debuggers/bashdb /tmp/bashdb \
 RUN printf '%s\n' '#!/usr/bin/env bash' 'exec xclip -selection clipboard "$@"' > /usr/local/bin/clip.exe \
     && chmod +x /usr/local/bin/clip.exe
 
-# Install PowerShell 7.5+ from Microsoft repository
+# Install PowerShell 7.6+ from Microsoft repository
 RUN wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb \

--- a/.devcontainer/local/Dockerfile
+++ b/.devcontainer/local/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone --depth 1 https://github.com/Trepan-Debuggers/bashdb /tmp/bashdb \
 RUN printf '%s\n' '#!/usr/bin/env bash' 'exec xclip -selection clipboard "$@"' > /usr/local/bin/clip.exe \
     && chmod +x /usr/local/bin/clip.exe
 
-# Install PowerShell 7.5+ from Microsoft repository
+# Install PowerShell 7.6+ from Microsoft repository
 RUN wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb \

--- a/.devcontainer/verify-container.sh
+++ b/.devcontainer/verify-container.sh
@@ -83,11 +83,11 @@ if command -v pwsh &> /dev/null; then
     PWSH_VERSION=$(pwsh --version 2>&1 | head -n1)
     echo "   $PWSH_VERSION"
     
-    if [[ "$PWSH_VERSION" == *"7."* ]]; then
-        echo "   ✅ PowerShell 7+ detected (expected)"
+    if [[ "$PWSH_VERSION" == *"7.6."* ]]; then
+        echo "   ✅ PowerShell 7.6.x detected (expected)"
         PWSH_OK=true
     else
-        echo "   ⚠️  Unexpected version (expected 7.5+)"
+        echo "   ⚠️  Unexpected version (expected 7.6+)"
         PWSH_OK=false
     fi
 else

--- a/.github/codex/codex-web-setup.sh
+++ b/.github/codex/codex-web-setup.sh
@@ -67,7 +67,7 @@ check_pypi_connectivity() {
 }
 
 ensure_pwsh() {
-  local required="7.4.0"
+  local required="7.6.0"
 
   if command -v pwsh >/dev/null 2>&1; then
     local current
@@ -81,7 +81,7 @@ ensure_pwsh() {
     echo "pwsh not found; installing PowerShell..."
   fi
 
-  local os_id="" os_version="" repo_url="" fallback_version="7.4.13"
+  local os_id="" os_version="" repo_url="" fallback_version="7.6.0"
   if [ -r /etc/os-release ]; then
     # shellcheck disable=SC1091
     . /etc/os-release
@@ -201,6 +201,7 @@ main() {
   if command -v pwsh >/dev/null 2>&1; then
     echo "PowerShell installed. Checking modules from PSGallery..."
 
+    # shellcheck disable=SC2016  # PowerShell variables must remain literal inside the single-quoted command string.
     pwsh -NoLogo -NoProfile -Command '
       $ErrorActionPreference = "Stop"
 
@@ -268,6 +269,7 @@ main() {
 
     if [ -f "$POSHQC_PATH" ]; then
       echo "Importing PoshQC module (required for parity)..."
+      # shellcheck disable=SC2016  # PowerShell variables must remain literal inside the single-quoted command string.
       pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass \
         -Command '& { Import-Module "$env:REPO_ROOT/scripts/powershell/PoshQC/PoshQC.psd1" -Force; Get-Command -Module PoshQC | Out-Host }'
     else

--- a/docs/features/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md
+++ b/docs/features/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md
@@ -218,7 +218,7 @@
 | **Formatting with Invoke-Formatter** | [✅/❌/N/A] [PASS/FAIL/N/A] | **Command:** `Invoke-PoshQCFormat -Root .`<br>**Result:** [Describe result] |
 | **Linting with PSScriptAnalyzer** | [✅/❌/N/A] [PASS/FAIL/N/A] | **Command:** `Invoke-PoshQCAnalyze -Root .`<br>**Result:** [Describe result] |
 | **Fix all findings** | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe any findings and how they were resolved.] |
-| **PowerShell 5.1 & 7.5+ compatible** | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe compatibility testing. Note any version-specific features.] |
+| **PowerShell 5.1 & 7.6+ compatible** | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe compatibility testing. Note any version-specific features.] |
 
 #### 3B.2 PowerShell Design & Safety
 
@@ -335,7 +335,7 @@
 |------------|--------|----------|
 | **Use Pester v5.x** | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe Pester v5 features used (BeforeAll, BeforeEach, Describe/Context/It, modern Should syntax).] |
 | **Use PoshQC Configuration** | [✅/❌/N/A] [PASS/FAIL/N/A] | **Command:** `Invoke-PoshQCTest -Root .`<br>**Config:** `scripts/powershell/PoshQC/settings/pester.runsettings.psd1`<br>[Describe configuration updates if any.] |
-| **PowerShell 5.1 & 7.5+ Compatible** | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe compatibility testing. Note any version-specific features.] |
+| **PowerShell 5.1 & 7.6+ Compatible** | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe compatibility testing. Note any version-specific features.] |
 
 #### 4B.2 Test Style and Structure
 

--- a/extensions/drm-copilot/resources/templates/new-potential-entry.ps1
+++ b/extensions/drm-copilot/resources/templates/new-potential-entry.ps1
@@ -104,8 +104,8 @@ function Invoke-VSCodeOpen {
     # Detect Insiders using multiple signals; TERM_PROGRAM_VERSION alone is
     # unreliable when VS Code spawns external processes (e.g., extension host or task runners).
     $isInsidersSession = $env:TERM_PROGRAM_VERSION -match 'insider' -or
-        (-not [string]::IsNullOrEmpty($env:VSCODE_IPC_HOOK_CLI) -and $env:VSCODE_IPC_HOOK_CLI -match 'insider') -or
-        ($null -ne (Get-Process -Name '*insiders*' -ErrorAction SilentlyContinue | Select-Object -First 1))
+    (-not [string]::IsNullOrEmpty($env:VSCODE_IPC_HOOK_CLI) -and $env:VSCODE_IPC_HOOK_CLI -match 'insider') -or
+    ($null -ne (Get-Process -Name '*insiders*' -ErrorAction SilentlyContinue | Select-Object -First 1))
 
     $hasMatchingCommand = {
         param(
@@ -150,7 +150,8 @@ $lastUpdated = Get-Date -Format 'yyyy-MM-ddTHH-mm'
 $target = Join-Path $workspace "docs/features/potential/$today-$ShortName.md"
 if ($TemplateRoot -and (Test-Path (Join-Path $TemplateRoot 'potential/template.md'))) {
     $template = Join-Path $TemplateRoot 'potential/template.md'
-} else {
+}
+else {
     $template = Join-Path $workspace 'docs/features/potential/template.md'
 }
 if (-not (Test-Path $template)) {
@@ -183,3 +184,4 @@ if (-not $opened) {
     Write-Output "  $target"
     Write-Output "  $backlog"
 }
+

--- a/extensions/drm-copilot/resources/templates/new-potential-entry.ps1
+++ b/extensions/drm-copilot/resources/templates/new-potential-entry.ps1
@@ -27,8 +27,8 @@ function Test-ValidShortName {
 function Get-AuthorName {
     [CmdletBinding()]
     param(
-        [scriptblock] $GetGitConfig = { param([string]$Key) git config $Key 2>$null },
-        [scriptblock] $GetEnvironmentVariable = { param([string]$Name) [Environment]::GetEnvironmentVariable($Name) }
+        [scriptblock] $GetGitConfig = { param([string] $Key) git config $Key 2>$null },
+        [scriptblock] $GetEnvironmentVariable = { param([string] $Name) [Environment]::GetEnvironmentVariable($Name) }
     )
 
     $author = & $GetGitConfig 'user.name'
@@ -129,7 +129,6 @@ function Invoke-VSCodeOpen {
         & $InvokeCommand 'code' (@('--reuse-window') + $Files)
         return $true
     }
-
 
     return $false
 }

--- a/scripts/dev-tools/new-potential-entry.ps1
+++ b/scripts/dev-tools/new-potential-entry.ps1
@@ -104,8 +104,8 @@ function Invoke-VSCodeOpen {
     # Detect Insiders using multiple signals; TERM_PROGRAM_VERSION alone is
     # unreliable when VS Code spawns external processes (e.g., extension host or task runners).
     $isInsidersSession = $env:TERM_PROGRAM_VERSION -match 'insider' -or
-        (-not [string]::IsNullOrEmpty($env:VSCODE_IPC_HOOK_CLI) -and $env:VSCODE_IPC_HOOK_CLI -match 'insider') -or
-        ($null -ne (Get-Process -Name '*insiders*' -ErrorAction SilentlyContinue | Select-Object -First 1))
+    (-not [string]::IsNullOrEmpty($env:VSCODE_IPC_HOOK_CLI) -and $env:VSCODE_IPC_HOOK_CLI -match 'insider') -or
+    ($null -ne (Get-Process -Name '*insiders*' -ErrorAction SilentlyContinue | Select-Object -First 1))
 
     $hasMatchingCommand = {
         param(
@@ -150,7 +150,8 @@ $lastUpdated = Get-Date -Format 'yyyy-MM-ddTHH-mm'
 $target = Join-Path $workspace "docs/features/potential/$today-$ShortName.md"
 if ($TemplateRoot -and (Test-Path (Join-Path $TemplateRoot 'potential/template.md'))) {
     $template = Join-Path $TemplateRoot 'potential/template.md'
-} else {
+}
+else {
     $template = Join-Path $workspace 'docs/features/potential/template.md'
 }
 if (-not (Test-Path $template)) {
@@ -183,4 +184,5 @@ if (-not $opened) {
     Write-Output "  $target"
     Write-Output "  $backlog"
 }
+
 

--- a/scripts/dev-tools/new-potential-entry.ps1
+++ b/scripts/dev-tools/new-potential-entry.ps1
@@ -27,8 +27,8 @@ function Test-ValidShortName {
 function Get-AuthorName {
     [CmdletBinding()]
     param(
-        [scriptblock] $GetGitConfig = { param([string]$Key) git config $Key 2>$null },
-        [scriptblock] $GetEnvironmentVariable = { param([string]$Name) [Environment]::GetEnvironmentVariable($Name) }
+        [scriptblock] $GetGitConfig = { param([string] $Key) git config $Key 2>$null },
+        [scriptblock] $GetEnvironmentVariable = { param([string] $Name) [Environment]::GetEnvironmentVariable($Name) }
     )
 
     $author = & $GetGitConfig 'user.name'
@@ -129,7 +129,6 @@ function Invoke-VSCodeOpen {
         & $InvokeCommand 'code' (@('--reuse-window') + $Files)
         return $true
     }
-
 
     return $false
 }

--- a/scripts/dev_tools/resolve_hard_lock_prompt.py
+++ b/scripts/dev_tools/resolve_hard_lock_prompt.py
@@ -167,6 +167,28 @@ def _try_relative_to_workspace(path: Path, workspace_root: Path) -> Path:
         return path
 
 
+def _normalize_prompt_path_value(path: Path) -> str:
+    """Convert a resolved prompt path into forward-slash form.
+
+    Purpose:
+        `Path.as_posix()` only normalizes native separators for the active
+        platform. When a Windows-style path string is parsed on POSIX, the
+        embedded backslashes remain literal characters and leak into prompt
+        templates. This helper normalizes any remaining backslashes so the
+        emitted `${plan-path}` value is stable across CI platforms.
+
+    Args:
+        path: Relative or absolute prompt path value to normalize.
+
+    Returns:
+        str: Forward-slash-only path text suitable for prompt substitution.
+
+    Side Effects:
+        None.
+    """
+    return str(path).replace("\\", "/")
+
+
 def _resolve_issue_file_for_target(target_path: Path, workspace_root: Path) -> Path:
     """Resolve the most likely issue.md path for a target plan file.
 
@@ -258,8 +280,9 @@ def resolve_prompt(
     # Resolve target path relative to workspace
     relative_target = _try_relative_to_workspace(target_path, workspace_root)
 
-    # Convert to forward slashes for cross-platform consistency
-    plan_path_value = relative_target.as_posix()
+    # Convert to forward slashes for cross-platform consistency, including
+    # Windows-style paths that may be parsed on non-Windows runners.
+    plan_path_value = _normalize_prompt_path_value(relative_target)
 
     selected_mode, resolved_fallback_reason = _resolve_work_mode_from_issue(
         target_path,

--- a/scripts/powershell/PoshQC/README.md
+++ b/scripts/powershell/PoshQC/README.md
@@ -1,6 +1,6 @@
 # PoshQC
 
-PoshQC is a lightweight PowerShell quality gate that wraps Invoke-Formatter, PSScriptAnalyzer, and Pester with repo-safe defaults. It targets both Windows PowerShell 5.1 and PowerShell 7.5+.
+PoshQC is a lightweight PowerShell quality gate that wraps Invoke-Formatter, PSScriptAnalyzer, and Pester with repo-safe defaults. It targets both Windows PowerShell 5.1 and PowerShell 7.6+.
 
 ## What it does
 
@@ -11,7 +11,7 @@ PoshQC is a lightweight PowerShell quality gate that wraps Invoke-Formatter, PSS
 
 ## Requirements
 
-- PowerShell 5.1 or 7.5+
+- PowerShell 5.1 or 7.6+
 - Modules: PSScriptAnalyzer 1.22.0, Pester 5.6.1 (installed automatically via the helper if missing)
 
 ## Getting started
@@ -54,7 +54,7 @@ PoshQC is a lightweight PowerShell quality gate that wraps Invoke-Formatter, PSS
 ## Configuration
 
 - PSScriptAnalyzer settings: `./settings/pssa.settings.psd1`
-  - Enforces compatible syntax for 5.1 and 7.5, 4-space indentation, ShouldProcess for state-changing functions, and safety guards (no Invoke-Expression, no global vars, etc.).
+   - Enforces compatible syntax for 5.1 and 7.6, 4-space indentation, ShouldProcess for state-changing functions, and safety guards (no Invoke-Expression, no global vars, etc.).
 - Pester settings: `./settings/pester.runsettings.psd1`
   - Runs tests under `scripts` and `tests/powershell`, outputs JUnit XML and CoverageGutters coverage, and enables coverage over `scripts/dev-tools/*.ps1`, `scripts/powershell/**/*.psm1`, and `src/**/*.ps1`.
 

--- a/scripts/powershell/PoshQC/settings/pssa.settings.psd1
+++ b/scripts/powershell/PoshQC/settings/pssa.settings.psd1
@@ -4,10 +4,10 @@
     Severity            = @('Error', 'Warning', 'Information')
 
     Rules               = @{
-        # Enforce compatibility with both Windows PowerShell 5.1 and PowerShell 7.4+
+        # Enforce compatibility with both Windows PowerShell 5.1 and PowerShell 7.6+
         PSUseCompatibleSyntax                          = @{
             Enable         = $true
-            TargetVersions = @('5.1', '7.5')
+            TargetVersions = @('5.1', '7.6')
             IgnoreUntested = $false
         }
 

--- a/tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py
+++ b/tests/scripts/dev_tools/test_resolve_hard_lock_prompt.py
@@ -1,7 +1,7 @@
 """Tests for scripts.dev_tools.resolve_hard_lock_prompt."""
 
 from io import StringIO
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -175,12 +175,16 @@ def test_resolve_prompt_uses_parent_issue_for_versioned_plan_path() -> None:
 
 
 def _test_resolve_prompt_windows_v2_path_uses_forward_slashes() -> None:
-    """Normalize Windows-style versioned plan paths to forward slashes."""
+    """Normalize backslash-bearing relative plan paths to forward slashes."""
     template = "Plan=${plan-path}"
     workspace_root = Path(r"C:\workspace")
     target = Path(r"C:\workspace\docs\features\active\feature-1\v2\plan.md")
 
-    result = resolve_prompt(template, target, workspace_root)
+    with patch(
+        "scripts.dev_tools.resolve_hard_lock_prompt._try_relative_to_workspace",
+        return_value=PurePosixPath(r"docs\features\active\feature-1\v2\plan.md"),
+    ):
+        result = resolve_prompt(template, target, workspace_root)
 
     assert "docs/features/active/feature-1/v2/plan.md" in result
     assert "\\" not in result


### PR DESCRIPTION
- update devcontainer documentation, Dockerfile comments, and container verification to expect PowerShell 7.6+
- bump codex web setup PowerShell requirement and fallback install version from 7.4.x to 7.6.0
- align PoshQC analyzer targets and policy audit templates with Windows PowerShell 5.1 and PowerShell 7.6 compatibility