### PR TITLE
feat(189): configurable pre-claude script for worktree session command

### DIFF
--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/code-review.2026-06-16T14-11.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/code-review.2026-06-16T14-11.md
@@ -1,0 +1,110 @@
+# Code Review: pre-claude-session-script (Issue #189)
+
+**Review Date:** 2026-06-16
+**Reviewer:** feature-review agent
+**Feature Folder:** `docs/features/active/2026-06-16-pre-claude-session-script-189`
+**Feature Folder Selection Rule:** Selected because its suffix (`-189`) matches the canonical issue number and it holds the primary changed scoping docs (`spec.md`, `user-story.md`).
+**Base Branch:** `main` (merge-base `93d83d5ea01d40b229e2721f057210d9ef698206`)
+**Head Branch:** `drm-copilot-wt-2026-06-16-13-41` (`72e415c389423e7a213bb899970278dff47ce7d5`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+This change adds a configurable pre-`claude` hook to the "New Claude Worktree Session" VS Code command. It is an additive, TypeScript-only change confined to the `extensions/drm-copilot` package.
+
+**What changed:**
+- `src/claude-worktree-session.ts`: extends `WorktreeSessionCommandInput` with `preClaudeScriptPath: string | undefined` and `WorktreeSessionCommands` with `preClaude: string | undefined`. In `buildWorktreeSessionCommands`, a trimmed path of length > 0 produces `if (Test-Path -LiteralPath '<path>') { & '<path>' }`, embedding the path twice via the existing `quoteForPwsh` helper; an undefined/empty/whitespace path yields `preClaude === undefined`.
+- `src/extension.ts`: reads `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` (default `.claude/hooks/pre-claude-session.ps1`), passes it into the builder, sends `commands.preClaude` after the poetry activate step and before the deferred `claude` send, and extends the output-channel log note to record whether a pre-claude command was emitted.
+- `package.json`: declares `contributes.configuration` for the new setting (type string, default, description).
+- Tests: 5 builder tests and 4 handler tests, plus a `getConfiguration` mock and `setPreClaudeScriptPathConfig` helper in the test harness; existing ordering tests set an empty path to isolate prior behavior.
+
+The implementation matches `spec.md` exactly, including the pure-module constraint (no `vscode`/`node:fs`/`node:child_process` import in `claude-worktree-session.ts`) and the runtime existence guard. The TypeScript toolchain passed (format/lint/typecheck/test, all EXIT 0). Coverage thresholds are met on both changed production files; the reviewer re-verified the figures from `coverage/lcov.info`.
+
+**Top 3 risks:**
+1. Test maintainability: `test/extension.workflow-commands.test.ts` is 957 lines, above the 500-line policy limit (pre-existing, aggravated by +162 lines here).
+2. Untrusted-path execution surface: the emitted command invokes whatever script exists at the configured worktree-relative path; this matches the existing trust model for the worktree session command but is the only new execution surface.
+3. The runtime `Test-Path` guard cannot be exercised by unit tests (PowerShell-runtime behavior), so the missing-script path is verified by the emitted command string only, not by execution.
+
+**PR readiness recommendation:** **Conditional Go** — The feature is correct, typed, and covered. One Minor maintainability finding (oversized pre-existing test file) is recommended for a separate follow-up and does not block this PR.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `extensions/drm-copilot/test/extension.workflow-commands.test.ts` | whole file (957 lines) | Test file exceeds the 500-line limit that `general-code-change.md` applies to test code. Pre-existing (795 at baseline); this change added 162 lines. | Split the worktree-session handler tests into a dedicated `*.test.ts` file in a separate maintenance change. | The 500-line limit applies to test code per policy; a 957-line suite reduces maintainability. Pre-existing, not introduced by this feature. | `wc -l` = 957; `git show 93d83d5:...` = 795 baseline. |
+| Info | `extensions/drm-copilot/test/*`, `package.json` | test framework | Package uses Jest while `.claude/rules/typescript.md` names Vitest. This is the package's pre-existing, established toolchain (`jest`, `ts-jest`, `run-jest.cjs`); the feature did not introduce it. | No action required for this feature; framework alignment is a repo-wide decision outside this scope. | `general-code-change.md` directs use of the established pattern. Recorded for transparency only. | `package.json` devDependencies; `scripts.test = "node run-jest.cjs"`. |
+| Info | `extensions/drm-copilot/src/extension.ts` | log note | Output-channel note now records `pre-claude script: emitted|none`; the configured path content is not logged. Matches `spec.md` logging guidance. | None. | Confirms no sensitive content leak in logs. | `extension.ts` diff lines for `preClaudeNote`. |
+
+No Blocker or Major findings.
+
+---
+
+## Implementation Audit
+
+### TypeScript implementation audit
+
+#### What changed well
+
+- The new logic reuses the existing `quoteForPwsh` single-quote escaping helper rather than re-implementing PowerShell quoting, so the spaces/apostrophes handling is consistent with the rest of the command builder.
+- The pure-module constraint is respected: existence is checked at PowerShell runtime via `Test-Path`, so `claude-worktree-session.ts` adds no `vscode`/`node:fs`/`node:child_process` import. The undefined/empty/whitespace contract is centralized in the builder, and the handler stays thin.
+- Command ordering is precise: the handler sends `commands.preClaude` only when defined, after the optional activate step and before the deferred `claude` send, matching AC6 and the spec's "immediately before claude" requirement. The deferred-claude grace window is preserved.
+
+#### Type safety and maintainability
+
+- New fields are typed `string | undefined`; the configuration read uses `get<string>("preClaudeScriptPath")` with a string default via `??`, so the value passed to the builder is always a string. No `any`, no new `as` assertions in production code, no new suppressions.
+- The control flow `input.preClaudeScriptPath?.trim() ?? ""` then `length > 0` correctly collapses undefined, empty, and whitespace-only into the no-command branch.
+- Maintainability gap is limited to the oversized handler test file (Minor finding above); the production modules remain small (184 and 301 lines).
+
+#### Error handling and logging
+
+- Failure behavior is explicit and matches the spec: a missing script is intentionally not an error (the `Test-Path` guard short-circuits at runtime); an empty/whitespace configured path emits no command at all.
+- The output-channel log note is extended to indicate emission state without logging script content beyond the non-sensitive configured value. No catch-all handlers introduced.
+
+---
+
+## Test Quality Audit
+
+The verification evidence reviewed includes the feature's QA-gate artifacts (final format/lint/typecheck/test-coverage), the coverage-delta artifact, and the machine-readable `coverage/lcov.info`. Coverage, no-regression, and per-file figures are all present. The only gap is the inherent inability of unit tests to exercise the PowerShell-runtime `Test-Path` guard, which is acceptable because the pure builder asserts the exact emitted command string and the runtime behavior is a host concern.
+
+### Reviewed test and QA artifacts
+
+- `extensions/drm-copilot/test/claude-worktree-session.test.ts` — 5 builder tests covering undefined/empty/whitespace (no command), guarded command for a normal path, and quote escaping for spaces/apostrophes. Exact-string assertions.
+- `extensions/drm-copilot/test/extension.workflow-commands.test.ts` — 4 handler tests covering default-applied, ordering with poetry, ordering without poetry, and no-extra-send when empty; uses fake timers to assert the deferred-claude boundary.
+- `extensions/drm-copilot/test/extension-test-harness.ts` — adds `getConfiguration` mock and `setPreClaudeScriptPathConfig`, with reset wired into `resetExtensionHarnessState`.
+- `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/coverage-delta.md` — proves no regression on changed lines and full coverage of feature-introduced lines.
+- `extensions/drm-copilot/coverage/lcov.info` — reviewer-parsed: `claude-worktree-session.ts` 184/184 line, 17/17 branch; `extension.ts` 297/301 line, 30/33 branch.
+
+### Quality assessment prompts
+
+- **Determinism:** Fake timers (`jest.useFakeTimers`/`advanceTimersByTime`) drive the deferred-claude window; no wall-clock or randomness in the new tests.
+- **Isolation:** Each test asserts a single emission/ordering behavior; harness state is reset between tests, including `preClaudeScriptPathConfig`.
+- **Speed:** Pure builder tests are synchronous; handler tests avoid real waits.
+- **Diagnostics:** Exact-string `toBe` assertions on the emitted PowerShell command produce precise failure output.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | No secrets added; the configured path is a non-sensitive repo-relative string. |
+| No unsafe subprocess or command construction | ✅ PASS | The path is embedded via `quoteForPwsh` (single-quote literal with doubled apostrophes) inside both `Test-Path -LiteralPath` and the call operator; `-LiteralPath` avoids wildcard interpretation. The execution surface matches the existing worktree-session trust model documented in `spec.md`. |
+| Input validation at boundaries | ✅ PASS | Undefined/empty/whitespace path collapses to no command; default applied when the setting is unset. |
+| Error handling remains explicit | ✅ PASS | Missing script handled by the runtime `Test-Path` guard by design; no silent catch-all. |
+| Configuration / path handling is safe | ✅ PASS | Path resolved relative to the worktree root and quoted literally; no shell interpolation of the raw value. |
+
+---
+
+## Research Log
+
+No external research was required. All conclusions are grounded in the branch diff, the feature-folder evidence, the bundled review templates, and the repository policy rule files.
+
+---
+
+## Verdict
+
+The change is ready for normal PR flow with one recommended, non-blocking follow-up. It correctly and minimally implements the configurable pre-`claude` hook, preserves the pure-module separation, reuses existing escaping, orders the command correctly relative to poetry activation and the deferred `claude` send, and is fully covered by deterministic unit tests with no coverage regression. The single Minor finding — the 957-line `extension.workflow-commands.test.ts` file exceeding the 500-line limit — is pre-existing and recommended for a separate maintenance change; it does not affect correctness, security, or coverage. This conclusion is consistent with the Findings Table and the Conditional Go recommendation above.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-format.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-format.md
@@ -1,0 +1,6 @@
+# Baseline — Format (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `npm run format` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary: Prettier ran over `src/**/*.ts`, `test/**/*.ts`, `*.json`, `*.cjs`. All files reported `(unchanged)`. No reformatting required at baseline.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-lint.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-lint.md
@@ -1,0 +1,6 @@
+# Baseline — Lint (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `npm run lint` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary: ESLint ran over `src` and `test`. 0 errors, 0 warnings. Clean baseline.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-test-coverage.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-test-coverage.md
@@ -1,0 +1,12 @@
+# Baseline — Test and Coverage (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `node run-jest.cjs --coverage` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary:
+- Test result: 348 passed / 348 total; 32 suites passed.
+- Coverage headline (All files): line 95.5%, branch 87.03%, funcs 95.87%, stmts 95.5%.
+- In-scope production files at baseline:
+  - `claude-worktree-session.ts`: line 100%, branch 100%, funcs 100%.
+  - `extension.ts`: line 98.59%, branch 89.28%, funcs 100% (uncovered lines 213-214, 220-221, unrelated to this feature).
+- `--coverage` is wired into `run-jest.cjs` (passthrough to jest); numeric coverage values reported above.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-typecheck.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-typecheck.md
@@ -1,0 +1,6 @@
+# Baseline — Type-check (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `npm run typecheck` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary: `tsc -p ./ --noEmit` completed with 0 type errors. Clean baseline.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,22 @@
+# Phase 0 — Instructions Read Evidence (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+
+Policy Order:
+1. `CLAUDE.md`
+2. `.claude/rules/general-code-change.md`
+3. `.claude/rules/general-unit-test.md`
+4. `.claude/rules/typescript.md` and `.claude/rules/typescript-suppressions.md`
+5. `.claude/rules/architecture-boundaries.md`
+6. `.claude/rules/quality-tiers.md`
+
+Files Read (explicit list):
+- `CLAUDE.md` — repository tone, policy-compliance order, four-layer architecture.
+- `.claude/rules/general-code-change.md` — cross-language code-change policy, design principles, mandatory toolchain loop, 500-line file limit.
+- `.claude/rules/general-unit-test.md` — cross-language unit-test policy, coverage requirements (line >= 85%, branch >= 75%), AAA structure, test-file location.
+- `.claude/rules/typescript.md` — TypeScript toolchain (format -> lint -> typecheck -> test), coding standards, ESLint stack, coverage thresholds.
+- `.claude/rules/typescript-suppressions.md` — suppression authorization policy (no new suppressions introduced by this work).
+- `.claude/rules/architecture-boundaries.md` — No-COM architecture rules, layer-boundary assertions; dependency-cruiser enforcement.
+- `.claude/rules/quality-tiers.md` — T1–T4 tier system, uniform coverage thresholds.
+
+Output Summary: All listed policy files were read in the required order before any code or test change. No policy file was modified. The pure module `src/claude-worktree-session.ts` remains constrained to import none of `vscode`, `node:child_process`, or `node:fs`.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/coverage-delta.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/coverage-delta.md
@@ -1,0 +1,36 @@
+# Coverage Delta and No-Regression Verification (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Baseline source: `evidence/baseline/baseline-test-coverage.md`
+Post-change source: `evidence/qa-gates/final-test-coverage.md`
+
+## All-files coverage
+
+| Metric | Baseline | Post-change | Threshold | Result |
+|---|---|---|---|---|
+| Line | 95.5% | 95.54% | >= 85% | PASS (no regression; +0.04) |
+| Branch | 87.03% | 87.14% | >= 75% | PASS (no regression; +0.11) |
+
+## Changed-file coverage
+
+### `src/claude-worktree-session.ts`
+- Baseline: line 100%, branch 100%.
+- Post-change: line 100%, branch 100%.
+- Changed lines (new `preClaude` builder logic: trimmed-path computation, `Test-Path` guarded command, `undefined` branch) are fully covered by the five new builder unit tests in `test/claude-worktree-session.test.ts`.
+- No regression on changed lines.
+
+### `src/extension.ts`
+- Baseline: line 98.59%, branch 89.28% (uncovered lines 213-214, 220-221).
+- Post-change: line 98.67%, branch 90.9% (uncovered lines 230-231, 237-238).
+- The post-change uncovered lines 230-231 and 237-238 are early-return branches inside the pre-existing `runPoshQCSuite` handler (the same code previously at lines 213-214, 220-221, shifted down by the new feature code). They are unrelated to this feature and were uncovered at baseline as well; this is not a regression.
+- Changed lines introduced by this feature (configuration read with default, the `commands.preClaude` guarded `sendText`, and the extended output-channel log note) are covered by the four new handler tests in `test/extension.workflow-commands.test.ts` (default-applied, ordering-with-poetry, ordering-without-poetry, no-extra-send-when-empty).
+- No regression on changed lines.
+
+## Test count
+
+- Baseline: 348 passed / 348 total.
+- Post-change: 357 passed / 357 total (9 new tests: 5 builder + 4 handler).
+
+## Outcome
+
+PASS. Line 95.54% >= 85% and branch 87.14% >= 75%. All feature-introduced lines are covered; no regression on changed lines in either changed file.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-format.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-format.md
@@ -1,0 +1,6 @@
+# Final QA — Format (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `npm run format` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary: Prettier ran over all globs (`src/**/*.ts`, `test/**/*.ts`, `*.json`, `*.cjs`). All 72 files reported `(unchanged)`. No reformatting required; format gate passes.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-lint.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-lint.md
@@ -1,0 +1,6 @@
+# Final QA — Lint (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `npm run lint` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary: ESLint ran over `src` and `test`. 0 errors, 0 warnings. Lint gate passes.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-test-coverage.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-test-coverage.md
@@ -1,0 +1,12 @@
+# Final QA — Test and Coverage (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `node run-jest.cjs --coverage` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary:
+- Test result: 357 passed / 357 total; 32 suites passed.
+- Coverage headline (All files): line 95.54%, branch 87.14%, funcs 95.9%, stmts 95.54%.
+- In-scope production files post-change:
+  - `claude-worktree-session.ts`: line 100%, branch 100%, funcs 100%.
+  - `extension.ts`: line 98.67%, branch 90.9%, funcs 100% (uncovered lines 230-231, 237-238 are pre-existing and unrelated to this feature).
+- Coverage thresholds met: line 95.54% >= 85%; branch 87.14% >= 75%.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-typecheck.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-typecheck.md
@@ -1,0 +1,6 @@
+# Final QA — Type-check (Issue #189)
+
+Timestamp: 2026-06-16T13-49
+Command: `npm run typecheck` (from `extensions/drm-copilot`)
+EXIT_CODE: 0
+Output Summary: `tsc -p ./ --noEmit` completed with 0 type errors. Type-check gate passes.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/feature-audit.2026-06-16T14-11.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/feature-audit.2026-06-16T14-11.md
@@ -1,0 +1,99 @@
+# Feature Audit: pre-claude-session-script (Issue #189)
+
+**Audit Date:** 2026-06-16
+**Feature Folder:** `docs/features/active/2026-06-16-pre-claude-session-script-189`
+**Base Branch:** `main`
+**Head Branch:** `drm-copilot-wt-2026-06-16-13-41`
+**Work Mode:** `full-feature`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `93d83d5ea01d40b229e2721f057210d9ef698206`)
+- **Head branch/commit:** `drm-copilot-wt-2026-06-16-13-41` (commit `72e415c389423e7a213bb899970278dff47ce7d5`)
+- **Merge base:** `93d83d5ea01d40b229e2721f057210d9ef698206`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/**`
+  - Additional evidence: `extensions/drm-copilot/coverage/lcov.info` (reviewer-parsed); branch diff `93d83d5..72e415c`
+- **Feature folder used:** `docs/features/active/2026-06-16-pre-claude-session-script-189`
+- **Requirements source:** `user-story.md` (AC1–AC8) and `spec.md`
+- **Work mode resolution note:** `issue.md` declares `- Work Mode: full-feature`. Per the work-mode contract, the authoritative AC sources are `spec.md` and `user-story.md`. The AC checkbox list lives in `user-story.md` under `## Acceptance Criteria`; `spec.md` defines the corresponding behavior, API surface, and Definition of Done.
+- **Scope note:** Audit scope is the full branch diff against `main`. The production change is TypeScript-only in `extensions/drm-copilot`. No scope narrowing was supplied or applied.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/2026-06-16-pre-claude-session-script-189/user-story.md` — primary (checkbox-backed AC1–AC8)
+- `docs/features/active/2026-06-16-pre-claude-session-script-189/spec.md` — secondary (behavior, API surface, Definition of Done)
+
+### Acceptance criteria (from user-story.md)
+
+1. AC1: The pure command builder accepts a configurable pre-`claude` script path and emits a `preClaude` PowerShell command when a non-empty path is supplied.
+2. AC2: When the supplied script path is `undefined`, empty, or whitespace-only, the builder emits `preClaude` as `undefined` (no command).
+3. AC3: The emitted `preClaude` command invokes the script only when it exists in the worktree, using a runtime existence guard (`if (Test-Path -LiteralPath '<path>') { & '<path>' }`), so a missing script does not cause an error.
+4. AC4: The script path is embedded using the existing PowerShell single-quote escaping helper so paths containing spaces or apostrophes are preserved literally.
+5. AC5: The `newClaudeWorktreeSession` handler reads the script path from the `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` configuration setting, which defaults to `.claude/hooks/pre-claude-session.ps1`.
+6. AC6: The handler sends the `preClaude` command after the poetry activation step (when present) and before the deferred `claude` command, so the script runs immediately before `claude`. When `preClaude` is `undefined`, no additional command is sent.
+7. AC7: `package.json` declares the new configuration setting under `contributes.configuration` with its type, default value, and description.
+8. AC8: Unit tests cover the builder behaviors (AC1–AC4) and the handler's configuration read and command ordering (AC5–AC6). The full TypeScript toolchain (format → lint → type-check → test) passes with coverage thresholds met.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | AC1 builder emits `preClaude` for non-empty path | PASS | `claude-worktree-session.ts` lines 167-174 build `if (Test-Path -LiteralPath ${q}) { & ${q} }` when `trimmedPreClaudePath.length > 0`. Test "emits a Test-Path-guarded preClaude command for a normal script path" asserts the exact string. | `git diff 93d83d5..72e415c -- .../claude-worktree-session.ts`; `node run-jest.cjs` | Field added to `WorktreeSessionCommandInput`/`WorktreeSessionCommands`. |
+| 2 | AC2 `preClaude` undefined for undefined/empty/whitespace | PASS | `input.preClaudeScriptPath?.trim() ?? ""` then `length > 0` else `undefined`. Three tests assert undefined for undefined, "", and "   ". | `node run-jest.cjs` | Negative + edge cases covered. |
+| 3 | AC3 runtime `Test-Path` guard so missing script is not an error | PASS | Emitted command is exactly `if (Test-Path -LiteralPath '<path>') { & '<path>' }`. Existence is checked at PowerShell runtime, preserving the pure-module constraint. | Diff inspection; builder test exact-string assertion | Runtime path not executed by unit tests by design; verified via emitted string. |
+| 4 | AC4 path escaped with existing single-quote helper | PASS | Path embedded via `quoteForPwsh(trimmedPreClaudePath)`. Test "preserves spaces and doubles apostrophes" asserts `'C:/o''connor dir/pre.ps1'`. | `node run-jest.cjs` | Reuses existing helper; no new escaping logic. |
+| 5 | AC5 handler reads setting with default `.claude/hooks/pre-claude-session.ps1` | PASS | `extension.ts`: `getConfiguration("drmCopilotExtension.newClaudeWorktreeSession").get<string>("preClaudeScriptPath") ?? ".claude/hooks/pre-claude-session.ps1"`. Test "applies the default ... when the setting is unset" asserts the default-path command. | `node run-jest.cjs`; diff inspection | Default applied via `??`. |
+| 6 | AC6 ordering after activate, before deferred claude; no send when undefined | PASS | `extension.ts` sends `commands.preClaude` (when defined) after the activate send and before the deferred claude send. Tests assert order with poetry (call index 4, after activate) and without poetry (call index 2, after Set-Location), and that no extra send occurs when path empty. | `node run-jest.cjs` | Fake timers confirm preClaude is synchronous and claude is deferred. |
+| 7 | AC7 `package.json` declares the configuration setting | PASS | `package.json` `contributes.configuration.properties["drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath"]` with `type: string`, `default: .claude/hooks/pre-claude-session.ps1`, and description. | `git diff 93d83d5..72e415c -- .../package.json` | Matches spec Inputs/Outputs. |
+| 8 | AC8 unit tests cover AC1–AC6; full toolchain passes with coverage thresholds met | PASS | 9 new tests (5 builder + 4 handler). Toolchain: `npm run format`/`lint`/`typecheck` and `node run-jest.cjs --coverage` all EXIT 0 (QA-gate evidence). Coverage: repo-wide 95.54% line / 87.14% branch; `claude-worktree-session.ts` 100%/100%; `extension.ts` 98.67%/90.91%. Reviewer re-verified via lcov. | `node run-jest.cjs --coverage`; lcov parse of `coverage/lcov.info` | Thresholds (line >= 85%, branch >= 75%) met; no regression on changed lines. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+**Criteria summary:**
+- **PASS:** 8 criteria
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. None. All acceptance criteria PASS.
+
+**Recommended follow-up verification steps:**
+
+1. Address the non-AC Minor finding (split the 957-line `test/extension.workflow-commands.test.ts` to satisfy the 500-line policy limit) in a separate maintenance change; tracked in remediation inputs.
+2. Optional: exercise the configured script end-to-end in a real worktree to confirm the PowerShell `Test-Path` guard behavior in the integrated terminal (not unit-testable).
+
+---
+
+## Acceptance Criteria Check-Off
+
+Per the acceptance-criteria tracking rules, all 8 criteria evaluated PASS. They were already checked `[x]` in `user-story.md` by the implementing run; this audit confirms the check-offs are evidence-backed and leaves them checked. No criterion required transitioning from `[ ]` to `[x]` during this review. `spec.md`'s `## Definition of Done` and `## Seeded Test Conditions` items remain `[ ]` in the source; they are process checklists rather than the authoritative AC checkbox list (which is `user-story.md` AC1–AC8) and are not reformatted here.
+
+### AC Status Summary
+
+- Source: `docs/features/active/2026-06-16-pre-claude-session-script-189/user-story.md` (authoritative AC checkboxes); `docs/features/active/2026-06-16-pre-claude-session-script-189/spec.md` (behavior/DoD)
+- Total AC items: 8
+- Checked off (delivered): 8
+- Remaining (unchecked): 0
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `user-story.md` | 8 | 8 | 0 | Checkbox-backed; all AC1–AC8 confirmed PASS and already checked. |
+| `spec.md` | 8 (DoD checklist) | 0 | 8 | Process/DoD checklist, not the authoritative AC checkbox list; left as-authored, not reformatted. |

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/issue.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/issue.md
@@ -1,0 +1,38 @@
+# pre-claude-session-script (Issue #189)
+
+- Date captured: 2026-06-16
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/pre-claude-session-script/ (Issue #189)
+
+- Issue: #189
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/189
+- Last Updated: 2026-06-16
+- Work Mode: full-feature
+
+## Problem / Why
+
+What need or gap does this idea address?
+
+## Proposed Behavior
+
+What should the feature do at a high level?
+
+## Acceptance Criteria (early draft)
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Constraints & Risks
+
+List notable constraints (performance, compatibility, scope) or risks.
+
+## Test Conditions to Consider
+
+- [ ] Unit coverage areas
+- [ ] Integration scenarios
+- [ ] CLI/API examples
+
+## Next Step
+
+- [ ] Promote to GitHub issue (feature request template)
+- [ ] Create `docs/features/active/pre-claude-session-script/` folder from the template

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/plan.2026-06-16T13-49.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/plan.2026-06-16T13-49.md
@@ -1,0 +1,194 @@
+# pre-claude-session-script - Plan
+
+- **Issue:** #189
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-16T13-49
+- **Status:** Draft
+- **Version:** 0.2
+- **Work Mode:** full-feature
+
+## Required References
+
+- General Coding Standards: `.github/instructions/general-code-change.instructions.md`
+- General Unit Test Policy: `.github/instructions/general-unit-test.instructions.md`
+- TypeScript Code Standards: `.github/instructions/typescript-code-change.instructions.md`
+- TypeScript Unit Test Policy: `.github/instructions/typescript-unit-test.instructions.md`
+- Repository tone policy: `.github/copilot-instructions.md`
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Scope and Authoritative Context
+
+- Acceptance-criteria source: `docs/features/active/2026-06-16-pre-claude-session-script-189/user-story.md` (AC1-AC8).
+- Spec: `docs/features/active/2026-06-16-pre-claude-session-script-189/spec.md`.
+- In-scope production files (2 production + 1 manifest):
+  - `extensions/drm-copilot/src/claude-worktree-session.ts` (pure builder; MUST NOT import `vscode`, `node:child_process`, or `node:fs`).
+  - `extensions/drm-copilot/src/extension.ts` (`newClaudeWorktreeSession` handler, lines 104-188).
+  - `extensions/drm-copilot/package.json` (`contributes.configuration`).
+- In-scope test/harness files:
+  - `extensions/drm-copilot/test/claude-worktree-session.test.ts`.
+  - `extensions/drm-copilot/test/extension.workflow-commands.test.ts`.
+  - `extensions/drm-copilot/test/extension-test-harness.ts` (the `vscode` mock currently lacks `workspace.getConfiguration`; it must be extended so the handler's configuration read is testable).
+- Language in scope: TypeScript only. Coverage policy applies: line >= 85%, branch >= 75%, no regression on changed lines.
+- Toolchain working directory for all commands: `extensions/drm-copilot`.
+
+## Evidence Location Invariant
+
+All evidence artifacts MUST be written under the canonical scheme `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/<kind>/`. Writing to `artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, or any other non-canonical path is a policy violation and is rejected. If a caller supplies a non-canonical evidence path, substitute the canonical path and record `EVIDENCE_LOCATION_OVERRIDE_REJECTED: <supplied path> replaced with <canonical path>`.
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Baseline Capture and Policy Read
+
+- [x] [P0-T1] Read the repository policy files in required order and record an evidence artifact at `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/phase0-instructions-read.md`
+  - Policy order: (1) `CLAUDE.md`; (2) `.claude/rules/general-code-change.md`; (3) `.claude/rules/general-unit-test.md`; (4) `.claude/rules/typescript.md` and `.claude/rules/typescript-suppressions.md`; (5) `.claude/rules/architecture-boundaries.md`; (6) `.claude/rules/quality-tiers.md`.
+  - Acceptance: artifact contains `Timestamp:`, `Policy Order:`, and the explicit list of files read. One binary outcome: file exists with all three fields populated.
+
+- [x] [P0-T2] Capture baseline format state and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-format.md`
+  - Command (run from `extensions/drm-copilot`): `npm run format`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. One binary outcome: artifact present with all four fields.
+
+- [x] [P0-T3] Capture baseline lint state and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-lint.md`
+  - Command (run from `extensions/drm-copilot`): `npm run lint`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (record lint error/warning counts).
+
+- [x] [P0-T4] Capture baseline type-check state and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-typecheck.md`
+  - Command (run from `extensions/drm-copilot`): `npm run typecheck`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`.
+
+- [x] [P0-T5] Capture baseline test-and-coverage state and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-test-coverage.md`
+  - Command (run from `extensions/drm-copilot`): `node run-jest.cjs --coverage`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. `Output Summary:` MUST record numeric baseline line-coverage and branch-coverage headline values and the passed/total test count. If `--coverage` is not wired into `run-jest.cjs`, record the exact invocation used and the numeric coverage values it reports; the baseline is incomplete without numeric coverage values.
+
+### Phase 1 — Pure Builder: preClaude command (AC1-AC4)
+
+- [x] [P1-T1] Extend `WorktreeSessionCommandInput` with `preClaudeScriptPath` in `extensions/drm-copilot/src/claude-worktree-session.ts`
+  - Add `readonly preClaudeScriptPath: string | undefined;` to the `WorktreeSessionCommandInput` interface, with a doc comment describing it as the worktree-relative pre-`claude` script path.
+  - Acceptance: interface declares the new field; module still imports none of `vscode`, `node:child_process`, `node:fs`. One binary outcome: type compiles.
+  - Maps to: AC1.
+
+- [x] [P1-T2] Extend `WorktreeSessionCommands` with `preClaude` in `extensions/drm-copilot/src/claude-worktree-session.ts`
+  - Add `readonly preClaude: string | undefined;` to the `WorktreeSessionCommands` interface, with a doc comment stating it is present only when a non-empty path is supplied and `undefined` otherwise.
+  - Acceptance: interface declares the new field. One binary outcome: type compiles.
+  - Maps to: AC1, AC2.
+
+- [x] [P1-T3] Implement the guarded `preClaude` command in `buildWorktreeSessionCommands` in `extensions/drm-copilot/src/claude-worktree-session.ts`
+  - Compute `const trimmedPreClaudePath = input.preClaudeScriptPath?.trim() ?? "";`. When `trimmedPreClaudePath.length > 0`, set `const quotedPreClaude = quoteForPwsh(trimmedPreClaudePath);` and `preClaude = `if (Test-Path -LiteralPath ${quotedPreClaude}) { & ${quotedPreClaude} }``. When the length is 0, set `preClaude = undefined`.
+  - Add `preClaude` to the returned object. Do not change `git`, `setLocation`, `poetryInstall`, `activate`, or `claude`.
+  - Acceptance: for a normal path the returned `preClaude` equals `if (Test-Path -LiteralPath '<path>') { & '<path>' }`; for undefined/empty/whitespace `preClaude === undefined`; path quoting uses `quoteForPwsh`. One binary outcome verified by P1-T4 tests.
+  - Maps to: AC1, AC2, AC3, AC4.
+
+- [x] [P1-T4] Add builder unit tests in `extensions/drm-copilot/test/claude-worktree-session.test.ts`
+  - Add `preClaudeScriptPath: undefined` to the shared `baseInput` (or supply it per-case) so existing cases keep compiling.
+  - Add cases asserting: (a) `preClaude` is `undefined` when `preClaudeScriptPath` is `undefined`; (b) `preClaude` is `undefined` for `""`; (c) `preClaude` is `undefined` for whitespace-only `"   "`; (d) for a normal path `".claude/hooks/pre-claude-session.ps1"` the command equals `if (Test-Path -LiteralPath '.claude/hooks/pre-claude-session.ps1') { & '.claude/hooks/pre-claude-session.ps1' }`; (e) for a path with spaces and an apostrophe (for example `"C:/o'connor dir/pre.ps1"`) the quoting doubles the apostrophe and preserves the space inside both the `Test-Path` and `&` positions.
+  - Use Arrange-Act-Assert with `@jest/globals` imports already present in the file.
+  - Acceptance: the five new cases exist and assert the exact strings above. One binary outcome: tests present and passing after P1-T5.
+  - Maps to: AC1, AC2, AC3, AC4, AC8.
+
+- [x] [P1-T5] Run the TypeScript toolchain loop after the Phase 1 source/test changes (from `extensions/drm-copilot`)
+  - Run in order: `npm run format` -> `npm run lint` -> `npm run typecheck` -> `node run-jest.cjs`. If any step changes files or fails, restart from `npm run format`.
+  - Acceptance: all four commands exit 0 in a single pass and the new builder tests pass. One binary outcome: clean single-pass loop.
+  - Maps to: AC8.
+
+### Phase 2 — Handler: configuration read and command ordering (AC5-AC6)
+
+- [x] [P2-T1] Extend the `vscode` mock in `extensions/drm-copilot/test/extension-test-harness.ts` with `workspace.getConfiguration`
+  - Add a `getConfigurationMock` (`jest.fn`) returning an object with a typed `get` method, and expose a helper `setPreClaudeScriptPathConfig(value: string | undefined): void` that controls what `get<string>("preClaudeScriptPath")` returns for section `"drmCopilotExtension.newClaudeWorktreeSession"`. Default the helper to `undefined` (unset) and reset it in `resetExtensionHarnessState`.
+  - Export the new helper (and the mock if needed by assertions) alongside the existing exports.
+  - Acceptance: the handler can call `vscode.workspace.getConfiguration("drmCopilotExtension.newClaudeWorktreeSession").get<string>("preClaudeScriptPath")` under test without throwing, and tests can set/clear the returned value. One binary outcome: helper present, wired into reset, exported.
+  - Maps to: AC5, AC8.
+
+- [x] [P2-T2] Read the configuration and pass `preClaudeScriptPath` into the builder in `extensions/drm-copilot/src/extension.ts`
+  - In the `newClaudeWorktreeSession` handler, after `usePoetry` is computed and before `buildWorktreeSessionCommands` is called, read `const configuredPreClaudeScriptPath = vscode.workspace.getConfiguration("drmCopilotExtension.newClaudeWorktreeSession").get<string>("preClaudeScriptPath") ?? ".claude/hooks/pre-claude-session.ps1";`.
+  - Pass `preClaudeScriptPath: configuredPreClaudeScriptPath` into the `buildWorktreeSessionCommands(...)` input object.
+  - Acceptance: the default `.claude/hooks/pre-claude-session.ps1` is applied when the setting is `undefined`; a configured value is passed through verbatim. One binary outcome verified by P2-T5 tests.
+  - Maps to: AC5.
+
+- [x] [P2-T3] Send `commands.preClaude` after activate and before the deferred `claude` send in `extensions/drm-copilot/src/extension.ts`
+  - After the `if (commands.activate !== undefined) { terminal.sendText(commands.activate, true); }` block and before the `setTimeout(...)` that sends `commands.claude`, add `if (commands.preClaude !== undefined) { terminal.sendText(commands.preClaude, true); }`.
+  - Do not alter the deferral of `commands.claude` or the `TERMINAL_AUTO_ACTIVATION_GRACE_MS` timing.
+  - Acceptance: when `commands.preClaude` is defined exactly one extra synchronous `sendText` fires after activate and before the deferred claude; when `undefined` no extra `sendText` fires. One binary outcome verified by P2-T5 tests.
+  - Maps to: AC6.
+
+- [x] [P2-T4] Extend the output-channel log line to indicate whether a pre-`claude` script command was emitted in `extensions/drm-copilot/src/extension.ts`
+  - Add a note to the existing `output.appendLine(...)` call (the one beginning `[${commandId}] opened terminal for branch ...`) indicating whether a pre-`claude` script command was emitted (for example append `, pre-claude script: emitted` or `, pre-claude script: none` based on `commands.preClaude !== undefined`). Do not log script file content beyond the already-configured path value if included.
+  - Acceptance: the single existing log line is extended with the pre-`claude` emission state; no new sensitive content is logged. One binary outcome: log line contains the emission indicator.
+  - Maps to: AC6 (logging note from spec Implementation Strategy).
+
+- [x] [P2-T5] Add handler unit tests in `extensions/drm-copilot/test/extension.workflow-commands.test.ts`
+  - Add cases (using `jest.useFakeTimers()` consistent with existing worktree-session tests):
+    - (a) Default applied when unset: with the config helper unset (default `undefined`), assert the `preClaude` `sendText` value equals `if (Test-Path -LiteralPath '.claude/hooks/pre-claude-session.ps1') { & '.claude/hooks/pre-claude-session.ps1' }`.
+    - (b) Ordering with poetry: set a poetry pyproject fixture and a configured path; assert `sendText` call order is git, Set-Location, poetry install, activate, preClaude (all synchronous), then after `jest.advanceTimersByTime(5000)` the deferred claude; assert the preClaude call index is immediately after activate and the claude call is last.
+    - (c) Ordering without poetry: no pyproject fixture, configured path set; assert synchronous order git, Set-Location, preClaude, then deferred claude after timer advance.
+    - (d) No extra send when `preClaude` is undefined: set the config helper to `""` (empty) so the builder yields `preClaude === undefined`; assert the synchronous `sendText` count matches the existing no-poetry baseline (git, Set-Location only) and that after timer advance only the claude send is added (no preClaude send).
+  - Acceptance: the four cases exist and assert ordering and presence/absence as described. One binary outcome: tests present and passing after P2-T6.
+  - Maps to: AC5, AC6, AC8.
+
+- [x] [P2-T6] Run the TypeScript toolchain loop after the Phase 2 source/test/harness changes (from `extensions/drm-copilot`)
+  - Run in order: `npm run format` -> `npm run lint` -> `npm run typecheck` -> `node run-jest.cjs`. If any step changes files or fails, restart from `npm run format`.
+  - Acceptance: all four commands exit 0 in a single pass; new handler tests pass. One binary outcome: clean single-pass loop.
+  - Maps to: AC8.
+
+### Phase 3 — Manifest Configuration Contribution (AC7)
+
+- [x] [P3-T1] Add the `contributes.configuration` block in `extensions/drm-copilot/package.json`
+  - Add a `configuration` key inside the existing `contributes` object (preserving `mcpServerDefinitionProviders` and `commands`). Declare a `properties` entry `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` with `"type": "string"`, `"default": ".claude/hooks/pre-claude-session.ps1"`, and a `description` stating it is the worktree-relative path to a PowerShell script run immediately before `claude`, that the path is resolved relative to the worktree root, and that a missing script at that path is not an error.
+  - Acceptance: `package.json` remains valid JSON; the new property is present with the exact type, default, and a clear description; existing `contributes` keys are unchanged. One binary outcome: JSON parses and contains the property.
+  - Maps to: AC7.
+
+- [x] [P3-T2] Run formatting on the manifest in `extensions/drm-copilot`
+  - Command: `npm run format` (the `format` script globs `*.json`).
+  - Acceptance: `npm run format` exits 0 and `package.json` is unchanged in semantics. One binary outcome: command exits 0.
+  - Maps to: AC7, AC8.
+
+### Phase 4 — Final QA Loop and Coverage Evidence (AC8)
+
+- [x] [P4-T1] Run final format check and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-format.md`
+  - Command (from `extensions/drm-copilot`): `npm run format`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; `EXIT_CODE` is 0. If this step changes files, restart the loop at this task before proceeding.
+
+- [x] [P4-T2] Run final lint and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-lint.md`
+  - Command (from `extensions/drm-copilot`): `npm run lint`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (record 0 errors); `EXIT_CODE` is 0.
+
+- [x] [P4-T3] Run final type-check and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-typecheck.md`
+  - Command (from `extensions/drm-copilot`): `npm run typecheck`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; `EXIT_CODE` is 0.
+
+- [x] [P4-T4] Run final test-with-coverage and write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-test-coverage.md`
+  - Command (from `extensions/drm-copilot`): `node run-jest.cjs --coverage`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; `EXIT_CODE` is 0. `Output Summary:` MUST record numeric post-change line-coverage and branch-coverage values and the passed/total test count.
+
+- [x] [P4-T5] Verify coverage thresholds and no-regression on changed lines; write evidence to `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/coverage-delta.md`
+  - Compare baseline (P0-T5) against post-change (P4-T4): record baseline line/branch coverage, post-change line/branch coverage, and coverage for the changed lines in `claude-worktree-session.ts` and `extension.ts`.
+  - Acceptance: artifact records baseline coverage, post-change coverage, and new/changed-code coverage; confirms line >= 85%, branch >= 75%, and no regression on changed lines. If any required coverage value is unavailable, the outcome is remediation-required, not PASS. One binary outcome: thresholds met and recorded, or remediation flagged.
+  - Maps to: AC8.
+
+## AC-to-Task Traceability
+
+- AC1: P1-T1, P1-T2, P1-T3, P1-T4.
+- AC2: P1-T2, P1-T3, P1-T4.
+- AC3: P1-T3, P1-T4.
+- AC4: P1-T3, P1-T4.
+- AC5: P2-T1, P2-T2, P2-T5.
+- AC6: P2-T3, P2-T4, P2-T5.
+- AC7: P3-T1, P3-T2.
+- AC8: P1-T4, P1-T5, P2-T5, P2-T6, P3-T2, P4-T1, P4-T2, P4-T3, P4-T4, P4-T5.
+
+## Test Plan
+
+- Unit (builder): `extensions/drm-copilot/test/claude-worktree-session.test.ts` — `preClaude` undefined for undefined/empty/whitespace; guarded command for a normal path; quote escaping for spaces and apostrophes.
+- Unit (handler): `extensions/drm-copilot/test/extension.workflow-commands.test.ts` — configuration default applied when unset; ordering with and without poetry (preClaude after activate, before deferred claude); no extra send when `preClaude` undefined.
+- Harness: `extensions/drm-copilot/test/extension-test-harness.ts` — `workspace.getConfiguration` mock and `setPreClaudeScriptPathConfig` helper.
+- Integration: none (no external systems; runtime existence check is a PowerShell `Test-Path` executed by the terminal, not exercised in unit tests).
+- Coverage evidence:
+  - Baseline: `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-test-coverage.md`.
+  - Post-change: `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-test-coverage.md`.
+  - Delta/threshold: `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/coverage-delta.md`.
+
+## Open Questions / Notes
+
+- The pure module `claude-worktree-session.ts` must remain side-effect free; the missing-script guard is implemented as a runtime PowerShell `Test-Path` check, not a TypeScript filesystem call.
+- The handler reads configuration via `vscode.workspace.getConfiguration("drmCopilotExtension.newClaudeWorktreeSession").get<string>("preClaudeScriptPath")` with a TypeScript-side default of `.claude/hooks/pre-claude-session.ps1`; `package.json` declares the same default so VS Code returns it when unset. The TypeScript-side `?? "..."` default also covers the test harness path where `getConfiguration` may return `undefined`.
+- If `node run-jest.cjs` does not accept `--coverage`, record the actual coverage invocation supported by `run-jest.cjs` in the baseline and final-QC artifacts; numeric coverage values remain mandatory.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/policy-audit.2026-06-16T14-11.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/policy-audit.2026-06-16T14-11.md
@@ -1,0 +1,443 @@
+# Policy Compliance Audit: pre-claude-session-script (Issue #189)
+
+**Audit Date:** 2026-06-16
+**Code Under Test:** TypeScript change in `extensions/drm-copilot`:
+- `extensions/drm-copilot/src/claude-worktree-session.ts` (MODIFIED, +27)
+- `extensions/drm-copilot/src/extension.ts` (MODIFIED, +19/-1)
+- `extensions/drm-copilot/package.json` (MODIFIED, +10)
+- `extensions/drm-copilot/test/claude-worktree-session.test.ts` (MODIFIED, +66)
+- `extensions/drm-copilot/test/extension.workflow-commands.test.ts` (MODIFIED, +162)
+- `extensions/drm-copilot/test/extension-test-harness.ts` (MODIFIED, +31)
+- `extensions/drm-copilot/package-lock.json` (MODIFIED, +1)
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| TypeScript | 6 source/test files (2 production: `claude-worktree-session.ts`, `extension.ts`) | 357 tests | ✅ 357 pass, 0 fail | line 95.5%, branch 87.03% | line 95.54%, branch 87.14% | `claude-worktree-session.ts` 100% line / 100% branch; `extension.ts` 98.67% line / 90.91% branch |
+| JSON | 1 file (`package.json`) | N/A | ✅ valid | N/A (config) | N/A (config) | N/A |
+
+**Note:** Python, PowerShell, and C# have zero changed files on this branch; their coverage verdicts are N/A on that basis only.
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/baseline/baseline-test-coverage.md`
+- TypeScript post-change coverage artifact: `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/final-test-coverage.md` and machine-readable `extensions/drm-copilot/coverage/lcov.info`
+- PowerShell baseline coverage artifact: `N/A - no PowerShell files changed on branch`
+- PowerShell post-change coverage artifact: `N/A - no PowerShell files changed on branch`
+- Per-language comparison summary: `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/coverage-delta.md`
+
+**Coverage independently verified by the reviewer** by parsing `extensions/drm-copilot/coverage/lcov.info`:
+- `src/claude-worktree-session.ts`: LH/LF = 184/184 (100.00% line); BRH/BRF = 17/17 (100.00% branch).
+- `src/extension.ts`: LH/LF = 297/301 (98.67% line); BRH/BRF = 30/33 (90.91% branch).
+
+---
+
+## Rejected Scope Narrowing
+
+No caller instruction attempted to narrow scope to a plan, task, phase, or file subset, and no instruction marked any language's coverage as out of scope or informational only. The supplied input correctly identified the full branch-vs-`main` diff as the audit scope. No narrowing to record.
+
+---
+
+## Evidence Location Compliance
+
+The branch diff was scanned for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`. None were found. All feature evidence is written under the canonical `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/<kind>/` path.
+
+- Scan command: `git diff --name-only 93d83d5..72e415c | grep -E '^artifacts/(baselines|qa|evidence|coverage)/'` → no matches.
+- Validator command: `python scripts/dev_tools/validate_evidence_locations.py --root .` → EXIT 0 (no violations).
+
+Verdict: PASS. No evidence-location violations.
+
+---
+
+## Executive Summary
+
+This feature adds a configurable pre-`claude` hook to the "New Claude Worktree Session" VS Code command. The pure builder `buildWorktreeSessionCommands` gains a guarded `preClaude` PowerShell command (`if (Test-Path -LiteralPath '<path>') { & '<path>' }`), the handler in `extension.ts` reads the `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` setting (default `.claude/hooks/pre-claude-session.ps1`) and sends the command between poetry activation and the deferred `claude` send, and `package.json` declares the configuration property. The change is TypeScript-only; no Python, PowerShell, or C# production files changed.
+
+The full TypeScript toolchain (format → lint → type-check → test with coverage) was executed by the implementing run with EXIT 0 at each stage, as recorded in the feature's QA-gate evidence and corroborated by the canonical PR-context summary. Coverage thresholds are met repo-wide and on both changed production files, with no regression on changed lines. The reviewer independently re-parsed `coverage/lcov.info` and confirmed the per-file figures.
+
+**Policy documents evaluated:**
+- ✅ `general-code-change.md`
+- ✅ `general-unit-test.md`
+
+**Language-specific policies evaluated:**
+- N/A `python-*` — no Python files changed on branch.
+- N/A `powershell-*` — no PowerShell files changed on branch.
+- ✅ `typescript.md` + `typescript-suppressions.md`
+- N/A `csharp-*` — no C# files changed on branch.
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary/one-time scripts were created during this review.
+- N/A No development scripts in scope.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | ✅ PASS | New tests construct inputs locally and reset harness state via `resetExtensionHarnessState`/`vi`-equivalent Jest reset; handler tests call `jest.useFakeTimers()`/`useRealTimers()` in try/finally. No shared mutable state leaks between tests. |
+| **Isolation** - Each test targets single behavior | ✅ PASS | Each new builder test asserts one `preClaude` outcome (undefined for undefined/empty/whitespace; guarded command for a normal path; quote escaping). Each handler test asserts one ordering/emission behavior. |
+| **Fast Execution** - Tests complete quickly | ✅ PASS | Pure builder tests are synchronous; handler tests use fake timers (`jest.advanceTimersByTime`) instead of real waits. 357 tests / 32 suites pass per `final-test-coverage.md`. |
+| **Determinism** - Consistent results | ✅ PASS | Fake timers used for the deferred-claude grace window; no wall-clock reads, no randomness, no network/filesystem in the new tests. |
+| **Readability & Maintainability** - Clear structure | ✅ PASS | Descriptive `it(...)` names; Arrange/Act/Assert comments present in the new tests. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | Baseline line 95.5% / branch 87.03% recorded in `evidence/baseline/baseline-test-coverage.md` (per `coverage-delta.md`). |
+| **No Coverage Regression** | ✅ PASS | Post-change line 95.54% (+0.04), branch 87.14% (+0.11). No regression on changed lines in either production file (`coverage-delta.md`). |
+| **New/Changed Code Coverage** | ✅ PASS | `claude-worktree-session.ts` 100% line/branch (lcov 184/184, 17/17). `extension.ts` 98.67% line / 90.91% branch; the 4 uncovered lines (230-231, 237-238) are in the pre-existing `runPoshQCSuite` early-return paths, unrelated to this feature and uncovered at baseline. All feature-introduced lines covered. Threshold for new/changed code (line >= 85%, branch >= 75%) met. |
+| **Comprehensive Coverage** | ✅ PASS | Builder `preClaude` paths (present/absent/empty/whitespace, quote escaping) and handler paths (default applied, ordering with/without poetry, no-extra-send when empty) all exercised. |
+| **Positive Flows** | ✅ PASS | Guarded command emitted for a normal path; default applied when setting unset; ordering after activate / after Set-Location. |
+| **Negative Flows** | ✅ PASS | `preClaude` undefined for undefined/empty/whitespace path; no extra `sendText` when path empty. |
+| **Edge Cases** | ✅ PASS | Whitespace-only path; path containing spaces and apostrophes (`C:/o'connor dir/pre.ps1`) escaped correctly. |
+| **Error Handling** | ✅ PASS | The missing-script case is handled at PowerShell runtime by the `Test-Path` guard, asserted by the emitted command string; a missing script is not an error by design. |
+| **Concurrency** | N/A | No concurrency introduced. |
+| **State Transitions** | ✅ PASS | Command-ordering transitions (git → Set-Location → [poetry install → activate] → preClaude → deferred claude) asserted across poetry-present and poetry-absent handler tests. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- TypeScript: Baseline line 95.5% / branch 87.03% -> Post-change line 95.54% / branch 87.14%. Change +0.04% line / +0.11% branch. New/changed-code coverage: `claude-worktree-session.ts` 100%; `extension.ts` 98.67% line (feature lines fully covered). Disposition: PASS. Evidence: `evidence/qa-gates/coverage-delta.md`, `extensions/drm-copilot/coverage/lcov.info`.
+- Python: N/A - no changed files on branch.
+- PowerShell: N/A - no changed files on branch.
+- C#: N/A - no changed files on branch.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | ✅ PASS | Assertions use exact-string `toBe` comparisons on the emitted PowerShell command, so a failure prints the precise expected/actual command. |
+| **Arrange-Act-Assert Pattern** | ✅ PASS | New tests use explicit Arrange/Act/Assert comment markers. |
+| **Document Intent** | ✅ PASS | Test names state the scenario (e.g., "emits preClaude as undefined for a whitespace-only preClaudeScriptPath"). |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | The `vscode` module is mocked in `extension-test-harness.ts`; no network, no real filesystem, no external process. |
+| **Use Mocks/Stubs** | ✅ PASS | New `getConfigurationMock` returns the configured `preClaudeScriptPath`; terminal `sendText` is a Jest mock. |
+| **Environment Stability** | ✅ PASS | No temporary files created. Harness state reset between tests; `preClaudeScriptPathConfig` reset to `undefined` in `resetExtensionHarnessState`. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | ✅ PASS | This document is the required policy review. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | ✅ PASS | Objective documented in `spec.md`, `user-story.md` (AC1–AC8), Issue #189. |
+| **Read existing change plans** | ✅ PASS | `plan.2026-06-16T13-49.md` present with completed P0/P1 tasks. |
+| **Document the plan** | ✅ PASS | Plan and evidence artifacts present in the feature folder. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | Minimal additive change: one builder branch, one handler send, one config property. No new classes or indirection. |
+| **Reusability** | ✅ PASS | Reuses the existing `quoteForPwsh` helper for single-quote escaping rather than duplicating escaping logic. |
+| **Extensibility** | ✅ PASS | `preClaudeScriptPath` added as a keyword-style optional field on `WorktreeSessionCommandInput`; `preClaude` added to `WorktreeSessionCommands`. |
+| **Separation of concerns** | ✅ PASS | Pure command construction stays in `claude-worktree-session.ts` (no `vscode`/`node:fs`/`node:child_process` import); the configuration read and terminal I/O stay in `extension.ts`. The runtime existence check is deferred to PowerShell `Test-Path`, preserving the pure-module constraint stated in `spec.md`. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | ✅ PASS | Builder logic in the pure module; wiring in the handler. |
+| **Under 500 lines** | ⚠️ PARTIAL | Production files compliant: `claude-worktree-session.ts` 184 lines, `extension.ts` 301 lines. However test file `test/extension.workflow-commands.test.ts` is 957 lines (was 795 at baseline; +162 by this change), exceeding the 500-line limit that `general-code-change.md` applies to test code. Pre-existing condition aggravated by this change. See Section 8 and the code review (Minor finding). |
+| **Public vs internal** | ✅ PASS | New exported surface is limited to the two extended interfaces; no internals exposed. |
+| **No circular dependencies** | ✅ PASS | No new imports introduced in the pure module; handler imports the builder as before. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | ✅ PASS | `preClaudeScriptPath`, `preClaude`, `trimmedPreClaudePath`, `quotedPreClaude`, `configuredPreClaudeScriptPath` are descriptive and follow camelCase. |
+| **Docs/docstrings** | ✅ PASS | JSDoc added to both new interface members explaining the undefined/empty/whitespace contract. |
+| **Comment why, not what** | ✅ PASS | Inline comments explain the rationale (runtime guard so a missing script is not an error; escaping preserves spaces/apostrophes; ordering relative to activate and deferred claude). |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | `npm run format` (Prettier) EXIT 0 — `evidence/qa-gates/final-format.md`, corroborated by PR-context summary. |
+| **2. Linting** | ✅ PASS | `npm run lint` (ESLint) EXIT 0 — `evidence/qa-gates/final-lint.md`. |
+| **3. Type checking** | ✅ PASS | `npm run typecheck` (tsc --noEmit) EXIT 0 — `evidence/qa-gates/final-typecheck.md`. |
+| **4. Testing** | ✅ PASS | `node run-jest.cjs --coverage` EXIT 0, 357/357 pass — `evidence/qa-gates/final-test-coverage.md`. |
+| **Full toolchain loop** | ✅ PASS | All stages report EXIT 0 in a single pass per the QA-gate evidence. |
+| **Explicit reporting** | ✅ PASS | Commands and results recorded in the feature evidence and in this audit's Appendix B. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | ✅ PASS | Summarized in `spec.md` and Section 9 below. |
+| **Design choices explained** | ✅ PASS | Pure-module constraint and runtime-guard rationale documented in `spec.md` Constraints & Risks. |
+| **Update supporting documents** | ✅ PASS | Feature folder docs updated; `package.json` configuration declared. |
+| **Provide next steps** | ✅ PASS | See Recommendation below. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3T: TypeScript Code Change Policy Compliance
+
+#### 3T.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with Prettier** | ✅ PASS | `npm run format` EXIT 0. |
+| **Linting with ESLint** | ✅ PASS | `npm run lint` EXIT 0. |
+| **Type checking with tsc** | ✅ PASS | `npm run typecheck` EXIT 0. |
+| **Testing** | ✅ PASS | `node run-jest.cjs --coverage` EXIT 0; 357/357 pass. |
+
+#### 3T.2 TypeScript Design & Typing
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Strong typing** | ✅ PASS | New fields typed `string \| undefined`. The handler reads config via `get<string>(...)` and applies a string default; no `any`. |
+| **No unjustified type assertions** | ✅ PASS | No new `as X` assertions in production code. (Test code uses narrow tuple assertions on Jest mock-call arrays, consistent with the existing test pattern.) |
+| **ES modules** | ✅ PASS | `import`/`export` syntax throughout; no `require`/`module.exports` introduced in production source. |
+| **Domain types / interfaces** | ✅ PASS | Domain modeled via the extended `WorktreeSessionCommandInput`/`WorktreeSessionCommands` interfaces. |
+
+#### 3T.3 TypeScript Error Handling
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Fail fast / explicit** | ✅ PASS | Empty/whitespace path yields `undefined` (no command), not a silent error; missing-script handling is an explicit `Test-Path` guard. |
+| **No catch-all** | ✅ PASS | No new try/catch introduced. |
+| **Established logging pattern** | ✅ PASS | Extends the existing output-channel log line to note whether a pre-claude script command was emitted; no script content logged beyond the non-sensitive configured value. |
+
+#### 3T.4 Suppressions
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **No new suppressions** | ✅ PASS | No `eslint-disable`, `@ts-expect-error`, or `@ts-ignore` added in this diff. |
+
+#### 3T.5 Test Framework Note (observation, non-blocking)
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Test framework** | ✅ PASS (observation) | `.claude/rules/typescript.md` names Vitest as the framework. The `extensions/drm-copilot` workspace is a separate VS Code extension package whose established, pre-existing toolchain is Jest (`jest`, `ts-jest`, `@jest/globals` in `package.json`; `run-jest.cjs` runner). This feature did not introduce Jest; it follows the package's established testing pattern, which `general-code-change.md` directs. Recorded as an observation, not a finding. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4T: TypeScript Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Framework (Jest, package-established)** | ✅ PASS | Tests use `@jest/globals` describe/it and Jest mocks, matching the package's pre-existing suite. |
+| **Coverage expectation** | ✅ PASS | New/changed-code line coverage >= 85% and branch >= 75% met (see Section 1.2). |
+| **Focused unit tests** | ✅ PASS | One behavior per test. |
+| **Mocking** | ✅ PASS | `vscode` mocked at module level; `getConfiguration`, terminal `sendText` mocked. No over-mocking of the unit under test (the pure builder is tested without mocks). |
+| **Test file location** | ✅ PASS | Tests live under `extensions/drm-copilot/test/`, mirroring `src/`; not colocated in the source tree. |
+| **No external dependencies / temp files** | ✅ PASS | None used. |
+| **Determinism (fake timers)** | ✅ PASS | `jest.useFakeTimers()` / `advanceTimersByTime` used for the deferred-claude window. |
+
+---
+
+## 5. Test Coverage Detail
+
+### buildWorktreeSessionCommands — preClaude (5 new builder tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| emits preClaude as undefined when preClaudeScriptPath is undefined | Negative | ✅ |
+| emits preClaude as undefined for an empty preClaudeScriptPath | Negative | ✅ |
+| emits preClaude as undefined for a whitespace-only preClaudeScriptPath | Edge case | ✅ |
+| emits a Test-Path-guarded preClaude command for a normal script path | Positive | ✅ |
+| preserves spaces and doubles apostrophes in the preClaude script path | Edge case | ✅ |
+
+**Coverage:** `claude-worktree-session.ts` 100% line / 100% branch (lcov 184/184, 17/17). **Not covered:** None.
+
+### newClaudeWorktreeSession handler — preClaude wiring (4 new handler tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| applies the default pre-claude script path when the setting is unset | Positive | ✅ |
+| sends preClaude immediately after activate and before deferred claude when poetry is present | State transition | ✅ |
+| sends preClaude after Set-Location and before deferred claude when poetry is absent | State transition | ✅ |
+| sends no extra command when the configured pre-claude path is empty | Negative | ✅ |
+
+**Coverage:** `extension.ts` 98.67% line / 90.91% branch. **Not covered:** lines 230-231, 237-238 (pre-existing `runPoshQCSuite` early-return paths, unrelated to this feature, uncovered at baseline). No regression on changed lines.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests | 357 | ✅ |
+| Tests Passed | 357 (100%) | ✅ |
+| Tests Failed | 0 | ✅ |
+| New Tests Added | 9 (5 builder + 4 handler) | ✅ |
+| Code Coverage (All files) | 95.54% line, 87.14% branch | ✅ |
+| Code Coverage (`claude-worktree-session.ts`) | 100% line, 100% branch | ✅ |
+| Code Coverage (`extension.ts`) | 98.67% line, 90.91% branch | ✅ |
+
+---
+
+## 7. Code Quality Checks
+
+**For TypeScript (`extensions/drm-copilot`):**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Prettier Formatting | `npm run format` | EXIT 0 | ✅ |
+| ESLint Linting | `npm run lint` | EXIT 0 | ✅ |
+| tsc Type Checking | `npm run typecheck` | EXIT 0 | ✅ |
+| Jest Tests + Coverage | `node run-jest.cjs --coverage` | EXIT 0, 357/357 | ✅ |
+
+**Notes:** The 4 uncovered lines in `extension.ts` (230-231, 237-238) are pre-existing `runPoshQCSuite` early-return paths unrelated to this feature and were uncovered at baseline. Not a regression.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+- **Test file size (`test/extension.workflow-commands.test.ts`)**: 957 lines, exceeds the 500-line limit that `general-code-change.md` applies to test code. Pre-existing (795 at baseline); this change added 162 lines. The feature did not create the violation but extended an already-non-compliant file. Severity: Minor (see code review). Recommended follow-up: split the worktree-session handler tests into a dedicated `*.test.ts` file in a separate, non-blocking maintenance change.
+
+### Approved Exceptions
+
+- **None.** No exceptions requested.
+
+### Removed/Skipped Tests
+
+- **None.** All planned tests implemented; 9 new tests added.
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This Branch (range 93d83d5..72e415c)
+
+The branch delivers the pre-claude-session-script feature (Issue #189) as an additive TypeScript change plus feature-folder documentation and evidence.
+
+### Files Modified
+
+1. **`extensions/drm-copilot/src/claude-worktree-session.ts`** (MODIFIED) — Added `preClaudeScriptPath` to `WorktreeSessionCommandInput`, `preClaude` to `WorktreeSessionCommands`, and the guarded `Test-Path` command construction in `buildWorktreeSessionCommands`.
+2. **`extensions/drm-copilot/src/extension.ts`** (MODIFIED) — Reads the configuration setting with the default `.claude/hooks/pre-claude-session.ps1`, passes it into the builder, sends `commands.preClaude` after activate and before the deferred claude send, and extends the output-channel log note.
+3. **`extensions/drm-copilot/package.json`** (MODIFIED) — Declares `contributes.configuration` with the new `preClaudeScriptPath` property (type string, default, description).
+4. **`extensions/drm-copilot/test/claude-worktree-session.test.ts`** (MODIFIED) — 5 new builder tests.
+5. **`extensions/drm-copilot/test/extension.workflow-commands.test.ts`** (MODIFIED) — 4 new handler tests plus `setPreClaudeScriptPathConfig("")` isolation calls in existing ordering tests.
+6. **`extensions/drm-copilot/test/extension-test-harness.ts`** (MODIFIED) — `getConfiguration` mock and `setPreClaudeScriptPathConfig` helper.
+7. **`extensions/drm-copilot/package-lock.json`** (MODIFIED) — +1 line, lockfile bookkeeping.
+8. Feature-folder docs and evidence (`issue.md`, `spec.md`, `user-story.md`, `plan.*`, `evidence/**`).
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ⚠️ PARTIALLY COMPLIANT
+
+The change is functionally complete, well-typed, well-tested, and meets all coverage thresholds with no regression. The only policy gap is the pre-existing 500-line test-file size limit, which this change aggravates (`test/extension.workflow-commands.test.ts`, 957 lines). This is a Minor, non-blocking maintainability finding and does not affect feature correctness, security, or coverage. No Blocking findings.
+
+**Fail-closed reminder:** All required baseline, QA, and coverage-comparison artifacts are present; coverage was independently re-verified from `coverage/lcov.info`.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- ✅ Before Making Changes: documented
+- ✅ Design Principles: simple, reuses `quoteForPwsh`, preserves pure-module separation
+- ⚠️ Module & File Structure: production files compliant; one pre-existing oversized test file aggravated
+- ✅ Naming, Docs, Comments: descriptive, JSDoc and rationale comments present
+- ✅ Toolchain Execution: format/lint/typecheck/test all EXIT 0
+- ✅ Summarize & Document: complete
+
+#### Language-Specific Code Change Policy (Section 3, TypeScript)
+- ✅ Tooling & Baseline
+- ✅ Design & Typing (no `any`, no new assertions in production)
+- ✅ Error Handling & Suppressions (none added)
+
+#### General Unit Test Policy (Section 1)
+- ✅ Core Principles
+- ✅ Coverage & Scenarios
+- ✅ Test Structure
+- ✅ External Dependencies
+- ✅ Policy Audit
+
+#### Language-Specific Unit Test Policy (Section 4, TypeScript)
+- ✅ Framework & Scope (Jest, package-established)
+- ✅ Test Style & Structure
+- ✅ Naming & Readability
+- ✅ Toolchain
+
+---
+
+### Metrics Summary
+
+- ✅ 357/357 tests passing (100%)
+- ✅ 95.54% line / 87.14% branch coverage repo-wide (TypeScript package)
+- ✅ `claude-worktree-session.ts` 100% line/branch; `extension.ts` 98.67% line / 90.91% branch
+- ✅ All TypeScript quality checks passing (format, lint, typecheck, test)
+- ⚠️ One pre-existing oversized test file (957 lines)
+
+---
+
+### Recommendation
+
+**Ready for merge (Conditional Go).** No Blocking findings. The single Minor finding (oversized pre-existing test file) is recommended for a separate maintenance change and does not block this PR. Remediation inputs are produced to track the Minor finding through the standard handoff because the policy audit contains a PARTIAL result on the file-size requirement.
+
+---
+
+## Appendix A: Test Inventory
+
+New tests added in this branch:
+
+1. buildWorktreeSessionCommands › emits preClaude as undefined when preClaudeScriptPath is undefined
+2. buildWorktreeSessionCommands › emits preClaude as undefined for an empty preClaudeScriptPath
+3. buildWorktreeSessionCommands › emits preClaude as undefined for a whitespace-only preClaudeScriptPath
+4. buildWorktreeSessionCommands › emits a Test-Path-guarded preClaude command for a normal script path
+5. buildWorktreeSessionCommands › preserves spaces and doubles apostrophes in the preClaude script path
+6. drm-copilot workflow command behavior › newClaudeWorktreeSession applies the default pre-claude script path when the setting is unset
+7. drm-copilot workflow command behavior › newClaudeWorktreeSession sends preClaude immediately after activate and before the deferred claude when poetry is present
+8. drm-copilot workflow command behavior › newClaudeWorktreeSession sends preClaude after Set-Location and before the deferred claude when poetry is absent
+9. drm-copilot workflow command behavior › newClaudeWorktreeSession sends no extra command when the configured pre-claude path is empty
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For TypeScript (run from `extensions/drm-copilot`):**
+```bash
+# Formatting
+npm run format
+
+# Linting
+npm run lint
+
+# Type checking
+npm run typecheck
+
+# Testing with coverage
+node run-jest.cjs --coverage   # produces coverage/lcov.info
+```
+
+**Reviewer verification commands:**
+```bash
+git diff --stat 93d83d5..72e415c
+git diff 93d83d5..72e415c -- extensions/drm-copilot/src extensions/drm-copilot/package.json
+python scripts/dev_tools/validate_evidence_locations.py --root .   # EXIT 0
+# lcov parse of extensions/drm-copilot/coverage/lcov.info for the two changed source files
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-06-16
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/remediation-inputs.2026-06-16T14-11.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/remediation-inputs.2026-06-16T14-11.md
@@ -1,0 +1,48 @@
+# Remediation Inputs: pre-claude-session-script (Issue #189)
+
+**Entry timestamp:** 2026-06-16T14-11
+**Feature Folder:** `docs/features/active/2026-06-16-pre-claude-session-script-189`
+**Base Branch:** `main` (merge-base `93d83d5ea01d40b229e2721f057210d9ef698206`)
+**Head:** `drm-copilot-wt-2026-06-16-13-41` (`72e415c389423e7a213bb899970278dff47ce7d5`)
+
+## Source audit artifacts
+
+- `docs/features/active/2026-06-16-pre-claude-session-script-189/policy-audit.2026-06-16T14-11.md` (Section 2.3, Section 8: file-size PARTIAL)
+- `docs/features/active/2026-06-16-pre-claude-session-script-189/code-review.2026-06-16T14-11.md` (Findings Table: Minor)
+- `docs/features/active/2026-06-16-pre-claude-session-script-189/feature-audit.2026-06-16T14-11.md` (all AC PASS; no AC-driven remediation)
+
+## Severity overview
+
+- **Blocking findings: 0.**
+- **Minor findings: 1** (non-blocking; pre-existing condition aggravated by this change).
+
+This remediation-inputs artifact is produced because the policy audit contains a PARTIAL result on the 500-line test-file-size requirement, which the feature-review workflow treats as a remediation trigger. There are zero Blocking findings; the feature itself is PR-ready (Conditional Go). The single item below may be deferred to a separate maintenance change at the orchestrator's discretion.
+
+## Enumerated fix list
+
+### Severity: Minor — Test file exceeds 500-line limit
+
+- **File:** `extensions/drm-copilot/test/extension.workflow-commands.test.ts`
+- **Current state:** 957 lines (795 at baseline `93d83d5`; +162 added by this change). Exceeds the 500-line limit that `general-code-change.md` applies to test code.
+- **Expected behavior after fix:** The worktree-session command tests are split so that no single test file exceeds 500 lines, with no loss of test coverage and no behavior change. For example, extract the `newClaudeWorktreeSession` ordering/handler tests (including the four new pre-claude tests) into a dedicated file such as `extensions/drm-copilot/test/extension.new-claude-worktree-session.test.ts`, preserving the existing shared harness imports.
+- **Constraints:** Production code under test must not change. Test assertions and scenario coverage must be preserved exactly. The new file(s) must remain under `extensions/drm-copilot/test/` (mirroring `src/`), not colocated in the source tree.
+- **Verification commands (from `extensions/drm-copilot`):**
+  - `wc -l test/*.test.ts` — confirm each test file is <= 500 lines.
+  - `npm run format` — EXIT 0.
+  - `npm run lint` — EXIT 0.
+  - `npm run typecheck` — EXIT 0.
+  - `node run-jest.cjs --coverage` — EXIT 0; test count unchanged (357) and coverage unchanged (`claude-worktree-session.ts` 100%; `extension.ts` line >= 98.67% / branch >= 90.91%); no regression on changed lines.
+- **Evidence target:** Write QA evidence under `docs/features/active/2026-06-16-pre-claude-session-script-189/evidence/qa-gates/` per the canonical evidence-location convention.
+
+## Do-not-do list
+
+- Do not modify production source (`src/claude-worktree-session.ts`, `src/extension.ts`, `package.json`) to satisfy this finding; the fix is a test-file split only.
+- Do not delete, weaken, or merge any test assertions to reduce line count; preserve all 357 tests and their scenarios.
+- Do not lower or waive the 500-line limit or any coverage threshold.
+- Do not relocate test files into the production source tree (`src/`).
+- Do not introduce new runtime dependencies or change the test framework.
+- Do not write evidence to non-canonical paths (`artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, `artifacts/evidence/`); use `<FEATURE>/evidence/<kind>/`.
+
+## Recommended disposition
+
+This is a single Minor, pre-existing maintainability item with zero Blocking findings. The orchestrator may either (a) open a remediation cycle scoped solely to the test-file split, or (b) defer it to a separate maintenance change and proceed with the PR, since the feature meets all acceptance criteria and coverage thresholds and carries no Blocking findings.

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/spec.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/spec.md
@@ -1,0 +1,74 @@
+# pre-claude-session-script — Spec
+
+- **Issue:** #189
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-16T13-49
+- **Status:** Draft
+- **Version:** 0.1
+
+## Overview
+
+The "New Claude Worktree Session" command runs a fixed sequence of pre-`claude` steps (git worktree add, Set-Location, optional poetry install/activate) before starting `claude`. This feature adds a configurable hook: a local PowerShell script, declared in the repository, that runs immediately before `claude` is invoked. This lets repositories carry their own pre-session setup without changes to the extension.
+
+## Behavior
+
+After the worktree is created, navigated into, and (when applicable) the poetry environment is installed and activated, the command runs a configured PowerShell script if it exists in the worktree, then starts `claude`. The script path is resolved from a configuration setting that defaults to a repo-local convention path. A missing script is not an error; the command proceeds to `claude`.
+
+## Inputs / Outputs
+
+- Inputs:
+  - Configuration setting `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` (string). Default: `.claude/hooks/pre-claude-session.ps1`. Resolved relative to the worktree root.
+- Outputs:
+  - An additional `preClaude` PowerShell command sent to the integrated terminal between poetry activation and the deferred `claude` command, when a non-empty path is configured.
+  - Output channel log line continues to record the session; no script content is logged.
+- Config keys and defaults:
+  - `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` — default `.claude/hooks/pre-claude-session.ps1`.
+- Versioning or backward-compatibility constraints:
+  - Existing git, Set-Location, poetry, and deferred-`claude` behavior is unchanged. When the setting resolves to empty/whitespace, no new command is emitted.
+
+## API / CLI Surface
+
+- `WorktreeSessionCommandInput` gains `preClaudeScriptPath: string | undefined`.
+- `WorktreeSessionCommands` gains `preClaude: string | undefined`.
+- Emitted command shape when path is non-empty:
+  - `if (Test-Path -LiteralPath '<quoted-path>') { & '<quoted-path>' }`
+  - The path is escaped with the existing `quoteForPwsh` helper.
+- When path is `undefined`/empty/whitespace: `preClaude === undefined`.
+
+## Data & State
+
+- No persistent state introduced. The script existence check happens at runtime in the new worktree via `Test-Path`.
+- Data flow: configuration setting → handler → pure builder → terminal `sendText`.
+
+## Constraints & Risks
+
+- The pure module (`claude-worktree-session.ts`) must remain side-effect free; it must not import `vscode`, `node:child_process`, or `node:fs`. Existence is therefore checked at PowerShell runtime, not in TypeScript.
+- The script runs with `--dangerously-skip-permissions` context only insofar as it precedes `claude`; the script itself runs in the user's PowerShell session. This matches existing trust assumptions for the worktree session command.
+- File-size limit (500 lines) applies; current `claude-worktree-session.ts` is well under the limit.
+
+## Implementation Strategy
+
+- Implementation scope:
+  - `src/claude-worktree-session.ts`: extend `WorktreeSessionCommandInput` and `WorktreeSessionCommands`; build the guarded `preClaude` command in `buildWorktreeSessionCommands`.
+  - `src/extension.ts`: read the configuration setting (with default), pass it into the builder, send `commands.preClaude` after activate and before the deferred `claude` send.
+  - `package.json`: add `contributes.configuration` declaring the setting (type string, default `.claude/hooks/pre-claude-session.ps1`, description).
+- New classes/functions/commands: none beyond the extended interfaces and builder logic.
+- Dependency changes: none.
+- Logging/telemetry: extend the existing output-channel log line to note whether a pre-`claude` script command was emitted (without logging the path content beyond the configured value, which is non-sensitive).
+- Rollout: no feature flag; default convention path makes the hook opt-in by presence of the script file.
+
+## Definition of Done
+
+- [ ] Acceptance criteria documented and mapped to tests (see user-story.md AC1–AC8)
+- [ ] Behavior matches acceptance criteria
+- [ ] Tests updated/added (unit)
+- [ ] Edge cases and error handling covered by tests (empty/whitespace path, path with quotes/spaces, missing script guard)
+- [ ] Docs updated (feature folder; README if applicable)
+- [ ] Logging updated
+- [ ] Toolchain pass completed (format → lint → type-check → test)
+
+## Seeded Test Conditions (from potential)
+- [ ] Unit coverage: builder `preClaude` for present/absent/whitespace paths and quote escaping
+- [ ] Unit coverage: handler configuration read and command ordering
+- [ ] CLI/API examples: emitted PowerShell command shape

--- a/docs/features/active/2026-06-16-pre-claude-session-script-189/user-story.md
+++ b/docs/features/active/2026-06-16-pre-claude-session-script-189/user-story.md
@@ -1,0 +1,44 @@
+# `pre-claude-session-script` — User Story
+
+- Issue: #189
+- Owner: drmoisan
+- Status: Draft
+- Last Updated: 2026-06-16T13-49
+
+## Story Statement
+
+- As a repository maintainer using the "New Claude Worktree Session" command, I want to point the command at a local PowerShell script that runs immediately before `claude` is invoked, so that repo-specific setup operations are configured in the local repository rather than centrally in the extension.
+
+## Problem / Why
+
+The "New Claude Worktree Session" command (`drmCopilotExtension.newClaudeWorktreeSession`) creates a worktree, navigates into it, optionally installs and activates a poetry environment, then starts `claude`. The pre-`claude` steps are fixed in the extension. Repositories that need additional local setup (for example, copying machine-local configuration, seeding environment variables, or running a repo-specific bootstrap) have no supported way to run those steps. Hard-coding them in the extension would force every consumer to carry them. The setup needs to be declared and maintained in the local repository.
+
+## Personas & Scenarios
+
+- Persona: Repository maintainer
+  - Configures developer tooling for a specific repository.
+  - Cares about reproducible, repo-local setup that does not require changes to a shared extension.
+  - Works on Windows with PowerShell as the configured runtime.
+- Scenario: Maintainer adds a bootstrap script
+  - The maintainer commits a PowerShell script to the repository (default path `.claude/hooks/pre-claude-session.ps1`).
+  - The maintainer optionally overrides the path via the `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` setting in the repository's `.vscode/settings.json`.
+  - When the maintainer runs "New Claude Worktree Session", the command creates the worktree, navigates into it, performs poetry steps when applicable, runs the configured script, then starts `claude`.
+  - If no script is present at the configured path in the worktree, the command proceeds to `claude` without error.
+
+## Acceptance Criteria
+
+- [x] AC1: The pure command builder accepts a configurable pre-`claude` script path and emits a `preClaude` PowerShell command when a non-empty path is supplied.
+- [x] AC2: When the supplied script path is `undefined`, empty, or whitespace-only, the builder emits `preClaude` as `undefined` (no command).
+- [x] AC3: The emitted `preClaude` command invokes the script only when it exists in the worktree, using a runtime existence guard (`if (Test-Path -LiteralPath '<path>') { & '<path>' }`), so a missing script does not cause an error.
+- [x] AC4: The script path is embedded using the existing PowerShell single-quote escaping helper so paths containing spaces or apostrophes are preserved literally.
+- [x] AC5: The `newClaudeWorktreeSession` handler reads the script path from the `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` configuration setting, which defaults to `.claude/hooks/pre-claude-session.ps1`.
+- [x] AC6: The handler sends the `preClaude` command after the poetry activation step (when present) and before the deferred `claude` command, so the script runs immediately before `claude`. When `preClaude` is `undefined`, no additional command is sent.
+- [x] AC7: `package.json` declares the new configuration setting under `contributes.configuration` with its type, default value, and description.
+- [x] AC8: Unit tests cover the builder behaviors (AC1–AC4) and the handler's configuration read and command ordering (AC5–AC6). The full TypeScript toolchain (format → lint → type-check → test) passes with coverage thresholds met.
+
+## Non-Goals
+
+- Supporting non-PowerShell pre-`claude` scripts (the worktree session command already requires the PowerShell runtime).
+- Running multiple pre-`claude` scripts; a single configurable path is in scope.
+- Passing the worktree session objective or other arguments into the script.
+- Changing the existing git, Set-Location, poetry, or deferred-`claude` behavior.

--- a/extensions/drm-copilot/README.md
+++ b/extensions/drm-copilot/README.md
@@ -28,12 +28,44 @@ The extension continues to contribute these stable command IDs:
 - `drmCopilotExtension.resolveAtomicPlanPrompt`
 - `drmCopilotExtension.syncAgentsFromInstructions`
 - `drmCopilotExtension.listMcpTools`
+- `drmCopilotExtension.newClaudeWorktreeSession`
 
 The interactive VS Code flows keep their current prompts and branch/file pickers, but now delegate through the shared repo-automation service used by the MCP bridge.
 
 ## Sync AGENTS.md from Instructions
 
 Use the `drm-copilot: Sync AGENTS.md from Instructions` command (command ID: `drmCopilotExtension.syncAgentsFromInstructions`) from the Command Palette to regenerate `AGENTS.md` in the active workspace. The bundled PowerShell script discovers all `.github/instructions/*.instructions.md` files under the active workspace root, aggregates their content in a deterministic order, and writes the consolidated result to `AGENTS.md` at the workspace root. This replaces any manual edits to `AGENTS.md` with a fully generated output derived from the workspace's canonical `.github` instruction files.
+
+## New Claude Worktree Session
+
+Use the `drm-copilot: New Claude Worktree Session` command (command ID: `drmCopilotExtension.newClaudeWorktreeSession`) from the Command Palette to open an integrated PowerShell terminal that creates a new git worktree, navigates into it, optionally installs and activates the poetry environment when the workspace declares poetry, and then starts an interactive `claude` session. The command prompts for an optional objective to pass to `claude` as the initial prompt.
+
+### Injecting a pre-`claude` script
+
+The command can run a local PowerShell script in the new worktree immediately before `claude` is started. This lets a repository carry its own pre-session setup (for example, copying machine-local configuration, seeding environment variables, or running a repo-specific bootstrap) in the local repository rather than centrally in the extension.
+
+How it works:
+
+- The script path is read from the `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` configuration setting.
+- The default value is `.claude/hooks/pre-claude-session.ps1`, resolved relative to the new worktree root.
+- After the worktree is created, navigated into, and (when applicable) the poetry environment is installed and activated, the command runs the configured script if it exists in the worktree, then starts `claude`.
+- The script runs only when it exists: the command emits a runtime existence guard (`if (Test-Path -LiteralPath '<path>') { & '<path>' }`), so a missing script is not an error and the session proceeds directly to `claude`.
+
+To use the default convention, commit a PowerShell script to the repository at `.claude/hooks/pre-claude-session.ps1`. Because the script lives in the repository, it is present in the new worktree after `git worktree add` and runs automatically on the next worktree session.
+
+To use a different path, set the configuration value in the repository's `.vscode/settings.json` so the setting travels with the local repository:
+
+```json
+{
+  "drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath": ".claude/hooks/my-bootstrap.ps1"
+}
+```
+
+Notes:
+
+- The path is resolved relative to the worktree root and is embedded with PowerShell single-quote escaping, so paths containing spaces or apostrophes are preserved literally.
+- Leaving the setting empty or whitespace-only suppresses the pre-`claude` step entirely; no additional command is sent.
+- The script runs in the worktree's PowerShell session before `claude` takes over the terminal.
 
 ## MCP Server
 

--- a/extensions/drm-copilot/package-lock.json
+++ b/extensions/drm-copilot/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "drm-copilot",
       "version": "0.0.2",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"
       },

--- a/extensions/drm-copilot/package.json
+++ b/extensions/drm-copilot/package.json
@@ -39,6 +39,16 @@
         "label": "drm-copilot Repo Automation"
       }
     ],
+    "configuration": {
+      "title": "drm-copilot",
+      "properties": {
+        "drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath": {
+          "type": "string",
+          "default": ".claude/hooks/pre-claude-session.ps1",
+          "description": "Worktree-relative path to a PowerShell script that the New Claude Worktree Session command runs immediately before 'claude'. The path is resolved relative to the worktree root. A missing script at this path is not an error; the command proceeds to 'claude'."
+        }
+      }
+    },
     "commands": [
       {
         "command": "drmCopilotExtension.helloPython",

--- a/extensions/drm-copilot/src/claude-worktree-session.ts
+++ b/extensions/drm-copilot/src/claude-worktree-session.ts
@@ -19,6 +19,12 @@ export interface WorktreeSessionCommandInput {
   readonly branchName: string;
   readonly usePoetry: boolean;
   readonly objective: string | undefined;
+  /**
+   * Worktree-relative path to a PowerShell script to run immediately before
+   * `claude`. When `undefined`, empty, or whitespace-only no pre-`claude`
+   * command is emitted.
+   */
+  readonly preClaudeScriptPath: string | undefined;
 }
 
 /**
@@ -37,6 +43,12 @@ export interface WorktreeSessionCommands {
   readonly setLocation: string;
   readonly poetryInstall: string | undefined;
   readonly activate: string | undefined;
+  /**
+   * Guarded PowerShell command that runs the configured pre-`claude` script
+   * only when it exists in the worktree. Present only when a non-empty script
+   * path is supplied; `undefined` otherwise.
+   */
+  readonly preClaude: string | undefined;
   readonly claude: string;
 }
 
@@ -147,11 +159,26 @@ export function buildWorktreeSessionCommands(
     ? "& './.venv/Scripts/Activate.ps1'"
     : undefined;
 
+  // Guard the pre-`claude` script behind a runtime Test-Path so a missing
+  // script at the configured path does not cause an error. The path is
+  // embedded with the single-quote escaping helper so spaces and apostrophes
+  // are preserved literally. An undefined/empty/whitespace path yields no
+  // command.
+  const trimmedPreClaudePath = input.preClaudeScriptPath?.trim() ?? "";
+  let preClaude: string | undefined;
+  if (trimmedPreClaudePath.length > 0) {
+    const quotedPreClaude = quoteForPwsh(trimmedPreClaudePath);
+    preClaude = `if (Test-Path -LiteralPath ${quotedPreClaude}) { & ${quotedPreClaude} }`;
+  } else {
+    preClaude = undefined;
+  }
+
   return {
     git: `git -C ${quotedRepoRoot} worktree add ${quotedPath} -b ${quotedBranch}`,
     setLocation: `Set-Location ${quotedPath}`,
     poetryInstall,
     activate,
+    preClaude,
     claude: `claude --dangerously-skip-permissions${objectiveSuffix}`,
   };
 }

--- a/extensions/drm-copilot/src/extension.ts
+++ b/extensions/drm-copilot/src/extension.ts
@@ -130,12 +130,18 @@ export function activate(context: vscode.ExtensionContext): void {
       );
       const branchName = buildBranchName(timestamp, repoName);
       const usePoetry = pyprojectHasPoetry(workspaceRoot);
+      const configuredPreClaudeScriptPath =
+        vscode.workspace
+          .getConfiguration("drmCopilotExtension.newClaudeWorktreeSession")
+          .get<string>("preClaudeScriptPath") ??
+        ".claude/hooks/pre-claude-session.ps1";
       const commands = buildWorktreeSessionCommands({
         repoRoot: workspaceRoot,
         worktreePath,
         branchName,
         usePoetry,
         objective,
+        preClaudeScriptPath: configuredPreClaudeScriptPath,
       });
 
       // The terminal must start inside the source repository so that
@@ -165,6 +171,13 @@ export function activate(context: vscode.ExtensionContext): void {
         terminal.sendText(commands.activate, true);
       }
 
+      // Run the configured pre-`claude` script (guarded by a runtime
+      // Test-Path) after the poetry activation step and before the deferred
+      // claude send, so repo-local setup runs immediately before claude.
+      if (commands.preClaude !== undefined) {
+        terminal.sendText(commands.preClaude, true);
+      }
+
       // Defer the final claude command. VS Code's Python extension auto-
       // injects its own venv activation via a deferred terminal.sendText.
       // If we start claude before that injection arrives, claude takes over
@@ -181,8 +194,12 @@ export function activate(context: vscode.ExtensionContext): void {
       const poetryNote = usePoetry
         ? "with poetry install and activation"
         : "no poetry";
+      const preClaudeNote =
+        commands.preClaude !== undefined
+          ? "pre-claude script: emitted"
+          : "pre-claude script: none";
       output.appendLine(
-        `[${commandId}] opened terminal for branch ${branchName} at ${worktreePath} (objective length: ${objectiveLength}, ${poetryNote}); claude send deferred by ${TERMINAL_AUTO_ACTIVATION_GRACE_MS}ms`,
+        `[${commandId}] opened terminal for branch ${branchName} at ${worktreePath} (objective length: ${objectiveLength}, ${poetryNote}, ${preClaudeNote}); claude send deferred by ${TERMINAL_AUTO_ACTIVATION_GRACE_MS}ms`,
       );
     },
   );

--- a/extensions/drm-copilot/test/claude-worktree-session.test.ts
+++ b/extensions/drm-copilot/test/claude-worktree-session.test.ts
@@ -120,6 +120,7 @@ describe("buildWorktreeSessionCommands", () => {
     worktreePath: "/parent/auth-wt-2026-04-20-09-59",
     branchName: "auth-wt-2026-04-20-09-59",
     usePoetry: false,
+    preClaudeScriptPath: undefined,
   };
 
   it("emits a git command that uses git -C <repoRoot> with quoted path and branch", () => {
@@ -241,6 +242,7 @@ describe("buildWorktreeSessionCommands", () => {
       branchName: "feature/o'connor",
       usePoetry: false,
       objective: undefined,
+      preClaudeScriptPath: undefined,
     };
 
     // Act
@@ -252,6 +254,70 @@ describe("buildWorktreeSessionCommands", () => {
     );
     expect(commands.setLocation).toBe(
       "Set-Location '/parent dir/o''connor-wt'",
+    );
+  });
+
+  it("emits preClaude as undefined when preClaudeScriptPath is undefined", () => {
+    // Arrange / Act
+    const commands = buildWorktreeSessionCommands({
+      ...baseInput,
+      objective: undefined,
+      preClaudeScriptPath: undefined,
+    });
+
+    // Assert
+    expect(commands.preClaude).toBeUndefined();
+  });
+
+  it("emits preClaude as undefined for an empty preClaudeScriptPath", () => {
+    // Arrange / Act
+    const commands = buildWorktreeSessionCommands({
+      ...baseInput,
+      objective: undefined,
+      preClaudeScriptPath: "",
+    });
+
+    // Assert
+    expect(commands.preClaude).toBeUndefined();
+  });
+
+  it("emits preClaude as undefined for a whitespace-only preClaudeScriptPath", () => {
+    // Arrange / Act
+    const commands = buildWorktreeSessionCommands({
+      ...baseInput,
+      objective: undefined,
+      preClaudeScriptPath: "   ",
+    });
+
+    // Assert
+    expect(commands.preClaude).toBeUndefined();
+  });
+
+  it("emits a Test-Path-guarded preClaude command for a normal script path", () => {
+    // Arrange / Act
+    const commands = buildWorktreeSessionCommands({
+      ...baseInput,
+      objective: undefined,
+      preClaudeScriptPath: ".claude/hooks/pre-claude-session.ps1",
+    });
+
+    // Assert
+    expect(commands.preClaude).toBe(
+      "if (Test-Path -LiteralPath '.claude/hooks/pre-claude-session.ps1') { & '.claude/hooks/pre-claude-session.ps1' }",
+    );
+  });
+
+  it("preserves spaces and doubles apostrophes in the preClaude script path", () => {
+    // Arrange / Act
+    const commands = buildWorktreeSessionCommands({
+      ...baseInput,
+      objective: undefined,
+      preClaudeScriptPath: "C:/o'connor dir/pre.ps1",
+    });
+
+    // Assert
+    expect(commands.preClaude).toBe(
+      "if (Test-Path -LiteralPath 'C:/o''connor dir/pre.ps1') { & 'C:/o''connor dir/pre.ps1' }",
     );
   });
 });

--- a/extensions/drm-copilot/test/extension-test-harness.ts
+++ b/extensions/drm-copilot/test/extension-test-harness.ts
@@ -51,6 +51,20 @@ const registerMcpServerDefinitionProviderMock = jest.fn(() => ({
   dispose: jest.fn(),
 }));
 
+let preClaudeScriptPathConfig: string | undefined = undefined;
+
+const getConfigurationMock = jest.fn((section?: string) => ({
+  get: <T>(key: string): T | undefined => {
+    if (
+      section === "drmCopilotExtension.newClaudeWorktreeSession" &&
+      key === "preClaudeScriptPath"
+    ) {
+      return preClaudeScriptPathConfig as T | undefined;
+    }
+    return undefined;
+  },
+}));
+
 jest.mock(
   "vscode",
   () => ({
@@ -73,6 +87,7 @@ jest.mock(
         return workspaceFoldersState;
       },
       openTextDocument: openTextDocumentMock,
+      getConfiguration: getConfigurationMock,
     },
     Uri: {
       joinPath: jest.fn((base: { fsPath: string }, ...segments: string[]) => ({
@@ -229,6 +244,19 @@ export function setWorkspaceFolders(
   workspaceFoldersState = value;
 }
 
+/**
+ * Controls the value returned by
+ * `vscode.workspace.getConfiguration("drmCopilotExtension.newClaudeWorktreeSession").get<string>("preClaudeScriptPath")`.
+ * Pass `undefined` to simulate the setting being unset (the default reset
+ * state), in which case the handler applies its TypeScript-side default.
+ *
+ * @param value The configured pre-`claude` script path, or `undefined` to
+ *              leave the setting unset.
+ */
+export function setPreClaudeScriptPathConfig(value: string | undefined): void {
+  preClaudeScriptPathConfig = value;
+}
+
 export function resetExtensionHarnessState(): void {
   process.env.PATH = "C:/bin";
   process.env.PATHEXT = ".EXE;.CMD";
@@ -236,6 +264,8 @@ export function resetExtensionHarnessState(): void {
   appendLineMock.mockReset();
   registerCommandMock.mockClear();
   registerMcpServerDefinitionProviderMock.mockClear();
+  getConfigurationMock.mockClear();
+  preClaudeScriptPathConfig = undefined;
   childProcessMock.spawn.mockReset();
   childProcessMock.spawnSync.mockReset();
   fsMock.readFileSync.mockReset();
@@ -312,6 +342,7 @@ export {
   createMockProcess,
   createMockProcessWithStderr,
   createTerminalMock,
+  getConfigurationMock,
   getFreshChildProcessMock,
   prepareFreshModulesWithPosixPathResolve,
   registerMcpServerDefinitionProviderMock,

--- a/extensions/drm-copilot/test/extension.workflow-commands.test.ts
+++ b/extensions/drm-copilot/test/extension.workflow-commands.test.ts
@@ -17,6 +17,7 @@ import {
   registerMcpServerDefinitionProviderMock,
   resetExtensionHarnessState,
   setExecutablePresence,
+  setPreClaudeScriptPathConfig,
   setPyprojectFixture,
   setWorkspaceFolders,
   showInputBoxMock,
@@ -426,6 +427,9 @@ describe("drm-copilot workflow command behavior", () => {
       setExecutablePresence({ pwsh: true, powershell: false });
       // No setPyprojectFixture call here means the workspace has no
       // pyproject.toml, so usePoetry resolves to false.
+      // Empty pre-claude path so this test isolates git/Set-Location/claude
+      // ordering without an additional preClaude send.
+      setPreClaudeScriptPathConfig("");
       showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
 
       const handler = activateAndGetHandler(
@@ -500,6 +504,9 @@ describe("drm-copilot workflow command behavior", () => {
       setPyprojectFixture(
         '[tool.poetry]\nname = "drm-copilot"\nversion = "0.1.0"\n',
       );
+      // Empty pre-claude path so this test isolates the poetry install and
+      // activate ordering without an additional preClaude send.
+      setPreClaudeScriptPathConfig("");
       showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
 
       const handler = activateAndGetHandler(
@@ -543,6 +550,9 @@ describe("drm-copilot workflow command behavior", () => {
       setPyprojectFixture(
         '[project]\nname = "plain"\nversion = "0.1.0"\nrequires-python = ">=3.13"\n',
       );
+      // Empty pre-claude path so this test isolates the no-poetry behavior
+      // without an additional preClaude send.
+      setPreClaudeScriptPathConfig("");
       showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
 
       const handler = activateAndGetHandler(
@@ -567,6 +577,9 @@ describe("drm-copilot workflow command behavior", () => {
     jest.useFakeTimers();
     try {
       setExecutablePresence({ pwsh: true, powershell: false });
+      // Empty pre-claude path so this test isolates the blank-objective claude
+      // command without an additional preClaude send.
+      setPreClaudeScriptPathConfig("");
       showInputBoxMock.mockResolvedValueOnce("   ");
 
       const handler = activateAndGetHandler(
@@ -596,6 +609,9 @@ describe("drm-copilot workflow command behavior", () => {
     jest.useFakeTimers();
     try {
       setExecutablePresence({ pwsh: true, powershell: false });
+      // Empty pre-claude path so this deferral guard isolates the git +
+      // Set-Location synchronous sends without an additional preClaude send.
+      setPreClaudeScriptPathConfig("");
       showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
 
       const handler = activateAndGetHandler(
@@ -617,6 +633,152 @@ describe("drm-copilot workflow command behavior", () => {
 
       // At the configured grace boundary, the claude sendText fires.
       jest.advanceTimersByTime(1);
+      expect(terminal.sendText).toHaveBeenCalledTimes(3);
+      const [claudeCmd] = terminal.sendText.mock.calls[2] as [string];
+      expect(claudeCmd).toContain("claude --dangerously-skip-permissions");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("newClaudeWorktreeSession applies the default pre-claude script path when the setting is unset", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      // No setPreClaudeScriptPathConfig call: the setting is unset, so the
+      // handler applies its TypeScript-side default.
+      showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newClaudeWorktreeSession",
+      );
+      await handler();
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        sendText: jest.Mock;
+      };
+
+      // No poetry => synchronous order is git, Set-Location, preClaude.
+      expect(terminal.sendText).toHaveBeenCalledTimes(3);
+      const [preClaudeCmd, preClaudeNewline] = terminal.sendText.mock
+        .calls[2] as [string, boolean];
+      expect(preClaudeNewline).toBe(true);
+      expect(preClaudeCmd).toBe(
+        "if (Test-Path -LiteralPath '.claude/hooks/pre-claude-session.ps1') { & '.claude/hooks/pre-claude-session.ps1' }",
+      );
+
+      jest.advanceTimersByTime(5000);
+      expect(terminal.sendText).toHaveBeenCalledTimes(4);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("newClaudeWorktreeSession sends preClaude immediately after activate and before the deferred claude when poetry is present", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      setPyprojectFixture(
+        '[tool.poetry]\nname = "drm-copilot"\nversion = "0.1.0"\n',
+      );
+      setPreClaudeScriptPathConfig("scripts/bootstrap.ps1");
+      showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newClaudeWorktreeSession",
+      );
+      await handler();
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        sendText: jest.Mock;
+      };
+
+      // Synchronous order: git, Set-Location, poetry install, activate,
+      // preClaude (five calls). claude is deferred.
+      expect(terminal.sendText).toHaveBeenCalledTimes(5);
+      const [poetryInstallCmd] = terminal.sendText.mock.calls[2] as [string];
+      const [activateCmd] = terminal.sendText.mock.calls[3] as [string];
+      const [preClaudeCmd] = terminal.sendText.mock.calls[4] as [string];
+      expect(poetryInstallCmd).toBe("poetry install --with dev");
+      expect(activateCmd).toBe("& './.venv/Scripts/Activate.ps1'");
+      expect(preClaudeCmd).toBe(
+        "if (Test-Path -LiteralPath 'scripts/bootstrap.ps1') { & 'scripts/bootstrap.ps1' }",
+      );
+
+      jest.advanceTimersByTime(5000);
+
+      // claude is the last call.
+      expect(terminal.sendText).toHaveBeenCalledTimes(6);
+      const [claudeCmd] = terminal.sendText.mock.calls[5] as [string];
+      expect(claudeCmd).toBe(
+        "claude --dangerously-skip-permissions 'Refactor the auth module.'",
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("newClaudeWorktreeSession sends preClaude after Set-Location and before the deferred claude when poetry is absent", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      // No pyproject fixture => no poetry.
+      setPreClaudeScriptPathConfig("scripts/bootstrap.ps1");
+      showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newClaudeWorktreeSession",
+      );
+      await handler();
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        sendText: jest.Mock;
+      };
+
+      // Synchronous order: git, Set-Location, preClaude (three calls).
+      expect(terminal.sendText).toHaveBeenCalledTimes(3);
+      const [setLocationCmd] = terminal.sendText.mock.calls[1] as [string];
+      const [preClaudeCmd] = terminal.sendText.mock.calls[2] as [string];
+      expect(setLocationCmd).toMatch(/^Set-Location '/);
+      expect(preClaudeCmd).toBe(
+        "if (Test-Path -LiteralPath 'scripts/bootstrap.ps1') { & 'scripts/bootstrap.ps1' }",
+      );
+
+      jest.advanceTimersByTime(5000);
+
+      expect(terminal.sendText).toHaveBeenCalledTimes(4);
+      const [claudeCmd] = terminal.sendText.mock.calls[3] as [string];
+      expect(claudeCmd).toBe(
+        "claude --dangerously-skip-permissions 'Refactor the auth module.'",
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("newClaudeWorktreeSession sends no extra command when the configured pre-claude path is empty", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      // Empty configured path => builder yields preClaude === undefined.
+      setPreClaudeScriptPathConfig("");
+      showInputBoxMock.mockResolvedValueOnce("Refactor the auth module.");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newClaudeWorktreeSession",
+      );
+      await handler();
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        sendText: jest.Mock;
+      };
+
+      // No poetry, no preClaude => only git and Set-Location synchronously.
+      expect(terminal.sendText).toHaveBeenCalledTimes(2);
+
+      jest.advanceTimersByTime(5000);
+
+      // Only the deferred claude send is added; no preClaude send.
       expect(terminal.sendText).toHaveBeenCalledTimes(3);
       const [claudeCmd] = terminal.sendText.mock.calls[2] as [string];
       expect(claudeCmd).toContain("claude --dangerously-skip-permissions");


### PR DESCRIPTION
## Summary

Adds the ability to point the "New Claude Worktree Session" command (`drmCopilotExtension.newClaudeWorktreeSession`) at a local PowerShell script that runs immediately before `claude` is invoked. The script path is read from a new VS Code setting, defaulting to a repo-local convention path, so pre-session setup is configured in the local repository rather than centrally in the extension.

Closes #189.

## Changes

- **`src/claude-worktree-session.ts`** — extend `WorktreeSessionCommandInput` (`preClaudeScriptPath`) and `WorktreeSessionCommands` (`preClaude`). The builder emits a runtime-guarded command `if (Test-Path -LiteralPath <path>) { & <path> }` using the existing `quoteForPwsh` escaping, or `undefined` for an empty/whitespace path. The module remains side-effect free.
- **`src/extension.ts`** — read `drmCopilotExtension.newClaudeWorktreeSession.preClaudeScriptPath` (default `.claude/hooks/pre-claude-session.ps1`), pass it to the builder, and send the `preClaude` command after poetry activation and before the deferred `claude` command. Output-channel log line extended.
- **`package.json`** — declare the new setting under `contributes.configuration`.
- **Tests** — builder behaviors, handler configuration read and command ordering, and test-harness `getConfiguration` mock support.

## Behavior

A missing script is not an error: the `Test-Path` guard runs in the new worktree at runtime, and the command proceeds to `claude` when no script is present.

## Verification

- TypeScript toolchain (format → lint → type-check → test) passes; 357/357 Jest tests pass.
- Coverage: `claude-worktree-session.ts` 100% line / 100% branch; `extension.ts` 98.67% line / 90.91% branch; repo-wide 95.54% line / 87.14% branch. No regression on changed lines.
- Feature review: zero blocking findings. All 8 acceptance criteria (AC1–AC8) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)