### PR TITLE
Bundle Codex setup assets and make packaged push-down publishers import-compatible

### DIFF
--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/codex-web-setup.plan.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/codex-web-setup.plan.md
@@ -1,0 +1,26 @@
+# Codex Web Setup Script Change Plan
+
+## Objective
+
+Fix `.codex/codex-web-setup.sh` so a Linux-based Codex Web bootstrap does not fail after successful dependency installation solely because the repository's build and test tasks require Windows-only Visual Studio tooling.
+
+## Assumptions
+
+- The requested defect is the non-zero exit caused by the Windows-only verification block shown in the provided log.
+- Codex Web should complete environment bootstrap on Linux even when full restore/build/test parity remains unavailable there.
+- Real setup failures such as missing `dotnet`, `pwsh`, `dotnet-coverage`, or `coverage.config` should still fail the script.
+
+## Planned Changes
+
+1. Refactor the verification path in `.codex/codex-web-setup.sh` so general prerequisite checks remain mandatory.
+2. Detect non-Windows PowerShell hosts and downgrade the Visual Studio-specific task verification from a hard failure to a warning.
+3. Update the script's repo notes so they describe partial verification on Linux instead of an expected non-zero exit.
+4. Update `.github/workflows/codex-web-setup-test.yml` so CI expects the new Linux warning-and-success behavior rather than the previous hard failure.
+5. Add non-default-branch CI triggers so the setup workflow can run from branch pushes and pull requests, not only from `workflow_dispatch` on the default branch.
+
+## Verification
+
+1. Run a syntax check for `.codex/codex-web-setup.sh`.
+2. Run the repository PowerShell quality commands required by policy.
+3. If practical, run a focused command path that exercises the non-Windows verification branch without reinstalling dependencies.
+4. Run `actionlint` against the updated workflow definition.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/codex-web-setup.sh
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/codex-web-setup.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Codex Web copies this script to /tmp before running it, so the script-relative
+# REPO_ROOT resolves to / rather than the actual checkout.  Fall back to the
+# working directory, which Codex sets to the repo root.
+if [ ! -f "${REPO_ROOT}/TaskMaster.sln" ]; then
+  REPO_ROOT="$(pwd)"
+fi
+
+log() {
+  printf '[codex-web-setup] %s\n' "$*"
+}
+
+fail() {
+  printf '[codex-web-setup] error: %s\n' "$*" >&2
+  exit 1
+}
+
+warn() {
+  printf '[codex-web-setup] warning: %s\n' "$*" >&2
+}
+
+read_global_json_sdk_version() {
+  local global_json_path="${REPO_ROOT}/global.json"
+
+  if [ ! -f "${global_json_path}" ]; then
+    return 1
+  fi
+
+  grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "${global_json_path}" |
+    head -n 1 |
+    sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+}
+
+append_if_missing() {
+  local file="$1"
+  local line="$2"
+
+  touch "$file"
+  if ! grep -Fqx "$line" "$file"; then
+    printf '%s\n' "$line" >>"$file"
+  fi
+}
+
+install_apt_packages() {
+  if ! command -v apt-get >/dev/null 2>&1; then
+    warn "apt-get is unavailable; skipping OS package installation."
+    return
+  fi
+
+  local runner=""
+  if [ "$(id -u)" -eq 0 ]; then
+    runner=""
+  elif command -v sudo >/dev/null 2>&1; then
+    runner="sudo"
+  else
+    warn "apt-get requires root and sudo is unavailable; skipping OS package installation."
+    return
+  fi
+
+  log "Installing Codex Web dependencies with apt-get..."
+  ${runner} apt-get update
+  ${runner} apt-get install -y \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    lsb-release \
+    mono-complete \
+    ripgrep \
+    unzip \
+    zip
+}
+
+install_powershell() {
+  if command -v pwsh >/dev/null 2>&1; then
+    log "PowerShell is already available; skipping."
+    return
+  fi
+
+  if ! command -v apt-get >/dev/null 2>&1; then
+    warn "apt-get is unavailable; skipping PowerShell installation."
+    return
+  fi
+
+  local runner=""
+  if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      runner="sudo"
+    else
+      warn "PowerShell installation requires root; skipping."
+      return
+    fi
+  fi
+
+  local ubuntu_version
+  ubuntu_version="$(lsb_release -rs 2>/dev/null || echo '24.04')"
+
+  log "Registering Microsoft package repository for PowerShell (Ubuntu ${ubuntu_version})..."
+  local ms_pkg
+  ms_pkg="$(mktemp --suffix=.deb)"
+  if curl -fsSL "https://packages.microsoft.com/config/ubuntu/${ubuntu_version}/packages-microsoft-prod.deb" -o "${ms_pkg}"; then
+    ${runner} dpkg -i "${ms_pkg}" || true
+    rm -f "${ms_pkg}"
+    ${runner} apt-get update
+    ${runner} apt-get install -y powershell
+  else
+    rm -f "${ms_pkg}"
+    warn "Could not download Microsoft package repo; skipping PowerShell installation."
+  fi
+}
+
+install_nuget() {
+  if command -v nuget >/dev/null 2>&1; then
+    log "nuget is already available; skipping."
+    return
+  fi
+
+  if ! command -v mono >/dev/null 2>&1; then
+    warn "mono is unavailable; cannot install nuget wrapper."
+    return
+  fi
+
+  log "Downloading nuget.exe and creating mono wrapper..."
+  local nuget_exe="/usr/local/bin/nuget.exe"
+  local nuget_wrapper="/usr/local/bin/nuget"
+
+  local runner=""
+  if [ "$(id -u)" -ne 0 ]; then
+    runner="sudo"
+  fi
+
+  if curl -fsSL "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -o "${nuget_exe}"; then
+    printf '#!/usr/bin/env bash\nexec mono %s "$@"\n' "${nuget_exe}" | ${runner} tee "${nuget_wrapper}" >/dev/null
+    ${runner} chmod +x "${nuget_wrapper}"
+    log "nuget wrapper installed at ${nuget_wrapper}."
+  else
+    warn "Could not download nuget.exe; skipping."
+  fi
+}
+
+install_dotnet_sdk() {
+  local dotnet_root="${REPO_ROOT}/.dotnet-sdk"
+  local dotnet_version=""
+  local install_script=""
+
+  dotnet_version="$(read_global_json_sdk_version || true)"
+  if [ -z "${dotnet_version}" ]; then
+    warn "Could not read the SDK version from global.json; skipping repo-local .NET SDK installation."
+    return
+  fi
+
+  if [ -x "${dotnet_root}/dotnet" ] && [ -d "${dotnet_root}/sdk/${dotnet_version}" ]; then
+    log "Repo-local .NET SDK ${dotnet_version} is already available at ${dotnet_root}."
+  else
+    log "Installing repo-local .NET SDK ${dotnet_version} into ${dotnet_root}..."
+    install_script="$(mktemp)"
+    curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${install_script}"
+    bash "${install_script}" --version "${dotnet_version}" --install-dir "${dotnet_root}"
+    rm -f "${install_script}"
+  fi
+
+  export DOTNET_ROOT="${dotnet_root}"
+  export PATH="${dotnet_root}:${PATH}"
+
+  append_if_missing "${HOME}/.bashrc" "export DOTNET_ROOT=\"${dotnet_root}\""
+  append_if_missing "${HOME}/.bashrc" "export PATH=\"${dotnet_root}:\$PATH\""
+}
+
+install_dotnet_tools() {
+  if ! command -v dotnet >/dev/null 2>&1; then
+    fail "dotnet is unavailable; cannot restore the required dotnet tool manifest."
+  fi
+
+  if [ ! -f "${REPO_ROOT}/dotnet-tools.json" ]; then
+    fail "Required dotnet tool manifest not found at ${REPO_ROOT}/dotnet-tools.json."
+  fi
+
+  log "Restoring repo-local dotnet tools from dotnet-tools.json..."
+  (
+    cd "${REPO_ROOT}"
+    dotnet tool restore --tool-manifest "${REPO_ROOT}/dotnet-tools.json"
+  )
+}
+
+install_dotnet_coverage() {
+  if ! command -v dotnet >/dev/null 2>&1; then
+    fail "dotnet is unavailable; cannot install dotnet-coverage."
+  fi
+
+  local dotnet_tools_dir="${HOME}/.dotnet/tools"
+  mkdir -p "${dotnet_tools_dir}"
+
+  export PATH="${dotnet_tools_dir}:${PATH}"
+  append_if_missing "${HOME}/.bashrc" "export PATH=\"\$HOME/.dotnet/tools:\$PATH\""
+
+  if command -v dotnet-coverage >/dev/null 2>&1; then
+    log "dotnet-coverage is already available; skipping."
+    return
+  fi
+
+  log "Installing dotnet-coverage as a global dotnet tool..."
+  if dotnet tool list --global | grep -Eq '^dotnet-coverage\s'; then
+    dotnet tool update --global dotnet-coverage
+  else
+    dotnet tool install --global dotnet-coverage
+  fi
+}
+
+install_actionlint() {
+  if command -v actionlint >/dev/null 2>&1; then
+    log "actionlint is already available; skipping."
+    return
+  fi
+
+  if ! command -v tar >/dev/null 2>&1; then
+    warn "tar is unavailable; skipping actionlint installation."
+    return
+  fi
+
+  local actionlint_version="1.7.7"
+  local temp_dir=""
+  local runner=""
+
+  if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      runner="sudo"
+    else
+      warn "actionlint installation requires root or sudo; skipping."
+      return
+    fi
+  fi
+
+  temp_dir="$(mktemp -d)"
+  log "Installing actionlint v${actionlint_version}..."
+  if curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/actionlint_${actionlint_version}_linux_amd64.tar.gz" -o "${temp_dir}/actionlint.tar.gz"; then
+    tar -xzf "${temp_dir}/actionlint.tar.gz" -C "${temp_dir}" actionlint
+    ${runner} install -m 0755 "${temp_dir}/actionlint" /usr/local/bin/actionlint
+    log "actionlint installed at /usr/local/bin/actionlint."
+  else
+    warn "Could not download actionlint; skipping."
+  fi
+
+  rm -rf "${temp_dir}"
+}
+
+restore_packages_if_needed() {
+  cd "${REPO_ROOT}"
+
+  if [ -d "${REPO_ROOT}/packages" ] && [ -n "$(find "${REPO_ROOT}/packages" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    log "packages/ is already populated; skipping restore."
+    return
+  fi
+
+  if ! command -v nuget >/dev/null 2>&1; then
+    warn "nuget is unavailable; cannot restore packages.config dependencies."
+    return
+  fi
+
+  log "Restoring solution packages into packages/..."
+  nuget restore "${REPO_ROOT}/TaskMaster.sln" -PackagesDirectory "${REPO_ROOT}/packages"
+}
+
+verify_formatting_capability() {
+  log "Verifying formatting capability..."
+
+  command -v dotnet >/dev/null 2>&1 || fail "dotnet is not available after setup."
+  command -v pwsh >/dev/null 2>&1 || fail "pwsh is not available after setup."
+
+  (
+    cd "${REPO_ROOT}"
+    dotnet tool run csharpier --version >/dev/null
+  ) || fail "CSharpier is not runnable via 'dotnet tool run csharpier'."
+}
+
+is_windows_powershell_host() {
+  pwsh -NoProfile -ExecutionPolicy Bypass -Command "& { if (\$IsWindows) { exit 0 } ; exit 1 }" >/dev/null 2>&1
+}
+
+verify_windows_visual_studio_task_capability() {
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "${REPO_ROOT}/scripts/vscode/Invoke-VSBuild.ps1" -SolutionPath TaskMaster.sln -Configuration Debug -Platform 'Any CPU' -NoExecute >/dev/null || fail "MSBuild tooling required by the restore/build/lint/type-check tasks is unavailable."
+
+  pwsh -NoProfile -ExecutionPolicy Bypass -Command "& {
+    \$vswherePath = Join-Path \${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path \$vswherePath)) {
+      throw 'vswhere.exe was not found. Install Visual Studio 2022 (or Build Tools) with Test Platform components.'
+    }
+
+    \$vstestPath = & \$vswherePath -latest -products * -find 'Common7\IDE\Extensions\TestPlatform\vstest.console.exe' | Select-Object -First 1
+    if (-not \$vstestPath) {
+      throw 'vstest.console.exe not found via vswhere. Install Visual Studio Test Platform components.'
+    }
+  }" >/dev/null || fail "Visual Studio test tooling required by the MSTest tasks is unavailable."
+}
+
+verify_build_and_test_capability() {
+  log "Verifying restore/build/lint/type-check/test capability..."
+
+  command -v pwsh >/dev/null 2>&1 || fail "pwsh is not available after setup."
+  command -v dotnet-coverage >/dev/null 2>&1 || fail "dotnet-coverage is not available after setup."
+  [ -f "${REPO_ROOT}/coverage.config" ] || fail "coverage.config is missing from the repository root."
+
+  if ! is_windows_powershell_host; then
+    warn "Skipping Windows-only Visual Studio task verification because this host is not Windows. Restore/build/test parity still requires Windows plus Visual Studio tooling discoverable via vswhere.exe."
+    return
+  fi
+
+  verify_windows_visual_studio_task_capability
+}
+
+verify_required_task_tooling() {
+  verify_formatting_capability
+  verify_build_and_test_capability
+}
+
+write_repo_notes() {
+  cat <<'EOF'
+
+Workspace profile detected:
+- Legacy Visual Studio solution targeting .NET Framework 4.8.1
+- Repo-pinned .NET SDK via global.json with install path rooted at .dotnet-sdk/
+- Local dotnet tool manifest for CSharpier
+- Global dotnet-coverage installation for MSTest coverage collection
+- Windows-first build/test scripts that rely on VS tools such as vswhere, MSBuild.exe, and vstest.console.exe
+- Outlook interop and VSTO references across the main add-in and supporting libraries
+
+Codex Web caveat:
+- This script verifies general Codex Web prerequisites everywhere, and it verifies the full Visual Studio task chain only on Windows hosts.
+- In Linux-based Codex Web, the script completes with a warning after skipping the Windows-only Visual Studio checks because the restore/build/test tasks require Windows plus Visual Studio 2022 or Build Tools components discoverable through vswhere.exe.
+- Full add-in build/debug parity still requires Windows with Visual Studio 2022, Office/VSTO tooling, and Outlook desktop.
+
+Useful follow-up commands after a successful setup run:
+- source ~/.bashrc
+- dotnet --info
+- dotnet tool run csharpier format .
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-Restore.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU"
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU" -EnableNETAnalyzers -EnforceCodeStyleInBuild
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-VSBuild.ps1 -SolutionPath TaskMaster.sln -Configuration Debug -Platform "Any CPU" -EnableNullable -TreatWarningsAsErrors
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTest.ps1 -SearchRoot . -Configuration Debug
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/vscode/Invoke-MSTestWithCoverage.ps1 -SearchRoot . -Configuration Debug
+
+Note:
+- The repo's existing PowerShell helper scripts under scripts/vscode/ are Windows/Visual Studio oriented by design, so Linux-based Codex Web setup can prepare only a partial toolchain.
+EOF
+}
+
+main() {
+  log "Bootstrapping a Codex Web environment for ${REPO_ROOT}"
+
+  export CI=true
+  export DOTNET_CLI_TELEMETRY_OPTOUT=1
+  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+  export DOTNET_MULTILEVEL_LOOKUP=0
+  export NUGET_XMLDOC_MODE=skip
+
+  append_if_missing "${HOME}/.bashrc" 'export CI=true'
+  append_if_missing "${HOME}/.bashrc" 'export DOTNET_CLI_TELEMETRY_OPTOUT=1'
+  append_if_missing "${HOME}/.bashrc" 'export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1'
+  append_if_missing "${HOME}/.bashrc" 'export DOTNET_MULTILEVEL_LOOKUP=0'
+  append_if_missing "${HOME}/.bashrc" 'export NUGET_XMLDOC_MODE=skip'
+
+  install_apt_packages
+  install_powershell
+  install_nuget
+  install_dotnet_sdk
+  install_dotnet_tools
+  install_dotnet_coverage
+  verify_required_task_tooling
+  install_actionlint
+  restore_packages_if_needed
+
+  if command -v git >/dev/null 2>&1; then
+    git config --global core.autocrlf input || true
+  fi
+
+  write_repo_notes
+  log "Setup complete."
+}
+
+main "$@"

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/feature-review-remediate.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/feature-review-remediate.md
@@ -1,0 +1,10 @@
+---
+description: Run feature review and, if needed, remediation planning with executor preflight
+---
+
+$feature-review
+Use pr_context as authoritative if present and valid. Only fall back to an explicit base branch if pr_context is missing, stale, or ambiguous.
+If remediation is required, explicitly spawn atomic-planner to create or revise the remediation plan.
+Before atomic-planner finalizes the plan, it must explicitly spawn atomic-executor in preflight-validation-only mode against that same file.
+If atomic-executor returns PREFLIGHT: REVISIONS REQUIRED, atomic-planner must revise the same file and repeat until PREFLIGHT: ALL CLEAR.
+Only then finalize the remediation plan and report all generated artifacts.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/generate-commit-message-repo.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/generate-commit-message-repo.md
@@ -1,0 +1,11 @@
+---
+description: Generate a conventional commit message for the current repository by spawning commit-steward
+---
+
+Spawn `commit-steward` to generate a single audit-quality conventional commit message for the current repository.
+
+Use an explicitly supplied commit-context artifact as the primary input when one is provided.
+If no explicit commit-context artifact is provided, prefer `artifacts/commit_context.txt` when that file exists in the workspace.
+If no commit-context artifact is available, have `commit-steward` inspect staged changes directly and scope the message to staged changes only.
+
+Return exactly one fenced `text` code block containing only the commit message.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/generate-pr.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/generate-pr.md
@@ -1,0 +1,15 @@
+---
+description: Generate a GitHub-ready PR body from the canonical PR-context bundle by spawning pr-author
+argument-hint: Optional notes or PR intent edits to apply while writing the PR body
+---
+
+Spawn `pr-author` to generate a GitHub-ready pull request body.
+
+Use only:
+- the canonical PR-context bundle
+- the additional context files enumerated inside that bundle
+- any explicit user directives supplied with this prompt invocation
+
+If the PR-context bundle is missing or stale, refresh it using the canonical mechanism before generating the PR body.
+
+Return exactly one fenced `markdown` code block containing only the pull request message.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/orchestrate-work.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/orchestrate-work.md
@@ -1,0 +1,22 @@
+---
+description: Route a request through budget-based orchestration and persist until the selected delivery path is complete
+argument-hint: Provide objective, likely files, feature-or-bug hint, constraints, and whether small-path execution should stop after Phase 0 for manual bootstrap
+---
+
+Spawn `orchestrator` to coordinate the current request from intake through completion.
+
+Inputs to provide or infer:
+- request summary and expected outcome
+- likely affected production and test files, when known
+- initial classification hint: `feature` or `bug`, when known
+- constraints, preserved APIs, or forbidden changes
+- whether small-path execution should stop after Phase 0 for manual bootstrap
+
+Required behavior:
+- estimate change budget first and choose the correct small or large path
+- maintain and resume from the canonical orchestration checkpoint
+- use migrated Codex subagents when available
+- route host-specific lifecycle automation through the shared adapter rules
+- continue until planning, execution, validation, and review are complete for the selected path, unless the request explicitly requires a manual-bootstrap pause
+
+On completion, report the selected route, branch, key variables, `plan-path` when applicable, checkpoint path, created or updated artifact paths, and final readiness summary.

--- a/extensions/drm-copilot/resources/scripts/dev_tools/push_down_codex_and_agents_customizations.py
+++ b/extensions/drm-copilot/resources/scripts/dev_tools/push_down_codex_and_agents_customizations.py
@@ -11,14 +11,26 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from scripts.dev_tools.push_down_copilot_customizations import (
-    PushDownFileSystem,
-    PushDownSummary,
-    RealPushDownFileSystem,
-)
-from scripts.dev_tools.push_down_copilot_customizations import (
-    push_down_customizations as push_down_scoped_customizations,
-)
+try:
+    from scripts.dev_tools.push_down_copilot_customizations import (
+        PushDownFileSystem,
+        PushDownSummary,
+        RealPushDownFileSystem,
+    )
+    from scripts.dev_tools.push_down_copilot_customizations import (
+        push_down_customizations as push_down_scoped_customizations,
+    )
+except ModuleNotFoundError as error:
+    if error.name is None or not error.name.startswith("scripts"):
+        raise
+    from dev_tools.push_down_copilot_customizations import (
+        PushDownFileSystem,
+        PushDownSummary,
+        RealPushDownFileSystem,
+    )
+    from dev_tools.push_down_copilot_customizations import (
+        push_down_customizations as push_down_scoped_customizations,
+    )
 
 ARTIFACT_DIRECTORY = "artifacts/codex-and-agents-customizations"
 MODULE_ENTRY_POINT = "scripts.dev_tools.push_down_codex_and_agents_customizations"

--- a/extensions/drm-copilot/resources/scripts/dev_tools/push_down_copilot_customizations.py
+++ b/extensions/drm-copilot/resources/scripts/dev_tools/push_down_copilot_customizations.py
@@ -16,14 +16,26 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypedDict
 
-from scripts.dev_tools.agentic_sync import ROOT_FOLDERS
-from scripts.dev_tools.push_down_copilot_customizations_filesystem import (
-    PushDownFileSystem,
-    RealPushDownFileSystem,
-)
-from scripts.dev_tools.push_down_copilot_customizations_rewrites import (
-    rewrite_text_references,
-)
+try:
+    from scripts.dev_tools.agentic_sync import ROOT_FOLDERS
+    from scripts.dev_tools.push_down_copilot_customizations_filesystem import (
+        PushDownFileSystem,
+        RealPushDownFileSystem,
+    )
+    from scripts.dev_tools.push_down_copilot_customizations_rewrites import (
+        rewrite_text_references,
+    )
+except ModuleNotFoundError as error:
+    if error.name is None or not error.name.startswith("scripts"):
+        raise
+    from dev_tools.agentic_sync import ROOT_FOLDERS
+    from dev_tools.push_down_copilot_customizations_filesystem import (
+        PushDownFileSystem,
+        RealPushDownFileSystem,
+    )
+    from dev_tools.push_down_copilot_customizations_rewrites import (
+        rewrite_text_references,
+    )
 
 ARTIFACT_DIRECTORY = "artifacts/copilot-customizations"
 MODULE_ENTRY_POINT = "scripts.dev_tools.push_down_copilot_customizations"

--- a/scripts/dev_tools/push_down_codex_and_agents_customizations.py
+++ b/scripts/dev_tools/push_down_codex_and_agents_customizations.py
@@ -11,14 +11,26 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from scripts.dev_tools.push_down_copilot_customizations import (
-    PushDownFileSystem,
-    PushDownSummary,
-    RealPushDownFileSystem,
-)
-from scripts.dev_tools.push_down_copilot_customizations import (
-    push_down_customizations as push_down_scoped_customizations,
-)
+try:
+    from scripts.dev_tools.push_down_copilot_customizations import (
+        PushDownFileSystem,
+        PushDownSummary,
+        RealPushDownFileSystem,
+    )
+    from scripts.dev_tools.push_down_copilot_customizations import (
+        push_down_customizations as push_down_scoped_customizations,
+    )
+except ModuleNotFoundError as error:
+    if error.name is None or not error.name.startswith("scripts"):
+        raise
+    from dev_tools.push_down_copilot_customizations import (
+        PushDownFileSystem,
+        PushDownSummary,
+        RealPushDownFileSystem,
+    )
+    from dev_tools.push_down_copilot_customizations import (
+        push_down_customizations as push_down_scoped_customizations,
+    )
 
 ARTIFACT_DIRECTORY = "artifacts/codex-and-agents-customizations"
 MODULE_ENTRY_POINT = "scripts.dev_tools.push_down_codex_and_agents_customizations"

--- a/scripts/dev_tools/push_down_copilot_customizations.py
+++ b/scripts/dev_tools/push_down_copilot_customizations.py
@@ -16,14 +16,26 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypedDict
 
-from scripts.dev_tools.agentic_sync import ROOT_FOLDERS
-from scripts.dev_tools.push_down_copilot_customizations_filesystem import (
-    PushDownFileSystem,
-    RealPushDownFileSystem,
-)
-from scripts.dev_tools.push_down_copilot_customizations_rewrites import (
-    rewrite_text_references,
-)
+try:
+    from scripts.dev_tools.agentic_sync import ROOT_FOLDERS
+    from scripts.dev_tools.push_down_copilot_customizations_filesystem import (
+        PushDownFileSystem,
+        RealPushDownFileSystem,
+    )
+    from scripts.dev_tools.push_down_copilot_customizations_rewrites import (
+        rewrite_text_references,
+    )
+except ModuleNotFoundError as error:
+    if error.name is None or not error.name.startswith("scripts"):
+        raise
+    from dev_tools.agentic_sync import ROOT_FOLDERS
+    from dev_tools.push_down_copilot_customizations_filesystem import (
+        PushDownFileSystem,
+        RealPushDownFileSystem,
+    )
+    from dev_tools.push_down_copilot_customizations_rewrites import (
+        rewrite_text_references,
+    )
 
 ARTIFACT_DIRECTORY = "artifacts/copilot-customizations"
 MODULE_ENTRY_POINT = "scripts.dev_tools.push_down_copilot_customizations"

--- a/tests/scripts/dev_tools/test_push_down_codex_and_agents_customizations.py
+++ b/tests/scripts/dev_tools/test_push_down_codex_and_agents_customizations.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import importlib
 import io
 import json
+import sys
 from contextlib import redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 
 @dataclass
@@ -63,12 +68,86 @@ class RecordingFileSystem:
         self.directories.add(path)
 
 
+def _bundled_scripts_root() -> Path:
+    """Resolve the bundled `resources/scripts` root used by the extension."""
+
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root / "extensions" / "drm-copilot" / "resources" / "scripts"
+
+
+def _bundled_only_sys_path(repo_root: Path, bundled_scripts_root: Path) -> list[str]:
+    """Build a sys.path that exposes bundled `dev_tools` without repo-root `scripts`."""
+
+    filtered_path: list[str] = []
+    for entry in sys.path:
+        if entry == "":
+            continue
+        try:
+            if Path(entry).resolve() == repo_root:
+                continue
+        except OSError:
+            pass
+        filtered_path.append(entry)
+
+    return [str(bundled_scripts_root), *filtered_path]
+
+
 def _load_module():
     """Import the Codex/agents push-down publisher under test."""
 
     return importlib.import_module(
         "scripts.dev_tools.push_down_codex_and_agents_customizations"
     )
+
+
+def test_bundled_module_imports_without_repo_root_scripts_package(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify bundled import works with only the packaged `dev_tools` path."""
+
+    repo_root = Path(__file__).resolve().parents[3]
+    bundled_scripts_root = _bundled_scripts_root()
+    import_state = [
+        "scripts",
+        "scripts.dev_tools",
+        "scripts.dev_tools.agentic_sync",
+        "scripts.dev_tools.push_down_copilot_customizations",
+        "scripts.dev_tools.push_down_copilot_customizations_filesystem",
+        "scripts.dev_tools.push_down_copilot_customizations_rewrites",
+        "scripts.dev_tools.push_down_codex_and_agents_customizations",
+        "dev_tools",
+        "dev_tools.agentic_sync",
+        "dev_tools.push_down_copilot_customizations",
+        "dev_tools.push_down_copilot_customizations_filesystem",
+        "dev_tools.push_down_copilot_customizations_rewrites",
+        "dev_tools.push_down_codex_and_agents_customizations",
+    ]
+    saved_modules = {name: sys.modules.get(name) for name in import_state}
+
+    for module_name in import_state:
+        sys.modules.pop(module_name, None)
+
+    monkeypatch.setattr(
+        sys,
+        "path",
+        _bundled_only_sys_path(repo_root, bundled_scripts_root),
+    )
+    importlib.invalidate_caches()
+
+    try:
+        module = importlib.import_module(
+            "dev_tools.push_down_codex_and_agents_customizations"
+        )
+        assert callable(module.push_down_customizations)
+        assert module.MODULE_ENTRY_POINT.endswith(
+            "push_down_codex_and_agents_customizations"
+        )
+    finally:
+        for module_name in import_state:
+            sys.modules.pop(module_name, None)
+        for module_name, module in saved_modules.items():
+            if module is not None:
+                sys.modules[module_name] = module
 
 
 def test_push_down_customizations_copies_codex_and_agents_paths() -> None:


### PR DESCRIPTION
Bundle Codex setup assets and make packaged push-down publishers import-compatible

## Summary
- Bundle the missing `.codex` setup scripts and prompt files into the extension’s `codex-and-agents-customizations` payload.
- Update the shared push-down publisher modules so they work in both repo-root `scripts.dev_tools` and packaged `dev_tools` import contexts.
- Keep the repo-root and bundled Python publisher copies aligned by applying the same import-compatibility change to both surfaces.
- Add regression coverage for bundled-only import execution in `tests/scripts/dev_tools/test_push_down_codex_and_agents_customizations.py`.
- Preserve the existing branch scope to 11 changed files with 5 Python files, 5 Markdown prompt/setup files, and 1 shell script.

## Why
The branch adds bundled `.codex` setup assets and adjusts the push-down publisher import path so the packaged extension can execute the same publisher logic as the repo-root copy. The changed-file set shows this PR is focused on extension-bundled customization payload parity plus the Python import boundary that those bundled publishers rely on.

## What Changed
- Core behavior / architecture
  - Added bundled `.codex` setup assets and prompt files under `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/...`.
  - Updated `push_down_codex_and_agents_customizations.py` and `push_down_copilot_customizations.py` in both repo-root and bundled locations.
- Tooling / automation / developer experience
  - Ensured the extension-bundled customization payload includes the same Codex setup materials needed by downstream workspaces.
- Tests
  - Added Python regression coverage in `tests/scripts/dev_tools/test_push_down_codex_and_agents_customizations.py`.
- Docs / templates / agents
  - Added bundled prompt/setup Markdown assets for Codex workflow support.

## Architecture / How It Fits Together
The branch keeps the push-down publisher logic mirrored between the repo-root `scripts/dev_tools` modules and the bundled `extensions/drm-copilot/resources/scripts/dev_tools` copies. The new bundled `.codex` assets expand the customization payload shipped with the extension, while the Python import-path changes let the same publisher modules execute correctly whether they are loaded from the repository package layout or from the installed extension’s packaged `dev_tools` layout.

## Verification
### Completed
- Not verified in this PR (no tool outputs recorded in the PR-context summary).

### Recommended
- `poetry run pytest tests/scripts/dev_tools/test_push_down_codex_and_agents_customizations.py`
- `poetry run pytest tests/scripts/dev_tools/test_push_down_copilot_customizations.py`
- `poetry run pytest --cov=src/lexile_corpus_tuner --cov=scripts/dev_tools --cov-report=term-missing`

## Backward Compatibility / Migration Notes
- The change is additive for the bundled customization payload and does not remove the existing publisher modules.
- The Python publisher update is compatibility-oriented: it supports both repo-root and packaged import paths instead of changing the public push-down entrypoint shape.

## Risks and Mitigations
- Risk: bundled customization payload drift could recur as `.codex` assets evolve.
  - Mitigation: this PR explicitly adds the missing bundled setup and prompt files to reduce current parity gaps.
- Risk: import-path handling could diverge between repo-root and packaged execution.
  - Mitigation: the same Python changes were applied to both the repo-root and bundled publisher copies, and regression coverage was added.

## Review Guide
- Review the newly added bundled `.codex` setup and prompt files under `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/`.
- Review the import-compatibility changes in:
  - `scripts/dev_tools/push_down_codex_and_agents_customizations.py`
  - `scripts/dev_tools/push_down_copilot_customizations.py`
  - `extensions/drm-copilot/resources/scripts/dev_tools/push_down_codex_and_agents_customizations.py`
  - `extensions/drm-copilot/resources/scripts/dev_tools/push_down_copilot_customizations.py`
- Review the new regression coverage in `tests/scripts/dev_tools/test_push_down_codex_and_agents_customizations.py`.

## Follow-ups
- Consider adding or strengthening automated parity checks for bundled Codex customization payload contents if future drift becomes a recurring maintenance issue.

## GitHub Auto-close
- Closes 124

## Related issues / PRs
- None
