### PR TITLE
Fix bundled extension script path resolution for Windows-style roots on POSIX hosts

### DIFF
--- a/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/code-review.2026-04-05T20-20.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/code-review.2026-04-05T20-20.md
@@ -1,0 +1,83 @@
+# Code Review: 2026-04-05-ci-failing-error-128
+
+## Executive Summary
+
+The reviewed working-tree change fixes cross-platform bundled-path resolution by updating `resolveBundledScriptPath` in `extensions/drm-copilot/src/command-runtime.ts` to preserve Windows drive-prefixed roots such as `C:/extension` when the host process uses POSIX path semantics. The change also adds four focused regressions in `extensions/drm-copilot/test/extension.test.ts` and `extensions/drm-copilot/test/repo-automation-service.test.ts` for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry`.
+
+The refreshed PR-context artifacts were anchored to `development`, and fresh review checks passed: non-mutating Prettier check, ESLint, TSC, targeted regression tests, full Jest unit suite, and Jest coverage. Functional behavior is correct and the three acceptance criteria are satisfied.
+
+### Top Risks
+
+1. `extensions/drm-copilot/test/extension.test.ts` is now 918 lines, which violates the repository’s 500-line file limit for touched test files.
+2. The new POSIX-path fresh-module helpers are duplicated across both touched test files, which increases maintenance drift risk.
+3. The committed branch range still reflects only the initial docs/baseline commit; the functional fix currently exists in the working tree and must be preserved carefully during remediation.
+
+### PR Readiness Recommendation
+
+**No-Go / Needs revision** until the touched oversized test file is brought back into policy compliance.
+
+## Scope Anchor
+
+**Feature Folder:** `docs/features/active/2026-04-05-ci-failing-error-128/`  
+**Selection Rule:** Used the explicitly provided feature folder and confirmed the same folder in the refreshed `artifacts/pr_context.summary.txt` additional-context list.  
+**Base Branch:** `development`
+
+## Findings
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Blocker | `extensions/drm-copilot/test/extension.test.ts` | file-wide; new helper block starts near line 220; new regressions near lines 489 and 526 | The touched test file is 918 lines after this change, exceeding the repo-wide 500-line limit that applies to test code. | Split or reorganize the touched test coverage so every touched file is under 500 lines. A shared helper for the POSIX fresh-module path setup is the most likely first extraction point. Preserve the new regression scenario names and expectations. | This is a direct policy violation on a touched file and the change worsened the pre-existing condition by adding 120 lines. | Fresh line count check: `extensions/drm-copilot/test/extension.test.ts: 918`; working-tree diff stat: `+120/-0`; general policy caps test files at 500 lines. |
+| Minor | `extensions/drm-copilot/test/extension.test.ts`, `extensions/drm-copilot/test/repo-automation-service.test.ts` | helper blocks near lines 220 and 38 respectively | The fresh-module POSIX-path mocking helpers are duplicated across both test files. | Consolidate the shared helper logic during the file-size remediation, either by extracting a shared test utility or by restructuring the test layout so the helper is defined once. | Duplication increases future maintenance cost and was a major contributor to the line-count growth in the touched extension command test file. | Matching helper names and logic appear in both files: `prepareFreshModulesWithPosixPathResolve`, `setFreshExecutablePresence`, and child-process helper accessors. |
+
+## Verified Strengths
+
+- `extensions/drm-copilot/src/command-runtime.ts` keeps the fix local to the shared path-resolution helper instead of scattering platform checks across call sites.
+- The new regression scenarios precisely model the CI failure mode by forcing POSIX `path.resolve` semantics with Windows-style mocked `extensionUri.fsPath` values.
+- Fresh verification passed:
+  - Prettier check
+  - ESLint
+  - TSC
+  - targeted regression run (`26 passed, 25 skipped, 51 total`)
+  - full unit suite (`140 passed, 140 total`)
+  - coverage (`88.30%` lines overall; `93.46%` lines for `src/command-runtime.ts`)
+
+## TypeScript Review
+
+### Design and Typing
+
+- No new `any` usage was introduced in the reviewed files.
+- The production fix remains a typed, deterministic branch inside `resolveBundledScriptPath`.
+- No public API was broken; `resolveBundledScriptPath` remains exported.
+
+### Suppressions
+
+- No new broad suppressions were introduced.
+- Existing single-line ESLint suppressions in tests remain narrowly scoped and justified.
+
+### Error Handling and Reliability
+
+- The change does not weaken subprocess safety or shell handling.
+- The new logic is constant-time string normalization and regex matching.
+- Existing runtime failure-path tests continue to pass in the full suite.
+
+## Test Quality Review
+
+- **Deterministic:** The new tests use mocked modules and fixed path fixtures.
+- **Isolated:** Each regression targets one command/service scenario.
+- **Fast:** The targeted regression run completed in well under one second.
+- **Diagnostics:** Scenario names clearly identify the cross-platform failure mode.
+- **Coverage:** The changed production file exceeds the 90% threshold in the collected coverage summary.
+
+## Security and Correctness Checks
+
+- No secrets or credentials were added.
+- No unsafe `shell: true` subprocess behavior was introduced.
+- The fix preserves bundled extension resource targeting and avoids checkout-prefixed hybrid paths on POSIX hosts.
+
+## Research Log
+
+No external research was required for this review.
+
+## Recommendation
+
+The bug fix is behaviorally correct, but the branch should not be treated as PR-ready until the touched oversized test file is brought back into compliance with the repository’s file-size policy and the verification artifacts are refreshed afterward.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/feature-audit.2026-04-05T20-20.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/feature-audit.2026-04-05T20-20.md
@@ -1,0 +1,53 @@
+# Feature Audit: 2026-04-05-ci-failing-error-128
+
+## Scope and Baseline
+
+- **Base Branch:** `development`
+- **Head Branch:** `bug/ci-failing-error-128`
+- **Feature Folder:** `docs/features/active/2026-04-05-ci-failing-error-128/`
+- **Feature Folder Selection Rule:** Used the user-provided active feature folder and confirmed the same folder in refreshed PR-context additional-context entries.
+- **Evidence Sources:**
+  - Primary: `artifacts/pr_context.summary.txt` (refreshed during this review)
+  - Secondary: `artifacts/pr_context.appendix.txt` (working-tree diff and hunk evidence)
+  - Feature evidence: `docs/features/active/2026-04-05-ci-failing-error-128/evidence/**`
+- **Work Mode:** `minor-audit`
+- **Authoritative AC Source:** `docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria`
+- **Non-required Docs Check:** `spec.md` absent; `user-story.md` absent. This satisfies the reduced-audit requirement.
+
+## Acceptance Criteria Inventory
+
+Authoritative acceptance criteria extracted from `issue.md`:
+
+1. Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
+2. Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
+3. Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.
+
+## Acceptance Criteria Evaluation
+
+| Criterion | Status | Evidence | Verification Command(s) | Notes |
+|---|---|---|---|---|
+| Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts. | PASS | `extensions/drm-copilot/src/command-runtime.ts` adds a drive-root guard in `resolveBundledScriptPath`; `p1-t8.green-jest.2026-04-05T20-12.md`; `p2-t4.test-unit.2026-04-05T20-14.md` | `Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; Pop-Location` | Fresh targeted run passed all four Windows-root scenarios. |
+| Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies. | PASS | `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` regressions all assert `C:/extension/resources/templates/...`; `p1-t8.green-jest.2026-04-05T20-12.md`; fresh targeted run output | `Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; Pop-Location` | The fresh targeted run and on-disk green-run artifact both confirm bundled-resource targeting. |
+| Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths. | PASS | `p1-t6.red-jest.2026-04-05T20-11.md`; `p1-t8.green-jest.2026-04-05T20-12.md`; `p2-t4.test-unit.2026-04-05T20-14.md`; fresh full Jest run (`140/140`) | `Push-Location extensions/drm-copilot; npm run test:unit; Pop-Location` | The feature has fail-before and pass-after evidence plus a fresh passing full-suite verification. |
+
+## Summary
+
+**Overall feature readiness:** PASS
+
+The implemented behavior satisfies all three acceptance criteria defined in the explicit `## Acceptance Criteria` section of `issue.md`. The required reduced-audit structure is intact: `spec.md` and `user-story.md` are absent, Phase 0 baseline evidence exists, the plan checklist is backed by on-disk artifacts and current code/test state, and the small-path production scope remains limited to `extensions/drm-copilot/src/command-runtime.ts`.
+
+**Top gaps preventing PR readiness:** None at the feature-behavior level. A separate policy-compliance issue remains, documented in `policy-audit.2026-04-05T20-20.md` and `code-review.2026-04-05T20-20.md`.
+
+**Recommended follow-up verification:** None required for acceptance behavior. Policy remediation is still required before PR readiness.
+
+## Acceptance Criteria Status
+
+- Source: `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`
+- Total AC items: 3
+- Checked off (delivered): 3
+- Remaining (unchecked): 0
+- Items remaining: None
+
+## Acceptance Criteria Check-Off
+
+No additional checkbox edits were required during this review because `issue.md` already had all three authoritative acceptance-criteria items marked `[x]`, and the review evidence supports those checked states.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/policy-audit.2026-04-05T20-20.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/policy-audit.2026-04-05T20-20.md
@@ -1,0 +1,255 @@
+# Policy Compliance Audit: 2026-04-05-ci-failing-error-128
+
+**Audit Date:** 2026-04-05  
+**Base Branch:** `development`  
+**Head Branch:** `bug/ci-failing-error-128`  
+**Feature Folder:** `docs/features/active/2026-04-05-ci-failing-error-128/`  
+**Feature Folder Selection Rule:** Used the user-provided active feature folder and confirmed it matched the refreshed `artifacts/pr_context.summary.txt` additional-context list for issue `#128`.  
+**Work Mode:** `minor-audit`  
+**Acceptance Criteria Source:** `docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria`
+
+**Code Under Review (working tree):**
+- `extensions/drm-copilot/src/command-runtime.ts`
+- `extensions/drm-copilot/test/extension.test.ts`
+- `extensions/drm-copilot/test/repo-automation-service.test.ts`
+- `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`
+- `docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md`
+
+## Coverage Metrics by Language
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | Changed Production File Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|----------------------------------|
+| TypeScript | 3 files | 10 Jest suites / 140 tests | ✅ PASS | N/A for reduced audit; Phase 0 captured baseline pass/fail evidence instead (`p0-t4`..`p0-t7`) | 88.30% lines, 80.64% functions, 81.25% branches (`coverage-summary.json`) | `src/command-runtime.ts`: 93.46% lines, 92.30% functions |
+
+## Executive Summary
+
+This review covered the active small-path bug fix for issue `#128` relative to `development`. The canonical PR-context artifacts were stale at the start of the review and were refreshed with `poetry run python -m scripts.dev_tools.pr_context.collector --base development`, after which the correct base/head pair resolved to `origin/development @ 73575e2f706b55472a48b95168ad617ead52cee1` and `bug/ci-failing-error-128 @ 26fbee07bc179e74194fd626020ab344286ac2e0`.
+
+Behavioral verification passed: fresh review checks reported clean formatting, lint, type-check, targeted Windows-root regression tests, full extension unit tests, and extension coverage above the repository minimum. The feature folder also satisfies the reduced-audit constraints that `spec.md` and `user-story.md` remain absent and that the explicit `## Acceptance Criteria` section in `issue.md` is the only AC source.
+
+The branch is **not fully policy-compliant** because a touched test file, `extensions/drm-copilot/test/extension.test.ts`, is now 918 lines and therefore violates the repository-wide 500-line file limit that applies to production code and test code. Because the change added 120 lines to that file, this review records the violation as a blocking remediation item even though the bug fix behavior itself is correct.
+
+**Recommendation:** **Needs revision** before PR readiness.
+
+## Temporary Artifacts Cleanup
+
+- [✅] No temporary throwaway scripts were introduced by this bug fix.
+- [✅] New artifacts are review evidence files stored under the feature folder’s canonical evidence directories.
+- [✅] No ongoing tooling scripts were added as part of this change.
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] PASS | Fresh Jest runs passed in isolation from `extensions/drm-copilot/` with no ordering requirements observed: targeted regression run (`26/26` relevant tests passed within two suites) and full run (`140/140` tests passed). |
+| Isolation | [✅] PASS | The added regressions assert only bundled-path resolution behavior for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry`; no external services are contacted. |
+| Fast Execution | [✅] PASS | Fresh targeted run: `0.397 s`; fresh full run: `0.925 s`; fresh coverage run: `3.746 s`. |
+| Determinism | [✅] PASS | Tests use Jest mocks for `node:path`, `node:fs`, and `node:child_process` to simulate POSIX host behavior with Windows-style `fsPath` values. |
+| Readability & Maintainability | [⚠️] PARTIAL | New test names are descriptive, but the touched file `extensions/drm-copilot/test/extension.test.ts` now exceeds the 500-line repo limit at 918 lines, which harms maintainability. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Baseline Evidence Documented | [✅] PASS | Phase 0 baseline artifacts exist: `phase0-instructions-read.md`, `p0-t2.requirements-scope.2026-04-05T19-57.md`, `p0-t3.focused-repro.2026-04-05T19-57.md`, `p0-t4.format.2026-04-05T19-57.md`, `p0-t5.lint.2026-04-05T19-57.md`, `p0-t6.typecheck.2026-04-05T19-57.md`, `p0-t7.test-unit.2026-04-05T19-57.md`, `p0-t8.small-path-scope.2026-04-05T19-57.md`. |
+| Repository Coverage >= 80% | [✅] PASS | Fresh coverage run: `88.30%` lines, `81.25%` branches, `80.64%` functions in `extensions/drm-copilot/coverage/coverage-summary.json`. |
+| Changed Production File Coverage >= 90% | [✅] PASS | `extensions/drm-copilot/src/command-runtime.ts` coverage from `coverage-summary.json`: `93.46%` lines, `92.30%` functions. |
+| Positive Flows | [✅] PASS | Fresh targeted run and `p1-t8.green-jest.2026-04-05T20-12.md` confirm passing scenarios for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` on simulated POSIX hosts. |
+| Negative / Regression Flow | [✅] PASS | `p1-t6.red-jest.2026-04-05T20-11.md` captured the expected failing regression state before the production fix. |
+| Edge Cases | [✅] PASS | The new tests exercise the cross-platform edge case where Windows-style `C:/extension` roots are processed under POSIX `path.resolve` semantics. |
+| Error Handling | [✅] PASS | Existing extension tests continue covering non-zero subprocess exits and runtime probe failures; full suite passed after the change. |
+| Concurrency | [N/A] N/A | Not applicable to the touched code path. |
+| State Transitions | [N/A] N/A | The touched code is a pure path-resolution helper plus stateless unit tests. |
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clear Failure Messages | [✅] PASS | Regression scenario names directly describe the failing host/path combination, e.g. `helloPython preserves C:/extension on POSIX hosts`. |
+| Arrange-Act-Assert Pattern | [✅] PASS | Each new regression prepares mocked path/runtime state, invokes the command or service method, and asserts the resolved bundled path. |
+| Document Intent | [✅] PASS | Scenario names encode the exact regression being protected. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Avoid External Dependencies | [✅] PASS | The reviewed tests use mocked filesystem and subprocess modules only. |
+| Use Mocks/Stubs | [✅] PASS | `node:path`, `node:fs`, `node:child_process`, and VS Code APIs are mocked to keep the tests deterministic. |
+| Environment Stability | [✅] PASS | No temporary files or network I/O were introduced; review runs executed entirely inside the extension test harness. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Pre-submission Review | [✅] PASS | This audit, together with `code-review.2026-04-05T20-20.md` and `feature-audit.2026-04-05T20-20.md`, serves as the required review output for the active feature folder. |
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clarify the objective | [✅] PASS | `issue.md` documents the Linux CI hybrid-path failure and the expected bundled-path behavior for Windows-style extension roots on POSIX hosts. |
+| Read existing change plans | [✅] PASS | `plan.2026-04-05T19-46.md` exists and Phase 0 evidence records policy-reading order in `evidence/baseline/phase0-instructions-read.md`. |
+| Document the plan | [✅] PASS | The approved plan exists at `docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md`. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Simplicity first | [✅] PASS | The production fix adds a single Windows-drive-path guard in `resolveBundledScriptPath` rather than widening the runtime abstraction surface. |
+| Reusability | [✅] PASS | The change preserves the shared `resolveBundledScriptPath` helper used by command handlers and repo automation. |
+| Extensibility | [✅] PASS | The fix handles any drive-prefixed root matching `/^[A-Za-z]:\//`, not only one hard-coded example. |
+| Separation of concerns | [✅] PASS | All runtime behavior stays in `src/command-runtime.ts`; tests validate behavior from call sites without moving path logic into commands. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Cohesive modules | [✅] PASS | Only the bundled-path helper and its two affected Jest modules were touched. Working-tree diff stats: `command-runtime.ts +12/-0`, `extension.test.ts +120/-0`, `repo-automation-service.test.ts +121/-0`. |
+| Under 500 lines | [❌] FAIL | `extensions/drm-copilot/src/command-runtime.ts` is 437 lines and `test/repo-automation-service.test.ts` is 313 lines, but touched file `extensions/drm-copilot/test/extension.test.ts` is **918 lines**. The repo policy applies the 500-line limit to production code and tests. |
+| Public vs internal | [✅] PASS | `resolveBundledScriptPath` remains the explicit exported helper; no accidental public surface expansion was observed. |
+| No circular dependencies | [✅] PASS | No new imports or module edges were introduced outside existing extension/test relationships. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Descriptive names | [✅] PASS | New test names explicitly describe the regression scenario and host model. |
+| Docs / comments | [✅] PASS | The new comment in `resolveBundledScriptPath` explains why POSIX `path.resolve` mishandles `C:/...` roots. |
+| Comment why, not what | [✅] PASS | The production comment documents rationale instead of narrating the string operations. |
+
+### 2.5 Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting | [✅] PASS | Fresh review command: `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; Pop-Location` → `All matched files use Prettier code style!` |
+| Linting | [✅] PASS | Fresh review command included `npm run lint` from `extensions/drm-copilot` → exit code `0`. |
+| Type checking | [✅] PASS | Fresh review command included `npm run typecheck` from `extensions/drm-copilot` → exit code `0`. |
+| Testing | [✅] PASS | Fresh review commands: targeted `npm run test:unit -- --runTestsByPath ... -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` and full `npm run test:unit`; both passed. |
+| Full toolchain loop | [✅] PASS | One consecutive fresh review pass completed without failures after the corrected non-mutating formatter invocation. |
+| Explicit reporting | [✅] PASS | Exact commands are captured in Appendix B below. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Summarize changes | [✅] PASS | This audit, the code review, and the feature audit summarize the reviewed working-tree change. |
+| Design choices explained | [✅] PASS | The production rationale and regression strategy are documented in `issue.md`, `plan.2026-04-05T19-46.md`, and this audit. |
+| Update supporting documents | [✅] PASS | The feature folder includes updated `issue.md`, `plan.2026-04-05T19-46.md`, and evidence artifacts. |
+| Provide next steps | [⚠️] PARTIAL | Next steps are clear, but remediation is still required before the branch is PR-ready. |
+
+## 3. TypeScript Code Change Policy Compliance
+
+### 3.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting with Prettier | [✅] PASS | Fresh non-mutating Prettier check passed. |
+| Linting with ESLint | [✅] PASS | `npm run lint` passed. |
+| Type checking with TSC | [✅] PASS | `npm run typecheck` passed. |
+| Testing with Jest | [✅] PASS | Targeted and full Jest runs passed; coverage run also passed. |
+
+### 3.2 TypeScript Design & Typing
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Strong typing by default | [✅] PASS | No new `any` or broad type suppression was introduced in the reviewed TypeScript files. |
+| Prefer explicit domain types | [✅] PASS | The production change stays inside the existing typed helper signature. |
+| Avoid cleverness | [✅] PASS | The fix is a small explicit absolute-path branch rather than a platform-specific workaround spread across call sites. |
+| Separation of concerns | [✅] PASS | Tests simulate path semantics; runtime logic remains centralized in `command-runtime.ts`. |
+
+### 3.3 Suppressions and Escape Hatches
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Narrow suppressions only | [✅] PASS | Existing single-line `eslint-disable-next-line @typescript-eslint/no-require-imports -- ...` comments remain scoped to fresh-module Jest helper loading in tests and include local reasons. |
+| No broad type weakening | [✅] PASS | No `@ts-ignore`, `@ts-nocheck`, or config loosening was introduced. |
+
+### 3.4 Project Organization and Reliability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Keep files focused | [⚠️] PARTIAL | `command-runtime.ts` remains focused, but `test/extension.test.ts` is oversized and should be split or reorganized. |
+| Dispose / lifecycle hygiene | [✅] PASS | The change does not introduce new disposables or lifecycle hooks. |
+| Performance / reliability | [✅] PASS | The added path check is constant-time string normalization and regex matching. |
+
+## 4. TypeScript Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Jest | [✅] PASS | All reviewed TypeScript tests run through Jest. |
+| Focused tests | [✅] PASS | Each added regression covers one command/service Windows-root POSIX scenario. |
+| Arrange–Act–Assert | [✅] PASS | The new tests follow mocked setup → handler/service invocation → path assertion. |
+| Avoid external dependencies | [✅] PASS | No network, filesystem mutation, or external process execution occurs outside mocked subprocess calls. |
+| Reset mocks between tests | [✅] PASS | Existing `beforeEach` / `afterEach` hooks reset mocks and state. |
+| Assertions and diagnostics | [✅] PASS | Assertions directly compare or prefix-check the resolved bundled path. |
+| Layout and naming | [⚠️] PARTIAL | Naming is strong, but the touched `extension.test.ts` file exceeds the repo size limit. |
+
+## 5. Gaps and Exceptions
+
+### Identified Gaps
+
+1. **Touched test file exceeds repository file-size limit**  
+   - File: `extensions/drm-copilot/test/extension.test.ts`  
+   - Current size: `918` lines  
+   - Working-tree delta: `+120/-0` lines  
+   - Policy impact: violates the repo-wide `<= 500` line limit for test files.  
+   - Minimum remediation: reorganize or split the touched test coverage so every touched file is under 500 lines while preserving the new POSIX Windows-root regressions.
+
+### Approved Exceptions
+
+**None.** No approved exception covers the file-size violation.
+
+### Removed / Skipped Tests
+
+**None.** The expected-fail red run and the green regression run both exist on disk.
+
+## 6. Summary of Reviewed Changes
+
+### Files Modified in Working Tree
+
+1. **`extensions/drm-copilot/src/command-runtime.ts`** (MODIFIED)  
+   - Adds a Windows-drive absolute-path guard in `resolveBundledScriptPath`.
+2. **`extensions/drm-copilot/test/extension.test.ts`** (MODIFIED)  
+   - Adds POSIX-host regressions for `helloPython` and `helloPowerShell` and fresh-module path mocking helpers.
+3. **`extensions/drm-copilot/test/repo-automation-service.test.ts`** (MODIFIED)  
+   - Adds POSIX-host regressions for `collectCommitContext` and `newPotentialEntry` and corresponding fresh-module helpers.
+4. **`docs/features/active/2026-04-05-ci-failing-error-128/issue.md`** (MODIFIED)  
+   - Checks off all three acceptance-criteria items.
+5. **`docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md`** (MODIFIED)  
+   - Checks off completed plan tasks.
+
+## 7. Compliance Verdict
+
+### Overall Status: ⚠️ PARTIALLY COMPLIANT
+
+The functional bug fix is verified and the acceptance criteria are satisfied, but the branch is not ready for PR because a touched test file violates the repository’s 500-line file-size policy.
+
+### Recommendation
+
+**Needs revision**
+
+Resolve the oversized touched test file, rerun the extension verification loop, and refresh the affected evidence and review artifacts before opening or merging a PR.
+
+## Appendix A: Acceptance-Scoped Test Inventory
+
+- `test/extension.test.ts :: helloPython preserves C:/extension on POSIX hosts`
+- `test/extension.test.ts :: helloPowerShell preserves C:/extension on POSIX hosts`
+- `test/repo-automation-service.test.ts :: collectCommitContext preserves C:/extension on POSIX hosts`
+- `test/repo-automation-service.test.ts :: newPotentialEntry preserves C:/extension on POSIX hosts`
+
+## Appendix B: Toolchain Commands Reference
+
+### Refreshed PR context
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base development`
+
+### Fresh review checks
+- `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; Pop-Location`
+- `Push-Location extensions/drm-copilot; npm run lint; npm run typecheck; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; npm run test:unit; Pop-Location`
+- `Push-Location extensions/drm-copilot; npx jest --coverage --coverageReporters=text-summary --runInBand; Pop-Location`
+
+**Audit Completed By:** GitHub Copilot  
+**Policy Version:** Current as of 2026-04-05

--- a/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/remediation-inputs.2026-04-05T20-20.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/remediation-inputs.2026-04-05T20-20.md
@@ -1,0 +1,54 @@
+# Remediation Inputs: 2026-04-05-ci-failing-error-128
+
+## Required Fixes
+
+1. **Bring the touched test file back under the repository 500-line limit**
+   - **Files / locations:**
+     - `extensions/drm-copilot/test/extension.test.ts` (file-wide; current size 918 lines)
+     - Any new or updated companion test utility/module created to support the split or extraction
+   - **Current problem:** The reviewed bug fix added 120 lines to `extensions/drm-copilot/test/extension.test.ts`, leaving a touched test file far above the repository’s 500-line limit.
+   - **Expected behavior:** The extension command tests remain functionally equivalent, including the new POSIX-host Windows-root regression scenarios, while every touched file complies with the 500-line limit.
+   - **Minimum acceptable outcome:**
+     - Keep the scenarios named exactly:
+       - `helloPython preserves C:/extension on POSIX hosts`
+       - `helloPowerShell preserves C:/extension on POSIX hosts`
+       - `collectCommitContext preserves C:/extension on POSIX hosts`
+       - `newPotentialEntry preserves C:/extension on POSIX hosts`
+     - Preserve the current assertions that bundled paths resolve under `C:/extension/resources/templates/`.
+     - Reduce `extensions/drm-copilot/test/extension.test.ts` to `<= 500` lines.
+     - Ensure any additional touched test file or helper file is also `<= 500` lines.
+   - **Verification commands:**
+     - `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; Pop-Location`
+     - `Push-Location extensions/drm-copilot; npm run lint; Pop-Location`
+     - `Push-Location extensions/drm-copilot; npm run typecheck; Pop-Location`
+     - `Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; Pop-Location`
+     - `Push-Location extensions/drm-copilot; npm run test:unit; Pop-Location`
+
+2. **Refresh the review evidence after the structural test remediation**
+   - **Files / locations:**
+     - `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/*`
+     - `docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/*` when file paths or scope evidence change
+     - `docs/features/active/2026-04-05-ci-failing-error-128/policy-audit.*.md`
+     - `docs/features/active/2026-04-05-ci-failing-error-128/code-review.*.md`
+   - **Expected behavior:** Evidence and review artifacts reflect the final remediated file layout and verification results.
+   - **Minimum acceptable outcome:**
+     - Regenerate or replace any evidence artifact whose file-path references or verification results are invalidated by the remediation.
+     - Preserve the reduced-audit structure: no `spec.md`, no `user-story.md`, and `issue.md` remains the sole AC source.
+   - **Verification commands:** reuse the commands listed in Fix 1 plus `poetry run python -m scripts.dev_tools.pr_context.collector --base development` if PR-context artifacts need refresh.
+
+## Do Not Do
+
+- Do not weaken or waive the repository 500-line file policy.
+- Do not remove or rename the four regression scenarios listed above.
+- Do not broaden the production-code change beyond `extensions/drm-copilot/src/command-runtime.ts` unless a new plan explicitly authorizes it.
+- Do not delete the red/green regression evidence without replacing it with equivalent or stronger evidence.
+- Do not infer acceptance criteria from anywhere other than `issue.md#acceptance-criteria`.
+- Do not introduce broad lint or type suppressions to avoid structural remediation.
+
+## Acceptance Criteria Still Outstanding
+
+**None.** All three feature acceptance criteria are satisfied. Remediation is required for policy compliance and PR readiness, not because feature behavior is incomplete.
+
+## Minimum Change Needed for Completion
+
+The smallest acceptable remediation is a structural reorganization of the touched extension command test coverage so that `extensions/drm-copilot/test/extension.test.ts` and any newly touched companion files are each `<= 500` lines while preserving the current production fix, the four Windows-root POSIX regressions, and the green final verification results.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/remediation-plan.2026-04-05T20-20.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-20/remediation-plan.2026-04-05T20-20.md
@@ -1,0 +1,104 @@
+# 2026-04-05-ci-failing-error-128 - Remediation Plan
+
+- **Issue:** 128
+- **Owner:** drmoisan
+- **Last Updated:** 2026-04-05T20-20
+- **Status:** Planned
+- **Version:** 1
+
+## Required References
+
+- General Coding Standards: [`.github/instructions/general-code-change.instructions.md`](../../../../.github/instructions/general-code-change.instructions.md)
+- General Unit Test Policy: [`.github/instructions/general-unit-test.instructions.md`](../../../../.github/instructions/general-unit-test.instructions.md)
+- TypeScript Code Change Policy: [`.github/instructions/typescript-code-change.instructions.md`](../../../../.github/instructions/typescript-code-change.instructions.md)
+- TypeScript Unit Test Policy: [`.github/instructions/typescript-unit-test.instructions.md`](../../../../.github/instructions/typescript-unit-test.instructions.md)
+- TypeScript Suppressions Policy: [`.github/instructions/typescript-suppressions.instructions.md`](../../../../.github/instructions/typescript-suppressions.instructions.md)
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+> Review fallback note: this remediation plan was drafted directly in the review environment because no executable atomic-planner command surface was discoverable here. The task structure follows the repository atomic-planner contract.
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Compliance & Remediation Baseline
+- [x] [P0-T1] Read `.github/copilot-instructions.md`
+  - Acceptance: Execution notes confirm the repository tone and response-policy file was read before any implementation work.
+
+- [x] [P0-T2] Read `.github/instructions/general-code-change.instructions.md`
+  - Acceptance: Execution notes confirm the general code-change policy was read before any implementation work.
+
+- [x] [P0-T3] Read `.github/instructions/general-unit-test.instructions.md`
+  - Acceptance: Execution notes confirm the general unit-test policy was read before any implementation work.
+
+- [x] [P0-T4] Read `.github/instructions/typescript-code-change.instructions.md`
+  - Acceptance: Execution notes confirm the TypeScript code-change policy was read before any implementation work.
+
+- [x] [P0-T5] Read `.github/instructions/typescript-unit-test.instructions.md` and `.github/instructions/typescript-suppressions.instructions.md`
+  - Acceptance: Execution notes confirm the TypeScript unit-test and suppression policies were read before any implementation work.
+
+- [x] [P0-T6] Record a Phase 0 instructions-read artifact at `docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/phase0-instructions-read.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Policy Order:`, and an explicit `Files Read:` list matching P0-T1 through P0-T5.
+
+- [x] [P0-T7] Confirm remediation scope by reading `docs/features/active/2026-04-05-ci-failing-error-128/remediation-inputs.2026-04-05T20-20.md`, `docs/features/active/2026-04-05-ci-failing-error-128/policy-audit.2026-04-05T20-20.md`, and `docs/features/active/2026-04-05-ci-failing-error-128/code-review.2026-04-05T20-20.md`
+  - Acceptance: Execution notes identify the file-size violation in `extensions/drm-copilot/test/extension.test.ts` as the primary remediation target.
+
+- [x] [P0-T8] Run `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; Pop-Location` and capture the baseline result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-prettier-check.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T9] Run `Push-Location extensions/drm-copilot; npm run lint; Pop-Location` and capture the baseline result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-eslint.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T10] Run `Push-Location extensions/drm-copilot; npm run typecheck; Pop-Location` and capture the baseline result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-tsc.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T11] Run `Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; Pop-Location` and capture the baseline regression result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-targeted-regressions.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` naming the four Windows-root POSIX scenarios.
+
+- [x] [P0-T12] Run `Push-Location extensions/drm-copilot; npx jest --coverage --coverageReporters=text-summary --runInBand; Pop-Location` and capture the result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-jest-coverage.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` with numeric overall coverage values and the changed production file coverage if available.
+
+- [x] [P0-T13] Record a remediation baseline artifact at `docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-line-counts.md` capturing the current line counts for `extensions/drm-copilot/test/extension.test.ts` and any planned companion test files
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE:`, and the current `918` line count for `extensions/drm-copilot/test/extension.test.ts`.
+
+### Phase 1 — Restructure the Oversized Test Surface
+- [x] [P1-T1] Extract or relocate the shared POSIX fresh-module path helper logic from `extensions/drm-copilot/test/extension.test.ts` so the file no longer owns duplicated setup that can be shared safely
+  - Acceptance: The duplicated helper logic is defined once in the remediated layout, and the resulting touched files remain strongly named and deterministic.
+- [x] [P1-T2] Reorganize `extensions/drm-copilot/test/extension.test.ts` into policy-compliant file sizes without removing the existing command behavior coverage
+  - Acceptance: `extensions/drm-copilot/test/extension.test.ts` and every newly touched or created companion/helper test file are each `<= 500` lines after the reorganization.
+- [x] [P1-T3] Update `extensions/drm-copilot/test/repo-automation-service.test.ts` and any new companion test file(s) to consume the remediated helper/layout while preserving the four Windows-root POSIX regression scenarios exactly as currently named
+  - Acceptance: The scenarios `helloPython preserves C:/extension on POSIX hosts`, `helloPowerShell preserves C:/extension on POSIX hosts`, `collectCommitContext preserves C:/extension on POSIX hosts`, and `newPotentialEntry preserves C:/extension on POSIX hosts` still exist with the same path expectations.
+- [x] [P1-T4] Verify the remediated touched-file set stays within the approved behavior scope: no production file changes, `extensions/drm-copilot/src/command-runtime.ts` remains unchanged from the current fix, no acceptance-criteria text changes, and no added policy suppressions beyond pre-authorized patterns
+  - Acceptance: A scope-check artifact confirms the final touched file set, confirms no production files changed, and confirms every touched test/helper file is `<= 500` lines.
+
+### Phase 2 — Verification and Evidence Refresh
+- [x] [P2-T1] Run `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; Pop-Location` and capture the result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-prettier-check.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` confirming formatting is clean.
+
+- [x] [P2-T2] Run `Push-Location extensions/drm-copilot; npm run lint; Pop-Location` and capture the result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-eslint.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` with no blocking ESLint diagnostics.
+
+- [x] [P2-T3] Run `Push-Location extensions/drm-copilot; npm run typecheck; Pop-Location` and capture the result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-tsc.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` with no blocking TSC diagnostics.
+
+- [x] [P2-T4] Run `Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; Pop-Location` and capture the result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-targeted-regressions.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` naming all four Windows-root POSIX scenarios as passing.
+
+- [x] [P2-T5] Run `Push-Location extensions/drm-copilot; npx jest --coverage --coverageReporters=text-summary --runInBand; Pop-Location` and capture the result in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-jest-coverage.md`
+  - Acceptance: The artifact includes `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` with numeric post-remediation coverage values sufficient to verify the repo thresholds remain satisfied.
+
+- [x] [P2-T6] Record a final scope-check artifact at `docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-scope-and-line-counts.md`
+  - Acceptance: The artifact confirms the final touched file set, records the final line counts for every touched test file, explicitly confirms every touched test/helper file is `<= 500` lines, confirms no production files changed and `extensions/drm-copilot/src/command-runtime.ts` remains unchanged from the current fix, and confirms the four Windows-root POSIX regression scenarios remain exactly as named.
+
+- [x] [P2-T7] Refresh `docs/features/active/2026-04-05-ci-failing-error-128/policy-audit.*.md` and `docs/features/active/2026-04-05-ci-failing-error-128/code-review.*.md` (or replace them with newer timestamped artifacts) so the review output references the remediated file layout and final verification evidence
+  - Acceptance: Updated review artifacts no longer report a touched file over 500 lines and conclude the branch is PR-ready if no other issues remain.
+
+## Test Plan
+
+- Unit: focused Windows-root POSIX regressions for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry`
+- Integration: full `extensions/drm-copilot` Jest suite
+- Manual/CLI: non-mutating Prettier check, ESLint, TSC, and line-count verification of all touched test files
+
+## Open Questions / Notes
+
+- Preserve the reduced-audit contract: `issue.md` remains the sole acceptance-criteria source, and `spec.md` / `user-story.md` remain absent.
+- If the remediation requires new test files, update the scope evidence and refreshed review artifacts to reflect the final touched-file list.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-42/code-review.2026-04-05T20-42.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-42/code-review.2026-04-05T20-42.md
@@ -1,0 +1,27 @@
+# Code Review: 2026-04-05-ci-failing-error-128 (Remediation Refresh)
+
+Review Timestamp: 2026-04-05T20:42:28.8607822-04:00
+
+## Executive Summary
+
+The remediation reorganized the touched extension test surface without altering the existing production fix. Shared POSIX fresh-module helpers were extracted into dedicated test helper modules, `extension.test.ts` was reduced to the core hello-command coverage plus the two preserved Windows-root POSIX regressions, and the remaining command coverage moved into `extension.workflow-commands.test.ts`.
+
+## Preserved Regression Scenarios
+
+- `helloPython preserves C:/extension on POSIX hosts`
+- `helloPowerShell preserves C:/extension on POSIX hosts`
+- `collectCommitContext preserves C:/extension on POSIX hosts`
+- `newPotentialEntry preserves C:/extension on POSIX hosts`
+
+## Final Verification
+
+- Prettier check: PASS
+- ESLint: PASS
+- TypeScript type-check: PASS
+- Targeted regressions: PASS
+- Full Jest coverage run: PASS
+- Coverage headline: 89.36% lines, 89.36% statements, 88.69% functions, 81.61% branches
+
+## Review Conclusion
+
+No touched test/helper file exceeds 500 lines, the existing production fix in `extensions/drm-copilot/src/command-runtime.ts` was not modified during remediation, and the refreshed evidence supports PR readiness if no unrelated issues remain.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-42/policy-audit.2026-04-05T20-42.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/audit-2026-04-05T20-42/policy-audit.2026-04-05T20-42.md
@@ -1,0 +1,30 @@
+# Policy Compliance Audit: 2026-04-05-ci-failing-error-128 (Remediation Refresh)
+
+Audit Timestamp: 2026-04-05T20:42:28.8607822-04:00
+Work Mode: minor-audit
+Acceptance Criteria Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria
+
+## Summary
+
+The remediation refresh resolves the blocking 500-line policy violation without changing production code. The current fix in `extensions/drm-copilot/src/command-runtime.ts` was left untouched, the four named Windows-root POSIX regression scenarios remain present exactly as named, and the touched extension test/helper files are now all within the repository 500-line limit.
+
+## Final Touched Test/Helper File Sizes
+
+- `extensions/drm-copilot/test/extension.test.ts` — 251 lines
+- `extensions/drm-copilot/test/extension.workflow-commands.test.ts` — 393 lines
+- `extensions/drm-copilot/test/extension-test-harness.ts` — 244 lines
+- `extensions/drm-copilot/test/runtime-test-helpers.ts` — 135 lines
+- `extensions/drm-copilot/test/repo-automation-service.test.ts` — 234 lines
+
+## Verification Evidence
+
+- `evidence/final-qa/final-prettier-check.md`
+- `evidence/final-qa/final-eslint.md`
+- `evidence/final-qa/final-tsc.md`
+- `evidence/final-qa/final-targeted-regressions.md`
+- `evidence/final-qa/final-jest-coverage.md`
+- `evidence/final-qa/final-scope-and-line-counts.md`
+
+## Verdict
+
+PASS. No touched test/helper file remains over 500 lines, no remediation-time production edits were introduced, and the branch is PR-ready if no unrelated issues remain.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/code-review.2026-04-05T20-45.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/code-review.2026-04-05T20-45.md
@@ -1,0 +1,81 @@
+# Code Review: 2026-04-05-ci-failing-error-128 (Reduced Audit Re-Review)
+
+**Review Timestamp:** 2026-04-05T20-45  
+**Base Branch:** `development`  
+**Feature Folder:** `docs/features/active/2026-04-05-ci-failing-error-128/`  
+**Feature Folder Selection Rule:** Used the user-specified active feature folder and confirmed it matches the refreshed PR-context additional-context entries.
+
+## Executive Summary
+
+The remediated branch state resolves the prior policy blocker without widening the production fix. The current working tree keeps the behavioral fix in `extensions/drm-copilot/src/command-runtime.ts`, splits the oversized extension test surface into focused companion files, preserves the four required Windows-root POSIX regressions exactly as named, and passes the live extension verification sequence.
+
+### Top 3 residual risks
+
+1. The refreshed canonical PR-context artifacts remain commit-based and do not yet reflect the unstaged remediation working tree; commit the current state before using PR-context-derived automation for PR authoring.
+2. The review artifacts created across `20-20`, `20-42`, and this `20-45` refresh are all present in the feature folder; ensure only the intended latest artifacts are cited in the eventual PR description.
+3. The reduced-audit pass depends on the companion helper split remaining unchanged; any further scope growth in test files should be rechecked against the 500-line policy immediately.
+
+### Recommendation
+
+**Go** for PR readiness. No additional remediation is required for the reduced audit.
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| None | — | — | No blocker, major, or minor defects were identified in the remediated working tree. | Proceed with commit/PR preparation using the refreshed `20-45` audit set. | The previous blocker was the oversized touched test file; the current line counts and live green verification resolve that issue. | `evidence/final-qa/final-scope-and-line-counts.md`; live Prettier/ESLint/TSC/Jest runs at 20:45 |
+| Nit | `artifacts/pr_context.summary.txt` | whole artifact | The PR-context summary still reflects `HEAD` rather than the unstaged remediation working tree. | Regenerate PR-context after committing the remediation if a PR body or downstream automation will rely on it. | Review evidence remains sound because it is supplemented by live `git status`, direct file inspection, and current test runs, but PR-context-derived automation should ideally match the committed branch state. | Refreshed collector run plus `git status --short` showing unstaged remediation files |
+
+## Typed TypeScript / Test-Surface Audit
+
+### Scope and typing
+
+- `extensions/drm-copilot/src/command-runtime.ts` remains the only production TypeScript file carrying the bug fix.
+- The remediation added companion test/helper files only:
+  - `extensions/drm-copilot/test/extension.workflow-commands.test.ts`
+  - `extensions/drm-copilot/test/extension-test-harness.ts`
+  - `extensions/drm-copilot/test/runtime-test-helpers.ts`
+- The helper split retains explicit types for executable presence, mocked fs behavior, mocked child processes, and command handlers.
+- No new `any`, `@ts-ignore`, or broad ESLint suppressions were introduced.
+
+### File-size compliance
+
+The touched test/helper files now satisfy the repository 500-line rule:
+
+- `extension.test.ts` — 251 lines
+- `extension.workflow-commands.test.ts` — 393 lines
+- `extension-test-harness.ts` — 244 lines
+- `runtime-test-helpers.ts` — 135 lines
+- `repo-automation-service.test.ts` — 234 lines
+
+### Correctness and control-flow review
+
+- `resolveBundledScriptPath()` still contains the targeted Windows drive-root guard and remains exported.
+- The regression names required by the approved plan and remediation inputs are still present exactly as authored:
+  - `helloPython preserves C:/extension on POSIX hosts`
+  - `helloPowerShell preserves C:/extension on POSIX hosts`
+  - `collectCommitContext preserves C:/extension on POSIX hosts`
+  - `newPotentialEntry preserves C:/extension on POSIX hosts`
+- Subprocess safety assertions (`shell: false`, argv-array execution) remain covered in the touched test files.
+
+## Test Quality Audit
+
+- **Deterministic:** Yes. All touched tests rely on mocks for VS Code APIs, `node:fs`, `node:child_process`, and controlled PATH/PATHEXT values.
+- **Isolated:** Yes. Each suite resets harness state in `beforeEach`/`afterEach`; fresh-module POSIX tests explicitly reset module state in `finally` blocks.
+- **Fast:** Yes. Targeted slice completed in 0.368 s; full extension unit suite completed in 1.033 s during this review.
+- **Clear failure messages:** Yes. The regression names are descriptive and assert explicit bundled-path expectations.
+- **Coverage expectations:** Satisfied for this re-review. `final-jest-coverage.md` reports a passing coverage run with 89.36% lines overall, and the production fix coverage reference remains above the repo threshold.
+
+## Security and Correctness Checks
+
+- **Secrets in code:** None observed in touched files.
+- **Unsafe subprocess usage:** None observed. The touched tests continue to assert argv-array subprocess launches with `shell: false`.
+- **Input validation at boundaries:** The command and repo-automation tests continue covering missing runtime, missing workspace, and invalid input paths where applicable.
+
+## Research Log
+
+No external research was needed for this re-review. Evidence came from repository policy files, the approved plan/remediation documents, direct source inspection, and live verification commands.
+
+## Review Conclusion
+
+The reduced audit now passes. The prior blocker was structural and has been resolved without widening the production fix. The branch is ready for PR review once the current working-tree state and refreshed audit artifacts are committed.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t2.requirements-scope.2026-04-05T19-57.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t2.requirements-scope.2026-04-05T19-57.md
@@ -1,0 +1,11 @@
+# P0-T2 Requirements Scope
+
+Timestamp: 2026-04-05T19-57
+Work Mode: minor-audit
+Requirements Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md
+Acceptance Criteria Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria
+spec.md: not required
+user-story.md: not required
+research.md: not required
+Production Target: extensions/drm-copilot/src/command-runtime.ts
+Regression Targets: extensions/drm-copilot/test/extension.test.ts, extensions/drm-copilot/test/repo-automation-service.test.ts

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t3.focused-repro.2026-04-05T19-57.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t3.focused-repro.2026-04-05T19-57.md
@@ -1,0 +1,13 @@
+# P0-T3 Focused Baseline Reproduction
+
+Timestamp: 2026-04-05T19-57
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"
+EXIT_CODE: 0
+Output Summary: focused repro passed; 2 suites passed, 22 targeted tests passed, 25 tests skipped, and no hybrid-path diagnostic was observed.
+
+Raw Output:
+- PASS test/extension.test.ts
+- PASS test/repo-automation-service.test.ts
+- Test Suites: 2 passed, 2 total
+- Tests: 25 skipped, 22 passed, 47 total
+- Time: 0.521 s

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t4.format.2026-04-05T19-57.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t4.format.2026-04-05T19-57.md
@@ -1,0 +1,10 @@
+# P0-T4 Baseline Format
+
+Timestamp: 2026-04-05T19-57
+Command: npm --prefix extensions/drm-copilot run format
+EXIT_CODE: 0
+Output Summary: no formatting changes reported.
+
+Raw Output:
+- prettier --write "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"
+- All reported extension files were unchanged.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t5.lint.2026-04-05T19-57.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t5.lint.2026-04-05T19-57.md
@@ -1,0 +1,9 @@
+# P0-T5 Baseline Lint
+
+Timestamp: 2026-04-05T19-57
+Command: npm --prefix extensions/drm-copilot run lint
+EXIT_CODE: 0
+Output Summary: passed.
+
+Raw Output:
+- eslint --no-error-on-unmatched-pattern src test

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t6.typecheck.2026-04-05T19-57.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t6.typecheck.2026-04-05T19-57.md
@@ -1,0 +1,9 @@
+# P0-T6 Baseline Type Check
+
+Timestamp: 2026-04-05T19-57
+Command: npm --prefix extensions/drm-copilot run typecheck
+EXIT_CODE: 0
+Output Summary: passed.
+
+Raw Output:
+- tsc -p ./ --noEmit

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t7.test-unit.2026-04-05T19-57.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t7.test-unit.2026-04-05T19-57.md
@@ -1,0 +1,11 @@
+# P0-T7 Baseline Extension Unit Tests
+
+Timestamp: 2026-04-05T19-57
+Command: npm --prefix extensions/drm-copilot run test:unit
+EXIT_CODE: 0
+Output Summary: 10 suites passed, 136 tests passed, 0 snapshots; no failing bundled-path scenario was observed.
+
+Raw Output:
+- Test Suites: 10 passed, 10 total
+- Tests: 136 passed, 136 total
+- Time: 0.976 s

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t8.small-path-scope.2026-04-05T19-57.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t8.small-path-scope.2026-04-05T19-57.md
@@ -1,0 +1,11 @@
+# P0-T8 Small-Path Scope
+
+Timestamp: 2026-04-05T19-57
+Budget: 1 production TypeScript file + 2 Jest modules
+Production Target: extensions/drm-copilot/src/command-runtime.ts
+Regression Targets: extensions/drm-copilot/test/extension.test.ts, extensions/drm-copilot/test/repo-automation-service.test.ts
+
+Acceptance Criteria:
+- Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
+- Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
+- Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,20 @@
+# Phase 0 Instructions Read
+
+Timestamp: 2026-04-05T19-57
+Work Mode: minor-audit
+Acceptance Criteria Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria
+Policy Order:
+1. `.github/copilot-instructions.md`
+2. `.github/instructions/general-code-change.instructions.md`
+3. `.github/instructions/general-unit-test.instructions.md`
+4. `.github/instructions/typescript-code-change.instructions.md`
+5. `.github/instructions/typescript-unit-test.instructions.md`
+6. `.github/instructions/typescript-suppressions.instructions.md`
+
+Files Read:
+- `.github/copilot-instructions.md`
+- `.github/instructions/general-code-change.instructions.md`
+- `.github/instructions/general-unit-test.instructions.md`
+- `.github/instructions/typescript-code-change.instructions.md`
+- `.github/instructions/typescript-unit-test.instructions.md`
+- `.github/instructions/typescript-suppressions.instructions.md`

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-eslint.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-eslint.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:41:44.1449726-04:00
+Command: Push-Location extensions/drm-copilot; npm run lint; Pop-Location
+EXIT_CODE: 0
+Output Summary: ESLint passed with no blocking diagnostics during the clean consecutive QA pass.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-jest-coverage.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-jest-coverage.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:42:14.7874757-04:00
+Command: Push-Location extensions/drm-copilot; npx jest --coverage --coverageReporters=text-summary --runInBand; Pop-Location
+EXIT_CODE: 0
+Output Summary: Full extension Jest coverage passed during the clean consecutive QA pass with 11 passed suites and 140 passed tests. Coverage headline: lines 89.36%, statements 89.36%, functions 88.69%, branches 81.61%. Because remediation touched only test/helper files and left extensions/drm-copilot/src/command-runtime.ts unchanged, the prior measured command-runtime.ts coverage remains the relevant production-file reference at 93.46% lines and 92.30% functions.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-prettier-check.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-prettier-check.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:41:30.4171791-04:00
+Command: Push-Location extensions/drm-copilot; npx prettier --check 'src/**/*.ts' 'test/**/*.ts' '*.json' '*.cjs'; Pop-Location
+EXIT_CODE: 0
+Output Summary: Final Prettier check passed during the clean consecutive QA pass. All matched extension TypeScript, test, JSON, and CJS files use Prettier code style.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-scope-and-line-counts.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-scope-and-line-counts.md
@@ -1,0 +1,25 @@
+Timestamp: 2026-04-05T20:42:28.8607822-04:00
+Final Touched Test/Helper Files:
+- extensions/drm-copilot/test/extension.test.ts
+- extensions/drm-copilot/test/extension.workflow-commands.test.ts
+- extensions/drm-copilot/test/extension-test-harness.ts
+- extensions/drm-copilot/test/runtime-test-helpers.ts
+- extensions/drm-copilot/test/repo-automation-service.test.ts
+Final Line Counts:
+- extensions/drm-copilot/test/extension.test.ts = 251
+- extensions/drm-copilot/test/extension.workflow-commands.test.ts = 393
+- extensions/drm-copilot/test/extension-test-harness.ts = 244
+- extensions/drm-copilot/test/runtime-test-helpers.ts = 135
+- extensions/drm-copilot/test/repo-automation-service.test.ts = 234
+Final Scope Checks:
+- Every touched test/helper file is <= 500 lines.
+- No production files were changed during remediation.
+- extensions/drm-copilot/src/command-runtime.ts remains unchanged from the current fix.
+- The exact Windows-root POSIX regression scenario names remain present:
+  - helloPython preserves C:/extension on POSIX hosts
+  - helloPowerShell preserves C:/extension on POSIX hosts
+  - collectCommitContext preserves C:/extension on POSIX hosts
+  - newPotentialEntry preserves C:/extension on POSIX hosts
+Supporting Evidence:
+- Final targeted regressions: docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-targeted-regressions.md
+- Final coverage: docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-jest-coverage.md

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-targeted-regressions.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-targeted-regressions.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:42:01.8436215-04:00
+Command: Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t 'helloPython|helloPowerShell|collectCommitContext|newPotentialEntry'; Pop-Location
+EXIT_CODE: 0
+Output Summary: Targeted final Windows-root POSIX regressions passed. Named passing scenarios: helloPython preserves C:/extension on POSIX hosts; helloPowerShell preserves C:/extension on POSIX hosts; collectCommitContext preserves C:/extension on POSIX hosts; newPotentialEntry preserves C:/extension on POSIX hosts. Jest reported 2 passed suites, 10 passed tests, 12 skipped tests, 22 total.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-tsc.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/final-qa/final-tsc.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:41:53.1220066-04:00
+Command: Push-Location extensions/drm-copilot; npm run typecheck; Pop-Location
+EXIT_CODE: 0
+Output Summary: TypeScript type-checking passed with zero blocking diagnostics during the clean consecutive QA pass.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t1.scope-lock.2026-04-05T20-08.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t1.scope-lock.2026-04-05T20-08.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-04-05T20-08
+Allowed Files:
+- extensions/drm-copilot/src/command-runtime.ts
+- extensions/drm-copilot/test/extension.test.ts
+- extensions/drm-copilot/test/repo-automation-service.test.ts
+- docs/features/active/2026-04-05-ci-failing-error-128/issue.md
+- docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md
+- docs/features/active/2026-04-05-ci-failing-error-128/evidence/**
+Out-of-Scope: any second production TypeScript file
+spec.md/user-story.md/research.md remain non-required minor-audit inputs

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t9.acceptance-mapping.2026-04-05T20-13.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t9.acceptance-mapping.2026-04-05T20-13.md
@@ -1,0 +1,16 @@
+Timestamp: 2026-04-05T20-13
+Requirements Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md
+Focused Regression Evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.*.md
+Planned Final QC Evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.*.md
+Only issue.md acceptance-criteria checkboxes may be changed from - [ ] to - [x] after supporting evidence exists; preserve the checkbox text exactly.
+
+Acceptance Criteria Mapping
+- [ ] Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
+  - Focused evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.*.md
+  - Final QC evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.*.md
+- [ ] Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
+  - Focused evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.*.md
+  - Final QC evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.*.md
+- [ ] Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.
+  - Focused evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.*.md
+  - Final QC evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.*.md

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t1.format.2026-04-05T20-14.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t1.format.2026-04-05T20-14.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20-14
+Command: npm --prefix extensions/drm-copilot run format
+EXIT_CODE: 0
+Output Summary: already formatted after final pass

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t2.lint.2026-04-05T20-14.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t2.lint.2026-04-05T20-14.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20-14
+Command: npm --prefix extensions/drm-copilot run lint
+EXIT_CODE: 0
+Output Summary: ESLint passed with no remaining blocking diagnostics.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t3.typecheck.2026-04-05T20-14.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t3.typecheck.2026-04-05T20-14.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20-14
+Command: npm --prefix extensions/drm-copilot run typecheck
+EXIT_CODE: 0
+Output Summary: TypeScript type-checking passed with zero blocking diagnostics.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.2026-04-05T20-14.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.2026-04-05T20-14.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20-14
+Command: npm --prefix extensions/drm-copilot run test:unit
+EXIT_CODE: 0
+Output Summary: All 10 extension Jest suites passed (10/10 suites, 140/140 tests), including the Windows-root bundled-path regression scenarios for helloPython, helloPowerShell, collectCommitContext, and newPotentialEntry.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t6.clean-pass-summary.2026-04-05T20-14.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t6.clean-pass-summary.2026-04-05T20-14.md
@@ -1,0 +1,21 @@
+Timestamp: 2026-04-05T20-14
+Status: PASS
+Final QC Artifacts:
+- docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t1.format.2026-04-05T20-14.md
+- docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t2.lint.2026-04-05T20-14.md
+- docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t3.typecheck.2026-04-05T20-14.md
+- docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.2026-04-05T20-14.md
+
+Acceptance Criteria Results
+- PASS — Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
+  - Focused regression evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.2026-04-05T20-12.md
+  - Final QC evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.2026-04-05T20-14.md
+- PASS — Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
+  - Focused regression evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.2026-04-05T20-12.md
+  - Final QC evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.2026-04-05T20-14.md
+- PASS — Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.
+  - Focused regression evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.2026-04-05T20-12.md
+  - Final QC evidence: docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.2026-04-05T20-14.md
+
+No Phase 2 command task was skipped.
+Non-Required Docs Confirmed: spec.md not required; user-story.md not required; research.md not required

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t6.red-jest.2026-04-05T20-11.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t6.red-jest.2026-04-05T20-11.md
@@ -1,0 +1,10 @@
+Timestamp: 2026-04-05T20-11
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"
+EXIT_CODE: 1
+Output Summary: Focused red regression run failed as expected on the four Windows-root POSIX-host scenarios in extension and repo-automation service tests.
+Failure: helloPython preserves C:/extension on POSIX hosts
+Additional Failures:
+- helloPowerShell preserves C:/extension on POSIX hosts
+- collectCommitContext preserves C:/extension on POSIX hosts
+- newPotentialEntry preserves C:/extension on POSIX hosts
+First Diagnostic: Expected "C:/extension/resources/templates/hello_python.py" but received a checkout-prefixed hybrid path under "/Users/DanMoisan/repos/drm-copilot/extensions/drm-copilot/C:/extension/...".

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.2026-04-05T20-12.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.2026-04-05T20-12.md
@@ -1,0 +1,11 @@
+Timestamp: 2026-04-05T20-12
+Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"
+EXIT_CODE: 0
+Output Summary: Focused green regression run passed for helloPython, helloPowerShell, collectCommitContext, and newPotentialEntry Windows-root scenarios.
+Passing Scenarios:
+- helloPython preserves C:/extension on POSIX hosts
+- helloPowerShell preserves C:/extension on POSIX hosts
+- collectCommitContext preserves C:/extension on POSIX hosts
+- newPotentialEntry preserves C:/extension on POSIX hosts
+Suite Totals: 2 passed, 2 total
+Test Totals: 26 passed, 25 skipped, 51 total

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-eslint.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-eslint.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:29:55.0902785-04:00
+Command: Push-Location extensions/drm-copilot; npm run lint; Pop-Location
+EXIT_CODE: 0
+Output Summary: ESLint baseline passed for the extension workspace with no blocking diagnostics.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-jest-coverage.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-jest-coverage.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:30:35.3315993-04:00
+Command: Push-Location extensions/drm-copilot; npx jest --coverage --coverageReporters=text-summary --runInBand; Pop-Location
+EXIT_CODE: 0
+Output Summary: Full extension Jest baseline passed with 10 passed suites and 140 passed tests. Coverage headline from the commanded run: lines 89.73%, statements 89.73%, functions 86.02%, branches 81.79%. Existing per-file coverage summary for the unchanged production fix reports src/command-runtime.ts at 93.46% lines and 92.30% functions.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-line-counts.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-line-counts.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:30:41.1203928-04:00
+Command: (Get-Content 'extensions/drm-copilot/test/extension.test.ts').Count; (Get-Content 'extensions/drm-copilot/test/repo-automation-service.test.ts').Count
+EXIT_CODE: 0
+Output Summary: Baseline touched-file line counts recorded before remediation. extensions/drm-copilot/test/extension.test.ts = 918 lines. extensions/drm-copilot/test/repo-automation-service.test.ts = 313 lines. The primary file-size violation is extension.test.ts at 918 lines.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-prettier-check.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-prettier-check.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:29:41.2095031-04:00
+Command: Push-Location extensions/drm-copilot; npx prettier --check 'src/**/*.ts' 'test/**/*.ts' '*.json' '*.cjs'; Pop-Location
+EXIT_CODE: 0
+Output Summary: Prettier baseline check passed for extension TypeScript, test, JSON, and CJS files with "All matched files use Prettier code style!".

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-targeted-regressions.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-targeted-regressions.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:30:17.3240390-04:00
+Command: Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t 'helloPython|helloPowerShell|collectCommitContext|newPotentialEntry'; Pop-Location
+EXIT_CODE: 0
+Output Summary: Targeted Windows-root POSIX regressions passed in baseline state. Named scenarios preserved: helloPython preserves C:/extension on POSIX hosts; helloPowerShell preserves C:/extension on POSIX hosts; collectCommitContext preserves C:/extension on POSIX hosts; newPotentialEntry preserves C:/extension on POSIX hosts. Jest reported 2 passed suites, 26 passed tests, 25 skipped tests, 51 total.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-tsc.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/baseline-tsc.md
@@ -1,0 +1,4 @@
+Timestamp: 2026-04-05T20:30:05.5536702-04:00
+Command: Push-Location extensions/drm-copilot; npm run typecheck; Pop-Location
+EXIT_CODE: 0
+Output Summary: TypeScript baseline type-check passed for the extension workspace with no blocking TSC diagnostics.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/phase0-instructions-read.md
@@ -1,0 +1,19 @@
+Timestamp: 2026-04-05T20:29:03.6845955-04:00
+Policy Order:
+1. .github/copilot-instructions.md
+2. .github/instructions/general-code-change.instructions.md
+3. .github/instructions/general-unit-test.instructions.md
+4. .github/instructions/typescript-code-change.instructions.md
+5. .github/instructions/typescript-unit-test.instructions.md
+6. .github/instructions/typescript-suppressions.instructions.md
+Files Read:
+- c:\Users\DanMoisan\repos\drm-copilot\.github\copilot-instructions.md
+- c:\Users\DanMoisan\repos\drm-copilot\.github\instructions\general-code-change.instructions.md
+- c:\Users\DanMoisan\repos\drm-copilot\.github\instructions\general-unit-test.instructions.md
+- c:\Users\DanMoisan\repos\drm-copilot\.github\instructions\typescript-code-change.instructions.md
+- c:\Users\DanMoisan\repos\drm-copilot\.github\instructions\typescript-unit-test.instructions.md
+- c:\Users\DanMoisan\repos\drm-copilot\.github\instructions\typescript-suppressions.instructions.md
+Notes:
+- Repository tone and response policy confirmed before implementation work.
+- General code-change, unit-test, and TypeScript-specific policies were read before remediation.
+- The active feature folder is in minor-audit mode and issue.md remains the sole acceptance-criteria source.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/phase1-scope-check.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/evidence/remediation-baseline/phase1-scope-check.md
@@ -1,0 +1,22 @@
+Timestamp: 2026-04-05T20:42:28.8607822-04:00
+Scope Summary:
+- Shared POSIX fresh-module helper logic now lives in test/runtime-test-helpers.ts.
+- extension.test.ts was reduced to the core hello-command coverage plus the two preserved Windows-root POSIX regressions.
+- Additional command coverage moved into test/extension.workflow-commands.test.ts.
+- repo-automation-service.test.ts now consumes the shared helper module.
+Touched Test/Helper Files:
+- extensions/drm-copilot/test/extension.test.ts
+- extensions/drm-copilot/test/extension.workflow-commands.test.ts
+- extensions/drm-copilot/test/extension-test-harness.ts
+- extensions/drm-copilot/test/runtime-test-helpers.ts
+- extensions/drm-copilot/test/repo-automation-service.test.ts
+Line Counts:
+- extension.test.ts = 251
+- extension.workflow-commands.test.ts = 393
+- extension-test-harness.ts = 244
+- runtime-test-helpers.ts = 135
+- repo-automation-service.test.ts = 234
+Scope Guard:
+- No production files were edited during remediation.
+- extensions/drm-copilot/src/command-runtime.ts was left unchanged from the current fix.
+- Preserved exact scenario names: helloPython preserves C:/extension on POSIX hosts; helloPowerShell preserves C:/extension on POSIX hosts; collectCommitContext preserves C:/extension on POSIX hosts; newPotentialEntry preserves C:/extension on POSIX hosts.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/feature-audit.2026-04-05T20-45.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/feature-audit.2026-04-05T20-45.md
@@ -1,0 +1,65 @@
+# Feature Audit: 2026-04-05-ci-failing-error-128
+
+## Scope and Baseline
+
+- **Base Branch:** `development`
+- **Feature Folder:** `docs/features/active/2026-04-05-ci-failing-error-128/`
+- **Feature Folder Selection Rule:** Used the user-provided active feature folder and confirmed the same folder is referenced by the refreshed PR-context additional-context list.
+- **Evidence Sources:**
+  - Primary: `artifacts/pr_context.summary.txt` (refreshed during this review; commit-based)
+  - Secondary: `artifacts/pr_context.appendix.txt`
+  - Supplemental live evidence: `git status --short`, direct file inspection, and the live extension verification commands run during this review
+  - Feature evidence: `docs/features/active/2026-04-05-ci-failing-error-128/evidence/**`
+- **Work Mode:** `minor-audit`
+- **Authoritative AC Source:** `docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria`
+- **Non-required Docs Verification:** `spec.md` absent; `user-story.md` absent.
+- **Phase 0 Baseline Evidence Verification:** `evidence/baseline/` contains `phase0-instructions-read.md` and the required `p0-t2` through `p0-t8` baseline artifacts.
+- **Plan Checklist Reconciliation:** All checked plan items are backed by on-disk evidence files or direct file-content inspection of the touched source/test files.
+
+## Acceptance Criteria Inventory
+
+Authoritative acceptance criteria extracted only from the explicit `## Acceptance Criteria` section in `issue.md`:
+
+1. Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
+2. Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
+3. Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.
+
+## Acceptance Criteria Evaluation
+
+| Criterion | Status | Evidence | Verification Command(s) | Notes |
+|---|---|---|---|---|
+| Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts. | PASS | `extensions/drm-copilot/src/command-runtime.ts`; `evidence/regression-testing/p1-t8.green-jest.2026-04-05T20-12.md`; live targeted regression run at 20:45 | `Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; Pop-Location` | The drive-root guard remains in place and the named POSIX regression scenarios passed live. |
+| Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies. | PASS | `extension.test.ts`, `repo-automation-service.test.ts`, `evidence/final-qa/final-targeted-regressions.md`, live targeted regression run at 20:45 | Same targeted Jest command as above | The preserved regression assertions continue to require `C:/extension/resources/templates/...` paths. |
+| Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths. | PASS | `evidence/regression-testing/p1-t6.red-jest.2026-04-05T20-11.md`; `evidence/regression-testing/p1-t8.green-jest.2026-04-05T20-12.md`; `evidence/final-qa/final-jest-coverage.md`; live full unit-suite run at 20:45 (`11/11` suites, `140/140` tests) | `Push-Location extensions/drm-copilot; npm run test:unit; Pop-Location` | The feature has fail-before, pass-after, and fresh full-suite evidence. |
+
+## Additional Reduced-Audit Verification
+
+| Requirement | Status | Evidence | Notes |
+|---|---|---|---|
+| `spec.md` and `user-story.md` are absent | PASS | Feature-folder listing | Matches `minor-audit` requirements. |
+| Required Phase 0 baseline evidence exists | PASS | `evidence/baseline/phase0-instructions-read.md` and `p0-t2`–`p0-t8` artifacts | Baseline capture is complete. |
+| Plan checklist state is backed by evidence on disk | PASS | Baseline, regression, QA-gate, and remediation evidence folders plus direct source inspection | Checked checklist state is supportable from files on disk. |
+| Remediated touched test/helper files are each `<= 500` lines | PASS | `evidence/final-qa/final-scope-and-line-counts.md`; live line-count capture | All five touched test/helper files are below the cap. |
+| Code change remains within approved scope and remediation constraints | PASS | `issue.md`, `plan.2026-04-05T19-46.md`, `remediation-plan.2026-04-05T20-20.md`, live source inspection | Production scope remains the single approved fix; remediation broadens only companion test/helper layout as authorized. |
+
+## Summary
+
+**Overall feature readiness:** PASS
+
+The active small-path bug fix satisfies all three authoritative acceptance criteria from `issue.md`, the reduced-audit structural requirements are met, the remediation resolved the file-size policy blocker, and the live extension verification pass is green.
+
+**Top gaps preventing PASS:** None.
+
+**Recommended follow-up verification:** None required for the reduced audit. Commit the refreshed working-tree state and audit artifacts before PR preparation so PR-context-derived automation reflects the same content.
+
+## Acceptance Criteria Status
+
+- Source: `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`
+- Total AC items: 3
+- Checked off (delivered): 3
+- Remaining (unchecked): 0
+- Items remaining: None
+
+## Acceptance Criteria Check-Off
+
+No checkbox edits were required during this re-review. All three authoritative acceptance-criteria items were already marked `[x]` in `issue.md`, and the current evidence supports those checked states.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/issue.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/issue.md
@@ -43,9 +43,9 @@ The run ends with `Test Suites: 7 failed, 3 passed, 10 total`, `Tests: 18 failed
 
 ## Acceptance Criteria
 
-- [ ] Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
-- [ ] Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
-- [ ] Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.
+- [x] Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
+- [x] Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
+- [x] Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.
 
 ## Logs / Screenshots
 

--- a/docs/features/active/2026-04-05-ci-failing-error-128/issue.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/issue.md
@@ -1,0 +1,89 @@
+# ci-failing-error (Issue #128)
+
+- Date captured: 2026-04-05
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/ci-failing-error/ (Issue #128)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #128
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/128
+- Last Updated: 2026-04-05
+- Work Mode: minor-audit
+
+## Summary
+
+The `extensions/drm-copilot` Jest suite fails in Linux CI because bundled script paths are resolved incorrectly when the tests use Windows-style mocked `fsPath` values such as `C:/extension`. The shared runtime produces hybrid paths like `/home/runner/.../C:/extension/...`, which breaks assertions that verify commands run bundled extension resources.
+
+## Environment
+
+- OS/version: GitHub Actions hosted Linux runner (`ubuntu-latest` behavior; log paths are rooted under `/home/runner/work/...`)
+- Python version: Not material to the repro; the failure happens during Jest assertions before any bundled Python script logic runs
+- Command/flags used: `npm --prefix extensions/drm-copilot run test`
+- Data source or fixture: Jest command/runtime tests with mocked `extensionUri.fsPath = "C:/extension"` and workspace root `C:/workspace` in `extensions/drm-copilot/test/*.test.ts`
+
+## Steps to Reproduce
+
+1. On a Linux host or in GitHub Actions, run `npm --prefix extensions/drm-copilot run test` from the repository root.
+2. Let the extension Jest suite execute tests that assert bundled script execution uses the mocked extension install root `C:/extension`.
+3. Observe failures in tests such as `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` where the spawned argv contains `/home/runner/work/.../C:/extension/...` instead of the expected `C:/extension/...` path.
+
+## Expected Behavior
+
+Bundled resource paths should remain rooted at the mocked extension install directory, for example `C:/extension/resources/templates/hello_python.py`, regardless of whether the Jest host is Windows or Linux. The extension test suite should pass in CI with the same bundled-path assertions that pass on Windows-oriented fixtures.
+
+## Actual Behavior
+
+CI reports multiple failing extension tests because the resolved script path is prefixed with the Linux checkout directory. Representative failures include:
+
+- expected `C:/extension/resources/templates/hello_python.py`
+- received `/home/runner/work/drm-copilot/drm-copilot/extensions/drm-copilot/C:/extension/resources/templates/hello_python.py`
+
+The run ends with `Test Suites: 7 failed, 3 passed, 10 total`, `Tests: 18 failed, 118 passed, 136 total`, and exit code `1`.
+
+## Acceptance Criteria
+
+- [ ] Windows-style absolute extension roots such as `C:/extension` remain absolute when bundled script paths are resolved on POSIX hosts.
+- [ ] Bundled command and repo-automation script invocations continue to target extension resources rather than workspace-relative copies.
+- [ ] Regression coverage verifies the Windows-style mocked `fsPath` scenario and the extension Jest suite no longer fails with checkout-prefixed hybrid paths.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet:
+
+	`FAIL test/extension.test.ts`
+
+	`Expected: "C:/extension/resources/templates/hello_python.py"`
+
+	`Received: "/home/runner/work/drm-copilot/drm-copilot/extensions/drm-copilot/C:/extension/resources/templates/hello_python.py"`
+
+	`FAIL test/repo-automation-service.test.ts`
+
+	`Expected: "C:/extension/resources/templates/collect_commit_context.py"`
+
+	`Received: "/home/runner/work/drm-copilot/drm-copilot/extensions/drm-copilot/C:/extension/resources/templates/collect_commit_context.py"`
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+The likely fault is in `extensions/drm-copilot/src/command-runtime.ts`, where `resolveBundledScriptPath()` currently uses `path.resolve(extensionRoot, bundledRelativePath).replace(/\\/g, "/")`. On a POSIX host, Node treats a Windows-style string such as `C:/extension` as a relative path instead of an absolute drive path, so `path.resolve()` anchors it under the current working directory and produces `/home/runner/.../C:/extension/...`.
+
+This shared helper is used by both the command layer and the repo-automation service, which explains why the same malformed prefix appears in `extensions/drm-copilot/test/extension.test.ts` and `extensions/drm-copilot/test/repo-automation-service.test.ts`. The issue may be limited to cross-platform test execution with Windows-style fixtures, but it currently breaks CI and masks whether bundled-path handling remains stable across hosts.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas: add focused coverage for `resolveBundledScriptPath()` with both POSIX and Windows-style `extensionRoot` inputs, plus command/service call sites that consume the resolved path.
+- [ ] Integration scenario to retest: rerun `npm --prefix extensions/drm-copilot run test` on Linux CI after the fix and confirm the bundled-path assertions in `test/extension.test.ts`, `test/repo-automation-service.test.ts`, and other `C:/extension` fixture suites no longer prepend the checkout root.
+- [ ] Manual verification notes: capture the logged `resolved script path` emitted by `executeBundledScriptFromExtensionRoot()` and confirm it always points inside the extension install root rather than the repo checkout directory or workspace root.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md
@@ -124,39 +124,39 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 
 ### Phase 1 — Constrained small-path implementation placeholder
 
-- [ ] [P1-T1] Lock execution scope to `extensions/drm-copilot/src/command-runtime.ts`, `extensions/drm-copilot/test/extension.test.ts`, `extensions/drm-copilot/test/repo-automation-service.test.ts`, `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`, `docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md`, and evidence artifacts under this feature folder.
+- [x] [P1-T1] Lock execution scope to `extensions/drm-copilot/src/command-runtime.ts`, `extensions/drm-copilot/test/extension.test.ts`, `extensions/drm-copilot/test/repo-automation-service.test.ts`, `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`, `docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md`, and evidence artifacts under this feature folder.
 	- Acceptance:
 		- Exactly one artifact matching `docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t1.scope-lock.*.md` exists.
 		- The artifact contains `Allowed Files:` followed by the exact file list above.
 		- The artifact contains `Out-of-Scope: any second production TypeScript file`.
 		- The artifact contains `spec.md/user-story.md/research.md remain non-required minor-audit inputs`.
 
-- [ ] [P1-T2] [expect-fail] Add or update the `helloPython` Windows-root regression scenario in `extensions/drm-copilot/test/extension.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled Python script path remains `C:/extension/resources/templates/hello_python.py`.
+- [x] [P1-T2] [expect-fail] Add or update the `helloPython` Windows-root regression scenario in `extensions/drm-copilot/test/extension.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled Python script path remains `C:/extension/resources/templates/hello_python.py`.
 	- Acceptance:
 		- `extensions/drm-copilot/test/extension.test.ts` contains the exact scenario string `helloPython preserves C:/extension on POSIX hosts`.
 		- `extensions/drm-copilot/test/extension.test.ts` contains the exact expected path string `C:/extension/resources/templates/hello_python.py`.
 		- The scenario uses a mocked Windows-style `extensionUri.fsPath` value of `C:/extension`.
 		- No production file is modified by this task.
 
-- [ ] [P1-T3] [expect-fail] Add or update the `helloPowerShell` Windows-root regression scenario in `extensions/drm-copilot/test/extension.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled PowerShell script path stays under `C:/extension/resources/templates/` rather than the Linux checkout root.
+- [x] [P1-T3] [expect-fail] Add or update the `helloPowerShell` Windows-root regression scenario in `extensions/drm-copilot/test/extension.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled PowerShell script path stays under `C:/extension/resources/templates/` rather than the Linux checkout root.
 	- Acceptance:
 		- `extensions/drm-copilot/test/extension.test.ts` contains the exact scenario string `helloPowerShell preserves C:/extension on POSIX hosts`.
 		- The scenario asserts that the spawned script path starts with `C:/extension/resources/templates/`.
 		- No production file is modified by this task.
 
-- [ ] [P1-T4] [expect-fail] Add or update the `collectCommitContext` Windows-root regression scenario in `extensions/drm-copilot/test/repo-automation-service.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled repo-automation script path remains under `C:/extension/resources/templates/`.
+- [x] [P1-T4] [expect-fail] Add or update the `collectCommitContext` Windows-root regression scenario in `extensions/drm-copilot/test/repo-automation-service.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled repo-automation script path remains under `C:/extension/resources/templates/`.
 	- Acceptance:
 		- `extensions/drm-copilot/test/repo-automation-service.test.ts` contains the exact scenario string `collectCommitContext preserves C:/extension on POSIX hosts`.
 		- The scenario asserts that the spawned script path starts with `C:/extension/resources/templates/`.
 		- No production file is modified by this task.
 
-- [ ] [P1-T5] [expect-fail] Add or update the `newPotentialEntry` Windows-root regression scenario in `extensions/drm-copilot/test/repo-automation-service.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled repo-automation script path remains under `C:/extension/resources/templates/`.
+- [x] [P1-T5] [expect-fail] Add or update the `newPotentialEntry` Windows-root regression scenario in `extensions/drm-copilot/test/repo-automation-service.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled repo-automation script path remains under `C:/extension/resources/templates/`.
 	- Acceptance:
 		- `extensions/drm-copilot/test/repo-automation-service.test.ts` contains the exact scenario string `newPotentialEntry preserves C:/extension on POSIX hosts`.
 		- The scenario asserts that the spawned script path starts with `C:/extension/resources/templates/`.
 		- No production file is modified by this task.
 
-- [ ] [P1-T6] [expect-fail] Run the targeted red Jest command `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` before changing `extensions/drm-copilot/src/command-runtime.ts` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t6.red-jest.*.md`.
+- [x] [P1-T6] [expect-fail] Run the targeted red Jest command `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` before changing `extensions/drm-copilot/src/command-runtime.ts` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t6.red-jest.*.md`.
 	- Acceptance:
 		- Exactly one artifact matching `p1-t6.red-jest.*.md` exists.
 		- The artifact contains `Timestamp:`.
@@ -164,13 +164,13 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 		- `EXIT_CODE:` is non-zero.
 		- The artifact contains `Failure:` text naming at least one of the four targeted Windows-root scenarios.
 
-- [ ] [P1-T7] Apply the minimal production change in `extensions/drm-copilot/src/command-runtime.ts` so `resolveBundledScriptPath` preserves Windows drive-prefixed extension roots such as `C:/extension` as absolute paths when the host process runs on POSIX.
+- [x] [P1-T7] Apply the minimal production change in `extensions/drm-copilot/src/command-runtime.ts` so `resolveBundledScriptPath` preserves Windows drive-prefixed extension roots such as `C:/extension` as absolute paths when the host process runs on POSIX.
 	- Acceptance:
 		- No production TypeScript file outside `extensions/drm-copilot/src/command-runtime.ts` is modified.
 		- `extensions/drm-copilot/src/command-runtime.ts` still exports `resolveBundledScriptPath`.
 		- The updated helper contains a deterministic code path that treats `C:/extension`-style roots as absolute before joining the bundled relative path.
 
-- [ ] [P1-T8] Run the targeted green Jest command `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.*.md`.
+- [x] [P1-T8] Run the targeted green Jest command `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.*.md`.
 	- Acceptance:
 		- Exactly one artifact matching `p1-t8.green-jest.*.md` exists.
 		- The artifact contains `Timestamp:`.
@@ -178,7 +178,7 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 		- `EXIT_CODE:` is `0`.
 		- `Output Summary:` names `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` as passing Windows-root regression scenarios.
 
-- [ ] [P1-T9] Write the acceptance-criteria mapping artifact `docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t9.acceptance-mapping.*.md`.
+- [x] [P1-T9] Write the acceptance-criteria mapping artifact `docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t9.acceptance-mapping.*.md`.
 	- Acceptance:
 		- Exactly one artifact matching `p1-t9.acceptance-mapping.*.md` exists.
 		- The artifact contains `Requirements Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md`.
@@ -188,7 +188,7 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 
 ### Phase 2 — Final QC loop
 
-- [ ] [P2-T1] Run the final extension formatter command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t1.format.*.md`; if this command changes files or exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+- [x] [P2-T1] Run the final extension formatter command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t1.format.*.md`; if this command changes files or exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
 	- Acceptance:
 		- Exactly one artifact matching `p2-t1.format.*.md` exists.
 		- The artifact contains `Timestamp:`.
@@ -196,7 +196,7 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 		- `EXIT_CODE:` is `0`.
 		- `Output Summary:` states either `formatted files` or `already formatted after final pass`.
 
-- [ ] [P2-T2] Run the final extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t2.lint.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+- [x] [P2-T2] Run the final extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t2.lint.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
 	- Acceptance:
 		- Exactly one artifact matching `p2-t2.lint.*.md` exists.
 		- The artifact contains `Timestamp:`.
@@ -204,7 +204,7 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 		- `EXIT_CODE:` is `0`.
 		- `Output Summary:` states that ESLint passed with no remaining blocking diagnostics.
 
-- [ ] [P2-T3] Run the final extension type-check command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t3.typecheck.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+- [x] [P2-T3] Run the final extension type-check command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t3.typecheck.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
 	- Acceptance:
 		- Exactly one artifact matching `p2-t3.typecheck.*.md` exists.
 		- The artifact contains `Timestamp:`.
@@ -212,7 +212,7 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 		- `EXIT_CODE:` is `0`.
 		- `Output Summary:` states that TypeScript type-checking passed with zero blocking diagnostics.
 
-- [ ] [P2-T4] Run the final extension unit-test command `npm --prefix extensions/drm-copilot run test:unit` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+- [x] [P2-T4] Run the final extension unit-test command `npm --prefix extensions/drm-copilot run test:unit` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
 	- Acceptance:
 		- Exactly one artifact matching `p2-t4.test-unit.*.md` exists.
 		- The artifact contains `Timestamp:`.
@@ -220,12 +220,12 @@ This minor-audit plan constrains Issue #128 to a small TypeScript fix in the ext
 		- `EXIT_CODE:` is `0`.
 		- `Output Summary:` reports suite and test totals and explicitly states that the Windows-root bundled-path regression scenarios for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` passed.
 
-- [ ] [P2-T5] Restart the QC loop from `[P2-T1]` if any command in `[P2-T1]` through `[P2-T4]` changes files or fails.
+- [x] [P2-T5] Restart the QC loop from `[P2-T1]` if any command in `[P2-T1]` through `[P2-T4]` changes files or fails.
 	- Acceptance:
 		- One clean consecutive iteration completes with `EXIT_CODE: 0` for `[P2-T1]`, `[P2-T2]`, `[P2-T3]`, and `[P2-T4]`.
 		- The final pass leaves no formatter-induced file changes pending.
 
-- [ ] [P2-T6] Write the clean-pass summary artifact `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t6.clean-pass-summary.*.md`.
+- [x] [P2-T6] Write the clean-pass summary artifact `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t6.clean-pass-summary.*.md`.
 	- Acceptance:
 		- Exactly one artifact matching `p2-t6.clean-pass-summary.*.md` exists.
 		- The artifact cites the exact artifact paths produced by `[P2-T1]`, `[P2-T2]`, `[P2-T3]`, and `[P2-T4]`.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md
@@ -1,0 +1,234 @@
+---
+title: "2026-04-05-ci-failing-error"
+issue: 128
+owner: "drmoisan"
+work_mode: "minor-audit"
+status: "Planned"
+status_color: "blue"
+last_updated: "2026-04-05T19-46"
+source_of_truth: "docs/features/active/2026-04-05-ci-failing-error-128/issue.md"
+plan_path: "docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md"
+---
+
+# 2026-04-05-ci-failing-error (Minimal-Audit Plan)
+
+## Overview
+
+This minor-audit plan constrains Issue #128 to a small TypeScript fix in the extension bundled-path runtime plus focused Jest regression coverage for the Windows-style `C:/extension` fixture path that currently breaks Linux CI. `issue.md` is the only requirements source, and only its explicit `## Acceptance Criteria` section is authoritative for acceptance tracking.
+
+## Deterministic Inputs
+
+- Sole requirements source: `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`
+- Acceptance criteria source: `docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria`
+- Non-required documents: `docs/features/active/2026-04-05-ci-failing-error-128/spec.md`, `docs/features/active/2026-04-05-ci-failing-error-128/user-story.md`, and `docs/features/active/2026-04-05-ci-failing-error-128/research.md`
+- Constrained production target: `extensions/drm-copilot/src/command-runtime.ts`
+- Constrained regression targets: `extensions/drm-copilot/test/extension.test.ts` and `extensions/drm-copilot/test/repo-automation-service.test.ts`
+- Focused baseline reproduction surface: the bundled-path Jest scenarios named in `issue.md` for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry`
+
+## Deterministic Constraints
+
+- `CON-001`: Use `issue.md` only; do not require, cite, or create `spec.md`, `user-story.md`, or `research.md`.
+- `CON-002`: Keep exactly three phases in this order: Phase 0 baseline capture, Phase 1 constrained small-path implementation placeholder, Phase 2 final QC loop.
+- `CON-003`: Keep production-code scope limited to `extensions/drm-copilot/src/command-runtime.ts`; any second production file requires replanning.
+- `CON-004`: Keep Jest regression scope limited to `extensions/drm-copilot/test/extension.test.ts` and `extensions/drm-copilot/test/repo-automation-service.test.ts`; do not create additional test modules.
+- `CON-005`: Every evidence artifact named in this plan must include `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` when it records a command step.
+- `CON-006`: Phase 0 must include `phase0-instructions-read.md` plus one baseline artifact per baseline command step.
+- `CON-007`: Phase 2 command tasks are unconditional and executor-facing; no Phase 2 command in this plan may be treated as in-scope/out-of-scope or recorded as skipped.
+- `CON-008`: If any Phase 2 command changes files or fails, the executor must restart the QC loop from `[P2-T1]` and record the clean pass artifacts from that final iteration.
+- `CON-009`: Only the three checkbox items under `issue.md` → `## Acceptance Criteria` may be checked off, and only after the supporting evidence named in this plan exists.
+
+## Small-Path Directives
+
+`DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`
+
+`DIRECTIVE: PREFLIGHT VALIDATION ONLY`
+
+## Evidence Naming Rules
+
+- Store baseline artifacts under `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/`.
+- Store targeted regression artifacts under `docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/`.
+- Store implementation and acceptance-mapping artifacts under `docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/`.
+- Store final QC artifacts under `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/`.
+- Use ISO-8601 timestamps in filenames with the format `yyyy-MM-ddTHH-mm`.
+
+### Phase 0 — Baseline capture
+
+- [x] [P0-T1] Read the mandatory policy files in repository order and write `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/phase0-instructions-read.md`.
+	- Acceptance:
+		- The artifact exists at the exact path above.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Policy Order:`.
+		- The artifact lists these exact files in order: `.github/copilot-instructions.md`, `.github/instructions/general-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, `.github/instructions/typescript-code-change.instructions.md`, `.github/instructions/typescript-unit-test.instructions.md`, `.github/instructions/typescript-suppressions.instructions.md`.
+		- The artifact contains `Work Mode: minor-audit`.
+		- The artifact contains `Acceptance Criteria Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria`.
+
+- [x] [P0-T2] Verify the minor-audit requirements scope and write `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t2.requirements-scope.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p0-t2.requirements-scope.*.md` exists.
+		- The artifact contains `Work Mode: minor-audit`.
+		- The artifact contains `Requirements Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md`.
+		- The artifact contains `Acceptance Criteria Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria`.
+		- The artifact contains `spec.md: not required`.
+		- The artifact contains `user-story.md: not required`.
+		- The artifact contains `research.md: not required`.
+		- The artifact contains `Production Target: extensions/drm-copilot/src/command-runtime.ts`.
+		- The artifact contains `Regression Targets: extensions/drm-copilot/test/extension.test.ts, extensions/drm-copilot/test/repo-automation-service.test.ts`.
+
+- [x] [P0-T3] Run the focused baseline reproduction command `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t3.focused-repro.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p0-t3.focused-repro.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"`.
+		- The artifact contains `EXIT_CODE:`.
+		- `Output Summary:` states whether the focused repro passed or failed and names the first observed hybrid-path diagnostic if the command fails.
+
+- [x] [P0-T4] Run the baseline extension formatter command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t4.format.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p0-t4.format.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run format`.
+		- The artifact contains `EXIT_CODE:`.
+		- `Output Summary:` states either `formatted files` or `no formatting changes reported`.
+
+- [x] [P0-T5] Run the baseline extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t5.lint.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p0-t5.lint.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run lint`.
+		- The artifact contains `EXIT_CODE:`.
+		- `Output Summary:` states either `passed` or names the first blocking ESLint diagnostic.
+
+- [x] [P0-T6] Run the baseline extension type-check command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t6.typecheck.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p0-t6.typecheck.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run typecheck`.
+		- The artifact contains `EXIT_CODE:`.
+		- `Output Summary:` states either `passed` or names the first blocking TypeScript diagnostic.
+
+- [x] [P0-T7] Run the baseline extension unit-test command `npm --prefix extensions/drm-copilot run test:unit` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t7.test-unit.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p0-t7.test-unit.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run test:unit`.
+		- The artifact contains `EXIT_CODE:`.
+		- `Output Summary:` reports suite and test totals and names the first failing bundled-path scenario if the command fails.
+
+- [x] [P0-T8] Record the constrained small-path scope in `docs/features/active/2026-04-05-ci-failing-error-128/evidence/baseline/p0-t8.small-path-scope.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p0-t8.small-path-scope.*.md` exists.
+		- The artifact contains `Budget: 1 production TypeScript file + 2 Jest modules`.
+		- The artifact contains `Production Target: extensions/drm-copilot/src/command-runtime.ts`.
+		- The artifact contains `Regression Targets: extensions/drm-copilot/test/extension.test.ts, extensions/drm-copilot/test/repo-automation-service.test.ts`.
+		- The artifact copies the exact three checkbox texts from `issue.md` under `## Acceptance Criteria`.
+
+### Phase 1 — Constrained small-path implementation placeholder
+
+- [ ] [P1-T1] Lock execution scope to `extensions/drm-copilot/src/command-runtime.ts`, `extensions/drm-copilot/test/extension.test.ts`, `extensions/drm-copilot/test/repo-automation-service.test.ts`, `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`, `docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md`, and evidence artifacts under this feature folder.
+	- Acceptance:
+		- Exactly one artifact matching `docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t1.scope-lock.*.md` exists.
+		- The artifact contains `Allowed Files:` followed by the exact file list above.
+		- The artifact contains `Out-of-Scope: any second production TypeScript file`.
+		- The artifact contains `spec.md/user-story.md/research.md remain non-required minor-audit inputs`.
+
+- [ ] [P1-T2] [expect-fail] Add or update the `helloPython` Windows-root regression scenario in `extensions/drm-copilot/test/extension.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled Python script path remains `C:/extension/resources/templates/hello_python.py`.
+	- Acceptance:
+		- `extensions/drm-copilot/test/extension.test.ts` contains the exact scenario string `helloPython preserves C:/extension on POSIX hosts`.
+		- `extensions/drm-copilot/test/extension.test.ts` contains the exact expected path string `C:/extension/resources/templates/hello_python.py`.
+		- The scenario uses a mocked Windows-style `extensionUri.fsPath` value of `C:/extension`.
+		- No production file is modified by this task.
+
+- [ ] [P1-T3] [expect-fail] Add or update the `helloPowerShell` Windows-root regression scenario in `extensions/drm-copilot/test/extension.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled PowerShell script path stays under `C:/extension/resources/templates/` rather than the Linux checkout root.
+	- Acceptance:
+		- `extensions/drm-copilot/test/extension.test.ts` contains the exact scenario string `helloPowerShell preserves C:/extension on POSIX hosts`.
+		- The scenario asserts that the spawned script path starts with `C:/extension/resources/templates/`.
+		- No production file is modified by this task.
+
+- [ ] [P1-T4] [expect-fail] Add or update the `collectCommitContext` Windows-root regression scenario in `extensions/drm-copilot/test/repo-automation-service.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled repo-automation script path remains under `C:/extension/resources/templates/`.
+	- Acceptance:
+		- `extensions/drm-copilot/test/repo-automation-service.test.ts` contains the exact scenario string `collectCommitContext preserves C:/extension on POSIX hosts`.
+		- The scenario asserts that the spawned script path starts with `C:/extension/resources/templates/`.
+		- No production file is modified by this task.
+
+- [ ] [P1-T5] [expect-fail] Add or update the `newPotentialEntry` Windows-root regression scenario in `extensions/drm-copilot/test/repo-automation-service.test.ts` so a mocked `extensionUri.fsPath = "C:/extension"` on a POSIX host asserts the bundled repo-automation script path remains under `C:/extension/resources/templates/`.
+	- Acceptance:
+		- `extensions/drm-copilot/test/repo-automation-service.test.ts` contains the exact scenario string `newPotentialEntry preserves C:/extension on POSIX hosts`.
+		- The scenario asserts that the spawned script path starts with `C:/extension/resources/templates/`.
+		- No production file is modified by this task.
+
+- [ ] [P1-T6] [expect-fail] Run the targeted red Jest command `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` before changing `extensions/drm-copilot/src/command-runtime.ts` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t6.red-jest.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p1-t6.red-jest.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"`.
+		- `EXIT_CODE:` is non-zero.
+		- The artifact contains `Failure:` text naming at least one of the four targeted Windows-root scenarios.
+
+- [ ] [P1-T7] Apply the minimal production change in `extensions/drm-copilot/src/command-runtime.ts` so `resolveBundledScriptPath` preserves Windows drive-prefixed extension roots such as `C:/extension` as absolute paths when the host process runs on POSIX.
+	- Acceptance:
+		- No production TypeScript file outside `extensions/drm-copilot/src/command-runtime.ts` is modified.
+		- `extensions/drm-copilot/src/command-runtime.ts` still exports `resolveBundledScriptPath`.
+		- The updated helper contains a deterministic code path that treats `C:/extension`-style roots as absolute before joining the bundled relative path.
+
+- [ ] [P1-T8] Run the targeted green Jest command `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/regression-testing/p1-t8.green-jest.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p1-t8.green-jest.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"`.
+		- `EXIT_CODE:` is `0`.
+		- `Output Summary:` names `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` as passing Windows-root regression scenarios.
+
+- [ ] [P1-T9] Write the acceptance-criteria mapping artifact `docs/features/active/2026-04-05-ci-failing-error-128/evidence/other/p1-t9.acceptance-mapping.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p1-t9.acceptance-mapping.*.md` exists.
+		- The artifact contains `Requirements Source: docs/features/active/2026-04-05-ci-failing-error-128/issue.md`.
+		- The artifact copies the exact three checkbox texts from `issue.md` under `## Acceptance Criteria`.
+		- The artifact maps each checkbox text to supporting evidence from `p1-t8.green-jest.*.md` and the final QC artifact from `[P2-T4]`.
+		- The artifact contains the exact sentence `Only issue.md acceptance-criteria checkboxes may be changed from - [ ] to - [x] after supporting evidence exists; preserve the checkbox text exactly.`
+
+### Phase 2 — Final QC loop
+
+- [ ] [P2-T1] Run the final extension formatter command `npm --prefix extensions/drm-copilot run format` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t1.format.*.md`; if this command changes files or exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+	- Acceptance:
+		- Exactly one artifact matching `p2-t1.format.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run format`.
+		- `EXIT_CODE:` is `0`.
+		- `Output Summary:` states either `formatted files` or `already formatted after final pass`.
+
+- [ ] [P2-T2] Run the final extension lint command `npm --prefix extensions/drm-copilot run lint` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t2.lint.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+	- Acceptance:
+		- Exactly one artifact matching `p2-t2.lint.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run lint`.
+		- `EXIT_CODE:` is `0`.
+		- `Output Summary:` states that ESLint passed with no remaining blocking diagnostics.
+
+- [ ] [P2-T3] Run the final extension type-check command `npm --prefix extensions/drm-copilot run typecheck` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t3.typecheck.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+	- Acceptance:
+		- Exactly one artifact matching `p2-t3.typecheck.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run typecheck`.
+		- `EXIT_CODE:` is `0`.
+		- `Output Summary:` states that TypeScript type-checking passed with zero blocking diagnostics.
+
+- [ ] [P2-T4] Run the final extension unit-test command `npm --prefix extensions/drm-copilot run test:unit` and save the result to `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t4.test-unit.*.md`; if this command exits non-zero, resume the QC loop from `[P2-T1]` after corrections.
+	- Acceptance:
+		- Exactly one artifact matching `p2-t4.test-unit.*.md` exists.
+		- The artifact contains `Timestamp:`.
+		- The artifact contains `Command: npm --prefix extensions/drm-copilot run test:unit`.
+		- `EXIT_CODE:` is `0`.
+		- `Output Summary:` reports suite and test totals and explicitly states that the Windows-root bundled-path regression scenarios for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` passed.
+
+- [ ] [P2-T5] Restart the QC loop from `[P2-T1]` if any command in `[P2-T1]` through `[P2-T4]` changes files or fails.
+	- Acceptance:
+		- One clean consecutive iteration completes with `EXIT_CODE: 0` for `[P2-T1]`, `[P2-T2]`, `[P2-T3]`, and `[P2-T4]`.
+		- The final pass leaves no formatter-induced file changes pending.
+
+- [ ] [P2-T6] Write the clean-pass summary artifact `docs/features/active/2026-04-05-ci-failing-error-128/evidence/qa-gates/p2-t6.clean-pass-summary.*.md`.
+	- Acceptance:
+		- Exactly one artifact matching `p2-t6.clean-pass-summary.*.md` exists.
+		- The artifact cites the exact artifact paths produced by `[P2-T1]`, `[P2-T2]`, `[P2-T3]`, and `[P2-T4]`.
+		- The artifact reports final PASS or FAIL status for each of the three acceptance criteria copied from `issue.md`, with citations to `p1-t8.green-jest.*.md` and `p2-t4.test-unit.*.md`.
+		- The artifact contains the exact sentence `No Phase 2 command task was skipped.`
+		- The artifact contains `Non-Required Docs Confirmed: spec.md not required; user-story.md not required; research.md not required`.

--- a/docs/features/active/2026-04-05-ci-failing-error-128/policy-audit.2026-04-05T20-45.md
+++ b/docs/features/active/2026-04-05-ci-failing-error-128/policy-audit.2026-04-05T20-45.md
@@ -1,0 +1,142 @@
+# Policy Compliance Audit: 2026-04-05-ci-failing-error-128
+
+**Audit Date:** 2026-04-05  
+**Base Branch:** `development`  
+**Work Mode:** `minor-audit`  
+**Feature Folder Selection Rule:** Used the user-specified active feature folder `docs/features/active/2026-04-05-ci-failing-error-128/` and confirmed it is the folder referenced by the refreshed PR-context additional-context entries.  
+**Acceptance Criteria Source:** `docs/features/active/2026-04-05-ci-failing-error-128/issue.md#acceptance-criteria`
+
+**Code Under Test:**
+- `extensions/drm-copilot/src/command-runtime.ts`
+- `extensions/drm-copilot/test/extension.test.ts`
+- `extensions/drm-copilot/test/extension.workflow-commands.test.ts`
+- `extensions/drm-copilot/test/extension-test-harness.ts`
+- `extensions/drm-copilot/test/runtime-test-helpers.ts`
+- `extensions/drm-copilot/test/repo-automation-service.test.ts`
+- `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`
+- `docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md`
+
+## Coverage Metrics by Language
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| TypeScript | 6 runtime/test files in the remediated working tree | Jest unit tests | [✅] 11 passed, 0 failed | `baseline-jest-coverage.md` captured pre-remediation baseline for review scope | `final-jest-coverage.md` reports 89.36% lines, 89.36% statements, 88.69% functions, 81.61% branches | N/A for remediation refresh; no new production code beyond the already-reviewed `command-runtime.ts` fix |
+
+## Executive Summary
+
+[✅] [PASS] The reduced audit now passes.
+
+The current remediated working tree satisfies the repository policy gates that were previously blocking PR readiness. The live verification pass completed cleanly in this review with Prettier check, ESLint, TypeScript type-checking, the focused Windows-root regression slice, and the full extension Jest suite all returning exit code `0`. The remediated touched test/helper files are each under the 500-line limit, `spec.md` and `user-story.md` remain absent as required for `minor-audit`, Phase 0 baseline evidence exists on disk, and the production-code scope remains limited to the already-approved fix in `extensions/drm-copilot/src/command-runtime.ts`.
+
+**Policy documents evaluated:**
+- [✅] `.github/instructions/general-code-change.instructions.md`
+- [✅] `.github/instructions/general-unit-test.instructions.md`
+- [✅] `.github/instructions/typescript-code-change.instructions.md`
+- [✅] `.github/instructions/typescript-unit-test.instructions.md`
+- [✅] `.github/instructions/typescript-suppressions.instructions.md`
+
+**Evidence note:** the refreshed `artifacts/pr_context.summary.txt` remains commit-based and therefore still reflects `HEAD` rather than the unstaged remediation working tree. This audit supplements PR-context evidence with live `git status --short`, direct file inspection, on-disk remediation evidence, and fresh terminal verification results captured during this review.
+
+**Temporary artifacts cleanup:**
+- [✅] [PASS] No temporary one-off scripts were introduced by the remediation reviewed here.
+
+## 1. General Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Independence | [✅] [PASS] | Jest tests rely on mocked `node:fs`, `node:child_process`, and mocked VS Code APIs. Each suite resets shared harness state in `beforeEach`/`afterEach`; no external services or temp files are used. |
+| Isolation | [✅] [PASS] | `extension.test.ts`, `extension.workflow-commands.test.ts`, and `repo-automation-service.test.ts` each target specific command/runtime behaviors. The fresh-module POSIX-path scenarios isolate the Windows-root behavior explicitly. |
+| Fast Execution | [✅] [PASS] | Live targeted run: 0.368 s for 22 tests in 2 suites. Live full suite: 1.033 s for 140 tests in 11 suites. |
+| Determinism | [✅] [PASS] | Tests use mocked PATH/PATHEXT values, mocked subprocesses, mocked workspace folders, and fresh module loading for `node:path` POSIX semantics. No network or filesystem writes occur. |
+| Readability & Maintainability | [✅] [PASS] | Remediation split the oversized `extension.test.ts` into focused files and extracted reusable helper logic into `extension-test-harness.ts` and `runtime-test-helpers.ts`, improving navigability while keeping named regression scenarios intact. |
+| Baseline Coverage Documented | [✅] [PASS] | `evidence/remediation-baseline/baseline-jest-coverage.md` and `evidence/remediation-baseline/baseline-line-counts.md` document the pre-remediation baseline, including the 918-line violation in `extension.test.ts`. |
+| No Coverage Regression | [✅] [PASS] | `evidence/final-qa/final-jest-coverage.md` reports a passing full coverage run after remediation. The remediation changed only test/helper layout, not production logic, and preserved the previously reviewed `command-runtime.ts` production coverage reference at 93.46% lines / 92.30% functions. |
+| New Code Coverage ≥90% | [✅] [PASS] | The remediation did not introduce new production behavior; it reorganized test/helper files only. For the feature fix itself, the named regression coverage remains present and green in both focused and full-suite runs. |
+| Comprehensive Coverage | [✅] [PASS] | The four authoritative Windows-root regressions remain present exactly as named and pass in both targeted and full-suite execution. Existing command and workflow command suites also pass. |
+| Positive / Negative / Edge / Error Scenarios | [✅] [PASS] | Positive flows, missing-runtime failures, no-workspace failures, non-zero subprocess exits, and Windows-root POSIX edge cases are all represented in the touched Jest files. |
+| External Dependencies Avoided | [✅] [PASS] | All touched tests use mocks/stubs; no external services, network calls, or temp files are required. |
+| Pre-submission Review | [✅] [PASS] | This audit, together with the companion code review and feature audit, serves as the required review artifact set for the refreshed reduced audit. |
+
+## 2. General Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Clarify the objective | [✅] [PASS] | Objective remained the approved small-path bug fix for Issue #128, plus remediation of the touched test-file size violation. Source files: `issue.md`, `plan.2026-04-05T19-46.md`, and `remediation-plan.2026-04-05T20-20.md`. |
+| Read existing change plans | [✅] [PASS] | Reviewed the approved plan and remediation plan during this re-review. |
+| Document the plan | [✅] [PASS] | Plan and remediation plan both exist in the feature folder and the checked checklist state matches on-disk evidence. |
+| Simplicity first | [✅] [PASS] | Production behavior remains a single targeted guard in `resolveBundledScriptPath`; remediation solved maintainability by extracting helpers rather than expanding production scope. |
+| Reusability | [✅] [PASS] | Shared fresh-module and process-mock logic now lives in `extension-test-harness.ts` and `runtime-test-helpers.ts` instead of remaining duplicated inside oversized test files. |
+| Separation of concerns | [✅] [PASS] | The production helper remains in `command-runtime.ts`; command-level tests and reusable harness helpers are now separated into dedicated test modules. |
+| Cohesive modules | [✅] [PASS] | Each touched test/helper file has a focused role: core command behavior, workflow commands, extension harness, runtime helpers, and repo automation behavior. |
+| Under 500 lines | [✅] [PASS] | Live line counts: `extension.test.ts` 251, `extension.workflow-commands.test.ts` 393, `extension-test-harness.ts` 244, `runtime-test-helpers.ts` 135, `repo-automation-service.test.ts` 234. |
+| Naming, docs, and comments | [✅] [PASS] | Helper names are descriptive and comments explain rationale for mocked fresh-module loading and POSIX path behavior. No new broad suppressions were introduced. |
+| Toolchain execution | [✅] [PASS] | Live review pass completed cleanly: Prettier check → ESLint → TypeScript typecheck → focused targeted Jest → full extension Jest. All commands returned exit code `0` in one pass. |
+| Update supporting documents | [✅] [PASS] | `issue.md` acceptance criteria are checked and supported by evidence; plan and remediation artifacts remain present. This review adds refreshed audit artifacts only. |
+| Provide next steps | [✅] [PASS] | Current recommendation is ready for PR on content/policy grounds; no further remediation plan is required. |
+
+## 3. TypeScript Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Formatting baseline | [✅] [PASS] | Live command `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; Pop-Location` returned `0` with `All matched files use Prettier code style!`. |
+| ESLint baseline | [✅] [PASS] | Live command `Push-Location extensions/drm-copilot; npm run lint; Pop-Location` returned `0`. |
+| Type checking baseline | [✅] [PASS] | Live command `Push-Location extensions/drm-copilot; npm run typecheck; Pop-Location` returned `0`. |
+| Avoid `any` / maintain strong typing | [✅] [PASS] | The remediated helpers use explicit types (`ExecutablePresence`, `MockExistsSync`, `MockChildProcess`, imported runtime types). No new `any` or broad `@ts-ignore` was introduced. |
+| No unauthorized suppressions | [✅] [PASS] | The touched files use only narrow pre-existing/pre-authorized single-line `eslint-disable-next-line @typescript-eslint/no-require-imports -- ...` comments with local justification for Jest fresh-module loading. No `@ts-ignore` or file-level disables were added. |
+| Public API compatibility | [✅] [PASS] | `resolveBundledScriptPath` remains exported from `command-runtime.ts`; remediation did not broaden production APIs. |
+| Security and subprocess safety | [✅] [PASS] | Touched tests continue asserting argv-array subprocess execution with `shell: false`; no unsafe runtime behavior was introduced by remediation. |
+
+## 4. TypeScript Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| Use Jest | [✅] [PASS] | All touched tests are Jest suites under `extensions/drm-copilot/test/*.ts`. |
+| Focused unit tests | [✅] [PASS] | The regression scenarios remain one-behavior-per-test and are now split into logically focused files. |
+| Arrange-Act-Assert | [✅] [PASS] | Touched tests consistently set mocked state, invoke a handler/service, and assert argv/output behavior. |
+| Targeted mocking | [✅] [PASS] | Only VS Code host APIs, `node:fs`, `node:child_process`, and fresh `node:path` semantics are mocked where required. |
+| Clear naming | [✅] [PASS] | Required scenario names remain unchanged and descriptive, including the four Windows-root POSIX regressions. |
+| Toolchain uses Jest | [✅] [PASS] | Live commands used Jest via `npm run test:unit` for both targeted and full-suite verification. |
+
+## 5. Reduced-Audit Requirement Verification
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| `spec.md` absent | [✅] [PASS] | Feature-folder listing contains no `spec.md`. |
+| `user-story.md` absent | [✅] [PASS] | Feature-folder listing contains no `user-story.md`. |
+| Required Phase 0 baseline evidence exists | [✅] [PASS] | `evidence/baseline/` contains `phase0-instructions-read.md`, `p0-t2.requirements-scope.2026-04-05T19-57.md`, `p0-t3.focused-repro.2026-04-05T19-57.md`, `p0-t4.format.2026-04-05T19-57.md`, `p0-t5.lint.2026-04-05T19-57.md`, `p0-t6.typecheck.2026-04-05T19-57.md`, `p0-t7.test-unit.2026-04-05T19-57.md`, and `p0-t8.small-path-scope.2026-04-05T19-57.md`. |
+| Plan checklist backed by evidence on disk | [✅] [PASS] | Phase 0 tasks are backed by baseline artifacts; `P1-T1`, `P1-T6`, `P1-T8`, and `P1-T9` are backed by `evidence/other/` and `evidence/regression-testing/`; `P2-T1`–`P2-T4` and `P2-T6` are backed by `evidence/qa-gates/`; `P2-T5` is backed by `p2-t6.clean-pass-summary.2026-04-05T20-14.md` plus this review’s clean live pass. File-content tasks `P1-T2`–`P1-T5` and `P1-T7` are backed by direct inspection of the current touched `.ts` files on disk. |
+| Remediated touched test/helper files are each `<= 500` lines | [✅] [PASS] | Verified by both `evidence/final-qa/final-scope-and-line-counts.md` and live line-count capture at 20:45. |
+| Code change remains within approved scope and remediation constraints | [✅] [PASS] | Production scope remains limited to the already-approved `extensions/drm-copilot/src/command-runtime.ts` fix. Remediation introduced only companion test/helper files explicitly permitted by `remediation-inputs.2026-04-05T20-20.md` and `remediation-plan.2026-04-05T20-20.md`. |
+
+## 6. Gaps and Exceptions
+
+**Identified Gaps:** None.
+
+**Approved Exceptions:** None.
+
+**Removed/Skipped Tests:** None during this review. The targeted and full-suite commands both ran successfully.
+
+## 7. Compliance Verdict
+
+### Overall Status: [✅] FULLY COMPLIANT
+
+The reduced audit now passes. The original behavioral acceptance criteria remain satisfied, the previous 500-line policy violation is resolved, the live toolchain checks pass in a single clean pass, and the remediated working tree stays inside the approved bug-fix scope and remediation constraints.
+
+### Recommendation
+
+**Ready for merge** after the current working-tree changes and refreshed audit artifacts are committed and pushed for PR review.
+
+## Appendix A: Toolchain Commands Reference
+
+- `poetry run python -m scripts.dev_tools.pr_context.collector --base development`
+- `git branch --show-current`
+- `git status --short`
+- `git diff --name-status origin/development...HEAD`
+- `Push-Location extensions/drm-copilot; npx prettier --check "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"; Pop-Location`
+- `Push-Location extensions/drm-copilot; npm run lint; Pop-Location`
+- `Push-Location extensions/drm-copilot; npm run typecheck; Pop-Location`
+- `Push-Location extensions/drm-copilot; npm run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"; Pop-Location`
+- `Push-Location extensions/drm-copilot; npm run test:unit; Pop-Location`
+
+**Audit Completed By:** GitHub Copilot  
+**Policy Version:** Current as of 2026-04-05

--- a/extensions/drm-copilot/src/command-runtime.ts
+++ b/extensions/drm-copilot/src/command-runtime.ts
@@ -247,6 +247,18 @@ export function resolveBundledScriptPath(
   extensionRoot: string,
   bundledRelativePath: string,
 ): string {
+  const normalizedExtensionRoot = extensionRoot.replace(/\\/g, "/");
+  const normalizedBundledRelativePath = bundledRelativePath
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "");
+
+  // Preserve Windows drive-prefixed roots as absolute paths even when the host
+  // process uses POSIX path semantics, where `path.resolve` would otherwise
+  // treat `C:/...` as a relative segment and prefix the checkout directory.
+  if (/^[A-Za-z]:\//.test(normalizedExtensionRoot)) {
+    return `${normalizedExtensionRoot.replace(/\/+$/, "")}/${normalizedBundledRelativePath}`;
+  }
+
   return path.resolve(extensionRoot, bundledRelativePath).replace(/\\/g, "/");
 }
 

--- a/extensions/drm-copilot/test/extension-test-harness.ts
+++ b/extensions/drm-copilot/test/extension-test-harness.ts
@@ -1,0 +1,244 @@
+import { jest } from "@jest/globals";
+import {
+  createMockProcess,
+  createMockProcessWithStderr,
+  getFreshChildProcessMock,
+  getFreshFsMock,
+  prepareFreshModulesWithPosixPathResolve,
+  setExecutablePresenceOnFsMock,
+  type ExecutablePresence,
+  type MockChildProcess,
+  type MockExistsSync,
+} from "./runtime-test-helpers";
+
+type CommandHandler = (...args: unknown[]) => Promise<void> | void;
+
+const commandHandlers = new Map<string, CommandHandler>();
+const appendLineMock = jest.fn<(line: string) => void>();
+const showInputBoxMock = jest.fn();
+const showQuickPickMock = jest.fn();
+const registerCommandMock = jest.fn(
+  (command: string, handler: CommandHandler) => {
+    commandHandlers.set(command, handler);
+    return { dispose: jest.fn() };
+  },
+);
+
+let quickPickResultLabel: string | undefined = "origin/main";
+let workspaceFoldersState: Array<{ uri: { fsPath: string } }> | undefined = [
+  { uri: { fsPath: "C:/workspace" } },
+];
+
+const registerMcpServerDefinitionProviderMock = jest.fn(() => ({
+  dispose: jest.fn(),
+}));
+
+jest.mock(
+  "vscode",
+  () => ({
+    commands: {
+      registerCommand: registerCommandMock,
+    },
+    window: {
+      createOutputChannel: jest.fn(() => ({
+        appendLine: appendLineMock,
+        dispose: jest.fn(),
+      })),
+      showInputBox: showInputBoxMock,
+      showQuickPick: showQuickPickMock,
+    },
+    workspace: {
+      get workspaceFolders() {
+        return workspaceFoldersState;
+      },
+    },
+    Uri: {
+      joinPath: jest.fn((base: { fsPath: string }, ...segments: string[]) => ({
+        fsPath: `${base.fsPath}/${segments.join("/")}`,
+      })),
+    },
+    lm: {
+      registerMcpServerDefinitionProvider:
+        registerMcpServerDefinitionProviderMock,
+    },
+    EventEmitter: jest.fn(() => ({
+      event: jest.fn(),
+      dispose: jest.fn(),
+    })),
+    McpStdioServerDefinition: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock("node:child_process", () => ({
+  spawn: jest.fn(),
+  spawnSync: jest.fn(),
+}));
+
+const fsMock = jest.requireMock("node:fs") as {
+  existsSync: MockExistsSync;
+};
+
+const childProcessMock = jest.requireMock("node:child_process") as {
+  spawn: jest.Mock;
+  spawnSync: jest.Mock;
+};
+
+function getExtensionModule(): typeof import("../src/extension") {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- the harness must load the mocked extension module graph used by Jest tests
+  return require("../src/extension") as typeof import("../src/extension");
+}
+
+export function setGitBranchDiscoveryState(input: {
+  readonly originHead?: string;
+  readonly remoteRefs?: ReadonlyArray<string>;
+  readonly localRefs?: ReadonlyArray<string>;
+}): void {
+  const originHead = input.originHead ?? "origin/main";
+  const remoteRefs = input.remoteRefs ?? ["origin/HEAD", "origin/main"];
+  const localRefs = input.localRefs ?? ["main"];
+
+  childProcessMock.spawnSync.mockImplementation((...rawArgs: unknown[]) => {
+    const args = (rawArgs[1] as ReadonlyArray<string> | undefined) ?? [];
+    const joined = args.join(" ");
+    if (joined.includes("symbolic-ref") && joined.includes("origin/HEAD")) {
+      return {
+        status: originHead.length > 0 ? 0 : 1,
+        stdout: originHead,
+        stderr: originHead.length > 0 ? "" : "origin/HEAD not set",
+      };
+    }
+
+    if (
+      joined.includes("for-each-ref") &&
+      joined.includes("refs/remotes/origin")
+    ) {
+      return {
+        status: 0,
+        stdout: remoteRefs.join("\n"),
+        stderr: "",
+      };
+    }
+
+    if (joined.includes("for-each-ref") && joined.includes("refs/heads")) {
+      return {
+        status: 0,
+        stdout: localRefs.join("\n"),
+        stderr: "",
+      };
+    }
+
+    return {
+      status: 0,
+      stdout: "",
+      stderr: "",
+    };
+  });
+
+  showQuickPickMock.mockImplementation(async (...rawArgs: unknown[]) => {
+    const items =
+      (rawArgs[0] as ReadonlyArray<{ label: string }> | undefined) ?? [];
+    if (!quickPickResultLabel) {
+      return undefined;
+    }
+
+    const matched = items.find((item) => item.label === quickPickResultLabel);
+    return matched ?? items[0];
+  });
+}
+
+export function setExecutablePresence(presence: ExecutablePresence): void {
+  setExecutablePresenceOnFsMock(fsMock, presence);
+}
+
+export function setFreshExecutablePresence(presence: ExecutablePresence): void {
+  setExecutablePresenceOnFsMock(getFreshFsMock(), presence);
+}
+
+export function setWorkspaceFolders(
+  value: Array<{ uri: { fsPath: string } }> | undefined,
+): void {
+  workspaceFoldersState = value;
+}
+
+export function resetExtensionHarnessState(): void {
+  process.env.PATH = "C:/bin";
+  process.env.PATHEXT = ".EXE;.CMD";
+  commandHandlers.clear();
+  appendLineMock.mockReset();
+  registerCommandMock.mockClear();
+  registerMcpServerDefinitionProviderMock.mockClear();
+  childProcessMock.spawn.mockReset();
+  childProcessMock.spawnSync.mockReset();
+  showInputBoxMock.mockReset();
+  showQuickPickMock.mockReset();
+  workspaceFoldersState = [{ uri: { fsPath: "C:/workspace" } }];
+  quickPickResultLabel = "origin/main";
+  setGitBranchDiscoveryState({
+    originHead: "origin/main",
+    remoteRefs: ["origin/HEAD", "origin/main", "origin/develop"],
+    localRefs: ["main"],
+  });
+}
+
+export function activateAndGetHandler(commandId: string): CommandHandler {
+  const extensionModule = getExtensionModule();
+  const context = {
+    extensionUri: { fsPath: "C:/extension" },
+    subscriptions: [] as Array<{ dispose(): void }>,
+  };
+
+  extensionModule.activate(context as never);
+  const handler = commandHandlers.get(commandId);
+  if (!handler) {
+    throw new Error(`Missing command handler: ${commandId}`);
+  }
+
+  return handler;
+}
+
+export async function activateFreshHandlerWithPosixPathResolve(
+  commandId: string,
+): Promise<CommandHandler> {
+  const extensionModule = getExtensionModule();
+  const context = {
+    extensionUri: { fsPath: "C:/extension" },
+    subscriptions: [] as Array<{ dispose(): void }>,
+  };
+  extensionModule.activate(context as never);
+  const handler = commandHandlers.get(commandId);
+  if (!handler) {
+    throw new Error(`Missing command handler: ${commandId}`);
+  }
+
+  return handler;
+}
+
+export function detectRuntime(
+  runtimeKind: import("../src/command-runtime").RuntimeKind,
+): import("../src/command-runtime").RuntimeResolution {
+  return getExtensionModule().detectRuntime(runtimeKind);
+}
+
+export function deactivate(): void {
+  getExtensionModule().deactivate();
+}
+
+export {
+  appendLineMock,
+  childProcessMock,
+  commandHandlers,
+  createMockProcess,
+  createMockProcessWithStderr,
+  getFreshChildProcessMock,
+  prepareFreshModulesWithPosixPathResolve,
+  registerMcpServerDefinitionProviderMock,
+  showInputBoxMock,
+  showQuickPickMock,
+};
+
+export type { CommandHandler, MockChildProcess };

--- a/extensions/drm-copilot/test/extension.test.ts
+++ b/extensions/drm-copilot/test/extension.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "node:events";
 import {
   afterEach,
   beforeEach,
@@ -8,233 +7,26 @@ import {
   jest,
 } from "@jest/globals";
 
-type CommandHandler = (...args: unknown[]) => Promise<void> | void;
-type MockChildProcess = EventEmitter & {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
-};
+import {
+  activateAndGetHandler,
+  activateFreshHandlerWithPosixPathResolve,
+  appendLineMock,
+  childProcessMock,
+  commandHandlers,
+  createMockProcess,
+  deactivate,
+  detectRuntime,
+  getFreshChildProcessMock,
+  prepareFreshModulesWithPosixPathResolve,
+  resetExtensionHarnessState,
+  setExecutablePresence,
+  setFreshExecutablePresence,
+  setWorkspaceFolders,
+} from "./extension-test-harness";
 
-const commandHandlers = new Map<string, CommandHandler>();
-const appendLineMock = jest.fn<(line: string) => void>();
-const showInputBoxMock = jest.fn();
-const showQuickPickMock = jest.fn();
-const registerCommandMock = jest.fn(
-  (command: string, handler: CommandHandler) => {
-    commandHandlers.set(command, handler);
-    return { dispose: jest.fn() };
-  },
-);
-
-let quickPickResultLabel: string | undefined = "origin/main";
-
-let workspaceFoldersState: Array<{ uri: { fsPath: string } }> | undefined = [
-  { uri: { fsPath: "C:/workspace" } },
-];
-
-const registerMcpServerDefinitionProviderMock = jest.fn(() => ({
-  dispose: jest.fn(),
-}));
-
-jest.mock(
-  "vscode",
-  () => ({
-    commands: {
-      registerCommand: registerCommandMock,
-    },
-    window: {
-      createOutputChannel: jest.fn(() => ({
-        appendLine: appendLineMock,
-        dispose: jest.fn(),
-      })),
-      showInputBox: showInputBoxMock,
-      showQuickPick: showQuickPickMock,
-    },
-    workspace: {
-      get workspaceFolders() {
-        return workspaceFoldersState;
-      },
-    },
-    Uri: {
-      joinPath: jest.fn((base: { fsPath: string }, ...segments: string[]) => ({
-        fsPath: `${base.fsPath}/${segments.join("/")}`,
-      })),
-    },
-    lm: {
-      registerMcpServerDefinitionProvider:
-        registerMcpServerDefinitionProviderMock,
-    },
-    EventEmitter: jest.fn(() => ({
-      event: jest.fn(),
-      dispose: jest.fn(),
-    })),
-    McpStdioServerDefinition: jest.fn(),
-  }),
-  { virtual: true },
-);
-
-jest.mock("node:fs", () => ({
-  existsSync: jest.fn(),
-}));
-
-jest.mock("node:child_process", () => ({
-  spawn: jest.fn(),
-  spawnSync: jest.fn(),
-}));
-
-import { activate, deactivate, detectRuntime } from "../src/extension";
-
-const fsMock = jest.requireMock("node:fs") as {
-  existsSync: jest.MockedFunction<(filePath: string) => boolean>;
-};
-
-const childProcessMock = jest.requireMock("node:child_process") as {
-  spawn: jest.Mock;
-  spawnSync: jest.Mock;
-};
-
-function setGitBranchDiscoveryState(input: {
-  readonly originHead?: string;
-  readonly remoteRefs?: ReadonlyArray<string>;
-  readonly localRefs?: ReadonlyArray<string>;
-}): void {
-  const originHead = input.originHead ?? "origin/main";
-  const remoteRefs = input.remoteRefs ?? ["origin/HEAD", "origin/main"];
-  const localRefs = input.localRefs ?? ["main"];
-
-  childProcessMock.spawnSync.mockImplementation((...rawArgs: unknown[]) => {
-    const args = (rawArgs[1] as ReadonlyArray<string> | undefined) ?? [];
-    const joined = args.join(" ");
-    if (joined.includes("symbolic-ref") && joined.includes("origin/HEAD")) {
-      return {
-        status: originHead.length > 0 ? 0 : 1,
-        stdout: originHead,
-        stderr: originHead.length > 0 ? "" : "origin/HEAD not set",
-      };
-    }
-
-    if (
-      joined.includes("for-each-ref") &&
-      joined.includes("refs/remotes/origin")
-    ) {
-      return {
-        status: 0,
-        stdout: remoteRefs.join("\n"),
-        stderr: "",
-      };
-    }
-
-    if (joined.includes("for-each-ref") && joined.includes("refs/heads")) {
-      return {
-        status: 0,
-        stdout: localRefs.join("\n"),
-        stderr: "",
-      };
-    }
-
-    return {
-      status: 0,
-      stdout: "",
-      stderr: "",
-    };
-  });
-
-  showQuickPickMock.mockImplementation(async (...rawArgs: unknown[]) => {
-    const items =
-      (rawArgs[0] as ReadonlyArray<{ label: string }> | undefined) ?? [];
-    if (!quickPickResultLabel) {
-      return undefined;
-    }
-
-    const matched = items.find((item) => item.label === quickPickResultLabel);
-    return matched ?? items[0];
-  });
-}
-
-function setExecutablePresence(presence: {
-  readonly python?: boolean;
-  readonly py?: boolean;
-  readonly pwsh?: boolean;
-  readonly powershell?: boolean;
-}): void {
-  fsMock.existsSync.mockImplementation((filePath: string) => {
-    const lowerPath = filePath.toLowerCase();
-    if (lowerPath.includes("python")) {
-      return presence.python ?? false;
-    }
-
-    if (lowerPath.includes(`${"\\"}py.`) || lowerPath.endsWith("/py")) {
-      return presence.py ?? false;
-    }
-
-    if (lowerPath.includes("pwsh")) {
-      return presence.pwsh ?? false;
-    }
-
-    if (lowerPath.includes("powershell")) {
-      return presence.powershell ?? false;
-    }
-
-    return false;
-  });
-}
-
-function createMockProcess(exitCode: number): MockChildProcess {
-  const processMock = new EventEmitter() as MockChildProcess;
-  processMock.stdout = new EventEmitter();
-  processMock.stderr = new EventEmitter();
-  process.nextTick(() => {
-    processMock.emit("close", exitCode);
-  });
-  return processMock;
-}
-
-function createMockProcessWithStderr(
-  exitCode: number,
-  stderrLine: string,
-): MockChildProcess {
-  const processMock = new EventEmitter() as MockChildProcess;
-  processMock.stdout = new EventEmitter();
-  processMock.stderr = new EventEmitter();
-  process.nextTick(() => {
-    processMock.stderr.emit("data", Buffer.from(stderrLine, "utf-8"));
-    processMock.emit("close", exitCode);
-  });
-  return processMock;
-}
-
-function activateAndGetHandler(commandId: string): CommandHandler {
-  const context = {
-    extensionUri: { fsPath: "C:/extension" },
-    subscriptions: [] as Array<{ dispose(): void }>,
-  };
-
-  activate(context as never);
-  const handler = commandHandlers.get(commandId);
-  if (!handler) {
-    throw new Error(`Missing command handler: ${commandId}`);
-  }
-
-  return handler;
-}
-
-describe("drm-copilot command behavior", () => {
+describe("drm-copilot core command behavior", () => {
   beforeEach(() => {
-    process.env.PATH = "C:/bin";
-    process.env.PATHEXT = ".EXE;.CMD";
-    commandHandlers.clear();
-    appendLineMock.mockReset();
-    registerCommandMock.mockClear();
-    childProcessMock.spawn.mockReset();
-    childProcessMock.spawnSync.mockReset();
-    showInputBoxMock.mockReset();
-    showQuickPickMock.mockReset();
-    workspaceFoldersState = [{ uri: { fsPath: "C:/workspace" } }];
-    quickPickResultLabel = "origin/main";
-    setGitBranchDiscoveryState({
-      originHead: "origin/main",
-      remoteRefs: ["origin/HEAD", "origin/main", "origin/develop"],
-      localRefs: ["main"],
-    });
+    resetExtensionHarnessState();
   });
 
   afterEach(() => {
@@ -251,54 +43,6 @@ describe("drm-copilot command behavior", () => {
     activateAndGetHandler("drmCopilotExtension.helloPowerShell");
 
     expect(commandHandlers.has("drmCopilotExtension.helloPowerShell")).toBe(
-      true,
-    );
-  });
-
-  it("registers collectCommitContext", () => {
-    activateAndGetHandler("drmCopilotExtension.collectCommitContext");
-
-    expect(
-      commandHandlers.has("drmCopilotExtension.collectCommitContext"),
-    ).toBe(true);
-  });
-
-  it("registers collectPrContext", () => {
-    activateAndGetHandler("drmCopilotExtension.collectPrContext");
-
-    expect(commandHandlers.has("drmCopilotExtension.collectPrContext")).toBe(
-      true,
-    );
-  });
-
-  it("registers pushDownCopilotCustomizations", () => {
-    activateAndGetHandler("drmCopilotExtension.pushDownCopilotCustomizations");
-
-    expect(
-      commandHandlers.has("drmCopilotExtension.pushDownCopilotCustomizations"),
-    ).toBe(true);
-  });
-
-  it("activate registers drmCopilotExtension.syncAgentsFromInstructions", () => {
-    activateAndGetHandler("drmCopilotExtension.syncAgentsFromInstructions");
-
-    expect(
-      commandHandlers.has("drmCopilotExtension.syncAgentsFromInstructions"),
-    ).toBe(true);
-  });
-
-  it("registers newPotentialBugEntry", () => {
-    activateAndGetHandler("drmCopilotExtension.newPotentialBugEntry");
-
-    expect(
-      commandHandlers.has("drmCopilotExtension.newPotentialBugEntry"),
-    ).toBe(true);
-  });
-
-  it("registers newPotentialEntry", () => {
-    activateAndGetHandler("drmCopilotExtension.newPotentialEntry");
-
-    expect(commandHandlers.has("drmCopilotExtension.newPotentialEntry")).toBe(
       true,
     );
   });
@@ -324,21 +68,8 @@ describe("drm-copilot command behavior", () => {
     ).toBe(false);
   });
 
-  it("activate registers the MCP server definition provider", () => {
-    activateAndGetHandler("drmCopilotExtension.helloPython");
-
-    expect(registerMcpServerDefinitionProviderMock).toHaveBeenCalledWith(
-      "drmCopilotMcpProvider",
-      expect.objectContaining({
-        onDidChangeMcpServerDefinitions: expect.any(Function),
-        provideMcpServerDefinitions: expect.any(Function),
-        resolveMcpServerDefinition: expect.any(Function),
-      }),
-    );
-  });
-
   it("no workspace throws clear no-workspace error", async () => {
-    workspaceFoldersState = undefined;
+    setWorkspaceFolders(undefined);
     setExecutablePresence({ python: true });
     childProcessMock.spawn.mockReturnValue(createMockProcess(0));
 
@@ -379,28 +110,6 @@ describe("drm-copilot command behavior", () => {
     });
   });
 
-  it("collectCommitContext fails when no workspace folder is open", async () => {
-    workspaceFoldersState = undefined;
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.collectCommitContext",
-    );
-    await expect(handler()).rejects.toThrow("No workspace folder is open.");
-  });
-
-  it("collectCommitContext fails when python runtime is unavailable", async () => {
-    setExecutablePresence({ python: false });
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.collectCommitContext",
-    );
-    await expect(handler()).rejects.toThrow(
-      "Python runtime 'python' not found on PATH.",
-    );
-  });
-
   it("helloPython uses bundled extension script path", async () => {
     setExecutablePresence({ python: true });
     childProcessMock.spawn.mockReturnValue(createMockProcess(0));
@@ -425,255 +134,6 @@ describe("drm-copilot command behavior", () => {
     expect(args[args.length - 1]).toBe(
       "C:/extension/resources/templates/hello_pwsh.ps1",
     );
-  });
-
-  it("collectCommitContext passes explicit output args to bundled script", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.collectCommitContext",
-    );
-    await handler();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    expect(args[0]).toBe(
-      "C:/extension/resources/templates/collect_commit_context.py",
-    );
-    expect(args[1]).toBe("--output");
-    expect(args[2]).toBe("artifacts/commit_context.txt");
-  });
-
-  it("collectCommitContext runs with workspace cwd", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.collectCommitContext",
-    );
-    await handler();
-
-    const [, , options] = childProcessMock.spawn.mock.calls[0] as [
-      string,
-      string[],
-      { cwd: string; shell: boolean },
-    ];
-    expect(options.cwd).toBe("C:/workspace");
-    expect(options.shell).toBe(false);
-  });
-
-  it("collectCommitContext logs and throws on non-zero exit", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(2));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.collectCommitContext",
-    );
-    await expect(handler()).rejects.toThrow("Command exited with code 2");
-
-    const logs = appendLineMock.mock.calls.map(([line]) => line);
-    expect(
-      logs.some((line) =>
-        line.includes(
-          "[drmCopilotExtension.collectCommitContext] command failure",
-        ),
-      ),
-    ).toBe(true);
-  });
-
-  it("collectCommitContext reports git failure details from collector stderr", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(
-      createMockProcessWithStderr(1, "git executable not found on PATH"),
-    );
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.collectCommitContext",
-    );
-    await expect(handler()).rejects.toThrow("Command exited with code 1");
-
-    const logs = appendLineMock.mock.calls.map(([line]) => line);
-    expect(
-      logs.some((line) => line.includes("git executable not found on PATH")),
-    ).toBe(true);
-  });
-
-  it("newPotentialBugEntry passes the bundled script path and short-name args", async () => {
-    setExecutablePresence({ python: true });
-    showInputBoxMock.mockResolvedValue("blank-pr-context");
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialBugEntry",
-    );
-    await handler();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    expect(args[0]).toBe(
-      "C:/extension/resources/templates/new_potential_bug_entry.py",
-    );
-    expect(args[1]).toBe("--short-name");
-    expect(args[2]).toBe("blank-pr-context");
-  });
-
-  it("newPotentialBugEntry direct --short-name invocation skips prompts", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialBugEntry",
-    );
-    await handler(["--short-name", "blank-pr-context"]);
-
-    expect(showInputBoxMock).not.toHaveBeenCalled();
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    expect(args[1]).toBe("--short-name");
-    expect(args[2]).toBe("blank-pr-context");
-  });
-
-  it("newPotentialBugEntry direct mode rejects invalid short-name pattern", async () => {
-    setExecutablePresence({ python: true });
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialBugEntry",
-    );
-
-    await expect(handler(["--short-name", "Invalid Name"])).rejects.toThrow(
-      /short-name/i,
-    );
-    expect(showInputBoxMock).not.toHaveBeenCalled();
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
-  });
-
-  it("newPotentialBugEntry returns early when the input box is cancelled", async () => {
-    showInputBoxMock.mockResolvedValue(undefined);
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialBugEntry",
-    );
-    await handler();
-
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
-  });
-
-  it("newPotentialBugEntry surfaces a missing python runtime error", async () => {
-    setExecutablePresence({ python: false });
-    showInputBoxMock.mockResolvedValue("blank-pr-context");
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialBugEntry",
-    );
-
-    await expect(handler()).rejects.toThrow(
-      "Python runtime 'python' not found on PATH.",
-    );
-  });
-
-  it("newPotentialBugEntry surfaces non-zero exit failures", async () => {
-    setExecutablePresence({ python: true });
-    showInputBoxMock.mockResolvedValue("blank-pr-context");
-    childProcessMock.spawn.mockReturnValue(createMockProcess(2));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialBugEntry",
-    );
-
-    await expect(handler()).rejects.toThrow("Command exited with code 2");
-  });
-
-  it("newPotentialEntry passes the bundled script path and short-name args", async () => {
-    setExecutablePresence({ pwsh: true, powershell: false });
-    showInputBoxMock.mockResolvedValue("stale-cache");
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-    await handler();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    expect(args).toContain(
-      "C:/extension/resources/templates/new-potential-entry.ps1",
-    );
-    expect(args).toContain("-ShortName");
-    expect(args).toContain("stale-cache");
-  });
-
-  it("newPotentialEntry direct -ShortName invocation skips prompts", async () => {
-    setExecutablePresence({ pwsh: true, powershell: false });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-    await handler(["-ShortName", "stale-cache"]);
-
-    expect(showInputBoxMock).not.toHaveBeenCalled();
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    expect(args).toContain("-ShortName");
-    expect(args).toContain("stale-cache");
-  });
-
-  it("newPotentialEntry direct mode rejects missing -ShortName value", async () => {
-    setExecutablePresence({ pwsh: true, powershell: false });
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-
-    await expect(handler(["-ShortName"])).rejects.toThrow(/-ShortName.*value/i);
-    expect(showInputBoxMock).not.toHaveBeenCalled();
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
-  });
-
-  it("newPotentialEntry direct mode rejects duplicate -ShortName flag", async () => {
-    setExecutablePresence({ pwsh: true, powershell: false });
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-
-    await expect(
-      handler(["-ShortName", "first-entry", "-ShortName", "second-entry"]),
-    ).rejects.toThrow(/duplicate.*-ShortName/i);
-    expect(showInputBoxMock).not.toHaveBeenCalled();
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
-  });
-
-  it("newPotentialEntry returns early when the input box is cancelled", async () => {
-    showInputBoxMock.mockResolvedValue(undefined);
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-    await handler();
-
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
-  });
-
-  it("newPotentialEntry surfaces a missing powershell runtime error", async () => {
-    setExecutablePresence({ pwsh: false, powershell: false });
-    showInputBoxMock.mockResolvedValue("stale-cache");
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-
-    await expect(handler()).rejects.toThrow(
-      "PowerShell runtime not found. Expected 'pwsh' or 'powershell' on PATH.",
-    );
-  });
-
-  it("newPotentialEntry surfaces non-zero exit failures", async () => {
-    setExecutablePresence({ pwsh: true, powershell: false });
-    showInputBoxMock.mockResolvedValue("stale-cache");
-    childProcessMock.spawn.mockReturnValue(createMockProcess(2));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-
-    await expect(handler()).rejects.toThrow("Command exited with code 2");
   });
 
   it("helloPython uses explicit executable and argv arrays", async () => {
@@ -737,57 +197,50 @@ describe("drm-copilot command behavior", () => {
     expect(executable.includes(" ")).toBe(false);
   });
 
-  it("newPotentialBugEntry passes --template-root pointing to bundled feature-templates", async () => {
-    setExecutablePresence({ python: true });
-    showInputBoxMock.mockResolvedValue("test-bug");
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("helloPython preserves C:/extension on POSIX hosts", async () => {
+    try {
+      prepareFreshModulesWithPosixPathResolve();
+      setFreshExecutablePresence({ python: true });
+      const freshChildProcessMock = getFreshChildProcessMock();
+      freshChildProcessMock.spawn.mockReturnValue(createMockProcess(0));
+      const handler = await activateFreshHandlerWithPosixPathResolve(
+        "drmCopilotExtension.helloPython",
+      );
+      await handler();
 
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialBugEntry",
-    );
-    await handler();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    const templateRootIdx = args.indexOf("--template-root");
-    expect(templateRootIdx).toBeGreaterThan(-1);
-    expect(args[templateRootIdx + 1]).toContain("resources/feature-templates");
+      const [, args] = freshChildProcessMock.spawn.mock.calls[0] as [
+        string,
+        string[],
+      ];
+      expect(args[0]).toBe("C:/extension/resources/templates/hello_python.py");
+    } finally {
+      jest.dontMock("node:path");
+      jest.resetModules();
+    }
   });
 
-  it("newPotentialEntry passes -TemplateRoot pointing to bundled feature-templates", async () => {
-    setExecutablePresence({ pwsh: true, powershell: false });
-    showInputBoxMock.mockResolvedValue("test-entry");
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("helloPowerShell preserves C:/extension on POSIX hosts", async () => {
+    try {
+      prepareFreshModulesWithPosixPathResolve();
+      setFreshExecutablePresence({ pwsh: true });
+      const freshChildProcessMock = getFreshChildProcessMock();
+      freshChildProcessMock.spawn.mockReturnValue(createMockProcess(0));
+      const handler = await activateFreshHandlerWithPosixPathResolve(
+        "drmCopilotExtension.helloPowerShell",
+      );
+      await handler();
 
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newPotentialEntry",
-    );
-    await handler();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    const templateRootIdx = args.indexOf("-TemplateRoot");
-    expect(templateRootIdx).toBeGreaterThan(-1);
-    expect(args[templateRootIdx + 1]).toContain("resources/feature-templates");
-  });
-
-  it("newActiveFeatureFolder passes --template-root pointing to bundled feature-templates", async () => {
-    setExecutablePresence({ python: true });
-    showQuickPickMock
-      .mockResolvedValueOnce("feature")
-      .mockResolvedValueOnce("minor-audit");
-    showInputBoxMock
-      .mockResolvedValueOnce("test-feature")
-      .mockResolvedValueOnce("");
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-
-    const handler = activateAndGetHandler(
-      "drmCopilotExtension.newActiveFeatureFolder",
-    );
-    await handler();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    const templateRootIdx = args.indexOf("--template-root");
-    expect(templateRootIdx).toBeGreaterThan(-1);
-    expect(args[templateRootIdx + 1]).toContain("resources/feature-templates");
+      const [, args] = freshChildProcessMock.spawn.mock.calls[0] as [
+        string,
+        string[],
+      ];
+      expect(
+        args[args.length - 1].startsWith("C:/extension/resources/templates/"),
+      ).toBe(true);
+    } finally {
+      jest.dontMock("node:path");
+      jest.resetModules();
+    }
   });
 });
 

--- a/extensions/drm-copilot/test/extension.workflow-commands.test.ts
+++ b/extensions/drm-copilot/test/extension.workflow-commands.test.ts
@@ -1,0 +1,393 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+import {
+  activateAndGetHandler,
+  appendLineMock,
+  childProcessMock,
+  createMockProcess,
+  createMockProcessWithStderr,
+  registerMcpServerDefinitionProviderMock,
+  resetExtensionHarnessState,
+  setExecutablePresence,
+  setWorkspaceFolders,
+  showInputBoxMock,
+  showQuickPickMock,
+} from "./extension-test-harness";
+
+describe("drm-copilot workflow command behavior", () => {
+  beforeEach(() => {
+    resetExtensionHarnessState();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registers collectCommitContext", () => {
+    activateAndGetHandler("drmCopilotExtension.collectCommitContext");
+  });
+
+  it("registers collectPrContext", () => {
+    activateAndGetHandler("drmCopilotExtension.collectPrContext");
+  });
+
+  it("registers pushDownCopilotCustomizations", () => {
+    activateAndGetHandler("drmCopilotExtension.pushDownCopilotCustomizations");
+  });
+
+  it("activate registers drmCopilotExtension.syncAgentsFromInstructions", () => {
+    activateAndGetHandler("drmCopilotExtension.syncAgentsFromInstructions");
+  });
+
+  it("registers newPotentialBugEntry", () => {
+    activateAndGetHandler("drmCopilotExtension.newPotentialBugEntry");
+  });
+
+  it("registers newPotentialEntry", () => {
+    activateAndGetHandler("drmCopilotExtension.newPotentialEntry");
+  });
+
+  it("activate registers the MCP server definition provider", () => {
+    activateAndGetHandler("drmCopilotExtension.helloPython");
+
+    expect(registerMcpServerDefinitionProviderMock).toHaveBeenCalledWith(
+      "drmCopilotMcpProvider",
+      expect.objectContaining({
+        onDidChangeMcpServerDefinitions: expect.any(Function),
+        provideMcpServerDefinitions: expect.any(Function),
+        resolveMcpServerDefinition: expect.any(Function),
+      }),
+    );
+  });
+
+  it("collectCommitContext fails when no workspace folder is open", async () => {
+    setWorkspaceFolders(undefined);
+    setExecutablePresence({ python: true });
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.collectCommitContext",
+    );
+    await expect(handler()).rejects.toThrow("No workspace folder is open.");
+  });
+
+  it("collectCommitContext fails when python runtime is unavailable", async () => {
+    setExecutablePresence({ python: false });
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.collectCommitContext",
+    );
+    await expect(handler()).rejects.toThrow(
+      "Python runtime 'python' not found on PATH.",
+    );
+  });
+
+  it("collectCommitContext passes explicit output args to bundled script", async () => {
+    setExecutablePresence({ python: true });
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.collectCommitContext",
+    );
+    await handler();
+
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args[0]).toBe(
+      "C:/extension/resources/templates/collect_commit_context.py",
+    );
+    expect(args[1]).toBe("--output");
+    expect(args[2]).toBe("artifacts/commit_context.txt");
+  });
+
+  it("collectCommitContext runs with workspace cwd", async () => {
+    setExecutablePresence({ python: true });
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.collectCommitContext",
+    );
+    await handler();
+
+    const [, , options] = childProcessMock.spawn.mock.calls[0] as [
+      string,
+      string[],
+      { cwd: string; shell: boolean },
+    ];
+    expect(options.cwd).toBe("C:/workspace");
+    expect(options.shell).toBe(false);
+  });
+
+  it("collectCommitContext logs and throws on non-zero exit", async () => {
+    setExecutablePresence({ python: true });
+    childProcessMock.spawn.mockReturnValue(createMockProcess(2));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.collectCommitContext",
+    );
+    await expect(handler()).rejects.toThrow("Command exited with code 2");
+
+    const logs = appendLineMock.mock.calls.map(([line]) => line);
+    expect(
+      logs.some((line) =>
+        line.includes(
+          "[drmCopilotExtension.collectCommitContext] command failure",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("collectCommitContext reports git failure details from collector stderr", async () => {
+    setExecutablePresence({ python: true });
+    childProcessMock.spawn.mockReturnValue(
+      createMockProcessWithStderr(1, "git executable not found on PATH"),
+    );
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.collectCommitContext",
+    );
+    await expect(handler()).rejects.toThrow("Command exited with code 1");
+
+    const logs = appendLineMock.mock.calls.map(([line]) => line);
+    expect(
+      logs.some((line) => line.includes("git executable not found on PATH")),
+    ).toBe(true);
+  });
+
+  it("newPotentialBugEntry passes the bundled script path and short-name args", async () => {
+    setExecutablePresence({ python: true });
+    showInputBoxMock.mockResolvedValue("blank-pr-context");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialBugEntry",
+    );
+    await handler();
+
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args[0]).toBe(
+      "C:/extension/resources/templates/new_potential_bug_entry.py",
+    );
+    expect(args[1]).toBe("--short-name");
+    expect(args[2]).toBe("blank-pr-context");
+  });
+
+  it("newPotentialBugEntry direct --short-name invocation skips prompts", async () => {
+    setExecutablePresence({ python: true });
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialBugEntry",
+    );
+    await handler(["--short-name", "blank-pr-context"]);
+
+    expect(showInputBoxMock).not.toHaveBeenCalled();
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args[1]).toBe("--short-name");
+    expect(args[2]).toBe("blank-pr-context");
+  });
+
+  it("newPotentialBugEntry direct mode rejects invalid short-name pattern", async () => {
+    setExecutablePresence({ python: true });
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialBugEntry",
+    );
+
+    await expect(handler(["--short-name", "Invalid Name"])).rejects.toThrow(
+      /short-name/i,
+    );
+    expect(showInputBoxMock).not.toHaveBeenCalled();
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("newPotentialBugEntry returns early when the input box is cancelled", async () => {
+    showInputBoxMock.mockResolvedValue(undefined);
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialBugEntry",
+    );
+    await handler();
+
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("newPotentialBugEntry surfaces a missing python runtime error", async () => {
+    setExecutablePresence({ python: false });
+    showInputBoxMock.mockResolvedValue("blank-pr-context");
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialBugEntry",
+    );
+
+    await expect(handler()).rejects.toThrow(
+      "Python runtime 'python' not found on PATH.",
+    );
+  });
+
+  it("newPotentialBugEntry surfaces non-zero exit failures", async () => {
+    setExecutablePresence({ python: true });
+    showInputBoxMock.mockResolvedValue("blank-pr-context");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(2));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialBugEntry",
+    );
+
+    await expect(handler()).rejects.toThrow("Command exited with code 2");
+  });
+
+  it("newPotentialEntry passes the bundled script path and short-name args", async () => {
+    setExecutablePresence({ pwsh: true, powershell: false });
+    showInputBoxMock.mockResolvedValue("stale-cache");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+    await handler();
+
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args).toContain(
+      "C:/extension/resources/templates/new-potential-entry.ps1",
+    );
+    expect(args).toContain("-ShortName");
+    expect(args).toContain("stale-cache");
+  });
+
+  it("newPotentialEntry direct -ShortName invocation skips prompts", async () => {
+    setExecutablePresence({ pwsh: true, powershell: false });
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+    await handler(["-ShortName", "stale-cache"]);
+
+    expect(showInputBoxMock).not.toHaveBeenCalled();
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    expect(args).toContain("-ShortName");
+    expect(args).toContain("stale-cache");
+  });
+
+  it("newPotentialEntry direct mode rejects missing -ShortName value", async () => {
+    setExecutablePresence({ pwsh: true, powershell: false });
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+
+    await expect(handler(["-ShortName"])).rejects.toThrow(/-ShortName.*value/i);
+    expect(showInputBoxMock).not.toHaveBeenCalled();
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("newPotentialEntry direct mode rejects duplicate -ShortName flag", async () => {
+    setExecutablePresence({ pwsh: true, powershell: false });
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+
+    await expect(
+      handler(["-ShortName", "first-entry", "-ShortName", "second-entry"]),
+    ).rejects.toThrow(/duplicate.*-ShortName/i);
+    expect(showInputBoxMock).not.toHaveBeenCalled();
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("newPotentialEntry returns early when the input box is cancelled", async () => {
+    showInputBoxMock.mockResolvedValue(undefined);
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+    await handler();
+
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("newPotentialEntry surfaces a missing powershell runtime error", async () => {
+    setExecutablePresence({ pwsh: false, powershell: false });
+    showInputBoxMock.mockResolvedValue("stale-cache");
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+
+    await expect(handler()).rejects.toThrow(
+      "PowerShell runtime not found. Expected 'pwsh' or 'powershell' on PATH.",
+    );
+  });
+
+  it("newPotentialEntry surfaces non-zero exit failures", async () => {
+    setExecutablePresence({ pwsh: true, powershell: false });
+    showInputBoxMock.mockResolvedValue("stale-cache");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(2));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+
+    await expect(handler()).rejects.toThrow("Command exited with code 2");
+  });
+
+  it("newPotentialBugEntry passes --template-root pointing to bundled feature-templates", async () => {
+    setExecutablePresence({ python: true });
+    showInputBoxMock.mockResolvedValue("test-bug");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialBugEntry",
+    );
+    await handler();
+
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    const templateRootIdx = args.indexOf("--template-root");
+    expect(templateRootIdx).toBeGreaterThan(-1);
+    expect(args[templateRootIdx + 1]).toContain("resources/feature-templates");
+  });
+
+  it("newPotentialEntry passes -TemplateRoot pointing to bundled feature-templates", async () => {
+    setExecutablePresence({ pwsh: true, powershell: false });
+    showInputBoxMock.mockResolvedValue("test-entry");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newPotentialEntry",
+    );
+    await handler();
+
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    const templateRootIdx = args.indexOf("-TemplateRoot");
+    expect(templateRootIdx).toBeGreaterThan(-1);
+    expect(args[templateRootIdx + 1]).toContain("resources/feature-templates");
+  });
+
+  it("newActiveFeatureFolder passes --template-root pointing to bundled feature-templates", async () => {
+    setExecutablePresence({ python: true });
+    showQuickPickMock
+      .mockResolvedValueOnce("feature")
+      .mockResolvedValueOnce("minor-audit");
+    showInputBoxMock
+      .mockResolvedValueOnce("test-feature")
+      .mockResolvedValueOnce("");
+    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newActiveFeatureFolder",
+    );
+    await handler();
+
+    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
+    const templateRootIdx = args.indexOf("--template-root");
+    expect(templateRootIdx).toBeGreaterThan(-1);
+    expect(args[templateRootIdx + 1]).toContain("resources/feature-templates");
+  });
+});

--- a/extensions/drm-copilot/test/repo-automation-service.test.ts
+++ b/extensions/drm-copilot/test/repo-automation-service.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "node:events";
 import {
   afterEach,
   beforeEach,
@@ -8,10 +7,13 @@ import {
   jest,
 } from "@jest/globals";
 
-type MockChildProcess = EventEmitter & {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
-};
+import {
+  createMockProcess,
+  getFreshChildProcessMock,
+  getFreshFsMock,
+  prepareFreshModulesWithPosixPathResolve,
+  setExecutablePresenceOnFsMock,
+} from "./runtime-test-helpers";
 
 const appendLineMock = jest.fn<(line: string) => void>();
 
@@ -35,21 +37,19 @@ const childProcessMock = jest.requireMock("node:child_process") as {
   spawn: jest.Mock;
 };
 
-function createMockProcess(
-  exitCode: number,
-  stdoutText: string = "",
-): MockChildProcess {
-  const processMock = new EventEmitter() as MockChildProcess;
-  processMock.stdout = new EventEmitter();
-  processMock.stderr = new EventEmitter();
-  process.nextTick(() => {
-    if (stdoutText.length > 0) {
-      processMock.stdout.emit("data", Buffer.from(stdoutText, "utf-8"));
-    }
+function setFreshExecutablePresence(presence: {
+  readonly python?: boolean;
+  readonly py?: boolean;
+  readonly pwsh?: boolean;
+  readonly powershell?: boolean;
+}): void {
+  setExecutablePresenceOnFsMock(getFreshFsMock(), presence);
+}
 
-    processMock.emit("close", exitCode);
-  });
-  return processMock;
+function createFreshRepoAutomationService(): typeof import("../src/repo-automation-service") {
+  return jest.requireActual<typeof import("../src/repo-automation-service")>(
+    "../src/repo-automation-service",
+  );
 }
 
 function setExecutablePresence(presence: {
@@ -58,26 +58,7 @@ function setExecutablePresence(presence: {
   readonly pwsh?: boolean;
   readonly powershell?: boolean;
 }): void {
-  fsMock.existsSync.mockImplementation((filePath: string) => {
-    const lowerPath = filePath.toLowerCase();
-    if (lowerPath.includes("python")) {
-      return presence.python ?? false;
-    }
-
-    if (lowerPath.includes(`${"\\"}py.`) || lowerPath.endsWith("/py")) {
-      return presence.py ?? false;
-    }
-
-    if (lowerPath.includes("pwsh")) {
-      return presence.pwsh ?? false;
-    }
-
-    if (lowerPath.includes("powershell")) {
-      return presence.powershell ?? false;
-    }
-
-    return false;
-  });
+  setExecutablePresenceOnFsMock(fsMock, presence);
 }
 
 describe("repo automation service", () => {
@@ -157,6 +138,36 @@ describe("repo automation service", () => {
     expect(options.shell).toBe(false);
   });
 
+  it("collectCommitContext preserves C:/extension on POSIX hosts", async () => {
+    prepareFreshModulesWithPosixPathResolve();
+    setFreshExecutablePresence({ python: true });
+    const freshChildProcessMock = getFreshChildProcessMock();
+    freshChildProcessMock.spawn.mockReturnValue(createMockProcess(0));
+    const freshModule = createFreshRepoAutomationService();
+    const service = freshModule.createRepoAutomationService({
+      extensionRoot: "C:/extension",
+      output: { appendLine: appendLineMock },
+    });
+
+    try {
+      await service.collectCommitContext({
+        workspaceRoot: "C:/workspace",
+        invocationId: "collect_commit_context",
+      });
+
+      const [, args] = freshChildProcessMock.spawn.mock.calls[0] as [
+        string,
+        string[],
+      ];
+      expect(args[0].startsWith("C:/extension/resources/templates/")).toBe(
+        true,
+      );
+    } finally {
+      jest.dontMock("node:path");
+      jest.resetModules();
+    }
+  });
+
   it("newPotentialEntry keeps subprocess execution argv-based with shell disabled", async () => {
     setExecutablePresence({ pwsh: true });
     childProcessMock.spawn.mockReturnValue(createMockProcess(0));
@@ -188,5 +199,36 @@ describe("repo automation service", () => {
     ]);
     expect(options.cwd).toBe("C:/workspace");
     expect(options.shell).toBe(false);
+  });
+
+  it("newPotentialEntry preserves C:/extension on POSIX hosts", async () => {
+    prepareFreshModulesWithPosixPathResolve();
+    setFreshExecutablePresence({ pwsh: true });
+    const freshChildProcessMock = getFreshChildProcessMock();
+    freshChildProcessMock.spawn.mockReturnValue(createMockProcess(0));
+    const freshModule = createFreshRepoAutomationService();
+    const service = freshModule.createRepoAutomationService({
+      extensionRoot: "C:/extension",
+      output: { appendLine: appendLineMock },
+    });
+
+    try {
+      await service.newPotentialEntry({
+        workspaceRoot: "C:/workspace",
+        invocationId: "new_potential_entry",
+        shortName: "mcp-entry",
+      });
+
+      const [, args] = freshChildProcessMock.spawn.mock.calls[0] as [
+        string,
+        string[],
+      ];
+      expect(args[5].startsWith("C:/extension/resources/templates/")).toBe(
+        true,
+      );
+    } finally {
+      jest.dontMock("node:path");
+      jest.resetModules();
+    }
   });
 });

--- a/extensions/drm-copilot/test/runtime-test-helpers.ts
+++ b/extensions/drm-copilot/test/runtime-test-helpers.ts
@@ -1,0 +1,135 @@
+import { EventEmitter } from "node:events";
+import { jest } from "@jest/globals";
+
+export interface ExecutablePresence {
+  readonly python?: boolean;
+  readonly py?: boolean;
+  readonly pwsh?: boolean;
+  readonly powershell?: boolean;
+}
+
+export type MockExistsSync = jest.MockedFunction<(filePath: string) => boolean>;
+
+export type MockChildProcess = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+};
+
+/**
+ * Applies the runtime-presence fixture to a mocked fs.existsSync implementation.
+ *
+ * @param fsModule The mocked fs module used by the test file.
+ * @param presence The executable-presence matrix to simulate.
+ */
+export function setExecutablePresenceOnFsMock(
+  fsModule: { existsSync: MockExistsSync },
+  presence: ExecutablePresence,
+): void {
+  fsModule.existsSync.mockImplementation((filePath: string) => {
+    const lowerPath = filePath.toLowerCase();
+    if (lowerPath.includes("python")) {
+      return presence.python ?? false;
+    }
+
+    if (lowerPath.includes(`${"\\"}py.`) || lowerPath.endsWith("/py")) {
+      return presence.py ?? false;
+    }
+
+    if (lowerPath.includes("pwsh")) {
+      return presence.pwsh ?? false;
+    }
+
+    if (lowerPath.includes("powershell")) {
+      return presence.powershell ?? false;
+    }
+
+    return false;
+  });
+}
+
+/**
+ * Forces node:path.resolve to use POSIX semantics for Windows-root fixture tests.
+ */
+export function prepareFreshModulesWithPosixPathResolve(): void {
+  jest.resetModules();
+  jest.doMock("node:path", () => {
+    const actual = jest.requireActual(
+      "node:path",
+    ) as typeof import("node:path");
+    return {
+      ...actual,
+      resolve: actual.posix.resolve,
+    };
+  });
+}
+
+/**
+ * Returns the freshly required child_process mock after a fresh-module setup.
+ *
+ * @returns The mocked child_process module for the fresh module graph.
+ */
+export function getFreshChildProcessMock(): {
+  spawn: jest.Mock;
+  spawnSync?: jest.Mock;
+} {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest fresh-module loading needs CommonJS require in this runner
+  return require("node:child_process") as {
+    spawn: jest.Mock;
+    spawnSync?: jest.Mock;
+  };
+}
+
+/**
+ * Returns the freshly required fs mock after a fresh-module setup.
+ *
+ * @returns The mocked fs module for the fresh module graph.
+ */
+export function getFreshFsMock(): { existsSync: MockExistsSync } {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest fresh-module loading needs CommonJS require in this runner
+  return require("node:fs") as { existsSync: MockExistsSync };
+}
+
+/**
+ * Creates a mock child process that exits with the provided code.
+ *
+ * @param exitCode The simulated process exit code.
+ * @param stdoutText Optional stdout text emitted before the process closes.
+ * @returns A mocked child process instance.
+ */
+export function createMockProcess(
+  exitCode: number,
+  stdoutText: string = "",
+): MockChildProcess {
+  const processMock = new EventEmitter() as MockChildProcess;
+  processMock.stdout = new EventEmitter();
+  processMock.stderr = new EventEmitter();
+  process.nextTick(() => {
+    if (stdoutText.length > 0) {
+      processMock.stdout.emit("data", Buffer.from(stdoutText, "utf-8"));
+    }
+
+    processMock.emit("close", exitCode);
+  });
+  return processMock;
+}
+
+/**
+ * Creates a mock child process that emits stderr before exiting.
+ *
+ * @param exitCode The simulated process exit code.
+ * @param stderrLine The stderr line emitted before exit.
+ * @returns A mocked child process instance.
+ */
+export function createMockProcessWithStderr(
+  exitCode: number,
+  stderrLine: string,
+): MockChildProcess {
+  const processMock = new EventEmitter() as MockChildProcess;
+  processMock.stdout = new EventEmitter();
+  processMock.stderr = new EventEmitter();
+  process.nextTick(() => {
+    processMock.stderr.emit("data", Buffer.from(stderrLine, "utf-8"));
+    processMock.emit("close", exitCode);
+  });
+  return processMock;
+}


### PR DESCRIPTION
Fix bundled extension script path resolution for Windows-style roots on POSIX hosts

## Summary

- Fix `extensions/drm-copilot/src/command-runtime.ts` so bundled script paths preserve Windows-style extension roots such as `C:/extension` when tests run on POSIX hosts.
- Restore Linux CI compatibility for extension command and repo-automation Jest scenarios that assert bundled resources stay under the extension install root instead of being prefixed by the checkout path.
- Add focused regression coverage for `helloPython`, `helloPowerShell`, `collectCommitContext`, and `newPotentialEntry` using mocked `extensionUri.fsPath = "C:/extension"` inputs on POSIX path semantics.
- Refactor the affected Jest coverage to use shared test harness helpers while keeping the production change constrained to the single approved runtime file.
- Record the bug issue, execution plan, regression evidence, and final QA-gate artifacts under `docs/features/active/2026-04-05-ci-failing-error-128/`.

## Why

The extension Jest suite was failing on Linux because `resolveBundledScriptPath()` used `path.resolve(extensionRoot, bundledRelativePath)` with Windows-style mocked paths such as `C:/extension`. On POSIX hosts, Node treated that drive-prefixed value as a relative segment, producing hybrid paths like `/home/runner/.../C:/extension/...` instead of `C:/extension/...`.

That failure broke assertions across both the command layer and the repo-automation service, masking whether bundled scripts were still executed from extension resources. The recorded acceptance criteria required three outcomes:

- Windows-style absolute extension roots must remain absolute on POSIX hosts.
- Bundled command and repo-automation invocations must continue to target extension resources rather than workspace-relative copies.
- Regression coverage must prove the Windows-style mocked `fsPath` scenario and confirm the extension Jest suite no longer fails with checkout-prefixed hybrid paths.

## What Changed

- **Core behavior / architecture**
  - Updated `extensions/drm-copilot/src/command-runtime.ts` so `resolveBundledScriptPath()` normalizes separators, strips leading separators from the bundled relative path, and short-circuits to a manual join when the extension root matches a Windows drive-prefixed absolute path.
  - Kept the existing `path.resolve(...)` fallback for non-drive-prefixed inputs so the change remains narrowly targeted.

- **Tests**
  - Updated `extensions/drm-copilot/test/extension.test.ts` with explicit POSIX-host regression scenarios for `helloPython` and `helloPowerShell`.
  - Updated `extensions/drm-copilot/test/repo-automation-service.test.ts` with matching POSIX-host regression scenarios for `collectCommitContext` and `newPotentialEntry`.
  - Introduced shared harness/helper usage in the test layer via `extensions/drm-copilot/test/extension-test-harness.ts` and `extensions/drm-copilot/test/runtime-test-helpers.ts` to support fresh-module POSIX path resolution coverage.

- **Docs / audit artifacts**
  - Added and updated `docs/features/active/2026-04-05-ci-failing-error-128/issue.md`, `plan.2026-04-05T19-46.md`, focused regression artifacts, and QA-gate summaries to document the repro, constrained scope, acceptance mapping, and clean verification pass.

## Architecture / How It Fits Together

The fix stays centered on the shared bundled-path resolver:

- `resolveBundledScriptPath()` in `extensions/drm-copilot/src/command-runtime.ts` is the common helper that converts an extension install root plus a bundled relative script path into the executable path passed to subprocess invocations.
- Extension command handlers such as `helloPython` and `helloPowerShell` consume that resolver through the command runtime.
- The repo-automation service also relies on the same resolver for scripts such as `collectCommitContext` and `newPotentialEntry`.
- The regression tests force POSIX path semantics while mocking `extensionUri.fsPath = "C:/extension"` so the call sites verify that the shared resolver still points into `C:/extension/resources/templates/...` rather than the repository checkout.

## Verification

### Completed

- Focused red regression recorded before the production fix:
  - `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"`
  - Recorded `EXIT_CODE: 1` with failures for all four Windows-root POSIX-host scenarios.
- Focused green regression recorded after the production fix:
  - `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"`
  - Recorded `EXIT_CODE: 0`; both suites passed and all four targeted scenarios were reported as passing.
- Final extension formatter pass:
  - `npm --prefix extensions/drm-copilot run format`
  - Recorded `EXIT_CODE: 0`.
- Final extension lint pass:
  - `npm --prefix extensions/drm-copilot run lint`
  - Recorded `EXIT_CODE: 0`.
- Final extension type-check pass:
  - `npm --prefix extensions/drm-copilot run typecheck`
  - Recorded `EXIT_CODE: 0`.
- Final extension unit-test pass:
  - `npm --prefix extensions/drm-copilot run test:unit`
  - Recorded `EXIT_CODE: 0` with `10/10` Jest suites and `140/140` tests passing, including the four Windows-root bundled-path regressions.

### Recommended

- `npm --prefix extensions/drm-copilot run format`
- `npm --prefix extensions/drm-copilot run lint`
- `npm --prefix extensions/drm-copilot run typecheck`
- `npm --prefix extensions/drm-copilot run test:unit`
- `npm --prefix extensions/drm-copilot run test:unit -- --runTestsByPath test/extension.test.ts test/repo-automation-service.test.ts -t "helloPython|helloPowerShell|collectCommitContext|newPotentialEntry"`

## Backward Compatibility / Migration Notes

- No public command IDs or user-facing workflows are renamed or removed.
- No migration steps are required for consumers of the extension.
- The runtime behavior change is intentionally narrow: only Windows drive-prefixed extension roots on POSIX hosts bypass `path.resolve(...)`; other path shapes continue through the existing fallback logic.
- The approved production scope remains limited to `extensions/drm-copilot/src/command-runtime.ts`; companion updates are test and audit artifacts.

## Risks and Mitigations

- **Risk:** The drive-prefix guard could over-match non-target path shapes.
  - **Mitigation:** The guard is limited to roots matching `^[A-Za-z]:/`, and all other inputs continue through the existing resolver path.
- **Risk:** Test refactoring could obscure whether the fix is real or only test-local.
  - **Mitigation:** The change is backed by fail-before and pass-after focused regressions plus a recorded full extension Jest pass.
- **Risk:** Cross-platform path handling regressions could reappear in other bundled-script call sites.
  - **Mitigation:** The shared resolver remains the single production choke point, and both command and repo-automation call paths are covered by the recorded regressions.

## Review Guide

- Review `docs/features/active/2026-04-05-ci-failing-error-128/issue.md` first for the bug description and authoritative acceptance criteria.
- Review `extensions/drm-copilot/src/command-runtime.ts` next; this is the only production TypeScript file changed for the runtime fix.
- Review `extensions/drm-copilot/test/extension.test.ts` for the `helloPython` and `helloPowerShell` Windows-root POSIX-host regressions.
- Review `extensions/drm-copilot/test/repo-automation-service.test.ts` for the matching repo-automation regressions.
- Review the shared test-support helpers referenced by those tests (`extension-test-harness.ts` and `runtime-test-helpers.ts`) to confirm the fresh-module POSIX path setup.
- Review `docs/features/active/2026-04-05-ci-failing-error-128/plan.2026-04-05T19-46.md` only if you want the constrained execution log and checklist reconciliation.
- Treat the evidence files under `docs/features/active/2026-04-05-ci-failing-error-128/evidence/` as supporting audit material rather than primary code-review content.

## Follow-ups

- Optional: add direct helper-level unit coverage for `resolveBundledScriptPath()` across additional root/path combinations beyond the current command and service call-site regressions.
- If the remaining audit artifacts in the working tree are intended to ship with this PR, refresh the PR-context bundle after staging them so the generated PR context matches the final branch state.

## GitHub Auto-close

- Closes #128

## Related issues / PRs

- None.