### PR TITLE
fix(orchestration): fail closed on missing audit evidence

### DIFF
--- a/docs/features/templates/bug/plan.yyyy-MM-ddTHH-mm.md
+++ b/docs/features/templates/bug/plan.yyyy-MM-ddTHH-mm.md
@@ -7,6 +7,10 @@
 - **Status:** <template>
 - **Version:** <version_number>
 
+**Fail-closed evidence rule:** Include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for each in-scope language when policy requires coverage. If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence accounting rule:** Record the expected artifact path or location in each evidence-producing task. Do not mark evidence-backed work complete without the artifact.
+
 
 **Phase 0 — Context & Inputs**
 - [ ] [P0-T1] Link approved spec: <spec link>
@@ -27,6 +31,7 @@
 **Phase 4 — Verification Loop**
 - [ ] [P4-T1] Re-run repro and regression test to confirm expected behavior
 - [ ] [P4-T2] Run formatter → linter → type checker → tests; restart loop if any step changes files or fails
+- [ ] [P4-T3] Record baseline, post-change, and comparison artifact paths for each in-scope language where coverage is required
 
 **Phase 5 — Documentation & Status**
 - [ ] [P5-T1] Update spec/issue with outcomes, decisions, and any deviations from scope

--- a/docs/features/templates/feature/plan.yyyy-MM-ddTHH-mm.md
+++ b/docs/features/templates/feature/plan.yyyy-MM-ddTHH-mm.md
@@ -23,6 +23,9 @@
 > - Start every task with a **strong verb** (Implement, Create, Update, Verify).
 > - No "bucket" tasks like "Refactor module" or "Write tests"; split them into specific, verifiable steps.
 > - **Self-Validating Phases:** Include necessary test creation/update tasks *within* the phase that implements the code. Do not defer verification to a final "Testing" phase.
+> - Include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for every language in scope when policy requires coverage.
+> - Name the expected artifact path or location in each evidence-producing task's acceptance criteria.
+> - If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
 
 ### Phase 0: Compliance & Context
 - [ ] [P0-T1] Confirm alignment with repo policies by reading `.github/instructions/general-code-change.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, and `.github/instructions/python-unit-test.instructions.md` before touching code
@@ -43,6 +46,7 @@
 - Unit: ...
 - Integration: ...
 - Manual/CLI: ...
+- Coverage evidence: list baseline artifact paths, post-change artifact paths, and comparison artifact paths for each in-scope language
 
 ## Open Questions / Notes
 

--- a/docs/features/templates/policy_audit/AGENTS.md
+++ b/docs/features/templates/policy_audit/AGENTS.md
@@ -50,11 +50,15 @@ When asked to perform a Policy Audit for a component, branch, or PR:
    - Generate a timestamp in ISO-8601 format `yyyy-MM-ddTHH-mm` (e.g., "2026-01-08T14-30" for Jan 8, 2026 at 2:30 PM).
    - Copy [policy-audit.yyyy-MM-ddTHH-mm.md](./policy-audit.yyyy-MM-ddTHH-mm.md) to the requested location with timestamped filename: `policy-audit.<timestamp>.md` (e.g., feature folder or PR docs).
    - Replace placeholders (`[Component Name]`, dates, paths, counts) as described in [README.md](./README.md).
+   - Preserve the explicit coverage evidence checklist in the template.
+     - Keep the TypeScript and PowerShell artifact lines even when those languages are out of scope; mark them `N/A - out of scope` rather than deleting them.
+     - Fill the per-language comparison summary reference with either an in-document section reference or an exact artifact path.
    - **For multi-language changes:**
      - Fill in the Coverage Metrics by Language table with one row per language.
      - Complete all applicable language sections (3A, 3B, 3C, 3D for code; 4A, 4B for tests).
      - Delete sections for languages NOT involved in this change.
    - **Fill in baseline coverage metrics** from pre-development measurement (per language that has coverage).
+   - Add one per-language comparison bullet for every in-scope language that has coverage requirements.
 
 3. **Evaluate policy compliance**
    - For each section of the template:
@@ -73,6 +77,11 @@ When asked to perform a Policy Audit for a component, branch, or PR:
      - Compare post-change coverage to baseline to verify no regression (per language).
      - Isolate and measure coverage of new/modified code only (must be ≥90% per language).
      - Use concrete examples showing calculations: "Baseline: 85.2% → Post-change: 87.1% (+1.9%) ✅"
+   - **Fail-closed evidence handling:**
+     - No policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage when required.
+     - If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the verdict must be BLOCKED or INCOMPLETE, never PASS.
+     - Do not synthesize or backfill missing audit evidence from memory or inference.
+     - If evidence is missing, stop and report the exact missing artifact paths.
    - **For scenario testing:**
      - Use deterministic, input→output→assertion format for all examples.
      - **Positive flows:** Show concrete valid inputs and expected outputs.
@@ -104,4 +113,5 @@ When asked to perform a Policy Audit for a component, branch, or PR:
 
 - Do **not** modify the canonical `.instructions.md` policy documents as part of an audit.
 - Do **not** treat this AGENTS file as a reason to change how normal code or tests are written; it is for **evaluation and documentation** only.
+- Do **not** report readiness as PASS when required audit evidence is absent; report incomplete with the missing artifact names or paths.
 - If you detect any conflict between this file and the canonical policy documents, halt and ask the user for clarification instead of guessing.

--- a/docs/features/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md
+++ b/docs/features/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md
@@ -37,6 +37,20 @@
 
 **Note:** Delete rows for languages not involved in this change. Add rows if additional languages are used.
 
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: [path or `N/A - out of scope`]
+- TypeScript post-change coverage artifact: [path or `N/A - out of scope`]
+- PowerShell baseline coverage artifact: [path or `N/A - out of scope`]
+- PowerShell post-change coverage artifact: [path or `N/A - out of scope`]
+- Per-language comparison summary: [section reference or artifact path]
+
+**Non-negotiable verdict rule:** No policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage when required.
+
+**Fail-closed rule:** If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence rule:** Do not synthesize or backfill missing audit evidence from memory or inference. If evidence is missing, stop and list the exact missing artifact paths.
+
 ---
 
 ## Executive Summary
@@ -90,6 +104,12 @@
 | **Error Handling** - Error paths | [✅/❌/N/A] [PASS/FAIL/N/A] | **All error scenarios tested:**<br>- `test_function_handles_network_timeout`: Mock network timeout → raises `TimeoutError` after retry<br>- `test_function_handles_file_not_found`: Missing file → raises `FileNotFoundError` with filepath<br>- `test_function_handles_json_parse_error`: Invalid JSON → raises `JSONDecodeError` with line number<br>**Total error handling tests:** [N] |
 | **Concurrency** - If applicable | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe concurrency testing or explain why it's not applicable. If applicable, describe how race conditions and thread safety are tested.] |
 | **State Transitions** - If applicable | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe state transition testing or explain why it's not applicable. If applicable, show that all state transitions are tested.] |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+Repeat one bullet per in-scope language that has coverage requirements. Keep the checklist above even when a language is out of scope, but use `N/A - out of scope` for the artifact path.
+
+- [Language]: Baseline: [N]% [unit] -> Post-change: [N]% [unit]. Change: [+/-N]% [unit delta]. New/changed-code coverage: [N]% or `N/A - out of scope`. Disposition: [PASS/FAIL/N/A]. Evidence: [artifact path(s)].
 
 ### 1.3 Test Structure and Diagnostics
 
@@ -494,6 +514,8 @@
 ### Overall Status: [✅ FULLY COMPLIANT / ⚠️ PARTIALLY COMPLIANT / ❌ NON-COMPLIANT]
 
 [Provide a brief summary of overall compliance status and any major findings.]
+
+**Fail-closed reminder:** Do not mark the audit PASS, fully compliant, or ready for merge when any required baseline artifact, QA artifact, coverage metric, or coverage-comparison artifact is missing.
 
 ---
 

--- a/docs/features/templates/refactor/plan.yyyy-MM-ddTHH-mm.md
+++ b/docs/features/templates/refactor/plan.yyyy-MM-ddTHH-mm.md
@@ -16,6 +16,10 @@
 
 Brief approach to reach the target structure while keeping behavior stable.
 
+Fail-closed evidence rule: include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for each in-scope language when policy requires coverage. If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+Evidence accounting rule: record the expected artifact path or location in each evidence-producing task. Do not mark evidence-backed work complete without the artifact.
+
 ## Work Breakdown
 
 ### Phase 1: Inventory & Plan [0%]
@@ -37,6 +41,7 @@ Brief approach to reach the target structure while keeping behavior stable.
 - Unit/Integration: impacted modules and any regression tests for invariants
 - CLI/Workflow: end-to-end commands/tasks expected to remain stable
 - Tooling: lint/type checks after path updates
+- Coverage evidence: list baseline artifact paths, post-change artifact paths, and comparison artifact paths for each in-scope language
 
 ## Rollback / Contingency
 

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/atomic-plan-contract/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/atomic-plan-contract/SKILL.md
@@ -94,11 +94,14 @@ For short-path/minimal-audit plans, Phase 0 evidence is incomplete unless both a
 For any language in scope where repository policy requires coverage validation:
 
 - The approved plan MUST include explicit baseline and final-QC coverage capture tasks.
+- The approved plan MUST include explicit artifact-path tasks for baseline artifacts, final-QA artifacts, and coverage-comparison artifacts for each in-scope language that requires coverage.
 - Baseline and final-QC artifacts MUST record numeric coverage values (not placeholders such as `UNVERIFIED`).
 - Where policy requires no-regression and new-code thresholds, the plan MUST include a delta/threshold verification task that reports:
 	- baseline coverage,
 	- post-change coverage,
 	- new/changed-code coverage.
+- If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict MUST be BLOCKED or INCOMPLETE, never PASS.
+- Do not synthesize or backfill missing evidence from memory or inference. Missing evidence MUST remain missing and be reported with exact artifact paths.
 - If required coverage values are unavailable, the plan outcome MUST be remediation-required and MUST NOT be reported as PASS.
 
 ## Final QA Loop (Required for Code/Test Changes)

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/feature-review/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/feature-review/SKILL.md
@@ -52,6 +52,8 @@ Each required review artifact MUST pass the matching validator command before re
 3. If PR context is missing or stale, refresh it through `repo-automation-adapter` using the resolved base branch.
 4. Determine the active feature folder deterministically from the scoping docs and PR context.
 5. Create the policy audit, code review, and feature audit.
+   - do not synthesize or backfill missing audit evidence from memory or inference
+   - if required baseline artifacts, QA artifacts, or coverage-comparison artifacts are missing, stop and report the exact missing artifact paths
    - validate each artifact immediately after writing it
 6. Check off passing acceptance criteria in the authoritative requirement sources per `acceptance-criteria-tracking`.
 7. If remediation is required, create remediation inputs first and then hand off plan creation using `remediation-handoff-atomic-planner`.
@@ -73,6 +75,9 @@ When remediation is required:
 - `policy-audit.<timestamp>.md`
   - MUST be copied from the canonical template and MUST NOT retain the template instruction block.
   - MUST contain the canonical major headings and Appendix B command reference.
+  - MUST include numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage when policy requires it.
+  - MUST include the explicit coverage evidence checklist lines for TypeScript baseline/post-change artifacts, PowerShell baseline/post-change artifacts, and the per-language comparison summary reference.
+  - MUST include a per-language comparison line with explicit delta text and disposition for every in-scope language that has coverage requirements.
 - `code-review.<timestamp>.md`
   - MUST contain `## Executive Summary`.
   - MUST contain `## Findings Table`.
@@ -89,4 +94,6 @@ When remediation is required:
 - Do not silently fix code during review.
 - Prefer check-only commands.
 - If a tool cannot be run, mark the related section as unverified or partial with a concrete reason.
+- Do not mark readiness as PASS or ready for merge when required coverage evidence is missing.
+- If required evidence is absent, report incomplete with the exact missing artifact names or paths.
 - Do not claim completion until every required artifact exists on disk and its validator passes.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrator-workflow/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrator-workflow/SKILL.md
@@ -213,6 +213,7 @@ Required behavior:
     Hard enforcement for Step 8:
     - Do not mark Step 8 complete until execution output includes execution summary, QA summary, lint/type/test/coverage deltas, and numeric baseline/post/new-code coverage metrics where policy requires them.
     - Do not accept PASS execution outcomes when required baseline or final-QA artifacts are missing, when checklist state is not backed by artifacts, or when coverage-bearing plan tasks remain unverified.
+    - Do not synthesize or backfill missing audit evidence from memory or inference.
     - Do not perform execution locally when this delegation cannot be started; set `step8_status` to `blocked`, set `blocked_reason`, and stop.
     - Record a delegation receipt and set `step8_status` to `verified` only after delegate output and validator checks pass.
 10. Spawn `feature-reviewer` for post-implementation review.
@@ -221,6 +222,9 @@ Required behavior:
     - Load canonical PR-context artifacts and refresh them through `repo-automation-adapter` when they are missing or stale relative to the current branch state.
     - Do not mark Step 9 complete until expected review artifacts are present on disk in `${feature-folder}`.
     - Do not accept PASS review outcomes when required coverage fields are left unverified, when PR-context artifacts are missing or stale relative to the current branch state, or when required remediation artifacts are missing.
+    - No policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage when required.
+    - If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, treat the review outcome as incomplete or blocked and report the exact missing artifact paths.
+    - Do not synthesize or backfill missing audit evidence from memory or inference.
     - Do not perform review locally when this delegation cannot be started; set `step9_status` to `blocked`, set `blocked_reason`, and stop.
     - Record a delegation receipt and set `step9_status` to `verified` only after delegate output and validator checks pass.
 11. If review triggers remediation, loop through remediation planning, remediation execution, and re-review until the gate is clean.
@@ -258,4 +262,5 @@ Do not claim mission completion until all of the following are true:
 - Do not create replacement audit artifacts yourself for any required delegated review step.
 - Do not execute required delegated steps locally as a fallback.
 - Do not accept stale PR-context artifacts, unsupported checklist checkoffs, or missing required evidence as PASS outcomes.
+- Do not synthesize or backfill missing audit evidence from memory or inference.
 - Do not claim completion without reporting the checkpoint path and the created or updated artifact paths.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/policy-audit-template-usage/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/policy-audit-template-usage/SKILL.md
@@ -24,8 +24,17 @@ Use this skill when:
 1) Resolve the policy-audit template through the MCP server tool `resolve_policy_audit_template_asset` with asset `template`, then copy the resolved asset to the target location using an ISO-8601 timestamp.
 2) Replace placeholders with actual values (component, date, files under test, commits).
 3) Remove any template usage instructions per template guidance.
-4) Mark each section PASS/FAIL/N/A using the template’s expected conventions.
-5) Preserve the canonical major sections from the template:
+4) Preserve the coverage evidence checklist in the audit and fill each required line with either an exact artifact path/reference or `N/A - out of scope`.
+   - Required checklist lines:
+     - `TypeScript baseline coverage artifact:`
+     - `TypeScript post-change coverage artifact:`
+     - `PowerShell baseline coverage artifact:`
+     - `PowerShell post-change coverage artifact:`
+     - `Per-language comparison summary:`
+5) Add one per-language comparison line for every language in scope that has coverage requirements.
+   - Each comparison line MUST include numeric baseline coverage, numeric post-change coverage, explicit delta/comparison text, a language-by-language disposition, and changed/new-code coverage when policy requires it.
+6) Mark each section PASS/FAIL/N/A using the template’s expected conventions.
+7) Preserve the canonical major sections from the template:
    - `## Executive Summary`
    - `## 1. General Unit Test Policy Compliance`
    - `## 2. General Code Change Policy Compliance`
@@ -39,10 +48,16 @@ Use this skill when:
    - `## 10. Compliance Verdict`
    - `## Appendix A: Test Inventory`
    - `## Appendix B: Toolchain Commands Reference`
-6) Run the `validate_orchestration_artifacts` MCP tool with `artifact_type: "policy-audit"` and `artifact_path: <path>` and fail closed on any non-zero result.
+8) Apply the non-negotiable verdict gate:
+   - no policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage when required,
+   - if any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the verdict MUST be BLOCKED or INCOMPLETE, never PASS.
+9) Do not synthesize or backfill missing audit evidence from memory or inference. If evidence is missing, stop and report the exact missing artifact paths.
+10) Run the `validate_orchestration_artifacts` MCP tool with `artifact_type: "policy-audit"` and `artifact_path: <path>` and fail closed on any non-zero result.
 
 ## Invalid Outputs
 
 - A freeform summary note is invalid.
 - A policy audit that retains the template instruction block is invalid.
 - A policy audit that omits the canonical major headings is invalid.
+- A policy audit that omits the coverage evidence checklist or the per-language comparison summary is invalid.
+- A policy audit that reports PASS while any required coverage metric or evidence path is missing is invalid.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/feature-reviewer.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/feature-reviewer.toml
@@ -27,6 +27,7 @@ Core behavior:
 - Determine the active feature folder deterministically from the repo’s scoping docs and PR context.
 - Write timestamped review artifacts into the active feature folder.
 - Validate each required review artifact with the `validate_orchestration_artifacts` MCP tool before reporting review completion.
+- Do not synthesize or backfill missing audit evidence from memory or inference.
 
 Required outputs:
 - policy-audit.<timestamp>.md
@@ -40,6 +41,8 @@ Review constraints:
 - Prefer check-only / no-mutation verification commands.
 - Do not silently fix code during review.
 - If tooling cannot be run, mark the relevant sections UNVERIFIED or PARTIAL with a concrete reason.
+- No policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage where required.
+- If required baseline artifacts, QA artifacts, or coverage-comparison artifacts are missing, stop and report incomplete with the exact missing artifact paths.
 - Continue until all required review artifacts exist on disk.
 
 Acceptance and remediation rules:

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
@@ -38,12 +38,15 @@ Core behavior:
 - Do not create or edit `${feature-folder}/issue.md`, `${feature-folder}/spec.md`, `${feature-folder}/user-story.md`, or `plan*.md` until potential entry creation, issue promotion, and active-folder creation all succeed.
 - Do not stop after partial setup while required downstream steps remain.
 - Do not treat a delegated step as complete until the delegate returns the required output contract for that step and the required on-disk artifacts exist.
+- Do not synthesize or backfill missing audit evidence from memory or inference.
 
 Completion contract:
 - Do not claim mission completion unless all required delegations completed with receipts.
 - Do not claim completion unless the checkpoint, approved `plan-path`, required review artifacts, required evidence-backed QA artifacts, and any required remediation artifacts are on disk.
 - Do not claim completion unless validator-backed checks for the plan, review artifacts, and checkpoint state pass.
 - Do not accept PASS outcomes that rely on stale PR-context artifacts, unsupported checklist checkoffs, or missing baseline/final-QA evidence required by the approved plan.
+- Do not accept PASS outcomes when a policy audit lacks numeric baseline or post-change coverage metrics for any language in scope, or lacks changed/new-code coverage where policy requires it.
+- If required baseline artifacts, QA artifacts, or coverage-comparison artifacts are missing, report incomplete with the exact missing artifact paths and do not claim final readiness as pass.
 - Do not claim completion if lifecycle setup used placeholder values, skipped ordered handoffs, or relied on non-canonical checkpoint files.
 
 Final response contract:

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/staged-review.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/staged-review.toml
@@ -14,6 +14,9 @@ Migration contract:
 - Prefer migrated Codex subagents, skills, and prompts when an equivalent Codex runtime surface exists; otherwise follow the source contract directly and record any fallback.
 - Treat .agents/skills, .codex/agents, and .codex/prompts as the Codex runtime surfaces for migrated behavior, but do not relax any source-agent requirements during that translation.
 - Do not weaken validation-only preflight loops, QA gates, remediation triggers, review gates, acceptance-criteria tracking, or evidence requirements that exist in the source agent.
+- Do not synthesize or backfill missing audit evidence from memory or inference.
+- No policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage where required.
+- If required baseline artifacts, QA artifacts, or coverage-comparison artifacts are missing, report incomplete with the exact missing artifact paths and do not mark readiness as pass.
 
 Mandatory source handoffs to preserve:
 - atomic_planner

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/orchestrate-work.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/prompts/orchestrate-work.md
@@ -17,6 +17,8 @@ Required behavior:
 - maintain and resume from the canonical orchestration checkpoint
 - use migrated Codex subagents when available
 - route host-specific lifecycle automation through the shared adapter rules
+- do not synthesize or backfill missing audit evidence from memory or inference
+- if required baseline artifacts, QA artifacts, or coverage-comparison artifacts are missing, report incomplete with the exact missing artifact names and do not mark readiness as pass
 - continue until planning, execution, validation, and review are complete for the selected path, unless the request explicitly requires a manual-bootstrap pause
 
 On completion, report the selected route, branch, key variables, `plan-path` when applicable, checkpoint path, created or updated artifact paths, and final readiness summary.

--- a/extensions/drm-copilot/resources/feature-templates/bug/plan.yyyy-MM-ddTHH-mm.md
+++ b/extensions/drm-copilot/resources/feature-templates/bug/plan.yyyy-MM-ddTHH-mm.md
@@ -7,6 +7,10 @@
 - **Status:** <template>
 - **Version:** <version_number>
 
+**Fail-closed evidence rule:** Include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for each in-scope language when policy requires coverage. If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence accounting rule:** Record the expected artifact path or location in each evidence-producing task. Do not mark evidence-backed work complete without the artifact.
+
 
 **Phase 0 — Context & Inputs**
 - [ ] [P0-T1] Link approved spec: <spec link>
@@ -27,6 +31,7 @@
 **Phase 4 — Verification Loop**
 - [ ] [P4-T1] Re-run repro and regression test to confirm expected behavior
 - [ ] [P4-T2] Run formatter → linter → type checker → tests; restart loop if any step changes files or fails
+- [ ] [P4-T3] Record baseline, post-change, and comparison artifact paths for each in-scope language where coverage is required
 
 **Phase 5 — Documentation & Status**
 - [ ] [P5-T1] Update spec/issue with outcomes, decisions, and any deviations from scope

--- a/extensions/drm-copilot/resources/feature-templates/feature/plan.yyyy-MM-ddTHH-mm.md
+++ b/extensions/drm-copilot/resources/feature-templates/feature/plan.yyyy-MM-ddTHH-mm.md
@@ -23,6 +23,9 @@
 > - Start every task with a **strong verb** (Implement, Create, Update, Verify).
 > - No "bucket" tasks like "Refactor module" or "Write tests"; split them into specific, verifiable steps.
 > - **Self-Validating Phases:** Include necessary test creation/update tasks *within* the phase that implements the code. Do not defer verification to a final "Testing" phase.
+> - Include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for every language in scope when policy requires coverage.
+> - Name the expected artifact path or location in each evidence-producing task's acceptance criteria.
+> - If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
 
 ### Phase 0: Compliance & Context
 - [ ] [P0-T1] Confirm alignment with repo policies by reading `.github/instructions/general-code-change.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, and `.github/instructions/python-unit-test.instructions.md` before touching code
@@ -43,6 +46,7 @@
 - Unit: ...
 - Integration: ...
 - Manual/CLI: ...
+- Coverage evidence: list baseline artifact paths, post-change artifact paths, and comparison artifact paths for each in-scope language
 
 ## Open Questions / Notes
 

--- a/extensions/drm-copilot/resources/feature-templates/refactor/plan.yyyy-MM-ddTHH-mm.md
+++ b/extensions/drm-copilot/resources/feature-templates/refactor/plan.yyyy-MM-ddTHH-mm.md
@@ -16,6 +16,10 @@
 
 Brief approach to reach the target structure while keeping behavior stable.
 
+Fail-closed evidence rule: include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for each in-scope language when policy requires coverage. If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+Evidence accounting rule: record the expected artifact path or location in each evidence-producing task. Do not mark evidence-backed work complete without the artifact.
+
 ## Work Breakdown
 
 ### Phase 1: Inventory & Plan [0%]
@@ -37,6 +41,7 @@ Brief approach to reach the target structure while keeping behavior stable.
 - Unit/Integration: impacted modules and any regression tests for invariants
 - CLI/Workflow: end-to-end commands/tasks expected to remain stable
 - Tooling: lint/type checks after path updates
+- Coverage evidence: list baseline artifact paths, post-change artifact paths, and comparison artifact paths for each in-scope language
 
 ## Rollback / Contingency
 

--- a/extensions/drm-copilot/resources/scripts/dev_tools/validate_orchestration_artifacts.py
+++ b/extensions/drm-copilot/resources/scripts/dev_tools/validate_orchestration_artifacts.py
@@ -19,6 +19,7 @@ PLAN_PHASE_RE = re.compile(r"^### Phase (?P<phase>\d+) — (?P<title>.+)$")
 PLAN_TASK_RE = re.compile(
     r"^- \[(?P<state>[ xX])\] \[P(?P<phase>\d+)-T(?P<task>\d+)\] (?P<title>.+)$"
 )
+COVERAGE_PERCENT_RE = re.compile(r"\b\d+(?:\.\d+)?%")
 
 POLICY_AUDIT_REQUIRED_HEADINGS = (
     "## Executive Summary",
@@ -35,6 +36,14 @@ POLICY_AUDIT_REQUIRED_HEADINGS = (
     "## Appendix A: Test Inventory",
     "## Appendix B: Toolchain Commands Reference",
 )
+POLICY_AUDIT_REQUIRED_CHECKLIST_LABELS = (
+    "TypeScript baseline coverage artifact:",
+    "TypeScript post-change coverage artifact:",
+    "PowerShell baseline coverage artifact:",
+    "PowerShell post-change coverage artifact:",
+    "Per-language comparison summary:",
+)
+POLICY_AUDIT_COMPARISON_HEADING = "### 1.2.1 Per-Language Coverage Comparison"
 CODE_REVIEW_REQUIRED_HEADINGS = (
     "## Executive Summary",
     "## Findings Table",
@@ -89,6 +98,16 @@ REQUIRED_RECEIPT_KEYS = (
     "completed_at",
     "result_signal",
     "artifact_paths",
+)
+PLACEHOLDER_MARKERS = (
+    "[n]",
+    "[path",
+    "[artifact",
+    "[section reference",
+    "[language]",
+    "tbd",
+    "unverified",
+    "missing",
 )
 
 
@@ -160,6 +179,201 @@ def validate_plan_text(text: str) -> list[str]:
     return errors
 
 
+def _has_numeric_coverage(value: str) -> bool:
+    """Return True when a coverage value contains a numeric percentage."""
+
+    return COVERAGE_PERCENT_RE.search(value) is not None
+
+
+def _is_na_value(value: str) -> bool:
+    """Return True when an audit field explicitly records not-applicable."""
+
+    return value.strip().lower().startswith("n/a")
+
+
+def _has_placeholder_marker(value: str) -> bool:
+    """Return True when an audit field still contains template placeholders."""
+
+    lowered = value.lower()
+    return any(marker in lowered for marker in PLACEHOLDER_MARKERS)
+
+
+def _extract_policy_audit_coverage_rows(text: str) -> list[dict[str, str]]:
+    """Parse the coverage metrics table rows from a policy audit."""
+
+    rows: list[dict[str, str]] = []
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.split("|")[1:-1]]
+        if len(cells) != 7:
+            continue
+        language = cells[0]
+        if language in {"Language", "----------"} or not language:
+            continue
+        if set(language) == {"-"}:
+            continue
+        rows.append(
+            {
+                "Language": language,
+                "Files Changed": cells[1],
+                "Tests": cells[2],
+                "Test Result": cells[3],
+                "Baseline Coverage": cells[4],
+                "Post-Change Coverage": cells[5],
+                "New Code Coverage": cells[6],
+            }
+        )
+    return rows
+
+
+def _find_policy_audit_checklist_line(text: str, label: str) -> str | None:
+    """Return the checklist line containing the provided label, if present."""
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- ") and label in stripped:
+            return stripped
+    return None
+
+
+def _extract_policy_audit_comparison_lines(text: str) -> dict[str, str]:
+    """Return per-language comparison lines keyed by normalized language name."""
+
+    in_section = False
+    comparison_lines: dict[str, str] = {}
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == POLICY_AUDIT_COMPARISON_HEADING:
+            in_section = True
+            continue
+        if in_section and stripped.startswith("### "):
+            break
+        if not in_section or not stripped.startswith("- "):
+            continue
+        language, separator, _ = stripped[2:].partition(":")
+        if not separator:
+            continue
+        comparison_lines[language.strip().lower()] = stripped
+
+    return comparison_lines
+
+
+def _comparison_line_has_labelled_percentage(line: str, label: str) -> bool:
+    """Return True when the line contains a numeric percentage after a label."""
+
+    pattern = re.compile(rf"{re.escape(label)}.*?\d+(?:\.\d+)?%")
+    return pattern.search(line) is not None
+
+
+def validate_policy_audit_substantive_requirements(text: str) -> list[str]:
+    """Validate policy-audit evidence requirements beyond headings."""
+
+    errors: list[str] = []
+
+    for label in POLICY_AUDIT_REQUIRED_CHECKLIST_LABELS:
+        line = _find_policy_audit_checklist_line(text, label)
+        if line is None:
+            errors.append(f"Policy audit missing required checklist line: {label}")
+            continue
+        if _has_placeholder_marker(line):
+            errors.append(
+                f"Policy audit checklist line still contains placeholder text: {label}"
+            )
+
+    coverage_rows = _extract_policy_audit_coverage_rows(text)
+    if not coverage_rows:
+        errors.append("Policy audit missing coverage metrics table rows.")
+
+    if POLICY_AUDIT_COMPARISON_HEADING not in text:
+        errors.append(
+            "Policy audit missing required heading: "
+            f"{POLICY_AUDIT_COMPARISON_HEADING}"
+        )
+
+    comparison_lines = _extract_policy_audit_comparison_lines(text)
+    for row in coverage_rows:
+        language = row["Language"]
+        baseline = row["Baseline Coverage"]
+        post_change = row["Post-Change Coverage"]
+        new_code = row["New Code Coverage"]
+        requires_coverage_comparison = any(
+            not _is_na_value(value) for value in (baseline, post_change, new_code)
+        )
+
+        if not _is_na_value(baseline) and not _has_numeric_coverage(baseline):
+            errors.append(
+                f"Policy audit missing numeric baseline coverage for {language}."
+            )
+        if not _is_na_value(post_change) and not _has_numeric_coverage(post_change):
+            errors.append(
+                f"Policy audit missing numeric post-change coverage for {language}."
+            )
+        if not _is_na_value(new_code) and not _has_numeric_coverage(new_code):
+            errors.append(
+                f"Policy audit missing numeric new/changed-code coverage for "
+                f"{language}."
+            )
+
+        if not requires_coverage_comparison:
+            continue
+
+        comparison_line = comparison_lines.get(language.lower())
+        if comparison_line is None:
+            errors.append(
+                "Policy audit missing per-language comparison line for " f"{language}."
+            )
+            continue
+
+        if not _comparison_line_has_labelled_percentage(comparison_line, "Baseline:"):
+            errors.append(
+                f"Policy audit comparison line missing numeric baseline for "
+                f"{language}."
+            )
+        if not _comparison_line_has_labelled_percentage(
+            comparison_line, "Post-change:"
+        ):
+            errors.append(
+                f"Policy audit comparison line missing numeric post-change "
+                f"coverage for {language}."
+            )
+        if "Change:" not in comparison_line:
+            errors.append(
+                f"Policy audit comparison line missing explicit change text for "
+                f"{language}."
+            )
+        if (
+            re.search(
+                r"Disposition:\s*(PASS|FAIL|N/A|INCOMPLETE|BLOCKED)",
+                comparison_line,
+            )
+            is None
+        ):
+            errors.append(
+                f"Policy audit comparison line missing disposition for " f"{language}."
+            )
+        if not _is_na_value(new_code) and not _comparison_line_has_labelled_percentage(
+            comparison_line, "New/changed-code coverage:"
+        ):
+            errors.append(
+                "Policy audit comparison line missing numeric new/changed-code "
+                f"coverage for {language}."
+            )
+        if "Evidence:" not in comparison_line:
+            errors.append(
+                f"Policy audit comparison line missing evidence reference for "
+                f"{language}."
+            )
+        elif _has_placeholder_marker(comparison_line):
+            errors.append(
+                "Policy audit comparison line still contains placeholder text for "
+                f"{language}."
+            )
+
+    return errors
+
+
 def validate_policy_audit_text(text: str) -> list[str]:
     """Validate template-derived policy-audit structure."""
 
@@ -171,6 +385,7 @@ def validate_policy_audit_text(text: str) -> list[str]:
     for heading in POLICY_AUDIT_REQUIRED_HEADINGS:
         if heading not in text:
             errors.append(f"Policy audit missing required heading: {heading}")
+    errors.extend(validate_policy_audit_substantive_requirements(text))
     return errors
 
 

--- a/extensions/drm-copilot/resources/templates/policy_audit/AGENTS.md
+++ b/extensions/drm-copilot/resources/templates/policy_audit/AGENTS.md
@@ -50,11 +50,15 @@ When asked to perform a Policy Audit for a component, branch, or PR:
    - Generate a timestamp in ISO-8601 format `yyyy-MM-ddTHH-mm` (e.g., "2026-01-08T14-30" for Jan 8, 2026 at 2:30 PM).
    - Copy [policy-audit.yyyy-MM-ddTHH-mm.md](./policy-audit.yyyy-MM-ddTHH-mm.md) to the requested location with timestamped filename: `policy-audit.<timestamp>.md` (e.g., feature folder or PR docs).
    - Replace placeholders (`[Component Name]`, dates, paths, counts) as described in [README.md](./README.md).
+   - Preserve the explicit coverage evidence checklist in the template.
+     - Keep the TypeScript and PowerShell artifact lines even when those languages are out of scope; mark them `N/A - out of scope` rather than deleting them.
+     - Fill the per-language comparison summary reference with either an in-document section reference or an exact artifact path.
    - **For multi-language changes:**
      - Fill in the Coverage Metrics by Language table with one row per language.
      - Complete all applicable language sections (3A, 3B, 3C, 3D for code; 4A, 4B for tests).
      - Delete sections for languages NOT involved in this change.
    - **Fill in baseline coverage metrics** from pre-development measurement (per language that has coverage).
+   - Add one per-language comparison bullet for every in-scope language that has coverage requirements.
 
 3. **Evaluate policy compliance**
    - For each section of the template:
@@ -73,6 +77,11 @@ When asked to perform a Policy Audit for a component, branch, or PR:
      - Compare post-change coverage to baseline to verify no regression (per language).
      - Isolate and measure coverage of new/modified code only (must be ≥90% per language).
      - Use concrete examples showing calculations: "Baseline: 85.2% → Post-change: 87.1% (+1.9%) ✅"
+   - **Fail-closed evidence handling:**
+     - No policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage when required.
+     - If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the verdict must be BLOCKED or INCOMPLETE, never PASS.
+     - Do not synthesize or backfill missing audit evidence from memory or inference.
+     - If evidence is missing, stop and report the exact missing artifact paths.
    - **For scenario testing:**
      - Use deterministic, input→output→assertion format for all examples.
      - **Positive flows:** Show concrete valid inputs and expected outputs.
@@ -104,4 +113,5 @@ When asked to perform a Policy Audit for a component, branch, or PR:
 
 - Do **not** modify the canonical `.instructions.md` policy documents as part of an audit.
 - Do **not** treat this AGENTS file as a reason to change how normal code or tests are written; it is for **evaluation and documentation** only.
+- Do **not** report readiness as PASS when required audit evidence is absent; report incomplete with the missing artifact names or paths.
 - If you detect any conflict between this file and the canonical policy documents, halt and ask the user for clarification instead of guessing.

--- a/extensions/drm-copilot/resources/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md
+++ b/extensions/drm-copilot/resources/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md
@@ -37,6 +37,20 @@
 
 **Note:** Delete rows for languages not involved in this change. Add rows if additional languages are used.
 
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: [path or `N/A - out of scope`]
+- TypeScript post-change coverage artifact: [path or `N/A - out of scope`]
+- PowerShell baseline coverage artifact: [path or `N/A - out of scope`]
+- PowerShell post-change coverage artifact: [path or `N/A - out of scope`]
+- Per-language comparison summary: [section reference or artifact path]
+
+**Non-negotiable verdict rule:** No policy audit may report PASS unless it includes numeric baseline and post-change coverage metrics for every language in scope, plus changed/new-code coverage when required.
+
+**Fail-closed rule:** If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence rule:** Do not synthesize or backfill missing audit evidence from memory or inference. If evidence is missing, stop and list the exact missing artifact paths.
+
 ---
 
 ## Executive Summary
@@ -90,6 +104,12 @@
 | **Error Handling** - Error paths | [✅/❌/N/A] [PASS/FAIL/N/A] | **All error scenarios tested:**<br>- `test_function_handles_network_timeout`: Mock network timeout → raises `TimeoutError` after retry<br>- `test_function_handles_file_not_found`: Missing file → raises `FileNotFoundError` with filepath<br>- `test_function_handles_json_parse_error`: Invalid JSON → raises `JSONDecodeError` with line number<br>**Total error handling tests:** [N] |
 | **Concurrency** - If applicable | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe concurrency testing or explain why it's not applicable. If applicable, describe how race conditions and thread safety are tested.] |
 | **State Transitions** - If applicable | [✅/❌/N/A] [PASS/FAIL/N/A] | [Describe state transition testing or explain why it's not applicable. If applicable, show that all state transitions are tested.] |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+Repeat one bullet per in-scope language that has coverage requirements. Keep the checklist above even when a language is out of scope, but use `N/A - out of scope` for the artifact path.
+
+- [Language]: Baseline: [N]% [unit] -> Post-change: [N]% [unit]. Change: [+/-N]% [unit delta]. New/changed-code coverage: [N]% or `N/A - out of scope`. Disposition: [PASS/FAIL/N/A]. Evidence: [artifact path(s)].
 
 ### 1.3 Test Structure and Diagnostics
 
@@ -494,6 +514,8 @@
 ### Overall Status: [✅ FULLY COMPLIANT / ⚠️ PARTIALLY COMPLIANT / ❌ NON-COMPLIANT]
 
 [Provide a brief summary of overall compliance status and any major findings.]
+
+**Fail-closed reminder:** Do not mark the audit PASS, fully compliant, or ready for merge when any required baseline artifact, QA artifact, coverage metric, or coverage-comparison artifact is missing.
 
 ---
 

--- a/scripts/dev_tools/validate_orchestration_artifacts.py
+++ b/scripts/dev_tools/validate_orchestration_artifacts.py
@@ -19,6 +19,7 @@ PLAN_PHASE_RE = re.compile(r"^### Phase (?P<phase>\d+) — (?P<title>.+)$")
 PLAN_TASK_RE = re.compile(
     r"^- \[(?P<state>[ xX])\] \[P(?P<phase>\d+)-T(?P<task>\d+)\] (?P<title>.+)$"
 )
+COVERAGE_PERCENT_RE = re.compile(r"\b\d+(?:\.\d+)?%")
 
 POLICY_AUDIT_REQUIRED_HEADINGS = (
     "## Executive Summary",
@@ -35,6 +36,14 @@ POLICY_AUDIT_REQUIRED_HEADINGS = (
     "## Appendix A: Test Inventory",
     "## Appendix B: Toolchain Commands Reference",
 )
+POLICY_AUDIT_REQUIRED_CHECKLIST_LABELS = (
+    "TypeScript baseline coverage artifact:",
+    "TypeScript post-change coverage artifact:",
+    "PowerShell baseline coverage artifact:",
+    "PowerShell post-change coverage artifact:",
+    "Per-language comparison summary:",
+)
+POLICY_AUDIT_COMPARISON_HEADING = "### 1.2.1 Per-Language Coverage Comparison"
 CODE_REVIEW_REQUIRED_HEADINGS = (
     "## Executive Summary",
     "## Findings Table",
@@ -89,6 +98,16 @@ REQUIRED_RECEIPT_KEYS = (
     "completed_at",
     "result_signal",
     "artifact_paths",
+)
+PLACEHOLDER_MARKERS = (
+    "[n]",
+    "[path",
+    "[artifact",
+    "[section reference",
+    "[language]",
+    "tbd",
+    "unverified",
+    "missing",
 )
 
 
@@ -160,6 +179,201 @@ def validate_plan_text(text: str) -> list[str]:
     return errors
 
 
+def _has_numeric_coverage(value: str) -> bool:
+    """Return True when a coverage value contains a numeric percentage."""
+
+    return COVERAGE_PERCENT_RE.search(value) is not None
+
+
+def _is_na_value(value: str) -> bool:
+    """Return True when an audit field explicitly records not-applicable."""
+
+    return value.strip().lower().startswith("n/a")
+
+
+def _has_placeholder_marker(value: str) -> bool:
+    """Return True when an audit field still contains template placeholders."""
+
+    lowered = value.lower()
+    return any(marker in lowered for marker in PLACEHOLDER_MARKERS)
+
+
+def _extract_policy_audit_coverage_rows(text: str) -> list[dict[str, str]]:
+    """Parse the coverage metrics table rows from a policy audit."""
+
+    rows: list[dict[str, str]] = []
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.split("|")[1:-1]]
+        if len(cells) != 7:
+            continue
+        language = cells[0]
+        if language in {"Language", "----------"} or not language:
+            continue
+        if set(language) == {"-"}:
+            continue
+        rows.append(
+            {
+                "Language": language,
+                "Files Changed": cells[1],
+                "Tests": cells[2],
+                "Test Result": cells[3],
+                "Baseline Coverage": cells[4],
+                "Post-Change Coverage": cells[5],
+                "New Code Coverage": cells[6],
+            }
+        )
+    return rows
+
+
+def _find_policy_audit_checklist_line(text: str, label: str) -> str | None:
+    """Return the checklist line containing the provided label, if present."""
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- ") and label in stripped:
+            return stripped
+    return None
+
+
+def _extract_policy_audit_comparison_lines(text: str) -> dict[str, str]:
+    """Return per-language comparison lines keyed by normalized language name."""
+
+    in_section = False
+    comparison_lines: dict[str, str] = {}
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == POLICY_AUDIT_COMPARISON_HEADING:
+            in_section = True
+            continue
+        if in_section and stripped.startswith("### "):
+            break
+        if not in_section or not stripped.startswith("- "):
+            continue
+        language, separator, _ = stripped[2:].partition(":")
+        if not separator:
+            continue
+        comparison_lines[language.strip().lower()] = stripped
+
+    return comparison_lines
+
+
+def _comparison_line_has_labelled_percentage(line: str, label: str) -> bool:
+    """Return True when the line contains a numeric percentage after a label."""
+
+    pattern = re.compile(rf"{re.escape(label)}.*?\d+(?:\.\d+)?%")
+    return pattern.search(line) is not None
+
+
+def validate_policy_audit_substantive_requirements(text: str) -> list[str]:
+    """Validate policy-audit evidence requirements beyond headings."""
+
+    errors: list[str] = []
+
+    for label in POLICY_AUDIT_REQUIRED_CHECKLIST_LABELS:
+        line = _find_policy_audit_checklist_line(text, label)
+        if line is None:
+            errors.append(f"Policy audit missing required checklist line: {label}")
+            continue
+        if _has_placeholder_marker(line):
+            errors.append(
+                f"Policy audit checklist line still contains placeholder text: {label}"
+            )
+
+    coverage_rows = _extract_policy_audit_coverage_rows(text)
+    if not coverage_rows:
+        errors.append("Policy audit missing coverage metrics table rows.")
+
+    if POLICY_AUDIT_COMPARISON_HEADING not in text:
+        errors.append(
+            "Policy audit missing required heading: "
+            f"{POLICY_AUDIT_COMPARISON_HEADING}"
+        )
+
+    comparison_lines = _extract_policy_audit_comparison_lines(text)
+    for row in coverage_rows:
+        language = row["Language"]
+        baseline = row["Baseline Coverage"]
+        post_change = row["Post-Change Coverage"]
+        new_code = row["New Code Coverage"]
+        requires_coverage_comparison = any(
+            not _is_na_value(value) for value in (baseline, post_change, new_code)
+        )
+
+        if not _is_na_value(baseline) and not _has_numeric_coverage(baseline):
+            errors.append(
+                f"Policy audit missing numeric baseline coverage for {language}."
+            )
+        if not _is_na_value(post_change) and not _has_numeric_coverage(post_change):
+            errors.append(
+                f"Policy audit missing numeric post-change coverage for {language}."
+            )
+        if not _is_na_value(new_code) and not _has_numeric_coverage(new_code):
+            errors.append(
+                f"Policy audit missing numeric new/changed-code coverage for "
+                f"{language}."
+            )
+
+        if not requires_coverage_comparison:
+            continue
+
+        comparison_line = comparison_lines.get(language.lower())
+        if comparison_line is None:
+            errors.append(
+                "Policy audit missing per-language comparison line for " f"{language}."
+            )
+            continue
+
+        if not _comparison_line_has_labelled_percentage(comparison_line, "Baseline:"):
+            errors.append(
+                f"Policy audit comparison line missing numeric baseline for "
+                f"{language}."
+            )
+        if not _comparison_line_has_labelled_percentage(
+            comparison_line, "Post-change:"
+        ):
+            errors.append(
+                f"Policy audit comparison line missing numeric post-change "
+                f"coverage for {language}."
+            )
+        if "Change:" not in comparison_line:
+            errors.append(
+                f"Policy audit comparison line missing explicit change text for "
+                f"{language}."
+            )
+        if (
+            re.search(
+                r"Disposition:\s*(PASS|FAIL|N/A|INCOMPLETE|BLOCKED)",
+                comparison_line,
+            )
+            is None
+        ):
+            errors.append(
+                f"Policy audit comparison line missing disposition for " f"{language}."
+            )
+        if not _is_na_value(new_code) and not _comparison_line_has_labelled_percentage(
+            comparison_line, "New/changed-code coverage:"
+        ):
+            errors.append(
+                "Policy audit comparison line missing numeric new/changed-code "
+                f"coverage for {language}."
+            )
+        if "Evidence:" not in comparison_line:
+            errors.append(
+                f"Policy audit comparison line missing evidence reference for "
+                f"{language}."
+            )
+        elif _has_placeholder_marker(comparison_line):
+            errors.append(
+                "Policy audit comparison line still contains placeholder text for "
+                f"{language}."
+            )
+
+    return errors
+
+
 def validate_policy_audit_text(text: str) -> list[str]:
     """Validate template-derived policy-audit structure."""
 
@@ -171,6 +385,7 @@ def validate_policy_audit_text(text: str) -> list[str]:
     for heading in POLICY_AUDIT_REQUIRED_HEADINGS:
         if heading not in text:
             errors.append(f"Policy audit missing required heading: {heading}")
+    errors.extend(validate_policy_audit_substantive_requirements(text))
     return errors
 
 

--- a/tests/scripts/dev_tools/test_validate_orchestration_artifacts.py
+++ b/tests/scripts/dev_tools/test_validate_orchestration_artifacts.py
@@ -56,13 +56,73 @@ def build_valid_orchestrator_state() -> dict[str, object]:
 
 
 def build_valid_policy_audit_text() -> str:
-    """Return a minimal policy-audit document that satisfies required headings."""
+    """Return a policy-audit document that satisfies structural and evidence gates."""
 
     return "\n".join(
         (
             "# Policy Compliance Audit: Component",
+            "**Audit Date:** 2026-04-12",
+            "**Code Under Test:** `src/example.ts`, `scripts/example.ps1`",
+            "**Coverage Metrics by Language:**",
+            "",
+            (
+                "| Language | Files Changed | Tests | Test Result | "
+                "Baseline Coverage | Post-Change Coverage | "
+                "New Code Coverage |"
+            ),
+            (
+                "|----------|--------------|-------|-------------|"
+                "-------------------|---------------------|"
+                "-------------------|"
+            ),
+            (
+                "| TypeScript | 2 files | 12 tests | [✅] 12 pass, 0 fail | "
+                "91% lines, 88% functions | 93% lines, 90% functions | 95% |"
+            ),
+            (
+                "| PowerShell | 1 file | 8 tests | [✅] 8 pass, 0 fail | "
+                "84% commands, 82% functions | 86% commands, 84% functions | "
+                "92% |"
+            ),
+            "",
+            "### Coverage Evidence Checklist",
+            "",
+            (
+                "- TypeScript baseline coverage artifact: "
+                "docs/features/active/example/evidence/baseline/typescript.md"
+            ),
+            (
+                "- TypeScript post-change coverage artifact: "
+                "docs/features/active/example/evidence/qa-gates/typescript.md"
+            ),
+            (
+                "- PowerShell baseline coverage artifact: "
+                "docs/features/active/example/evidence/baseline/powershell.md"
+            ),
+            (
+                "- PowerShell post-change coverage artifact: "
+                "docs/features/active/example/evidence/qa-gates/powershell.md"
+            ),
+            "- Per-language comparison summary: Section 1.2.1",
             "## Executive Summary",
             "## 1. General Unit Test Policy Compliance",
+            "### 1.2.1 Per-Language Coverage Comparison",
+            (
+                "- TypeScript: Baseline: 91% lines, 88% functions -> "
+                "Post-change: 93% lines, 90% functions. Change: +2% lines, "
+                "+2% functions. New/changed-code coverage: 95%. "
+                "Disposition: PASS. Evidence: "
+                "docs/features/active/example/evidence/baseline/typescript.md; "
+                "docs/features/active/example/evidence/qa-gates/typescript.md."
+            ),
+            (
+                "- PowerShell: Baseline: 84% commands, 82% functions -> "
+                "Post-change: 86% commands, 84% functions. Change: "
+                "+2% commands, +2% functions. New/changed-code coverage: 92%. "
+                "Disposition: PASS. Evidence: "
+                "docs/features/active/example/evidence/baseline/powershell.md; "
+                "docs/features/active/example/evidence/qa-gates/powershell.md."
+            ),
             "## 2. General Code Change Policy Compliance",
             "## 3. Language-Specific Code Change Policy Compliance",
             "## 4. Language-Specific Unit Test Policy Compliance",
@@ -134,6 +194,34 @@ def test_validate_policy_audit_text_rejects_template_block() -> None:
     )
 
     assert "template instruction block" in errors[0]
+
+
+def test_validate_policy_audit_text_requires_checklist_lines() -> None:
+    """Reject policy audits that omit the required coverage checklist."""
+
+    errors = validator.validate_policy_audit_text(
+        build_valid_policy_audit_text().replace(
+            "- PowerShell post-change coverage artifact: "
+            "docs/features/active/example/evidence/qa-gates/powershell.md\n",
+            "",
+        )
+    )
+
+    assert any("required checklist line" in error for error in errors)
+
+
+def test_validate_policy_audit_text_requires_numeric_coverage_values() -> None:
+    """Reject policy audits that omit numeric coverage metrics."""
+
+    errors = validator.validate_policy_audit_text(
+        build_valid_policy_audit_text().replace(
+            "91% lines, 88% functions",
+            "baseline pending",
+            1,
+        )
+    )
+
+    assert any("numeric baseline coverage for TypeScript" in error for error in errors)
 
 
 def test_validate_code_review_text_requires_findings_table() -> None:


### PR DESCRIPTION
- Require baseline, post-change, and comparison artifact paths in plan and policy-audit templates
- Reject PASS outcomes when policy audits omit numeric coverage metrics or per-language evidence summaries
- Extend orchestration guidance and validator tests to block synthesized or missing audit evidence