### PR TITLE
Fix sync-agents ordering so general instructions lead AGENTS.md generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,11 @@
 > NOTE: This file is **generated** from:
 >
 > - .github/copilot-instructions.md
+> - .github/instructions/general-code-change.instructions.md
+> - .github/instructions/general-unit-test.instructions.md
 > - .github/instructions/codexer.instructions.md
 > - .github/instructions/csharp-code-change.instructions.md
 > - .github/instructions/csharp-unit-test.instructions.md
-> - .github/instructions/general-code-change.instructions.md
-> - .github/instructions/general-unit-test.instructions.md
 > - .github/instructions/github-actions-ci-cd-best-practices.instructions.md
 > - .github/instructions/github-actions.instructions.md
 > - .github/instructions/powershell-code-change.instructions.md
@@ -44,241 +44,6 @@
 - If a sentence could read as casual, playful, or informal, rewrite it in neutral business language.
 
 <!-- END: copilot-instructions -->
-
-## Codexer Instructions (Placeholder)
-
-<!-- BEGIN: codexer -->
-# Codexer Instructions (Placeholder)
-
-This file is a placeholder to satisfy agent synchronization tooling.
-
-<!-- END: codexer -->
-
-## C# Code Change Policy
-
-<!-- BEGIN: csharp-code-change -->
-# C# Code Change Policy
-
-You must:
-
-- Apply **all** rules in the general code change policy.
-- Apply **all** C#-specific rules in this file.
-- Apply the unit test policies (`general-unit-test.instructions.md` and `csharp-unit-test.instructions.md`) for any work involving tests.
-
----
-
-## 1. Tooling & Baseline for C#
-
-These are the required tools for C# code in this repo:
-
-1. **Formatting — `csharpier`**
-
-   - All C# source files (`*.cs`) must be formatted with `csharpier`.
-   - Do **not** use `dotnet format` — it loads the solution/project model and can mis-handle legacy VSTO / .NET Framework projects by rewriting `.csproj` files.
-   - `csharpier` is file-based and formats only `*.cs` without touching project files.
-   - Do not hand-format; if a diff disagrees with `csharpier`, formatter output wins.
-   - Approved commands:
-     - `dotnet tool run csharpier .`
-     - or `csharpier .` (if installed globally)
-
-2. **Linting / Static Analysis — .NET analyzers**
-
-   - C# code must pass Roslyn/.NET analyzer diagnostics configured by `.editorconfig`, `.globalconfig`, and project properties.
-   - Enforce analyzer diagnostics in build using `EnableNETAnalyzers` and `EnforceCodeStyleInBuild`.
-   - Prefer fixing diagnostics over suppressing them.
-   - Approved commands (Windows; choose the variant for your shell):
-     - **CMD / Developer Command Prompt:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
-     - **PowerShell:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
-
-3. **Type Checking — C# compiler + nullable analysis**
-
-   - Treat C# compiler diagnostics and nullable-flow warnings as first-class type-safety checks.
-   - Enable nullable reference types and fail builds on warnings for touched code paths.
-   - Avoid introducing nullable warnings; fix the root null-state issue instead.
-   - Approved commands (Windows; choose the variant for your shell):
-     - **CMD / Developer Command Prompt:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
-     - **PowerShell:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:Nullable=enable /p:TreatWarningsAsErrors=true`
-
-> **Testing tools and behavior are defined in the unit test policies.** Do not define test behavior here; instead, obey `general-unit-test.instructions.md` and `csharp-unit-test.instructions.md`.
-
----
-
-## 2. C# Design & Type-Safety Principles
-
-These refine the general design principles for C# code.
-
-1. **Strong contracts and explicit APIs**
-
-   - Public methods, constructors, and properties must express clear contracts.
-   - Use explicit types at public boundaries; use `var` only when the type is obvious.
-
-2. **Null-safety by default**
-
-   - Keep nullable reference types enabled.
-   - Model optional values explicitly with nullable annotations and guard clauses.
-   - Use nullability attributes where needed to improve flow analysis.
-
-3. **Prefer composition and focused types**
-
-   - Keep classes cohesive and scoped to one core responsibility.
-   - Favor composition over inheritance unless polymorphism is a clear requirement.
-
-4. **Asynchrony and resource safety**
-
-   - Use `async`/`await` for I/O-bound operations.
-   - Prefer `using`/`await using` for disposable resources.
-
----
-
-## 3. Classes, Methods, and APIs (C#-Specific Guidance)
-
-### 3.1 Classes for domain concepts and workflows
-
-Use classes/records when:
-
-- Modeling domain concepts with state + behavior.
-- Protecting invariants across related members.
-- Providing multiple implementations behind interfaces.
-- Orchestrating multi-step workflows that share context.
-
-When using classes/records:
-
-- Keep methods small and focused.
-- Avoid god objects.
-- Prefer immutable records/value objects for data-centric models where practical.
-
-### 3.2 Methods and local functions for focused logic
-
-Use methods/local functions when:
-
-- Implementing narrow, deterministic behavior.
-- Encapsulating reusable, stateless transformations.
-
-Rules:
-
-- Name methods by behavior.
-- Keep branching shallow where possible.
-- Extract helper methods instead of deeply nested conditionals.
-
-### 3.3 Interfaces and contracts
-
-- Use interfaces when multiple implementations are expected.
-- Keep public APIs stable and avoid unnecessary breaking changes.
-- Document non-obvious side effects and failure modes.
-
----
-
-## 4. Error Handling, Logging, and Contracts (C#)
-
-1. **Exceptions**
-
-   - Fail fast with explicit exceptions when invariants are violated.
-   - Avoid catching broad `Exception` unless at a clear boundary and with added context.
-
-2. **Logging**
-
-   - Use the repository/project logging pattern, not ad-hoc console output in production code.
-   - Log actionable context at appropriate levels.
-
-3. **Contracts / invariants**
-
-   - Validate constructor and method preconditions.
-   - Use `Debug.Assert` only for internal invariants, not user-facing validation.
-
----
-
-## 5. Module & File Structure (C#)
-
-1. **Cohesive files and namespaces**
-
-   - Keep files focused on one responsibility area.
-   - Keep file size under the repo limit in `general-code-change.instructions.md`.
-
-2. **Public vs internal**
-
-   - Keep public surface area intentional and minimal.
-   - Prefer `internal` for non-public APIs.
-
-3. **Imports and namespace hygiene**
-
-   - Prefer explicit `using` directives at file scope.
-   - Avoid circular dependencies.
-
----
-
-## 6. Naming, Docs, and Comments (C#)
-
-1. **Naming conventions**
-
-   - `PascalCase` for types and public members.
-   - `camelCase` for local variables and private fields/parameters.
-   - Use descriptive names over abbreviations.
-
-2. **Documentation comments**
-
-   - Public APIs should include XML documentation comments when behavior or contract is non-obvious.
-
-3. **Comments**
-
-   - Comment **why**, not what.
-   - Keep comments synchronized with behavior.
-
----
-
-## 7. Dependencies and Analyzer Configuration (C#)
-
-- Prefer built-in .NET SDK analyzers and configuration through `.editorconfig` / `.globalconfig`.
-- Use project-level properties (`EnableNETAnalyzers`, `AnalysisLevel`, `AnalysisMode`, `EnforceCodeStyleInBuild`) rather than ad-hoc per-command behavior where possible.
-- Avoid adding external dependencies unless unavoidable and approved by the project direction.
-- If suppression is unavoidable, keep it as narrow as possible and document the rationale in-code.
-
-<!-- END: csharp-code-change -->
-
-## C# Unit Test Policy
-
-<!-- BEGIN: csharp-unit-test -->
-# C# Unit Test Policy
-
-- The general unit test policy, and
-- The C#-specific rules below.
-
----
-
-## 1. Framework Selection
-
-- **Testing framework**
-  - Use **MSTest** (`Microsoft.VisualStudio.TestTools.UnitTesting`) for C# unit tests in this repository.
-  - Do not introduce xUnit or NUnit into existing test projects.
-
----
-
-## 2. C#-Specific Libraries and Conventions
-
-- **Mocking library**
-  - Use **Moq** for mocks/stubs in C# unit tests.
-
-- **Assertion library**
-  - Prefer **FluentAssertions** for new and updated assertions.
-  - Use MSTest `Assert` APIs only when FluentAssertions is not practical for a specific assertion shape.
-
-- **MSTest style**
-  - Use `[TestClass]`, `[TestMethod]`, and other MSTest attributes from `Microsoft.VisualStudio.TestTools.UnitTesting`.
-
----
-
-## 3. C# Toolchain Command Selection
-
-- For C# work, use these concrete commands for the general policy toolchain loop:
-  1. `csharpier .`
-  2. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
-  3. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
-  4. `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`
-
-- The loop behavior (restart rules, must-pass requirements, and audit expectations) is defined by `general-code-change.instructions.md` and is intentionally not repeated here.
-
-This file is intentionally limited to C#-specific framework/library/tool selection. Cross-language testing principles and policy requirements are defined in `general-unit-test.instructions.md` and `general-code-change.instructions.md`.
-
-<!-- END: csharp-unit-test -->
 
 ## Agent Code Change Policy
 
@@ -663,6 +428,241 @@ Before submitting any change that includes unit tests:
 If any test cannot comply with these rules for a good reason, **call out the exception explicitly** in the change description.
 
 <!-- END: general-unit-test -->
+
+## Codexer Instructions (Placeholder)
+
+<!-- BEGIN: codexer -->
+# Codexer Instructions (Placeholder)
+
+This file is a placeholder to satisfy agent synchronization tooling.
+
+<!-- END: codexer -->
+
+## C# Code Change Policy
+
+<!-- BEGIN: csharp-code-change -->
+# C# Code Change Policy
+
+You must:
+
+- Apply **all** rules in the general code change policy.
+- Apply **all** C#-specific rules in this file.
+- Apply the unit test policies (`general-unit-test.instructions.md` and `csharp-unit-test.instructions.md`) for any work involving tests.
+
+---
+
+## 1. Tooling & Baseline for C#
+
+These are the required tools for C# code in this repo:
+
+1. **Formatting — `csharpier`**
+
+   - All C# source files (`*.cs`) must be formatted with `csharpier`.
+   - Do **not** use `dotnet format` — it loads the solution/project model and can mis-handle legacy VSTO / .NET Framework projects by rewriting `.csproj` files.
+   - `csharpier` is file-based and formats only `*.cs` without touching project files.
+   - Do not hand-format; if a diff disagrees with `csharpier`, formatter output wins.
+   - Approved commands:
+     - `dotnet tool run csharpier .`
+     - or `csharpier .` (if installed globally)
+
+2. **Linting / Static Analysis — .NET analyzers**
+
+   - C# code must pass Roslyn/.NET analyzer diagnostics configured by `.editorconfig`, `.globalconfig`, and project properties.
+   - Enforce analyzer diagnostics in build using `EnableNETAnalyzers` and `EnforceCodeStyleInBuild`.
+   - Prefer fixing diagnostics over suppressing them.
+   - Approved commands (Windows; choose the variant for your shell):
+     - **CMD / Developer Command Prompt:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+     - **PowerShell:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+
+3. **Type Checking — C# compiler + nullable analysis**
+
+   - Treat C# compiler diagnostics and nullable-flow warnings as first-class type-safety checks.
+   - Enable nullable reference types and fail builds on warnings for touched code paths.
+   - Avoid introducing nullable warnings; fix the root null-state issue instead.
+   - Approved commands (Windows; choose the variant for your shell):
+     - **CMD / Developer Command Prompt:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+     - **PowerShell:** `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform='Any CPU' /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+
+> **Testing tools and behavior are defined in the unit test policies.** Do not define test behavior here; instead, obey `general-unit-test.instructions.md` and `csharp-unit-test.instructions.md`.
+
+---
+
+## 2. C# Design & Type-Safety Principles
+
+These refine the general design principles for C# code.
+
+1. **Strong contracts and explicit APIs**
+
+   - Public methods, constructors, and properties must express clear contracts.
+   - Use explicit types at public boundaries; use `var` only when the type is obvious.
+
+2. **Null-safety by default**
+
+   - Keep nullable reference types enabled.
+   - Model optional values explicitly with nullable annotations and guard clauses.
+   - Use nullability attributes where needed to improve flow analysis.
+
+3. **Prefer composition and focused types**
+
+   - Keep classes cohesive and scoped to one core responsibility.
+   - Favor composition over inheritance unless polymorphism is a clear requirement.
+
+4. **Asynchrony and resource safety**
+
+   - Use `async`/`await` for I/O-bound operations.
+   - Prefer `using`/`await using` for disposable resources.
+
+---
+
+## 3. Classes, Methods, and APIs (C#-Specific Guidance)
+
+### 3.1 Classes for domain concepts and workflows
+
+Use classes/records when:
+
+- Modeling domain concepts with state + behavior.
+- Protecting invariants across related members.
+- Providing multiple implementations behind interfaces.
+- Orchestrating multi-step workflows that share context.
+
+When using classes/records:
+
+- Keep methods small and focused.
+- Avoid god objects.
+- Prefer immutable records/value objects for data-centric models where practical.
+
+### 3.2 Methods and local functions for focused logic
+
+Use methods/local functions when:
+
+- Implementing narrow, deterministic behavior.
+- Encapsulating reusable, stateless transformations.
+
+Rules:
+
+- Name methods by behavior.
+- Keep branching shallow where possible.
+- Extract helper methods instead of deeply nested conditionals.
+
+### 3.3 Interfaces and contracts
+
+- Use interfaces when multiple implementations are expected.
+- Keep public APIs stable and avoid unnecessary breaking changes.
+- Document non-obvious side effects and failure modes.
+
+---
+
+## 4. Error Handling, Logging, and Contracts (C#)
+
+1. **Exceptions**
+
+   - Fail fast with explicit exceptions when invariants are violated.
+   - Avoid catching broad `Exception` unless at a clear boundary and with added context.
+
+2. **Logging**
+
+   - Use the repository/project logging pattern, not ad-hoc console output in production code.
+   - Log actionable context at appropriate levels.
+
+3. **Contracts / invariants**
+
+   - Validate constructor and method preconditions.
+   - Use `Debug.Assert` only for internal invariants, not user-facing validation.
+
+---
+
+## 5. Module & File Structure (C#)
+
+1. **Cohesive files and namespaces**
+
+   - Keep files focused on one responsibility area.
+   - Keep file size under the repo limit in `general-code-change.instructions.md`.
+
+2. **Public vs internal**
+
+   - Keep public surface area intentional and minimal.
+   - Prefer `internal` for non-public APIs.
+
+3. **Imports and namespace hygiene**
+
+   - Prefer explicit `using` directives at file scope.
+   - Avoid circular dependencies.
+
+---
+
+## 6. Naming, Docs, and Comments (C#)
+
+1. **Naming conventions**
+
+   - `PascalCase` for types and public members.
+   - `camelCase` for local variables and private fields/parameters.
+   - Use descriptive names over abbreviations.
+
+2. **Documentation comments**
+
+   - Public APIs should include XML documentation comments when behavior or contract is non-obvious.
+
+3. **Comments**
+
+   - Comment **why**, not what.
+   - Keep comments synchronized with behavior.
+
+---
+
+## 7. Dependencies and Analyzer Configuration (C#)
+
+- Prefer built-in .NET SDK analyzers and configuration through `.editorconfig` / `.globalconfig`.
+- Use project-level properties (`EnableNETAnalyzers`, `AnalysisLevel`, `AnalysisMode`, `EnforceCodeStyleInBuild`) rather than ad-hoc per-command behavior where possible.
+- Avoid adding external dependencies unless unavoidable and approved by the project direction.
+- If suppression is unavoidable, keep it as narrow as possible and document the rationale in-code.
+
+<!-- END: csharp-code-change -->
+
+## C# Unit Test Policy
+
+<!-- BEGIN: csharp-unit-test -->
+# C# Unit Test Policy
+
+- The general unit test policy, and
+- The C#-specific rules below.
+
+---
+
+## 1. Framework Selection
+
+- **Testing framework**
+  - Use **MSTest** (`Microsoft.VisualStudio.TestTools.UnitTesting`) for C# unit tests in this repository.
+  - Do not introduce xUnit or NUnit into existing test projects.
+
+---
+
+## 2. C#-Specific Libraries and Conventions
+
+- **Mocking library**
+  - Use **Moq** for mocks/stubs in C# unit tests.
+
+- **Assertion library**
+  - Prefer **FluentAssertions** for new and updated assertions.
+  - Use MSTest `Assert` APIs only when FluentAssertions is not practical for a specific assertion shape.
+
+- **MSTest style**
+  - Use `[TestClass]`, `[TestMethod]`, and other MSTest attributes from `Microsoft.VisualStudio.TestTools.UnitTesting`.
+
+---
+
+## 3. C# Toolchain Command Selection
+
+- For C# work, use these concrete commands for the general policy toolchain loop:
+  1. `csharpier .`
+  2. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:EnableNETAnalyzers=true /p:EnforceCodeStyleInBuild=true`
+  3. `msbuild TaskMaster.sln /t:Build /p:Configuration=Debug /p:Platform="Any CPU" /p:Nullable=enable /p:TreatWarningsAsErrors=true`
+  4. `vstest.console.exe <test-assembly-paths> /EnableCodeCoverage`
+
+- The loop behavior (restart rules, must-pass requirements, and audit expectations) is defined by `general-code-change.instructions.md` and is intentionally not repeated here.
+
+This file is intentionally limited to C#-specific framework/library/tool selection. Cross-language testing principles and policy requirements are defined in `general-unit-test.instructions.md` and `general-code-change.instructions.md`.
+
+<!-- END: csharp-unit-test -->
 
 ## GitHub Actions CI/CD Best Practices
 

--- a/docs/features/active/2026-04-05-general-instructions-first-122/code-review.2026-04-05T13-42.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/code-review.2026-04-05T13-42.md
@@ -1,0 +1,70 @@
+# Code Review: general-instructions-first (Issue #122)
+
+## Executive Summary
+
+Relative to `development`, there is no remaining code diff to review: refreshed PR context resolves both `origin/development` and `HEAD` to `f720ff7fae4e11e62b61d62b3072d03c84a2307b`, and `git diff --name-only origin/development...HEAD` returns no files. The scoped feature implementation recorded in `docs/features/active/2026-04-05-general-instructions-first-122` remains technically sound and already present in the base branch: it adds a small grouped sort-key helper, preserves bundled parity, adds targeted ordering regressions, and regenerates `AGENTS.md` with the required general-first ordering.
+
+Top risks:
+1. No code risk remains relative to `development`; the only practical risk is opening a redundant no-op PR.
+2. The stored evidence does not include an exact changed-line coverage percentage, even though behavior coverage and no-regression evidence are present.
+3. Reviewers should avoid re-validating this feature against `spec.md` or `user-story.md`; this is a `minor-audit` bugfix and only the exact `## Acceptance Criteria` section in `issue.md` is authoritative.
+
+**Go/No-Go recommendation for `development`:** **Go**. The ready-to-merge gate passes, but there is nothing left to merge because the branch is already at the `development` tip.
+
+**Feature-folder selection rule:** The user explicitly supplied `docs/features/active/2026-04-05-general-instructions-first-122`, so this review uses that folder as the authoritative scope anchor despite the empty live diff.
+
+## Findings
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `artifacts/pr_context.summary.txt` | `Base/Head`, `Changed files overview` | The refreshed comparison against `development` is empty. | Do not open a new PR to `development` unless additional commits are added; treat the gate as passed and the branch as already merged. | A no-op PR adds review overhead without delivering any additional change. | Refreshed summary shows `Base ref (resolved): origin/development @ f720ff7...`, `Head ref (resolved): bug/general-instructions-first-122 @ f720ff7...`, and `Core logic changes: 0 files`. |
+| Minor | `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/` | coverage evidence set | The evidence proves behavior and no coverage regression but does not isolate a changed-line percentage. | If a stricter audit package is needed later, add a short focused coverage note; no code remediation is required now. | This is an audit completeness note, not a correctness issue. | Baseline/final Pester artifacts show `47.57%` → `47.86%` command coverage. |
+| Nit | `docs/features/active/2026-04-05-general-instructions-first-122/issue.md` | `## Acceptance Criteria` | The issue already contains the exact minor-audit AC section with all five items checked. | Keep using only this section as the source of truth for future review references. | This preserves the repository’s minor-audit integrity contract. | Direct issue inspection shows `AC_START=64`, `AC_CHECKED=5`, `AC_UNCHECKED=0`. |
+
+## Reviewed Implementation Notes
+
+### What changed in the feature scope
+
+- `scripts/dev-tools/sync-agents-from-instructions.ps1`
+  - Added `Get-InstructionSortKey`.
+  - Switched discovery ordering to grouped sort keys so `general*` basenames precede language-specific instruction files while preserving deterministic order inside each group.
+- `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1`
+  - Remains byte-identical to the repo-root script.
+- `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1`
+  - Added a helper-ordering regression test.
+  - Added a generated-output ordering regression test.
+- `AGENTS.md`
+  - Regenerated to prove the grouped order.
+
+### Strengths
+
+- The fix is small, local, and easy to reason about.
+- The helper is pure and does not widen the command surface.
+- Tests cover both internal ordering and user-visible output ordering.
+- Bundled parity is preserved.
+- The feature evidence set is complete enough to support a pass decision relative to `development`.
+
+## Typed Python Audit
+
+No Python files are in the scoped feature implementation. Typed Python review is **N/A** for this feature folder.
+
+## Test Quality Audit
+
+- **Deterministic:** Yes. The new ordering tests use mocked discovery inputs and assert explicit order relationships.
+- **Isolated:** Yes. No network or temporary filesystem dependency is introduced.
+- **Fast:** Yes. Final Pester evidence reports `9.96s` total execution time.
+- **Diagnostics:** Good. The red regression artifact records the exact failing ordering assertion before the fix.
+- **Coverage posture:** Good for behavior and no-regression evidence; partial only for exact changed-line reporting.
+
+## Security and Correctness Checks
+
+- No secrets or credentials were introduced.
+- No unsafe subprocess or shelling behavior was added.
+- The new behavior is a pure string-based ordering helper.
+- Minor-audit integrity holds: `spec.md` and `user-story.md` are absent, and only the exact `## Acceptance Criteria` section in `issue.md` is used as the acceptance source.
+
+## Go/No-Go Recommendation
+
+**Go relative to `development`.**
+
+The gate passes because there is no remaining diff against the selected base branch and the feature-folder evidence confirms the scoped bugfix was implemented and verified. No remediation is required. The only operational note is that a PR to `development` would be redundant unless additional commits are added after this review.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-analyze.2026-04-05T13-19.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-analyze.2026-04-05T13-19.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-19
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."
+EXIT_CODE: 0
+Output Summary: PSScriptAnalyzer completed successfully with the summary `PSScriptAnalyzer passed: no findings under .`.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-format.2026-04-05T13-19.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-format.2026-04-05T13-19.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-19
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."
+EXIT_CODE: 0
+Output Summary: Formatter completed successfully. Output reported the enumerated PowerShell files as already formatted, including `scripts/dev-tools/sync-agents-from-instructions.ps1` and its bundled template mirror. No formatter edits were reported in the command output.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-test.2026-04-05T13-19.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-test.2026-04-05T13-19.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-19
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."
+EXIT_CODE: 0
+Output Summary: Pester discovery found 245 tests. Test execution completed in 9.51s with 238 passed, 0 failed, 7 skipped, and 0 inconclusive. Coverage processing completed and reported `Covered 47.57% / 0%. 1,625 analyzed Commands in 16 Files.`

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,18 @@
+Timestamp: 2026-04-05T13-18
+Policy Order:
+1. .github/copilot-instructions.md
+2. .github/instructions/general-code-change.instructions.md
+3. .github/instructions/general-unit-test.instructions.md
+4. .github/instructions/powershell-code-change.instructions.md
+5. .github/instructions/powershell-unit-test.instructions.md
+Files Read:
+- .github/copilot-instructions.md
+- .github/instructions/general-code-change.instructions.md
+- .github/instructions/general-unit-test.instructions.md
+- .github/instructions/powershell-code-change.instructions.md
+- .github/instructions/powershell-unit-test.instructions.md
+Work Mode: minor-audit
+AC Source: issue.md -> ## Acceptance Criteria
+Target Plan Path: c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-04-05-general-instructions-first-122\plan.2026-04-05T13-13.md
+spec.md: not required
+user-story.md: not required

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-agents-regeneration.2026-04-05T13-27.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-agents-regeneration.2026-04-05T13-27.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-27
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1
+EXIT_CODE: 0
+Output Summary: The sync script regenerated `AGENTS.md` successfully. The generated source list now places `.github/instructions/general-code-change.instructions.md` and `.github/instructions/general-unit-test.instructions.md` immediately after `.github/copilot-instructions.md` and before language-specific instruction files such as C#, PowerShell, Python, and TypeScript. The corresponding sections follow the same grouped order: `## Agent Code Change Policy` and `## General Unit Test Policy` appear before `## Codexer Instructions (Placeholder)` and the language-specific sections.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-analyze.2026-04-05T13-26.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-analyze.2026-04-05T13-26.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-26
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."
+EXIT_CODE: 0
+Output Summary: PSScriptAnalyzer completed successfully with the summary `PSScriptAnalyzer passed: no findings under .` during the clean final pass.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-format.2026-04-05T13-26.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-format.2026-04-05T13-26.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-26
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."
+EXIT_CODE: 0
+Output Summary: Formatter completed successfully. Output reported the touched root script, bundled template, and `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` as already formatted. No formatter edits were reported in the clean final pass.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-26
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."
+EXIT_CODE: 0
+Output Summary: Pester discovery found 247 tests. Test execution completed in 9.96s with 240 passed, 0 failed, 7 skipped, and 0 inconclusive. Coverage processing completed and reported `Covered 47.86% / 0%. 1,634 analyzed Commands in 16 Files.` The new ordering scenarios in `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` passed in the clean final pass.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/scope-lock.2026-04-05T16-20.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/scope-lock.2026-04-05T16-20.md
@@ -1,0 +1,42 @@
+Timestamp: 2026-04-05T16-20
+Command: git status --short --untracked-files=all
+EXIT_CODE: 0
+Output Summary: PASS retained scope evidence captured for [P1-T1]. The working tree is limited to the expected minor-audit implementation files (`scripts/dev-tools/sync-agents-from-instructions.ps1`, `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1`, `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1`, `AGENTS.md`) plus this feature folder's retained documentation artifacts (`issue.md`, `plan.2026-04-05T13-13.md`, and files under `docs/features/active/2026-04-05-general-instructions-first-122/evidence/`). No `spec.md` or `user-story.md` is required or present for this minor-audit scope.
+
+Captured Changed Paths:
+- `AGENTS.md`
+- `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1`
+- `scripts/dev-tools/sync-agents-from-instructions.ps1`
+- `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1`
+- `docs/features/active/2026-04-05-general-instructions-first-122/issue.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/plan.2026-04-05T13-13.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-analyze.2026-04-05T13-19.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-format.2026-04-05T13-19.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-test.2026-04-05T13-19.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-agents-regeneration.2026-04-05T13-27.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-analyze.2026-04-05T13-26.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-format.2026-04-05T13-26.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/scope-lock.2026-04-05T16-20.md`
+- `docs/features/active/2026-04-05-general-instructions-first-122/evidence/regression-testing/regression-general-first-order.2026-04-05T13-23.md`
+
+Captured `git status --short --untracked-files=all` Output:
+```text
+ M AGENTS.md
+ M extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1
+ M scripts/dev-tools/sync-agents-from-instructions.ps1
+ M tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-analyze.2026-04-05T13-19.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-format.2026-04-05T13-19.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-test.2026-04-05T13-19.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-agents-regeneration.2026-04-05T13-27.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-analyze.2026-04-05T13-26.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-format.2026-04-05T13-26.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/scope-lock.2026-04-05T16-20.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/evidence/regression-testing/regression-general-first-order.2026-04-05T13-23.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/issue.md
+?? docs/features/active/2026-04-05-general-instructions-first-122/plan.2026-04-05T13-13.md
+```

--- a/docs/features/active/2026-04-05-general-instructions-first-122/evidence/regression-testing/regression-general-first-order.2026-04-05T13-23.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/evidence/regression-testing/regression-general-first-order.2026-04-05T13-23.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T13-23
+Command: pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."
+EXIT_CODE: 1
+Output Summary: Pester discovery found 246 tests. Test execution completed with 238 passed, 1 failed, 7 skipped, and 0 inconclusive. The intentional regression failure was `sync-agents-from-instructions.ps1.Get-AgentContent ordering.emits general instruction files before language-specific instruction files in generated AGENTS.md output`, which failed because `general-code-change.instructions.md` appeared after `csharp-code-change.instructions.md` in generated output (`Expected the actual value to be less than 92, but got 152.`).

--- a/docs/features/active/2026-04-05-general-instructions-first-122/feature-audit.2026-04-05T13-42.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/feature-audit.2026-04-05T13-42.md
@@ -1,0 +1,53 @@
+# Feature Audit: general-instructions-first (Issue #122)
+
+## Scope and Baseline
+
+- **Base branch:** `development`
+- **Feature folder:** `docs/features/active/2026-04-05-general-instructions-first-122`
+- **Work mode marker:** `minor-audit`
+- **Authoritative acceptance-criteria source:** `docs/features/active/2026-04-05-general-instructions-first-122/issue.md` under the exact heading `## Acceptance Criteria`
+- **Minor-audit integrity:** `spec.md` absent = `True`; `user-story.md` absent = `True`
+- **Primary evidence sources:**
+  - `artifacts/pr_context.summary.txt` refreshed against `development`
+  - `artifacts/pr_context.appendix.txt`
+  - Feature evidence under `docs/features/active/2026-04-05-general-instructions-first-122/evidence/`
+
+## Acceptance Criteria Inventory (Authoritative)
+
+Source: `docs/features/active/2026-04-05-general-instructions-first-122/issue.md`
+
+1. The sync command emits discovered instruction files whose basenames start with `general` before language-specific instruction files in generated `AGENTS.md` output.
+2. Ordering remains deterministic within the `general` group and within the remaining language-specific group.
+3. The bundled template at `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` remains byte-identical to `scripts/dev-tools/sync-agents-from-instructions.ps1`.
+4. Pester tests cover the ordering rule and pass.
+5. Running the sync script regenerates `AGENTS.md` with the expected grouped order.
+
+## Acceptance Criteria Evaluation
+
+| Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|---|---|---|---|
+| 1. `general*` basenames emit before language-specific instruction files in generated `AGENTS.md` output | PASS | `evidence/qa-gates/final-agents-regeneration.2026-04-05T13-27.md` confirms the generated source list places `general-code-change` and `general-unit-test` immediately after `.github/copilot-instructions.md` and before language-specific entries. | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1` | The refreshed `development` diff is empty, so this acceptance evidence is already present in the base branch. |
+| 2. Ordering remains deterministic within the `general` and remaining groups | PASS | `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` includes a deterministic grouped-order scenario; `evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md` confirms it passed. | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."` | The test explicitly asserts `general-code-change` before `general-unit-test`, then `csharp`, `powershell`, `python`, `typescript`. |
+| 3. Bundled template remains byte-identical to the root script | PASS | The existing parity scenario remains present and passed in the final Pester run; the feature evidence and regenerated output both rely on matching root/bundled behavior. | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."` | No drift is indicated in the refreshed no-op diff against `development`. |
+| 4. Pester tests cover the ordering rule and pass | PASS | `evidence/regression-testing/regression-general-first-order.2026-04-05T13-23.md` captures the red failure before the fix; `evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md` captures the final green pass. | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."` | Regression-first workflow requirement is satisfied. |
+| 5. Running the sync script regenerates `AGENTS.md` with the expected grouped order | PASS | `evidence/qa-gates/final-agents-regeneration.2026-04-05T13-27.md` records successful regeneration with grouped order. | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1` | The generated output is already incorporated in `development`. |
+
+## Summary
+
+**Overall feature readiness:** PASS
+
+The feature folder satisfies all five acceptance criteria using only the exact `## Acceptance Criteria` section in `issue.md`, and minor-audit integrity is preserved because `spec.md` and `user-story.md` are absent. Relative to `development`, the refreshed branch comparison is empty, so the ready-to-merge gate passes and no remediation is required.
+
+**Branch note:** The pass result means the feature is already present in `development`. A new PR to that base would be a no-op unless additional commits are added later.
+
+## Acceptance Criteria Status
+
+- Source: `docs/features/active/2026-04-05-general-instructions-first-122/issue.md`
+- Total AC items: 5
+- Checked off (delivered): 5
+- Remaining (unchecked): 0
+- Items remaining: none
+
+## Check-off Notes
+
+No source-file checkbox edits were required during this review because all five acceptance criteria were already checked in `issue.md` and this review confirmed each one as PASS.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/issue.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/issue.md
@@ -1,0 +1,75 @@
+# general-instructions-first (Issue #122)
+
+- Date captured: 2026-04-05
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/general-instructions-first/ (Issue #122)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #122
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/122
+- Last Updated: 2026-04-05T13-27
+- Work Mode: minor-audit
+
+## Summary
+
+The bundled `drm-copilot: Sync AGENTS.md from Instructions` command does not guarantee that instruction files whose names begin with `general` are emitted before language-specific instruction sections in the generated `AGENTS.md`. The generated order should place the general instruction files first so the consolidated guidance matches the repository policy precedence.
+
+## Environment
+
+- OS/version: Windows 11 / VS Code Insiders
+- PowerShell version: 7.x
+- Command/flags used: `drm-copilot: Sync AGENTS.md from Instructions`
+- Data source or fixture: repository `.github/instructions/*.instructions.md` files
+
+## Steps to Reproduce
+
+1. Run `drm-copilot: Sync AGENTS.md from Instructions` in the repo.
+2. Inspect the generated `AGENTS.md` source-file order and the corresponding section order.
+3. Observe that general instruction files are not consistently grouped ahead of language-specific instruction files.
+
+## Expected Behavior
+
+Any discovered instruction files whose basenames begin with `general` should appear before language-specific instruction files in the generated `AGENTS.md` output, while preserving deterministic ordering within each group.
+
+## Actual Behavior
+
+The sync output does not enforce the required precedence for `general*.instructions.md` files relative to language-specific instruction files.
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet: Compare the generated order of `general-code-change.instructions.md` and `general-unit-test.instructions.md` against language-specific sections such as Python, PowerShell, C#, and TypeScript.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [x] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+- The sync script likely relies on simple path ordering instead of a grouping rule for `general*` basenames.
+- The root script and bundled template must stay byte-identical after the fix.
+- Pester coverage should lock in the required ordering behavior.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Update the sync ordering logic so `general*.instructions.md` files sort before language-specific instruction files.
+- [x] Add or update Pester tests that verify the grouped ordering contract.
+- [x] Keep the bundled template mirror in sync with the root script.
+- [x] Regenerate `AGENTS.md` and verify the output order reflects the new precedence.
+
+## Acceptance Criteria
+
+- [x] The sync command emits discovered instruction files whose basenames start with `general` before language-specific instruction files in generated `AGENTS.md` output.
+- [x] Ordering remains deterministic within the `general` group and within the remaining language-specific group.
+- [x] The bundled template at `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` remains byte-identical to `scripts/dev-tools/sync-agents-from-instructions.ps1`.
+- [x] Pester tests cover the ordering rule and pass.
+- [x] Running the sync script regenerates `AGENTS.md` with the expected grouped order.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [x] Move to active fix folder / branch

--- a/docs/features/active/2026-04-05-general-instructions-first-122/plan.2026-04-05T13-13.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/plan.2026-04-05T13-13.md
@@ -1,0 +1,120 @@
+# 2026-04-05-general-instructions-first (Plan)
+
+- **Issue:** #122
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-04-05T13-13
+- **Status:** Draft
+- **Version:** 0.2
+- **Work Mode:** minor-audit
+- **Directive:** `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
+- **Validation Mode:** `DIRECTIVE: PREFLIGHT VALIDATION ONLY`
+
+## Overview
+
+Fix the PowerShell sync-ordering bug described in Issue #122 with a constrained small-path bugfix. The plan uses `issue.md` as the only requirements source, records Phase 0 baseline evidence with the direct PoshQC commands, and ends with an unconditional final QC loop plus issue status updates.
+
+## Requirement Source
+
+- Sole requirements source: `docs/features/active/2026-04-05-general-instructions-first-122/issue.md`
+- Authoritative acceptance-criteria source: the exact `## Acceptance Criteria` section in `issue.md`
+- `spec.md` and `user-story.md` do not exist for this minor-audit fix and must not be required by execution or validation
+
+## Small-Path Scope
+
+| File | Role | Planned change |
+|---|---|---|
+| `scripts/dev-tools/sync-agents-from-instructions.ps1` | Root PowerShell production script | Minimal ordering bugfix |
+| `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` | Bundled PowerShell mirror | Byte-identical mirror of the root script |
+| `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` | Pester coverage | Ordering regression coverage |
+| `AGENTS.md` | Generated output | Regenerated to verify grouped general-first order |
+
+## Toolchain Commands
+
+1. Format: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
+2. Analyze: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
+3. Test: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
+
+## Evidence Locations
+
+- Baseline: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/`
+- Regression testing: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/regression-testing/`
+- QA gates: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/`
+
+---
+
+### Phase 0 — Baseline Capture
+
+- [x] [P0-T1] Read `.github/copilot-instructions.md`
+	- Acceptance: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md` records `.github/copilot-instructions.md` under `Files Read:`.
+
+- [x] [P0-T2] Read `.github/instructions/general-code-change.instructions.md`
+	- Acceptance: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md` records `.github/instructions/general-code-change.instructions.md` under `Files Read:`.
+
+- [x] [P0-T3] Read `.github/instructions/general-unit-test.instructions.md`
+	- Acceptance: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md` records `.github/instructions/general-unit-test.instructions.md` under `Files Read:`.
+
+- [x] [P0-T4] Read `.github/instructions/powershell-code-change.instructions.md`
+	- Acceptance: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md` records `.github/instructions/powershell-code-change.instructions.md` under `Files Read:`.
+
+- [x] [P0-T5] Read `.github/instructions/powershell-unit-test.instructions.md`
+	- Acceptance: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md` records `.github/instructions/powershell-unit-test.instructions.md` under `Files Read:`.
+
+- [x] [P0-T6] Write the Phase 0 policy-read artifact to `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/phase0-instructions-read.md`
+	- Acceptance: `phase0-instructions-read.md` contains `Timestamp:`, `Policy Order:`, `Files Read:`, `Work Mode: minor-audit`, `AC Source: issue.md -> ## Acceptance Criteria`, `Target Plan Path: c:\Users\DanMoisan\repos\drm-copilot\docs\features\active\2026-04-05-general-instructions-first-122\plan.2026-04-05T13-13.md`, `spec.md: not required`, and `user-story.md: not required`.
+
+- [x] [P0-T7] Run the baseline PoshQC formatter command
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-format.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T8] Run the baseline PoshQC analyzer command
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-analyze.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T9] Run the baseline PoshQC Pester command
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/baseline/baseline-poshqc-test.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+### Phase 1 — Constrained Small-Path Implementation
+
+- [x] [P1-T1] Lock execution scope to `scripts/dev-tools/sync-agents-from-instructions.ps1`, `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1`, `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1`, `AGENTS.md`, `issue.md`, and evidence artifacts under this feature folder
+	- Acceptance: `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/scope-lock.2026-04-05T16-20.md` retains the `git status --short --untracked-files=all` output summary for the final minor-audit changed-file set and confirms it is limited to `scripts/dev-tools/sync-agents-from-instructions.ps1`, `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1`, `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1`, `AGENTS.md`, `docs/features/active/2026-04-05-general-instructions-first-122/issue.md`, `docs/features/active/2026-04-05-general-instructions-first-122/plan.2026-04-05T13-13.md`, and files under `docs/features/active/2026-04-05-general-instructions-first-122/evidence/`; no task in this plan requires `spec.md` or `user-story.md`.
+
+- [x] [P1-T2] [expect-fail] Add a Pester regression scenario in `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` that proves basenames starting with `general` must appear before language-specific instruction files in generated `AGENTS.md` output
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/regression-testing/regression-general-first-order.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`; the recorded `EXIT_CODE:` is non-zero and the summary identifies the new ordering assertion as the failure signal.
+
+- [x] [P1-T3] Update `scripts/dev-tools/sync-agents-from-instructions.ps1` so discovered instruction files whose basenames start with `general` sort before the remaining instruction files while preserving deterministic ordering inside each group
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
+	- Acceptance: the regression scenario added in [P1-T2] passes under the command above after this code change is applied.
+
+- [x] [P1-T4] Add a Pester scenario in `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` that verifies deterministic ordering is preserved inside the `general` group and inside the remaining language-specific group
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
+	- Acceptance: the new scenario asserts the relative order `general-code-change.instructions.md` before `general-unit-test.instructions.md` and `csharp-code-change.instructions.md` before `powershell-code-change.instructions.md` before `python-code-change.instructions.md` before `typescript-code-change.instructions.md`, and the scenario passes under the command above after [P1-T3].
+
+- [x] [P1-T5] Copy `scripts/dev-tools/sync-agents-from-instructions.ps1` byte-for-byte to `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1`
+	- Acceptance: `(Get-Content -Raw -LiteralPath "extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1") -eq (Get-Content -Raw -LiteralPath "scripts/dev-tools/sync-agents-from-instructions.ps1")` returns `$true`.
+
+### Phase 2 — Final QC Loop
+
+- [x] [P2-T1] Run the final PoshQC formatter command without conditions
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-format.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P2-T2] Run the final PoshQC analyzer command without conditions
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-analyze.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P2-T3] Run the final PoshQC Pester command without conditions
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-poshqc-test.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`; the summary reports pass/fail counts and confirms the new ordering scenarios passed.
+
+- [x] [P2-T4] Run the sync script to regenerate `AGENTS.md` without conditions
+	- Command: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1`
+	- Acceptance: exactly one artifact matching `docs/features/active/2026-04-05-general-instructions-first-122/evidence/qa-gates/final-agents-regeneration.*.md` exists and contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`; the summary states that generated `AGENTS.md` lists `general-code-change.instructions.md` and `general-unit-test.instructions.md` before language-specific instruction files and that the corresponding sections follow the same grouped order.
+
+- [x] [P2-T5] Repeat [P2-T1] through [P2-T4] from [P2-T1] if any command fails or changes files
+	- Acceptance: one clean consecutive iteration completes with zero non-zero exit codes and no formatter-induced file changes remaining.
+
+- [x] [P2-T6] Update `docs/features/active/2026-04-05-general-instructions-first-122/issue.md` after evidence-backed verification
+	- Acceptance: `issue.md` updates only the `## Acceptance Criteria` checkboxes, the relevant `## Proposed Fix / Validation Ideas` checkboxes, and `- Last Updated:`; each checkbox changed to `[x]` has corresponding evidence from [P1-T2] through [P2-T5], and any unmet checkbox remains `[ ]`.

--- a/docs/features/active/2026-04-05-general-instructions-first-122/policy-audit.2026-04-05T13-42.md
+++ b/docs/features/active/2026-04-05-general-instructions-first-122/policy-audit.2026-04-05T13-42.md
@@ -1,0 +1,320 @@
+# Policy Compliance Audit: general-instructions-first (Issue #122)
+
+**Audit Date:** 2026-04-05  
+**Base Branch:** `development`  
+**Feature Folder:** `docs/features/active/2026-04-05-general-instructions-first-122`  
+**Code Under Test:** No live diff relative to `development`; feature-scoped validation references `scripts/dev-tools/sync-agents-from-instructions.ps1`, `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1`, `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1`, and generated `AGENTS.md` evidence already captured in the feature folder.
+
+**Feature-folder selection rule:** The user explicitly identified `docs/features/active/2026-04-05-general-instructions-first-122` as the active folder, so this audit treats that folder as authoritative even though the refreshed PR context against `development` is a no-op range.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed vs `development` | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|-------------------------------|-------|-------------|-------------------|---------------------|-------------------|
+| PowerShell | 0 in live diff; 2 production + 1 test + 1 generated file in feature evidence | Pester | [✅] 240 pass, 0 fail, 7 skip | 47.57% commands | 47.86% commands | Not isolated numerically in stored evidence |
+
+## Executive Summary
+
+Relative to `development`, the current branch is already fully merged: refreshed PR context reports `origin/development` and `HEAD` at the same commit (`f720ff7fae4e11e62b61d62b3072d03c84a2307b`) with an empty comparison range and zero changed files. For this review, policy compliance is therefore assessed as a no-op branch check plus feature-folder validation. The minor-audit integrity rules hold: `issue.md` contains the exact `## Acceptance Criteria` section, all five items are already checked, and `spec.md` / `user-story.md` are absent. Existing feature evidence also shows the PowerShell quality loop passed, the regression-first ordering tests passed, bundled parity holds, and `AGENTS.md` regenerates with the expected general-first ordering.
+
+**Policy documents evaluated:**
+- [✅] `general-code-change.instructions.md`
+- [✅] `general-unit-test.instructions.md`
+- [✅] `powershell-code-change.instructions.md`
+- [✅] `powershell-unit-test.instructions.md`
+
+**Temporary artifacts cleanup:**
+- [✅] No temporary throwaway scripts were required for this feature review.
+- [✅] Existing feature evidence remains in canonical feature-folder locations.
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] [PASS] | The added Pester ordering scenarios use mocks and do not rely on external mutable state; see `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` and `evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md`. |
+| Isolation | [✅] [PASS] | The regression scenarios each target one ordering contract: grouped discovery order and generated output order. |
+| Fast Execution | [✅] [PASS] | Final Pester evidence reports `247` discovered tests completed in `9.96s`. |
+| Determinism | [✅] [PASS] | Tests mock discovery results and assert explicit ordinal positions, eliminating filesystem-order variance. |
+| Readability & Maintainability | [✅] [PASS] | Test names explicitly describe the ordering rule they protect. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Baseline Coverage Documented | [✅] [PASS] | `evidence/baseline/baseline-poshqc-test.2026-04-05T13-19.md` records `47.57%` command coverage. |
+| No Coverage Regression | [✅] [PASS] | Final evidence records `47.86%` command coverage, which is higher than baseline. |
+| New Code Coverage ≥90% | [N/A] [N/A] | Relative to `development`, the refreshed branch comparison is empty, so there is no live changed-code slice to measure in this review run. Feature-scoped regression evidence still covers the ordering behavior. |
+| Comprehensive Coverage | [✅] [PASS] | Both helper-level and generated-output ordering behavior are covered. |
+| Positive Flows | [✅] [PASS] | `evidence/qa-gates/final-agents-regeneration.2026-04-05T13-27.md` confirms successful grouped regeneration. |
+| Negative Flows | [✅] [PASS] | `evidence/regression-testing/regression-general-first-order.2026-04-05T13-23.md` captures the expected pre-fix failure. |
+| Edge Cases | [✅] [PASS] | Group-internal deterministic order is explicitly asserted in the new Pester scenario. |
+| Error Handling | [✅] [PASS] | The regression artifact records the exact failing ordering assertion before the fix. |
+| Concurrency | [N/A] [N/A] | Not applicable to this synchronous generation workflow. |
+| State Transitions | [N/A] [N/A] | No stateful component was changed. |
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clear Failure Messages | [✅] [PASS] | The red-run artifact records `Expected the actual value to be less than 92, but got 152.` |
+| Arrange-Act-Assert Pattern | [✅] [PASS] | The added Pester cases arrange mocked inputs, invoke the target function, and assert explicit order relationships. |
+| Document Intent | [✅] [PASS] | The new test names describe the behavior under review without ambiguity. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Avoid External Dependencies | [✅] [PASS] | The reviewed tests use mocks only; no network or temp-file dependency is introduced. |
+| Use Mocks/Stubs | [✅] [PASS] | `Test-Path`, `Get-ChildItem`, `Get-InstructionFileData`, and `Get-InstructionsBody` are mocked to isolate ordering behavior. |
+| Environment Stability | [✅] [PASS] | Deterministic mocked `C:\repo` paths avoid dependence on actual path enumeration. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Pre-submission Review | [✅] [PASS] | This audit, plus the companion `code-review` and `feature-audit`, provides the requested branch review record for `development`. |
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clarify the objective | [✅] [PASS] | `issue.md` defines the ordering bug and the required grouped `general*` precedence. |
+| Read existing change plans | [✅] [PASS] | `plan.2026-04-05T13-13.md` exists in the feature folder and records the scoped workflow. |
+| Document the plan | [✅] [PASS] | The plan captures the regression-first approach and final QC loop. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Simplicity first | [✅] [PASS] | The implementation adds one small sort-key helper instead of restructuring the script. |
+| Reusability | [✅] [PASS] | The helper centralizes grouping behavior instead of duplicating basename checks. |
+| Extensibility | [✅] [PASS] | The grouped sort-key preserves deterministic ordering within each bucket. |
+| Separation of concerns | [✅] [PASS] | Discovery logic, verification tests, and generated output remain cleanly separated. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Cohesive modules | [✅] [PASS] | The feature-scoped files remain limited to the sync-agents workflow and its mirror/tests. |
+| Under 500 lines | [✅] [PASS] | The reviewed PowerShell script/test remain within the repository file-size limit, as already assessed in the feature evidence set. |
+| Public vs internal | [✅] [PASS] | The added helper remains internal to the script. |
+| No circular dependencies | [✅] [PASS] | No new dependency edges are introduced. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Descriptive names | [✅] [PASS] | `Get-InstructionSortKey` describes the new behavior directly. |
+| Docs/docstrings | [✅] [PASS] | Existing script conventions remain intact and the new helper is self-explanatory. |
+| Comment why, not what | [✅] [PASS] | Existing comments continue to explain deterministic-order intent. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| 1. Formatting | [✅] [PASS] | `evidence/qa-gates/final-poshqc-format.2026-04-05T13-26.md` reports a clean formatter pass. |
+| 2. Linting | [✅] [PASS] | `evidence/qa-gates/final-poshqc-analyze.2026-04-05T13-26.md` reports no analyzer findings. |
+| 3. Type checking | [N/A] [N/A] | Not applicable for PowerShell per repo policy. |
+| 4. Testing | [✅] [PASS] | `evidence/qa-gates/final-poshqc-test.2026-04-05T13-26.md` reports `240 passed, 0 failed, 7 skipped`. |
+| Full toolchain loop | [✅] [PASS] | Feature evidence shows the intentional red regression capture followed by a clean final pass. |
+| Explicit reporting | [✅] [PASS] | Exact commands, timestamps, and exit codes are recorded in the feature evidence artifacts. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Summarize changes | [✅] [PASS] | `issue.md`, `plan.2026-04-05T13-13.md`, and QA evidence summarize the scoped fix. |
+| Design choices explained | [✅] [PASS] | The helper-based ordering strategy is evident in the diff and tests. |
+| Update supporting documents | [✅] [PASS] | `AGENTS.md` regeneration evidence is present and the feature folder contains the supporting artifacts. |
+| Provide next steps | [✅] [PASS] | Relative to `development`, no remediation is required; the only operational note is that the branch is already at the base commit. |
+
+## 3. PowerShell Code Change Policy Compliance
+
+### 3.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting with Invoke-Formatter | [✅] [PASS] | Final formatter evidence passed with no edits required. |
+| Linting with PSScriptAnalyzer | [✅] [PASS] | Final analyzer evidence reports `no findings under .`. |
+| Fix all findings | [✅] [PASS] | No findings remained in the clean final pass. |
+| PowerShell 7+ compatible | [✅] [PASS] | The script passed the repository’s PoshQC/Pester workflow under the current PowerShell 7 environment. |
+
+### 3.2 PowerShell Design & Safety
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Advanced functions | [✅] [PASS] | The helper follows the existing advanced-function pattern with `CmdletBinding()`. |
+| Parameter validation | [✅] [PASS] | The helper takes a mandatory `[string]$RelativePath` parameter. |
+| Avoid global state | [✅] [PASS] | The added ordering logic is pure and local. |
+| Error handling | [✅] [PASS] | The feature preserves explicit failures for unsupported discovery scenarios. |
+
+### 3.3 Structure, Naming, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Cohesive and under 500 lines | [✅] [PASS] | The touched script/test remain feature-focused and within the repo size limits. |
+| Approved verbs | [✅] [PASS] | The new helper uses the approved `Get` verb. |
+| Comment why | [✅] [PASS] | Deterministic-order rationale remains documented in existing comments. |
+
+### 3.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Step 1: Format | [✅] [PASS] | Clean final pass recorded. |
+| Step 2: Analyze | [✅] [PASS] | Clean final pass recorded. |
+| Step 3: Type check | [N/A] [N/A] | Not applicable. |
+| Step 4: Test | [✅] [PASS] | Clean final Pester pass recorded. |
+| Rerun loop if needed | [✅] [PASS] | Red/green evidence is present in the feature folder. |
+
+## 4. PowerShell Unit Test Policy Compliance
+
+### 4.1 Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Pester v5.x | [✅] [PASS] | Tests run through `Invoke-PoshQCTest -Root .` and the final evidence records Pester discovery/results. |
+| Use PoshQC Configuration | [✅] [PASS] | The recorded commands use the repository-standard PoshQC entrypoints. |
+| PowerShell 7+ Compatible | [✅] [PASS] | The final Pester run succeeded in the current workspace environment. |
+
+### 4.2 Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Focused Unit Tests | [✅] [PASS] | The added tests separately validate grouped discovery order and generated output order. |
+| Test Behavior Over Implementation | [✅] [PASS] | Assertions focus on observable ordering in output, not incidental list mutation. |
+| Mocking Used Sparingly | [✅] [PASS] | Only discovery seams are mocked. |
+| Organization | [✅] [PASS] | Test location mirrors the script under test. |
+
+### 4.3 Naming and Readability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| File Naming - *.Tests.ps1 | [✅] [PASS] | `sync-agents-from-instructions.Tests.ps1` follows policy. |
+| Describe/Context/It Structure | [✅] [PASS] | The ordering scenarios are grouped into dedicated `Context` blocks. |
+| Logical Grouping | [✅] [PASS] | Helper-ordering and generated-output ordering are separated cleanly. |
+| Docstrings/Comments | [✅] [PASS] | Self-documenting Pester names communicate the scenarios clearly. |
+
+### 4.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use PoshQCTest Command | [✅] [PASS] | The feature evidence uses `Invoke-PoshQCTest -Root .`. |
+| No Alternative Test Runners | [✅] [PASS] | No alternate PowerShell test runner was introduced. |
+
+## 5. Test Coverage Detail
+
+### `scripts/dev-tools/sync-agents-from-instructions.ps1` ordering behavior
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `Get-DiscoveredInstructionFile preserves deterministic ordering within the general and language-specific groups` | Edge case / deterministic ordering | [✅] |
+| `emits general instruction files before language-specific instruction files in generated AGENTS.md output` | Positive behavior / generated output ordering | [✅] |
+| `Bundled sync-agents template matches the repo-root script exactly` | Contract / parity | [✅] |
+
+**Not covered numerically:** Exact changed-line coverage percentage was not isolated in the stored evidence.
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests | 247 discovered | [✅] |
+| Tests Passed | 240 | [✅] |
+| Tests Failed | 0 | [✅] |
+| Tests Skipped | 7 | [✅] |
+| Execution Time | 9.96s total | [✅] |
+| Code Coverage | 47.86% commands / 0% branches | [✅] No regression |
+
+## 7. Code Quality Checks
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| PR context refresh | `poetry run python -m scripts.dev_tools.pr_context.collector --base development` | Passed; refreshed summary shows `HEAD == origin/development` and zero changed files | [✅] |
+| Diff check | `git diff --name-only origin/development...HEAD` | Passed; no files listed | [✅] |
+| Invoke-Formatter | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."` | Passed in feature evidence | [✅] |
+| PSScriptAnalyzer | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."` | Passed in feature evidence | [✅] |
+| Pester Tests | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."` | Passed in feature evidence | [✅] |
+| Sync Regeneration | `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1` | Passed in feature evidence | [✅] |
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+**None.** Relative to `development`, this review found no remaining policy gaps that require remediation.
+
+### Approved Exceptions
+
+**None.** No policy exceptions were used.
+
+### Removed/Skipped Tests
+
+**None.** No feature-specific tests were removed or skipped during this review.
+
+## 9. Summary of Changes
+
+### Files Modified (feature scope, already present in `development`)
+
+1. `scripts/dev-tools/sync-agents-from-instructions.ps1` (MODIFIED)
+   - Added grouped sort-key ordering so `general*.instructions.md` basenames come first.
+2. `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` (MODIFIED)
+   - Preserved byte-identical bundled parity.
+3. `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` (MODIFIED)
+   - Added ordering regression coverage.
+4. `AGENTS.md` (MODIFIED / generated)
+   - Regenerated with the general-first grouped order.
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+Relative to `development`, the branch is a no-op diff and the requested minor-audit feature is already present in the base branch. The feature-folder evidence confirms the scoped fix satisfied its acceptance criteria and passed the recorded PowerShell quality loop. The ready-to-merge gate therefore passes relative to `development`, with the practical note that opening a PR would produce no code changes.
+
+### Policy-by-Policy Summary
+
+- [✅] General code change policy: satisfied for the feature-scoped implementation and no-op branch range.
+- [✅] PowerShell code change policy: satisfied by recorded formatter/analyzer/test evidence.
+- [✅] General unit test policy: regression-first evidence and deterministic tests are present.
+- [✅] PowerShell unit test policy: Pester/PoshQC structure and execution are compliant.
+- [✅] Branch readiness relative to `development`: passes because `HEAD` already equals `origin/development`.
+
+### Metrics Summary
+
+- [✅] Refreshed comparison range: empty (`origin/development...HEAD`)
+- [✅] Final Pester result: 240 passed, 0 failed, 7 skipped
+- [✅] Coverage: 47.57% baseline → 47.86% final
+- [✅] Bundled parity: verified
+- [✅] General-first order: verified
+
+### Recommendation
+
+**Ready for merge**
+
+The gate passes relative to `development`. No remediation is required for this feature relative to that base branch. Operationally, the branch is already merged into `development`, so any new PR to that base would be a no-op.
+
+## Appendix A: Test Inventory
+
+- `sync-agents-from-instructions.ps1 › Get-DiscoveredInstructionFile › Get-DiscoveredInstructionFile preserves deterministic ordering within the general and language-specific groups`
+- `sync-agents-from-instructions.ps1 › Get-AgentContent ordering › emits general instruction files before language-specific instruction files in generated AGENTS.md output`
+- `sync-agents-from-instructions.ps1 › Bundled parity › Bundled sync-agents template matches the repo-root script exactly`
+
+## Appendix B: Toolchain Commands Reference
+
+```powershell
+# Refresh PR context against the requested base
+poetry run python -m scripts.dev_tools.pr_context.collector --base development
+
+# Confirm live diff is empty
+git diff --name-only origin/development...HEAD
+
+# Feature-scoped PowerShell evidence commands already recorded in the feature folder
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1
+```
+
+**Audit Completed By:** GitHub Copilot  
+**Policy Version:** Current as of 2026-04-05

--- a/extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1
+++ b/extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1
@@ -154,6 +154,20 @@ function Get-SectionTitle {
             }) -join ' ')
 }
 
+function Get-InstructionSortKey {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath
+    )
+
+    $fileName = [System.IO.Path]::GetFileName($RelativePath)
+    $groupPrefix = if ($fileName.StartsWith('general', [System.StringComparison]::OrdinalIgnoreCase)) { '0' } else { '1' }
+
+    return "$groupPrefix|$RelativePath"
+}
+
 function Get-DiscoveredInstructionFile {
     [CmdletBinding()]
     [OutputType([object[]])]
@@ -171,20 +185,24 @@ function Get-DiscoveredInstructionFile {
     }
 
     $instructionFilesByRelativePath = @{}
-    $relativePaths = [System.Collections.Generic.List[string]]::new()
+    $sortKeysByRelativePath = @{}
+    $sortKeys = [System.Collections.Generic.List[string]]::new()
 
     # Normalize discovered paths relative to the repo root before sorting so output is deterministic across platforms.
     foreach ($candidateFile in $candidateFiles) {
         $instructionFile = Get-InstructionFileData -Path $candidateFile.FullName -RepoRootParam $RepoRootParam
         $instructionFilesByRelativePath[$instructionFile.RelativePath] = $instructionFile
-        $relativePaths.Add($instructionFile.RelativePath)
+        $sortKey = Get-InstructionSortKey -RelativePath $instructionFile.RelativePath
+        $sortKeysByRelativePath[$sortKey] = $instructionFile.RelativePath
+        $sortKeys.Add($sortKey)
     }
 
-    $sortedRelativePaths = $relativePaths.ToArray()
-    [System.Array]::Sort($sortedRelativePaths, [System.StringComparer]::Ordinal)
+    $sortedSortKeys = $sortKeys.ToArray()
+    [System.Array]::Sort($sortedSortKeys, [System.StringComparer]::Ordinal)
 
     return @(
-        foreach ($relativePath in $sortedRelativePaths) {
+        foreach ($sortKey in $sortedSortKeys) {
+            $relativePath = $sortKeysByRelativePath[$sortKey]
             $instructionFilesByRelativePath[$relativePath]
         }
     )

--- a/scripts/dev-tools/sync-agents-from-instructions.ps1
+++ b/scripts/dev-tools/sync-agents-from-instructions.ps1
@@ -154,6 +154,20 @@ function Get-SectionTitle {
             }) -join ' ')
 }
 
+function Get-InstructionSortKey {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath
+    )
+
+    $fileName = [System.IO.Path]::GetFileName($RelativePath)
+    $groupPrefix = if ($fileName.StartsWith('general', [System.StringComparison]::OrdinalIgnoreCase)) { '0' } else { '1' }
+
+    return "$groupPrefix|$RelativePath"
+}
+
 function Get-DiscoveredInstructionFile {
     [CmdletBinding()]
     [OutputType([object[]])]
@@ -171,20 +185,24 @@ function Get-DiscoveredInstructionFile {
     }
 
     $instructionFilesByRelativePath = @{}
-    $relativePaths = [System.Collections.Generic.List[string]]::new()
+    $sortKeysByRelativePath = @{}
+    $sortKeys = [System.Collections.Generic.List[string]]::new()
 
     # Normalize discovered paths relative to the repo root before sorting so output is deterministic across platforms.
     foreach ($candidateFile in $candidateFiles) {
         $instructionFile = Get-InstructionFileData -Path $candidateFile.FullName -RepoRootParam $RepoRootParam
         $instructionFilesByRelativePath[$instructionFile.RelativePath] = $instructionFile
-        $relativePaths.Add($instructionFile.RelativePath)
+        $sortKey = Get-InstructionSortKey -RelativePath $instructionFile.RelativePath
+        $sortKeysByRelativePath[$sortKey] = $instructionFile.RelativePath
+        $sortKeys.Add($sortKey)
     }
 
-    $sortedRelativePaths = $relativePaths.ToArray()
-    [System.Array]::Sort($sortedRelativePaths, [System.StringComparer]::Ordinal)
+    $sortedSortKeys = $sortKeys.ToArray()
+    [System.Array]::Sort($sortedSortKeys, [System.StringComparer]::Ordinal)
 
     return @(
-        foreach ($relativePath in $sortedRelativePaths) {
+        foreach ($sortKey in $sortedSortKeys) {
+            $relativePath = $sortKeysByRelativePath[$sortKey]
             $instructionFilesByRelativePath[$relativePath]
         }
     )

--- a/tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1
+++ b/tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1
@@ -119,6 +119,43 @@ applyTo: "**"
                 '.github/sub/c.instructions.md'
             )
         }
+
+        It "Get-DiscoveredInstructionFile preserves deterministic ordering within the general and language-specific groups" {
+            Mock -CommandName Test-Path -MockWith { $true }
+            Mock -CommandName Get-ChildItem -MockWith {
+                @(
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\python-code-change.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\general-unit-test.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\typescript-code-change.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\csharp-code-change.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\general-code-change.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\powershell-code-change.instructions.md' }
+                )
+            }
+            Mock -CommandName Get-InstructionFileData -MockWith {
+                param($Path, $RepoRootParam)
+
+                [void]$RepoRootParam
+                $relativePath = $Path.Substring('C:\repo\'.Length) -replace '\\', '/'
+                [pscustomobject]@{
+                    Path            = $Path
+                    RelativePath    = $relativePath
+                    Body            = ''
+                    FrontMatterName = $null
+                    FirstHeading    = $null
+                }
+            }
+
+            $result = Get-DiscoveredInstructionFile -RepoRootParam 'C:\repo'
+            $result.RelativePath | Should -Be @(
+                '.github/instructions/general-code-change.instructions.md'
+                '.github/instructions/general-unit-test.instructions.md'
+                '.github/instructions/csharp-code-change.instructions.md'
+                '.github/instructions/powershell-code-change.instructions.md'
+                '.github/instructions/python-code-change.instructions.md'
+                '.github/instructions/typescript-code-change.instructions.md'
+            )
+        }
     }
 
     Context "Get-AgentContent" {
@@ -172,6 +209,57 @@ applyTo: "**"
             $result.Content | Should -Match "ps unit"
             $result.Content | Should -Match "codexer unit"
             $result.Content | Should -Match "self-explanatory-code-commenting unit"
+        }
+    }
+
+    Context "Get-AgentContent ordering" {
+        BeforeEach {
+            Mock -CommandName Test-Path -MockWith { $true }
+            Mock -CommandName Get-InstructionsBody -MockWith {
+                param($Path)
+
+                if ($Path -eq (Join-Path -Path 'C:\repo' -ChildPath '.github/copilot-instructions.md')) {
+                    return 'copilot body'
+                }
+
+                throw "Unexpected path $Path"
+            }
+            Mock -CommandName Get-ChildItem -MockWith {
+                @(
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\python-code-change.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\general-unit-test.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\csharp-code-change.instructions.md' }
+                    [pscustomobject]@{ FullName = 'C:\repo\.github\instructions\general-code-change.instructions.md' }
+                )
+            }
+            Mock -CommandName Get-InstructionFileData -MockWith {
+                param($Path, $RepoRootParam)
+
+                [void]$RepoRootParam
+                $relativePath = $Path.Substring('C:\repo\'.Length) -replace '\\', '/'
+
+                return [pscustomobject]@{
+                    Path            = $Path
+                    RelativePath    = $relativePath
+                    Body            = "body for $relativePath"
+                    FrontMatterName = $null
+                    FirstHeading    = $null
+                }
+            }
+        }
+
+        It "emits general instruction files before language-specific instruction files in generated AGENTS.md output" {
+            $result = Get-AgentContent -RepoRootParam 'C:\repo'
+
+            $generalCodeIndex = $result.Content.IndexOf('> - .github/instructions/general-code-change.instructions.md', [System.StringComparison]::Ordinal)
+            $generalUnitIndex = $result.Content.IndexOf('> - .github/instructions/general-unit-test.instructions.md', [System.StringComparison]::Ordinal)
+            $csharpIndex = $result.Content.IndexOf('> - .github/instructions/csharp-code-change.instructions.md', [System.StringComparison]::Ordinal)
+            $pythonIndex = $result.Content.IndexOf('> - .github/instructions/python-code-change.instructions.md', [System.StringComparison]::Ordinal)
+
+            $generalCodeIndex | Should -BeLessThan $csharpIndex
+            $generalCodeIndex | Should -BeLessThan $pythonIndex
+            $generalUnitIndex | Should -BeLessThan $csharpIndex
+            $generalUnitIndex | Should -BeLessThan $pythonIndex
         }
     }
 


### PR DESCRIPTION
Fix sync-agents ordering so general instructions lead AGENTS.md generation

## Summary

- Update the sync-agents generation flow so instruction files whose basenames start with `general` are emitted before language-specific instruction files in generated `AGENTS.md`.
- Preserve deterministic ordering within both the `general*` group and the remaining language-specific group.
- Keep `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` byte-identical to `scripts/dev-tools/sync-agents-from-instructions.ps1`.
- Add targeted Pester regression coverage for both the grouped discovery order and the generated `AGENTS.md` output order.
- Regenerate `AGENTS.md` and add feature-folder evidence and audit artifacts for the constrained minor-audit fix.

## Why

The bundled `drm-copilot: Sync AGENTS.md from Instructions` command did not guarantee that `general*.instructions.md` files would appear before language-specific instruction sections in generated `AGENTS.md`, even though the consolidated guidance is expected to reflect repository policy precedence.

This change stays intentionally narrow because the feature plan defines a constrained small-path bugfix with `issue.md` as the sole requirements source. The documented constraints were to:
- fix the ordering rule without widening scope,
- keep the bundled template mirror byte-identical to the repo-root script,
- lock in the behavior with Pester coverage, and
- regenerate `AGENTS.md` to prove the grouped order.

## What Changed

- **Core behavior / architecture**
  - Update `scripts/dev-tools/sync-agents-from-instructions.ps1` to sort discovered instruction files using a grouped order that places `general*` basenames before other instruction files.
  - Mirror the same logic in `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` to preserve bundled parity.

- **Tooling / automation / DevEx**
  - Regenerate `AGENTS.md` so the generated source list and section order reflect the new general-first precedence.
  - Record constrained-scope execution evidence and audit artifacts under `docs/features/active/2026-04-05-general-instructions-first-122/`.

- **Tests**
  - Extend `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` with regression scenarios that verify:
    - `general*` instruction files appear before language-specific files, and
    - ordering remains deterministic inside both groups.

- **Docs / templates / agents**
  - Add `issue.md`, `plan.2026-04-05T13-13.md`, verification evidence, and audit outputs for the minor-audit workflow.

## Architecture / How It Fits Together

- `scripts/dev-tools/sync-agents-from-instructions.ps1` discovers instruction files and now assigns them a grouped sort order before rendering consolidated output.
- The bundled template at `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` mirrors the repo-root script so extension-driven sync behavior matches the repo command behavior.
- `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` validates both the internal ordering contract and the user-visible generated `AGENTS.md` ordering.
- Running the sync script regenerates `AGENTS.md`, which is the visible artifact proving the new precedence rule.

## Verification

### Completed

- Recorded a failing regression run before the fix:
  - `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
  - `EXIT_CODE: 1`
  - Failure showed `general-code-change.instructions.md` appeared after `csharp-code-change.instructions.md` in generated output.
- Recorded a clean formatter pass:
  - `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
  - `EXIT_CODE: 0`
  - No formatter edits were reported in the final pass.
- Recorded a clean analyzer pass:
  - `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
  - `EXIT_CODE: 0`
  - PSScriptAnalyzer reported no findings.
- Recorded a clean final Pester pass:
  - `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
  - `EXIT_CODE: 0`
  - 247 tests discovered; 240 passed, 0 failed, 7 skipped; coverage reported as `47.86% / 0%`.
- Recorded successful regeneration of `AGENTS.md`:
  - `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1`
  - `EXIT_CODE: 0`
  - Output confirms `.github/instructions/general-code-change.instructions.md` and `.github/instructions/general-unit-test.instructions.md` now appear immediately after `.github/copilot-instructions.md` and before language-specific instruction files.

### Recommended

- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -Root ."`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -Root ."`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCTest -Root ."`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/sync-agents-from-instructions.ps1`

## Backward Compatibility / Migration Notes

- No public API or command-surface change is described in the PR context.
- The observable behavior change is limited to generated instruction ordering in `AGENTS.md`.
- The bundled sync script remains aligned with the repo-root script, so extension and repo workflows continue to use the same implementation.

## Risks and Mitigations

- Risk: Future instruction files could rely on ordering assumptions outside the new `general*` grouping.
  - Mitigation: The implementation preserves deterministic within-group ordering, and the new Pester scenarios lock in the current contract.
- Risk: Root and bundled sync scripts could drift.
  - Mitigation: This PR updates both files together and keeps the bundled template byte-identical to the repo-root script.
- Risk: Generated output changes can be noisy in review.
  - Mitigation: `AGENTS.md` is regenerated from the updated script, and the evidence artifacts document the intended ordering change.

## Review Guide

- Review `scripts/dev-tools/sync-agents-from-instructions.ps1` first for the grouped ordering logic.
- Review `extensions/drm-copilot/resources/templates/sync-agents-from-instructions.ps1` next to confirm it mirrors the repo-root script.
- Review `tests/scripts/dev-tools/sync-agents-from-instructions.Tests.ps1` for the new ordering regressions.
- Review `AGENTS.md` as the generated proof that general instruction sections now appear before language-specific sections.
- Review `docs/features/active/2026-04-05-general-instructions-first-122/issue.md` for the bug statement and acceptance criteria.
- Review `docs/features/active/2026-04-05-general-instructions-first-122/evidence/regression-testing/regression-general-first-order.2026-04-05T13-23.md` and the final QA-gate artifacts for red/green verification.
- Treat the feature-folder audit documents as supporting evidence, not the primary implementation review surface.

## Follow-ups

- Monitor future instruction-category additions to determine whether the grouped ordering contract should expand beyond the current `general*` precedence rule.
- Rely on normal PR/CI execution after opening the PR, because CI status is not available in the PR context bundle.

## GitHub Auto-close

- Closes #122

## Related issues / PRs

- None