### PR TITLE
(fix(extension-runtime)): use fallback runtimes for bundled workflows

### DIFF
--- a/extensions/drm-copilot/src/command-runtime.ts
+++ b/extensions/drm-copilot/src/command-runtime.ts
@@ -181,14 +181,26 @@ export function detectRuntime(runtimeKind: RuntimeKind): RuntimeResolution {
   // Python commands have a single acceptable runtime, so fail fast with a
   // targeted error message instead of falling through the PowerShell probes.
   if (runtimeKind === "python") {
-    if (!executableExists("python")) {
-      throw new Error("Python runtime 'python' not found on PATH.");
+    // Keep `python` as the primary probe everywhere, then fall back to the
+    // Windows launcher so common Windows installations still work when only
+    // `py` is exposed on PATH.
+    if (executableExists("python")) {
+      return {
+        executable: "python",
+        argsPrefix: [],
+      };
     }
 
-    return {
-      executable: "python",
-      argsPrefix: [],
-    };
+    if (executableExists("py")) {
+      return {
+        executable: "py",
+        argsPrefix: ["-3"],
+      };
+    }
+
+    throw new Error(
+      "Python runtime 'python' not found on PATH. On Windows, 'py -3' is also accepted.",
+    );
   }
 
   // Prefer PowerShell Core when available, then fall back to Windows PowerShell

--- a/extensions/drm-copilot/src/mcp-provider.ts
+++ b/extensions/drm-copilot/src/mcp-provider.ts
@@ -30,7 +30,7 @@ export function registerMcpProvider(
         // point in the extension's output directory.
         const serverDef = new vscode.McpStdioServerDefinition(
           "drmCopilotExtension",
-          "node",
+          process.execPath,
           [
             vscode.Uri.joinPath(context.extensionUri, "out", "mcp-server.js")
               .fsPath,

--- a/extensions/drm-copilot/test/extension.integration.test.ts
+++ b/extensions/drm-copilot/test/extension.integration.test.ts
@@ -74,6 +74,10 @@ jest.mock("node:child_process", () => ({
 
 import { activate } from "../src/extension";
 
+const fsMock = jest.requireMock("node:fs") as {
+  existsSync: jest.MockedFunction<(filePath: string) => boolean>;
+};
+
 const childProcessMock = jest.requireMock("node:child_process") as {
   spawn: jest.Mock;
   spawnSync: jest.Mock;
@@ -181,6 +185,29 @@ function isPlaceholderOnlyArtifact(text: string, heading: string): boolean {
   );
 }
 
+function setExecutablePresence(presence: {
+  readonly python?: boolean;
+  readonly py?: boolean;
+  readonly pwsh?: boolean;
+}): void {
+  fsMock.existsSync.mockImplementation((filePath: string) => {
+    const lowerPath = filePath.toLowerCase();
+    if (lowerPath.includes("python")) {
+      return presence.python ?? false;
+    }
+
+    if (lowerPath.includes(`${"\\"}py.`) || lowerPath.endsWith("/py")) {
+      return presence.py ?? false;
+    }
+
+    if (lowerPath.includes("pwsh")) {
+      return presence.pwsh ?? false;
+    }
+
+    return false;
+  });
+}
+
 describe("drm-copilot integration behavior", () => {
   beforeEach(() => {
     handlers.clear();
@@ -196,6 +223,7 @@ describe("drm-copilot integration behavior", () => {
       remoteRefs: ["origin/HEAD", "origin/main", "origin/develop"],
       localRefs: ["main"],
     });
+    setExecutablePresence({ python: true, py: false, pwsh: true });
     childProcessMock.spawn.mockImplementation(() => mockProcessSuccess());
 
     const context = {
@@ -475,6 +503,26 @@ describe("drm-copilot integration behavior", () => {
     const destinationIndex = args.indexOf("--destination");
     expect(destinationIndex).toBeGreaterThan(-1);
     expect(args[destinationIndex + 1]).toBe("C:/workspace");
+  });
+
+  it("pushDownCopilotCustomizations falls back to py -3 when python is unavailable", async () => {
+    setExecutablePresence({ python: false, py: true, pwsh: true });
+
+    await handlerFor("drmCopilotExtension.pushDownCopilotCustomizations")();
+
+    const [executable, args, options] = childProcessMock.spawn.mock
+      .calls[0] as [string, string[], { cwd: string }];
+    expect(executable).toBe("py");
+    expect(args[0]).toBe("-3");
+    expect(
+      normalizePath(args[1]).endsWith(
+        "resources/templates/push_down_copilot_customizations.py",
+      ),
+    ).toBe(true);
+    const destinationIndex = args.indexOf("--destination");
+    expect(destinationIndex).toBeGreaterThan(-1);
+    expect(args[destinationIndex + 1]).toBe("C:/workspace");
+    expect(options.cwd).toBe("C:/workspace");
   });
 
   it("syncAgentsFromInstructions runs the bundled PowerShell template against the active workspace root", async () => {

--- a/extensions/drm-copilot/test/extension.test.ts
+++ b/extensions/drm-copilot/test/extension.test.ts
@@ -152,6 +152,7 @@ function setGitBranchDiscoveryState(input: {
 
 function setExecutablePresence(presence: {
   readonly python?: boolean;
+  readonly py?: boolean;
   readonly pwsh?: boolean;
   readonly powershell?: boolean;
 }): void {
@@ -159,6 +160,10 @@ function setExecutablePresence(presence: {
     const lowerPath = filePath.toLowerCase();
     if (lowerPath.includes("python")) {
       return presence.python ?? false;
+    }
+
+    if (lowerPath.includes(`${"\\"}py.`) || lowerPath.endsWith("/py")) {
+      return presence.py ?? false;
     }
 
     if (lowerPath.includes("pwsh")) {
@@ -362,6 +367,16 @@ describe("drm-copilot command behavior", () => {
     expect(() => detectRuntime("python")).toThrow(
       "Python runtime 'python' not found on PATH.",
     );
+  });
+
+  it("detectRuntime falls back to py -3 when python is unavailable", () => {
+    setExecutablePresence({ python: false, py: true });
+
+    const runtime = detectRuntime("python");
+    expect(runtime).toEqual({
+      executable: "py",
+      argsPrefix: ["-3"],
+    });
   });
 
   it("collectCommitContext fails when no workspace folder is open", async () => {

--- a/extensions/drm-copilot/test/mcp-provider.test.ts
+++ b/extensions/drm-copilot/test/mcp-provider.test.ts
@@ -155,7 +155,7 @@ describe("registerMcpProvider", () => {
     const [name, runtime, args] = McpStdioServerDefinitionMock.mock
       .calls[0] as [string, string, string[]];
     expect(name).toBe("drmCopilotExtension");
-    expect(runtime).toBe("node");
+    expect(runtime).toBe(process.execPath);
     expect(args[0]).toContain("mcp-server.js");
     // Callback must return the constructed definition.
     expect(results).toHaveLength(1);

--- a/extensions/drm-copilot/test/repo-automation-service.test.ts
+++ b/extensions/drm-copilot/test/repo-automation-service.test.ts
@@ -54,6 +54,7 @@ function createMockProcess(
 
 function setExecutablePresence(presence: {
   readonly python?: boolean;
+  readonly py?: boolean;
   readonly pwsh?: boolean;
   readonly powershell?: boolean;
 }): void {
@@ -61,6 +62,10 @@ function setExecutablePresence(presence: {
     const lowerPath = filePath.toLowerCase();
     if (lowerPath.includes("python")) {
       return presence.python ?? false;
+    }
+
+    if (lowerPath.includes(`${"\\"}py.`) || lowerPath.endsWith("/py")) {
+      return presence.py ?? false;
     }
 
     if (lowerPath.includes("pwsh")) {
@@ -125,6 +130,31 @@ describe("repo automation service", () => {
       "C:/workspace/artifacts/pr_context.summary.txt",
       "C:/workspace/artifacts/pr_context.appendix.txt",
     ]);
+  });
+
+  it("collectPrContext falls back to py -3 when python is unavailable", async () => {
+    setExecutablePresence({ python: false, py: true });
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+    const service = createRepoAutomationService({
+      extensionRoot: "C:/extension",
+      output: { appendLine: appendLineMock },
+    });
+
+    await service.collectPrContext({
+      workspaceRoot: "C:/workspace",
+      invocationId: "collect_pr_context",
+      base: "origin/main",
+    });
+
+    const [executable, args, options] = childProcessMock.spawn.mock
+      .calls[0] as [string, string[], { cwd: string; shell: boolean }];
+    expect(executable).toBe("py");
+    expect(args[0]).toBe("-3");
+    expect(args[1]).toBe(
+      "C:/extension/resources/templates/collect_pr_context.py",
+    );
+    expect(options.cwd).toBe("C:/workspace");
+    expect(options.shell).toBe(false);
   });
 
   it("newPotentialEntry keeps subprocess execution argv-based with shell disabled", async () => {


### PR DESCRIPTION
- fall back from `python` to `py -3` when bundled Python commands run without a `python` executable on PATH
- launch the MCP stdio server with `process.execPath` instead of assuming a `node` command is globally available
- extend unit and integration coverage for runtime probing, repo-automation execution, and push-down command wiring