### PR TITLE
test(pester): resolve Test Explorer adapter ID collisions from case-only test names

### DIFF
--- a/docs/features/active/2026-06-17-pester-adapter-id-collision-198/code-review.2026-06-17T21-22.md
+++ b/docs/features/active/2026-06-17-pester-adapter-id-collision-198/code-review.2026-06-17T21-22.md
@@ -1,0 +1,110 @@
+# Code Review: pester-adapter-id-collision (Issue #198)
+
+**Review Date:** 2026-06-17
+**Reviewer:** feature-review agent (Claude Opus 4.8)
+**Feature Folder:** `docs/features/active/2026-06-17-pester-adapter-id-collision-198`
+**Feature Folder Selection Rule:** Folder suffix `-198` matches the issue number in the branch name `fix/pester-adapter-id-collision-198`; it is the only active folder with material scoping-doc changes in this diff.
+**Base Branch:** `main` (merge-base `fb05bbea85d5efcf7f2f4d5b311ced644c607d9d`)
+**Head Branch:** `fix/pester-adapter-id-collision-198` (`9eb40c16c355ecd9f50b0e6ca5501956d1037dd4`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+This change resolves issue #198, in which the VS Code `pspester.pester-test` Test Explorer adapter folds discovered test IDs to uppercase during static discovery, causing sibling Describe/Context/It names — and `-ForEach`/`-TestCases` expansions — that differ only by letter case to collide to a single adapter ID and be dropped or misreported. `Invoke-Pester` does not fold case, so the engine reports green and hides the defect.
+
+The change is test-only and contains two parts. First, `Invoke-FullRelease.Tests.ps1` merges the two confirmation-token case-sensitivity `It` blocks (`"YES"` and `"Yes"`) into one `-ForEach` block carrying a non-case `CaseLabel` (`uppercase`/`titlecase`) included in the `It` name, so the uppercased adapter IDs differ (`...(UPPERCASE)...` vs `...(TITLECASE)...`). Both exit-code-2 assertions are preserved. Second, a new regression guard `test-name-uniqueness.Tests.ps1` AST-parses every `*.Tests.ps1` under `tests/`, mirrors the adapter's uppercase ID-folding rules, and asserts that no two sibling test names — and no two literal `-ForEach`/`-TestCases` expansions — collide case-insensitively.
+
+**What changed:**
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` (+10/-16): disambiguation via a `-ForEach` block with a `CaseLabel` discriminator.
+- `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` (+495, NEW): AST-based collision guard with 5 tests (2 positive, 2 negative, 1 repository suite scan) and 6 helper functions sharing a single detection path (`Get-AdapterIdCollision`).
+- No production code changed.
+
+**Top 3 risks:**
+1. The guard only inspects literal `-ForEach`/`-TestCases` arrays of literal hashtables; non-literal data (variable references, function calls) is skipped, not failed. This is an intentional, documented limitation, but a future collision introduced via a non-literal data set would not be caught.
+2. The guard mirrors the adapter's ID-folding heuristic (uppercase name + appended `KEY=VALUE` segments). If a future adapter version changes its ID scheme, the guard's discriminator computation could drift from the real adapter behavior.
+3. AC6 (CI required checks green on the PR head) is unverified pending PR creation; this is expected for a pre-PR review and is outside the local diff scope.
+
+**PR readiness recommendation:** **Go** — The change is test-only, the PowerShell toolchain passes clean, the regression guard is well-structured and deterministic, and no blocking or major findings were identified. The documented non-literal limitation is acceptable and matches the spec's stated scope.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Info | `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` | `ConvertTo-LiteralDataRow` / `Get-LiteralHashtableElement` (lines 116-216) | Non-literal `-ForEach`/`-TestCases` arguments are skipped rather than detected, so a case collision introduced via a variable-bound data set would not be caught. | Keep as the documented limitation; consider a follow-up note if non-literal `-ForEach` data becomes common in the suite. | The guard's value is scoped to the literal pattern that caused #198; the limitation is explicitly tested ("skips a non-literal -ForEach argument") and documented in spec Risks & Mitigations. | spec.md Risks & Mitigations; test at lines 456-471 |
+| Info | `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` | `Get-AdapterIdCollision` parent-scope resolution (lines 367-377) | Parent scope keys use `GetHashCode().ToString()` on the AST node. This is correct within a single parse but relies on AST node identity, not a structural path. | No change required; AST node identity is stable within one `ParseInput` call, which is the only context used. | Worth noting for maintainers, but not a defect: scopes are only compared within one file's single parse. | Inspected lines 367-392 |
+| Info | `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` | Suite-scan `It` (lines 474-493) | The repository suite-scan test reads every `*.Tests.ps1` under `tests/`, so the guard's runtime grows with the suite size. | Acceptable; AST parsing is fast and the qa-gate shows the full scan completing within a normal Pester run. | Determinism and speed are preserved (no external I/O); only a forward-looking scale note. | qa-gate.md (294/0/2 within normal run) |
+
+No Blockers or Major findings.
+
+---
+
+## Implementation Audit
+
+### PowerShell implementation audit
+
+#### What changed well
+
+- The detection logic is consolidated into a single shared path (`Get-AdapterIdCollision`) exercised by both in-memory fixtures and the repository-wide scan, so the proven behavior and the enforced invariant cannot diverge.
+- The `-ForEach` disambiguation in `Invoke-FullRelease.Tests.ps1` is the minimal correct fix: it preserves both confirmation-token assertions while making the uppercased adapter IDs distinct via a non-case `CaseLabel` that is included in the `It` name.
+- Helper decomposition is clean and each helper carries comment-based help: literal extraction (`Get-LiteralArgumentValue`), hashtable-row conversion (`ConvertTo-LiteralHashtableRow`), array-shape handling (`Get-LiteralHashtableElement`), data-row assembly (`ConvertTo-LiteralDataRow`), and discriminator computation (`Get-BlockDiscriminator`).
+- The `tests/` root is resolved by walking up from `$PSScriptRoot`, not from CWD, which preserves Terminal/Test Explorer parity — directly relevant to the bug being fixed.
+
+#### API and safety notes
+
+- All helper functions use mandatory, typed parameters; `[AllowNull()]` is applied where a null AST is a valid input. Approved verbs are used throughout (Get, ConvertTo).
+- Invariant-culture uppercasing (`CultureInfo.InvariantCulture.TextInfo.ToUpper`) is used for folding, avoiding locale-dependent case behavior — a correct choice for matching the adapter's deterministic folding.
+- No `Invoke-Expression`, no plaintext secrets, no hard-coded absolute paths. Only `$script:TestsRoot` is script-scoped, which is required to share the resolved root from `BeforeAll` into the `It` blocks.
+
+#### Error handling and logging
+
+- The `tests/` root resolution throws a clear, specific message when the root cannot be found (fail-fast).
+- Non-literal data is handled by returning `$null` and skipping, which is the documented intent rather than a silent error; the skip path is explicitly tested.
+- Collision messages name the source label and the folded discriminator, and the suite-scan assertion uses `-Because ($allCollisions -join "`n")` so a failure prints every offending file and name.
+
+---
+
+## Test Quality Audit
+
+The verification evidence is the feature-folder qa-gate plus direct inspection of the two changed files. The qa-gate records a clean format -> analyze -> test loop and a passing new guard file.
+
+### Reviewed test and QA artifacts
+
+- `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` — 5 tests covering positive collision detection (sibling `It`, `-ForEach` data-value), negative cases (disambiguated `-ForEach`, non-literal skip), and the repository-wide invariant. Deterministic, no external dependencies.
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` — the disambiguated case-sensitivity `-ForEach` block; mocks only the wrapper seams (`Invoke-NpmExe`, `Invoke-PublishScript`, `Invoke-GitExe`, `Write-StderrLine`), consistent with the wrapper-seam mocking rule.
+- `docs/features/active/2026-06-17-pester-adapter-id-collision-198/evidence/qa-gates/2026-06-18T01-11/qa-gate.md` — format EXIT 0, analyze EXIT 0 (0 findings), Pester 294/0/2 on scan folders, guard 5/5, file-size 495 lines (< 500).
+- `artifacts/pester/powershell-coverage.xml` — repo-wide PowerShell production line coverage 96.8% (275/284).
+
+### Quality assessment prompts
+
+- **Determinism:** No randomness, wall-clock reads, network, or temporary files. AST parsing and file reads only. `tests/` root resolved from `$PSScriptRoot`.
+- **Isolation:** Each `It` targets one behavior; fixtures are self-contained in-memory strings.
+- **Speed:** AST parsing of in-memory strings and file content; the full scan-folder suite completes within a normal Pester run (qa-gate).
+- **Diagnostics:** The suite-scan assertion prints every colliding file and discriminator on failure; fixture assertions match on the expected folded discriminator substring.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | Inspected both files; no credentials, tokens, or secrets. |
+| No unsafe subprocess or command construction | ✅ PASS | No external process invocation; AST parsing and file reads only. No `Invoke-Expression`. |
+| Input validation at boundaries | ✅ PASS | Mandatory/typed parameters; `tests/` root resolution throws when unresolved; non-literal data returns `$null` and is skipped. |
+| Error handling remains explicit | ✅ PASS | Fail-fast `throw` on unresolved root; explicit `$null` returns for non-literal shapes; no broad catch-all. |
+| Configuration / path handling is safe | ✅ PASS | Paths resolved from `$PSScriptRoot` (CWD-independent); no hard-coded absolute paths. |
+
+---
+
+## Research Log
+
+No external research was required. The review is grounded in the branch diff, the feature-folder scoping documents, the qa-gate evidence, the coverage artifact, and the repository policy rules (`general-code-change.md`, `general-unit-test.md`, `powershell.md`).
+
+---
+
+## Verdict
+
+The change is ready for normal PR flow. It is a focused, test-only fix that both disambiguates the colliding case-sensitivity cases and adds a deterministic, well-structured regression guard against future case-insensitive sibling-name collisions. The PowerShell toolchain passes clean, the new tests are deterministic and isolated, and no blocking or major findings were identified. The only notes are informational: the guard intentionally scopes to literal `-ForEach`/`-TestCases` data (documented limitation), and the suite-scan runtime scales with suite size. This conclusion is consistent with the Findings Table and the **Go** PR-readiness recommendation above. The remaining acceptance item AC6 (CI green on the PR head) is expected to be satisfied by the S9 CI gate after PR creation and is outside the local diff scope.

--- a/docs/features/active/2026-06-17-pester-adapter-id-collision-198/evidence/qa-gates/2026-06-18T01-11/qa-gate.md
+++ b/docs/features/active/2026-06-17-pester-adapter-id-collision-198/evidence/qa-gates/2026-06-18T01-11/qa-gate.md
@@ -1,0 +1,59 @@
+# QA Gate - Issue #198 adapter-ID collision guard
+
+Timestamp: 2026-06-18T01-11
+Scope (touched files):
+- tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1 (new, test-only)
+
+No production PowerShell files were modified. The previously-fixed
+`tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` was not changed by this work.
+
+## Toolchain (format -> analyze -> test), scan folders: tests/scripts/claude-runtime, tests/scripts/dev-tools
+
+Tool entry points: repository PoshQC modules
+(`scripts/powershell/PoshQC/PoshQC.psd1`: `Invoke-PoshQCFormat`,
+`Invoke-PoshQCAnalyze`) and Pester 5.6.1. The canonical `mcp__drm-copilot__*`
+PoshQC MCP tools were not available in this execution environment; the
+repository module functions that those MCP tools wrap were invoked directly with
+identical settings (`scripts/powershell/PoshQC/settings/pssa.settings.psd1`).
+
+### Format
+Command: Invoke-PoshQCFormat -ScanFolders tests/scripts/claude-runtime, tests/scripts/dev-tools
+EXIT_CODE: 0
+Output Summary: All files already formatted; no files changed.
+
+### Analyze (PSScriptAnalyzer)
+Command: Invoke-PoshQCAnalyze -ScanFolders tests/scripts/claude-runtime, tests/scripts/dev-tools
+EXIT_CODE: 0
+Output Summary: 0 findings. (Two warnings on the new file - PSUseBOMForUnicodeEncodedFile
+and PSReviewUnusedParameter - were resolved before this gate by removing non-ASCII
+characters and making the SourceLabel parameter usage explicit via [string]::Format.)
+
+### Test (Pester 5.6.1)
+Command: Invoke-Pester -Path tests/scripts/claude-runtime, tests/scripts/dev-tools
+EXIT_CODE: 0
+Output Summary: Passed=294 Failed=0 Skipped=2 Total=296. The 2 skips are pre-existing
+and unrelated to this change.
+
+## Guard test results (new file)
+Command: Invoke-Pester -Path tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1
+EXIT_CODE: 0
+Output Summary: Passed=5 Failed=0 Skipped=0 Total=5.
+- [+] detects two sibling It names that differ only by letter case (positive)
+- [+] detects a literal -ForEach whose rows differ only by data-value case (positive)
+- [+] reports no collision when a literal -ForEach disambiguates rows with a distinct data key (negative)
+- [+] skips a non-literal -ForEach argument without raising a collision (negative)
+- [+] reports zero folded adapter-ID collisions across all tests/**/*.Tests.ps1 (suite scan, negative)
+
+## File-size check
+tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1: 495 lines (< 500 limit).
+
+## Helper function (shared code path)
+`Get-AdapterIdCollision` is the single detection helper exercised by both the
+in-memory fixtures and the repository suite scan. Supporting helpers:
+`Get-LiteralArgumentValue`, `ConvertTo-LiteralHashtableRow`,
+`Get-LiteralHashtableElement`, `ConvertTo-LiteralDataRow`, `Get-BlockDiscriminator`.
+
+## Delta vs baseline
+- PSScriptAnalyzer delta: 0 new findings.
+- Pester delta: 0 new failing tests (added 5 new passing tests).
+- Production coverage delta: not applicable; test-only change, no production lines modified.

--- a/docs/features/active/2026-06-17-pester-adapter-id-collision-198/feature-audit.2026-06-17T21-22.md
+++ b/docs/features/active/2026-06-17-pester-adapter-id-collision-198/feature-audit.2026-06-17T21-22.md
@@ -1,0 +1,97 @@
+# Feature Audit: pester-adapter-id-collision (Issue #198)
+
+**Audit Date:** 2026-06-17
+**Feature Folder:** `docs/features/active/2026-06-17-pester-adapter-id-collision-198`
+**Base Branch:** `main`
+**Head Branch:** `fix/pester-adapter-id-collision-198`
+**Work Mode:** `full-bug`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `fb05bbea85d5efcf7f2f4d5b311ced644c607d9d`)
+- **Head branch/commit:** `fix/pester-adapter-id-collision-198` (commit `9eb40c16c355ecd9f50b0e6ca5501956d1037dd4`)
+- **Merge base:** `fb05bbea85d5efcf7f2f4d5b311ced644c607d9d`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-06-17-pester-adapter-id-collision-198/evidence/qa-gates/2026-06-18T01-11/qa-gate.md`
+  - Additional evidence: `git diff fb05bbe..9eb40c1`; `artifacts/pester/powershell-coverage.xml`
+- **Feature folder used:** `docs/features/active/2026-06-17-pester-adapter-id-collision-198`
+- **Requirements source:** `spec.md` (`## Acceptance Criteria` section)
+- **Work mode resolution note:** `issue.md` carries the explicit marker `- Work Mode: full-bug`. Per the work-mode contract, the authoritative AC source for `full-bug` is `spec.md` only.
+- **Scope note:** Audit performed against the full branch diff `fb05bbe..9eb40c1`. The change is test-only (2 PowerShell `*.Tests.ps1` files plus feature docs); no production code changed. CI status for the head SHA is not available in this environment (no PR exists yet).
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/2026-06-17-pester-adapter-id-collision-198/spec.md` — only source (work mode `full-bug`)
+
+### Acceptance criteria (from spec.md `## Acceptance Criteria`)
+
+1. AC1: The two confirmation-token case-sensitivity cases in `Invoke-FullRelease.Tests.ps1` produce distinct adapter IDs (no duplicate-item error from the adapter). Verified: adapter discovery emits distinct IDs `...(UPPERCASE)...` and `...(TITLECASE)...`.
+2. AC2: A new regression guard test exists that fails on a case-insensitive sibling test-name collision and passes when none exist. Path: `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1`; helper `Get-AdapterIdCollision`; 5 tests passing.
+3. AC3: Adapter discovery across all `tests/**/*.Tests.ps1` produces zero colliding IDs. Verified: 39 files, 608 items, 0 collisions.
+4. AC4: No production code changed; both case-sensitivity assertions are preserved.
+5. AC5: Full PowerShell toolchain passes (format → analyze → test) with zero new findings. Verified: full suite 604 passed / 0 failed / 9 skipped.
+6. AC6: CI required checks are green on the PR head. Pending PR creation and S9 CI gate.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | AC1: Two case-sensitivity cases produce distinct adapter IDs | PASS | Diff of `Invoke-FullRelease.Tests.ps1` merges the two `It` blocks into one `-ForEach` with `CaseLabel = "uppercase"`/`"titlecase"` included in the `It` name `is case-sensitive: ConfirmToken '<ConfirmToken>' (<CaseLabel>) is rejected with code 2`, so the uppercased IDs differ. The guard's "disambiguated" fixture test (lines 437-454) asserts 0 collisions for exactly this pattern. | `git diff fb05bbe..9eb40c1 -- tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` | The `CaseLabel` is a non-case discriminator, so the folded IDs no longer collide. |
+| 2 | AC2: New regression guard fails on collision, passes when none exist | PASS | `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` exists with helper `Get-AdapterIdCollision` and 5 passing tests, including 2 positive (collision detected) and 2 negative (no collision) fixtures plus the suite scan. qa-gate records 5/5 passing. | `Invoke-Pester -Path tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` (EXIT 0) | Positive paths prove the guard fails on collisions; negative paths prove it passes when none exist. |
+| 3 | AC3: Adapter discovery across all `tests/**/*.Tests.ps1` produces zero colliding IDs | PASS | The repository suite-scan `It` (lines 474-493) enumerates every `*.Tests.ps1` under `tests/` and asserts `$allCollisions.Count | Should -Be 0`. This test passes (qa-gate: guard 5/5; suite-scan is one of the 5). | `Invoke-Pester -Path tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` (EXIT 0) | The spec's "39 files, 608 items" figure was the executor's count; the audit confirms the suite-scan assertion passes, which is the authoritative check. |
+| 4 | AC4: No production code changed; both assertions preserved | PASS | `git diff --name-status fb05bbe..9eb40c1` shows only `*.Tests.ps1` and docs changed; no `scripts/**` production file. Both exit-code-2 assertions remain in the disambiguated `-ForEach` block (`$result | Should -Be 2` plus the three `Should -Invoke ... -Times 0`). | `git diff --name-status fb05bbe..9eb40c1` | Production script `scripts/dev-tools/Invoke-FullRelease.ps1` is unchanged. |
+| 5 | AC5: Full PowerShell toolchain passes with zero new findings | PASS | qa-gate records format EXIT 0 (no changes), analyze EXIT 0 (0 findings), Pester EXIT 0 (294 passed / 0 failed / 2 skipped on scan folders; new guard 5/5). | `Invoke-PoshQCFormat`; `Invoke-PoshQCAnalyze`; `Invoke-Pester` | The spec's "604 passed / 9 skipped" reflects a full-suite run; the recorded qa-gate scan-folder run (294/0/2) is the canonical evidence in the feature folder. Both show 0 failures and 0 new findings. |
+| 6 | AC6: CI required checks green on the PR head | UNVERIFIED | No PR exists for this branch (PR context: "No PR exists yet for this branch"; CI status "(not available)"). CI green on the head SHA cannot be verified locally. | `gh pr checks` (no PR) | Expected for a pre-PR review. Satisfied later by the S9 CI gate after PR creation. Not a defect in the delivered change. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+The delivered fix satisfies all five locally verifiable acceptance criteria (AC1–AC5). The single remaining criterion, AC6, requires a PR and CI run that do not exist yet; it is UNVERIFIED rather than FAIL because it is contingent on a future S9 CI gate and not on any deficiency in the branch.
+
+**Criteria summary:**
+- **PASS:** 5 criteria (AC1–AC5)
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 1 criterion (AC6 — pending PR creation and CI)
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. AC6 (CI green on PR head) is pending PR creation. This is procedural, not a defect; it does not block the local acceptance verdict.
+
+**Recommended follow-up verification steps:**
+
+1. Create the PR and confirm CI required checks are green on the head SHA, then check off AC6.
+2. Optionally re-run the full Pester suite (not just scan folders) to reconfirm the spec's full-suite figures before merge.
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules, AC1–AC5 are evaluated PASS and were already checked off (`- [x]`) in `spec.md` by the executor. The audit confirms those check-offs are evidence-backed and leaves them checked. AC6 is UNVERIFIED and remains `- [ ]`. No source-file checkbox state required modification by this audit.
+
+### AC Status Summary
+
+- Source: `docs/features/active/2026-06-17-pester-adapter-id-collision-198/spec.md`
+- Total AC items: 6
+- Checked off (delivered): 5 (AC1–AC5)
+- Remaining (unchecked): 1 (AC6)
+- Items remaining: AC6: CI required checks are green on the PR head. Pending PR creation and S9 CI gate.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `spec.md` | 6 | 5 | 1 | Checkbox-backed; AC1–AC5 confirmed PASS and remain checked; AC6 UNVERIFIED, remains unchecked. |
+
+No source-file checkbox change was made by this audit: AC1–AC5 were already `- [x]` and the audit confirms each is evidence-backed; AC6 correctly remains `- [ ]` because CI on the PR head is not yet verifiable.

--- a/docs/features/active/2026-06-17-pester-adapter-id-collision-198/issue.md
+++ b/docs/features/active/2026-06-17-pester-adapter-id-collision-198/issue.md
@@ -1,0 +1,64 @@
+# pester-adapter-id-collision (Issue #198)
+
+- Date captured: 2026-06-17
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/2026-06-17-pester-adapter-id-collision-198/ (Issue #198)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #198
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/198
+- Last Updated: 2026-06-17
+- Work Mode: full-bug
+
+## Summary
+
+The VS Code Test Explorer drops or misreports Pester tests whose sibling names differ only by letter case, because the `pspester.pester-test` adapter folds discovered test IDs to uppercase and treats the collisions as duplicates.
+
+## Environment
+
+- OS/version: Windows, VS Code with `pspester.pester-test` 2023.7.8
+- Python version: n/a (PowerShell/Pester)
+- Command/flags used: Test Explorer "Run Tests" (adapter runs `PesterInterface.ps1`)
+- Data source or fixture: `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`
+
+## Steps to Reproduce
+
+1. Define sibling tests whose names differ only by letter case (confirmation tokens `"YES"` and `"Yes"`).
+2. Run the file's tests in the VS Code Test Explorer.
+3. One case-variant item is dropped or reported failed/ghost.
+
+## Expected Behavior
+
+Every discovered test has a distinct adapter ID and is reported with its true result.
+
+## Actual Behavior
+
+The adapter emits `Duplicate test item ... detected. ... The duplicate will be ignored.` because both case variants fold to the uppercased ID `...CONFIRMTOKEN=YES`.
+
+## Logs / Screenshots
+
+- [x] Captured minimal logs
+- Snippet: adapter discovery emits two `type:"Test"` records with the identical uppercased `id` ending `...IS REJECTED WITH CODE 2>>CONFIRMTOKEN=YES`.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+The adapter constructs test IDs from uppercased Describe/Context/It names. Case-only differences between siblings (or `-ForEach` expansions) collide. `Invoke-Pester` does not fold case, so the engine reports green and hides the defect.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: disambiguate the colliding case-sensitivity cases; add a regression guard for case-insensitive sibling-name uniqueness.
+- [x] Integration scenario to retest: adapter discovery across all `tests/**/*.Tests.ps1` yields zero colliding IDs.
+- [x] Manual verification notes: reload VS Code; confirm all `Invoke-FullRelease` items report.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [x] Move to active fix folder / branch

--- a/docs/features/active/2026-06-17-pester-adapter-id-collision-198/plan.2026-06-17T21-05.md
+++ b/docs/features/active/2026-06-17-pester-adapter-id-collision-198/plan.2026-06-17T21-05.md
@@ -1,0 +1,43 @@
+# pester-adapter-id-collision (Plan)
+
+- **Issue:** #198
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-17T21-05
+- **Status:** Active
+- **Version:** 1.0
+
+**Fail-closed evidence rule:** This change is test-only PowerShell; no production lines change, so no production coverage delta is possible. Adapter-collision evidence is the controlling artifact.
+
+**Evidence accounting rule:** Record the expected artifact path or location in each evidence-producing task.
+
+**Phase 0 — Context & Inputs**
+- [x] [P0-T1] Link approved spec: `docs/features/active/2026-06-17-pester-adapter-id-collision-198/spec.md`
+- [x] [P0-T2] Record branch/commit baseline: branch `fix/pester-adapter-id-collision-198` off `main`
+- [x] [P0-T3] Required environment/fixtures: Pester 5.6.1, `pspester.pester-test` adapter `PesterInterface.ps1` for collision verification
+
+**Phase 1 — Preparation**
+- [x] [P1-T1] Scope locked: disambiguate colliding case-sensitivity cases + add case-insensitive sibling-name guard; no production changes
+- [x] [P1-T2] Workspace synced to branch; PoshQC toolchain available
+
+**Phase 2 — Regression Test (must fail first)**
+- [x] [P2-T1] [expect-fail] Add `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` that asserts no two sibling Describe/Context/It names — and no two literal `-ForEach` expansions — collide case-insensitively across `tests/**/*.Tests.ps1`
+- [x] [P2-T2] [expect-fail] Confirm the guard fails against a synthetic case-only-distinct fixture and passes against the current (fixed) suite
+
+**Phase 3 — Minimal Fix**
+- [x] [P3-T1] Disambiguate the `-ForEach` cases in `Invoke-FullRelease.Tests.ps1` with a non-case `CaseLabel` included in the `It` name; preserve both assertions
+
+**Phase 4 — Verification Loop**
+- [x] [P4-T1] Re-run the guard and the `Invoke-FullRelease` file under Pester 5.6.1 to confirm expected behavior (full suite 604 passed / 0 failed / 9 skipped)
+- [x] [P4-T2] Run PoshQC format → analyze → test; restart loop if any step changes files or fails (format clean, analyze 0 findings, test green)
+- [x] [P4-T3] Adapter discovery across all `tests/**/*.Tests.ps1` produces zero colliding IDs (controlling evidence: 39 files, 608 items, 0 collisions)
+
+**Phase 5 — Documentation & Status**
+- [x] [P5-T1] Update spec/issue with root cause, fix, and AC; record outcomes
+
+**Phase 6 — PR & Handoff**
+- [ ] [P6-T1] Pre-review commit; feature-review; PR with summary, risks, validation, links to issue #198 and tests
+
+**Phase 7 — Rollout / Follow-up**
+- [ ] [P7-T1] S9 CI green gate on PR head; remediate until green
+- [ ] [P7-T2] Record links (issue #198, PR, related docs) for traceability

--- a/docs/features/active/2026-06-17-pester-adapter-id-collision-198/policy-audit.2026-06-17T21-22.md
+++ b/docs/features/active/2026-06-17-pester-adapter-id-collision-198/policy-audit.2026-06-17T21-22.md
@@ -1,0 +1,410 @@
+# Policy Compliance Audit: pester-adapter-id-collision (Issue #198)
+
+**Audit Date:** 2026-06-17
+**Code Under Test:**
+- `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` (NEW, PowerShell test, +495/-0)
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` (MODIFIED, PowerShell test, +10/-16)
+- Docs (non-code): `spec.md`, `issue.md`, `plan.2026-06-17T21-05.md`, `evidence/qa-gates/2026-06-18T01-11/qa-gate.md`
+
+**Base branch:** `main` (merge-base `fb05bbea85d5efcf7f2f4d5b311ced644c607d9d`)
+**Head:** `fix/pester-adapter-id-collision-198` (`9eb40c16c355ecd9f50b0e6ca5501956d1037dd4`)
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| PowerShell | 2 files (both `*.Tests.ps1`, test-only) | 5 new guard tests; full scan-folder suite 294 | ✅ 294 pass, 0 fail, 2 skip | 96.8% lines (repo-wide PS, pre-change) | 96.8% lines (275/284), repo-wide PS | N/A — both changed files are test files, excluded from the coverage denominator per `general-unit-test.md` |
+
+**Note:** Only PowerShell has changed files in the branch diff. Python, TypeScript, C#, and Bash have zero changed files on this branch and are therefore N/A.
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: N/A - out of scope (no TypeScript files changed on this branch).
+- TypeScript post-change coverage artifact: N/A - out of scope (no TypeScript files changed on this branch).
+- PowerShell baseline coverage artifact: `artifacts/pester/powershell-coverage.xml` (repo-wide production line coverage 96.8%; test-only change, no production lines modified, so the pre-change repo-wide value is the baseline).
+- PowerShell post-change coverage artifact: `artifacts/pester/powershell-coverage.xml` (repo-wide line coverage 275 covered / 9 missed = 96.8%).
+- Per-language comparison summary: Section 1.2.1 below.
+- Branch coverage: the Pester JaCoCo report emits no `BRANCH` counter (a documented PowerShell/Pester limitation). Branch coverage is recorded UNVERIFIED for this reason; it is not a regression because no production branches were added or modified.
+
+**Coverage verdict (PowerShell):** PASS. Repo-wide line coverage 96.8% (>= 85%). Both changed files are test files (correctly excluded from the coverage denominator); no production code was added or modified, so no new-code or modified-file coverage threshold applies to production source.
+
+---
+
+## Rejected Scope Narrowing
+
+None. The caller prompt did not attempt to narrow scope to a plan, task, phase, or file subset, and did not mark any language as out-of-scope or informational-only. The audit was performed against the full branch diff `fb05bbe..9eb40c1`.
+
+---
+
+## Evidence Location Compliance
+
+The branch diff `fb05bbe..9eb40c1` was scanned for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`.
+
+- Branch-diff result: **zero** such files. All feature evidence in this branch is written to the canonical `docs/features/active/2026-06-17-pester-adapter-id-collision-198/evidence/qa-gates/...` path.
+- `validate_evidence_locations.py --root .` reports VIOLATION entries under `artifacts/evidence/baseline/**` and `artifacts/evidence/post-change/**`. These are pre-existing **untracked working-tree files** (`git ls-files artifacts/evidence` returns empty) belonging to an unrelated prior feature; none of them appear in this branch's diff (`git diff --name-only fb05bbe..9eb40c1 | grep artifacts/evidence` returns nothing).
+
+**Disposition:** PASS for this feature. No evidence-location violation is introduced by this branch. The validator's working-tree findings are out of scope for this feature-vs-base audit and are recorded here for transparency only.
+
+---
+
+## Executive Summary
+
+This is a test-only change addressing issue #198, in which the VS Code `pspester.pester-test` adapter folds discovered Pester test IDs to uppercase, causing sibling Describe/Context/It names (including `-ForEach`/`-TestCases` expansions) that differ only by letter case to collide to a single adapter ID and be dropped/misreported.
+
+Two PowerShell test files changed and no production code changed:
+1. `Invoke-FullRelease.Tests.ps1` — the two case-sensitivity confirmation-token `It` cases were merged into one `-ForEach` block carrying a non-case `CaseLabel` (`uppercase`/`titlecase`) included in the `It` name, so the uppercased adapter IDs differ. Both assertions (exit code 2 for a non-`yes` token) are preserved.
+2. `test-name-uniqueness.Tests.ps1` (new) — a deterministic regression guard that AST-parses every `*.Tests.ps1` under `tests/` and asserts that no two sibling test names — and no two literal `-ForEach`/`-TestCases` expansions — collide case-insensitively.
+
+**Policy documents evaluated:**
+- ✅ `general-code-change.md`
+- ✅ `general-unit-test.md`
+
+**Language-specific policies evaluated:**
+- N/A `python-*` — no Python files changed.
+- ✅ `powershell.md` (`powershell-code-change` + `powershell-unit-test` equivalents) — applies.
+- N/A `typescript-*`, `csharp-*`, Bash, JSON — no files changed.
+
+Toolchain evidence (from `evidence/qa-gates/2026-06-18T01-11/qa-gate.md`): format EXIT 0 (no changes), analyze EXIT 0 (0 findings), Pester EXIT 0 (294 passed / 0 failed / 2 pre-existing skips on the scan folders; new guard file 5/5 passing). The MCP PoshQC tools were unavailable in the executor environment; the repository PoshQC module functions those tools wrap were invoked directly with identical settings.
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary or one-time scripts were created by this change.
+- ✅ The new guard file is a permanent, tested regression artifact compliant with repo policy.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** | ✅ PASS | The guard tests share no mutable state; each `It` builds its own in-memory fixture string or enumerates files freshly. The suite-scan `It` reads files via `Get-Content -Raw` with no ordering dependency. |
+| **Isolation** | ✅ PASS | Each in-memory fixture `It` targets one detection behavior (case-only sibling collision, `-ForEach` data-value collision, disambiguated rows, non-literal skip). The suite-scan `It` targets the repository-wide invariant. |
+| **Fast Execution** | ✅ PASS | AST parsing of in-memory strings and file content; no external process, network, or sleep. qa-gate records the scan-folder suite (296 total) completing within a normal Pester run. |
+| **Determinism** | ✅ PASS | No randomness, no wall-clock reads, no network. `tests/` root is resolved by walking up from `$PSScriptRoot`, making the scan CWD-independent (Terminal and Test Explorer parity). |
+| **Readability & Maintainability** | ✅ PASS | Descriptive `It` names, comment-based help on every helper, AAA comments in each fixture test. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | Repo-wide PowerShell production coverage (`.claude/hooks` package) is 96.8% lines per `artifacts/pester/powershell-coverage.xml`. Test-only change; no production baseline regression possible. |
+| **No Coverage Regression** | ✅ PASS | No production lines modified. Post-change repo-wide PS line coverage 96.8% (275/284). |
+| **New Code Coverage** | N/A | The new file is a test file, excluded from the coverage denominator. The guard's helper `Get-AdapterIdCollision` and supporting functions are exercised by the 5 in-file tests (positive, negative, and suite-scan paths). |
+| **Comprehensive Coverage** | ✅ PASS | The detection helper is exercised through positive collision detection (sibling `It`, `-ForEach` data-value), negative cases (disambiguated `-ForEach`, non-literal skip), and the repository-wide scan. |
+| **Positive Flows** | ✅ PASS | "detects two sibling It names that differ only by letter case"; "detects a literal -ForEach whose rows differ only by data-value case". |
+| **Negative Flows** | ✅ PASS | "reports no collision when a literal -ForEach disambiguates rows with a distinct data key"; "skips a non-literal -ForEach argument without raising a collision". |
+| **Edge Cases** | ✅ PASS | Three literal array shapes handled (`Get-LiteralHashtableElement`); non-literal `-ForEach` argument is skipped rather than failing (documented limitation). |
+| **Error Handling** | ✅ PASS | `tests/` root resolution throws a clear message when the root cannot be found; collision messages name the source label and folded discriminator. |
+| **Concurrency** | N/A | No concurrent behavior under test. |
+| **State Transitions** | N/A | No stateful component under test. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- PowerShell: Baseline: 96.8% lines (repo-wide production, `.claude/hooks` package). Post-change: 96.8% lines (275 covered / 9 missed). Change: 0% (test-only change, no production lines modified). New/changed-code coverage: N/A (both changed files are test files, excluded from the denominator). Branch coverage: not measurable from this artifact because the Pester JaCoCo report emits no BRANCH counter; no production branches were added or modified, so there is no branch regression. Disposition: PASS. Evidence: `artifacts/pester/powershell-coverage.xml`, `evidence/qa-gates/2026-06-18T01-11/qa-gate.md`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | ✅ PASS | Suite-scan asserts `Should -Be 0 -Because ($allCollisions -join "`n")`, so a failure prints every colliding file and discriminator. |
+| **Arrange-Act-Assert Pattern** | ✅ PASS | Each fixture `It` is labeled Arrange / Act / Assert. |
+| **Document Intent** | ✅ PASS | Test names are self-documenting; the file header explains the adapter mechanism and the guard's purpose. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | Pure AST parsing and file reads; no network, DB, or external process. |
+| **Use Mocks/Stubs** | ✅ PASS | `Invoke-FullRelease.Tests.ps1` mocks the wrapper seams (`Invoke-NpmExe`, `Invoke-PublishScript`, `Invoke-GitExe`, `Write-StderrLine`) per the wrapper-seam mocking rule; the guard file needs no mocks. |
+| **Environment Stability** | ✅ PASS | No temporary files created. `tests/` root resolved from `$PSScriptRoot`, not CWD or PATH. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | ✅ PASS | This audit, plus the feature folder qa-gate, constitute the required review. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | ✅ PASS | Objective documented in `issue.md` and `spec.md` (issue #198). |
+| **Read existing change plans** | ✅ PASS | `plan.2026-06-17T21-05.md` present with completed P0–P4 tasks. |
+| **Document the plan** | ✅ PASS | Plan and spec recorded in the feature folder. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | The disambiguation merges two near-identical `It` blocks into one `-ForEach`, reducing duplication. |
+| **Reusability** | ✅ PASS | `Get-AdapterIdCollision` is a single detection path exercised by both fixtures and the suite scan. |
+| **Extensibility** | ✅ PASS | Helpers are decomposed (`Get-LiteralArgumentValue`, `ConvertTo-LiteralHashtableRow`, `Get-LiteralHashtableElement`, `ConvertTo-LiteralDataRow`, `Get-BlockDiscriminator`). |
+| **Separation of concerns** | ✅ PASS | AST literal extraction, data-row conversion, discriminator computation, and collision detection are separate functions. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | ✅ PASS | The new file is a single cohesive regression guard. |
+| **Under 500 lines** | ✅ PASS | `test-name-uniqueness.Tests.ps1` is 495 lines (< 500). `Invoke-FullRelease.Tests.ps1` net -6 lines, remains under limit. |
+| **Public vs internal** | ✅ PASS | Helpers are defined inside `BeforeAll` scope, not exported. |
+| **No circular dependencies** | ✅ PASS | No module imports; self-contained AST logic. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | ✅ PASS | Approved-verb function names; descriptive nouns. |
+| **Docs/docstrings** | ✅ PASS | Comment-based help on every helper function. |
+| **Comment why, not what** | ✅ PASS | Comments explain the adapter folding mechanism and the literal-only limitation rationale. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | `Invoke-PoshQCFormat` EXIT 0, no files changed (qa-gate). |
+| **2. Linting** | ✅ PASS | `Invoke-PoshQCAnalyze` EXIT 0, 0 findings (qa-gate). |
+| **3. Type checking** | N/A | Not applicable for PowerShell. |
+| **4. Testing** | ✅ PASS | Pester EXIT 0, 294 passed / 0 failed / 2 skipped on scan folders (qa-gate). |
+| **Full toolchain loop** | ✅ PASS | format -> analyze -> test completed clean in a single pass (qa-gate). |
+| **Explicit reporting** | ✅ PASS | Commands and results recorded in `evidence/qa-gates/2026-06-18T01-11/qa-gate.md`. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | ✅ PASS | Spec "Proposed Fix" and qa-gate document the change. |
+| **Design choices explained** | ✅ PASS | Spec documents the `CaseLabel` disambiguation and AST guard design. |
+| **Update supporting documents** | ✅ PASS | spec.md, issue.md, plan.md, qa-gate.md all present. |
+| **Provide next steps** | ✅ PASS | AC6 (CI green on PR head) documented as pending PR creation. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3B: PowerShell Code Change Policy Compliance
+
+#### 3B.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with Invoke-Formatter** | ✅ PASS | `Invoke-PoshQCFormat` EXIT 0 (qa-gate). |
+| **Linting with PSScriptAnalyzer** | ✅ PASS | `Invoke-PoshQCAnalyze` EXIT 0, 0 findings. Two transient warnings (PSUseBOMForUnicodeEncodedFile, PSReviewUnusedParameter) were resolved before the gate. |
+| **Fix all findings** | ✅ PASS | 0 residual findings. |
+| **PowerShell 7+ compatible** | ✅ PASS | Uses `[System.Management.Automation.Language.Parser]`, generic collections, invariant-culture upper; PS7-compatible. PSSA settings enforce 7+. |
+
+#### 3B.2 PowerShell Design & Safety
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Advanced functions** | N/A (test file) | Helpers are local `param()` functions inside `BeforeAll`; advanced-function/CmdletBinding expectations apply to production functions, not in-test helpers. Parameters use `[Parameter(Mandatory)]` and `[AllowNull()]` where appropriate. |
+| **Parameter validation** | ✅ PASS | Mandatory and typed parameters on each helper. |
+| **Avoid global state** | ✅ PASS | Only `$script:TestsRoot` is script-scoped, required for `BeforeAll`-to-`It` sharing of the resolved root; no mutable global state. |
+| **Error handling** | ✅ PASS | `throw` with a clear message when the `tests/` root cannot be resolved; non-literal data returns `$null` and is skipped rather than silently mis-detected. |
+
+#### 3B.3 Structure, Naming, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive and under 500 lines** | ✅ PASS | 495 lines. |
+| **Approved verbs** | ✅ PASS | `Get-LiteralArgumentValue`, `ConvertTo-LiteralHashtableRow`, `Get-LiteralHashtableElement`, `ConvertTo-LiteralDataRow`, `Get-BlockDiscriminator`, `Get-AdapterIdCollision` — all use approved verbs (Get, ConvertTo). |
+| **Comment why** | ✅ PASS | Comments explain rationale, not mechanics. |
+
+#### 3B.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Step 1: Format** | ✅ PASS | EXIT 0 (qa-gate). |
+| **Step 2: Analyze** | ✅ PASS | EXIT 0, 0 findings. |
+| **Step 3: Type check** | N/A | Not applicable for PowerShell. |
+| **Step 4: Test** | ✅ PASS | EXIT 0. |
+| **Rerun loop if needed** | ✅ PASS | Single clean pass. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4B: PowerShell Unit Test Policy Compliance
+
+#### 4B.1 Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use Pester v5.x** | ✅ PASS | `BeforeAll`, `Describe`/`Context`/`It`, modern `Should` syntax; Pester 5.6.1. |
+| **Use PoshQC Configuration** | ✅ PASS | Run via repository PoshQC module functions with `pester.runsettings.psd1`/`pssa.settings.psd1`. |
+| **PowerShell 7+ Compatible** | ✅ PASS | PS7 AST and collection APIs. |
+
+#### 4B.2 Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Focused Unit Tests** | ✅ PASS | One behavior per `It`. |
+| **Test Behavior Over Implementation** | ✅ PASS | Tests assert collision presence/absence, not internal data structures. |
+| **Mocking Used Sparingly** | ✅ PASS | Guard file uses no mocks; `Invoke-FullRelease.Tests.ps1` mocks only the wrapper seams. |
+| **Organization** | ✅ PASS | `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` lives under the `tests/` tree (not colocated with production source). `Invoke-FullRelease.Tests.ps1` mirrors `scripts/dev-tools/Invoke-FullRelease.ps1`. |
+
+#### 4B.3 Naming and Readability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **File Naming - *.Tests.ps1** | ✅ PASS | Both files end in `.Tests.ps1`. |
+| **Describe/Context/It Structure** | ✅ PASS | 1 Describe, 2 Context, 5 It in the guard file. |
+| **Logical Grouping** | ✅ PASS | "detection logic (in-memory fixtures)" vs "repository suite scan". |
+| **Docstrings/Comments** | ✅ PASS | Self-documenting names plus comment-based help. |
+
+#### 4B.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use PoshQCTest Command** | ✅ PASS | Pester run via PoshQC module; EXIT 0. |
+| **No Alternative Test Runners** | ✅ PASS | Only Pester used. |
+
+---
+
+## 5. Test Coverage Detail
+
+### test-name-uniqueness adapter-ID collision guard (5 tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| detects two sibling It names that differ only by letter case | Positive | ✅ |
+| detects a literal -ForEach whose rows differ only by data-value case | Positive | ✅ |
+| reports no collision when a literal -ForEach disambiguates rows with a distinct data key | Negative | ✅ |
+| skips a non-literal -ForEach argument without raising a collision | Negative/Edge | ✅ |
+| reports zero folded adapter-ID collisions across all tests/**/*.Tests.ps1 | Negative (suite scan) | ✅ |
+
+**Coverage:** Detection helper and supporting AST functions are exercised across positive, negative, edge, and repository-wide paths.
+
+**Not covered:** Non-literal `-ForEach` data arguments are intentionally skipped (documented limitation in spec Risks & Mitigations).
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (scan folders) | 296 (294 passed, 2 skipped) | ✅ |
+| Tests Passed | 294 (99.3% of non-skipped) | ✅ |
+| Tests Failed | 0 | ✅ |
+| New guard file tests | 5 passed / 0 failed | ✅ |
+| Test File Size | 495 lines | ✅ Maintainable |
+| Code Coverage (repo-wide PS production) | 96.8% lines (275/284); branches UNVERIFIED (no BRANCH counter) | ✅ |
+
+---
+
+## 7. Code Quality Checks
+
+**For PowerShell:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Invoke-Formatter | `Invoke-PoshQCFormat -ScanFolders tests/scripts/claude-runtime, tests/scripts/dev-tools` | EXIT 0, no changes | ✅ |
+| PSScriptAnalyzer | `Invoke-PoshQCAnalyze -ScanFolders tests/scripts/claude-runtime, tests/scripts/dev-tools` | EXIT 0, 0 findings | ✅ |
+| Pester Tests | `Invoke-Pester -Path tests/scripts/claude-runtime, tests/scripts/dev-tools` | EXIT 0, 294/0/2 | ✅ |
+
+**Notes:** The MCP `mcp__drm-copilot__*` PoshQC tools were unavailable in the executor environment; the wrapped repository module functions were invoked directly with identical settings (`scripts/powershell/PoshQC/settings/pssa.settings.psd1`). The 2 skips are pre-existing and unrelated to this change.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+- **Branch coverage metric:** UNVERIFIED for PowerShell because the Pester JaCoCo report emits no `BRANCH` counter (a documented PowerShell/Pester limitation). This is not a regression: the change adds no production branches and modifies no production code. Not remediation-triggering.
+
+### Approved Exceptions
+- **None.** No exceptions needed.
+
+### Removed/Skipped Tests
+- **None.** The two original case-sensitivity `It` blocks were merged into one `-ForEach` block; both assertions are preserved (not removed).
+
+---
+
+## 9. Summary of Changes
+
+### Files Modified
+
+1. **`tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1`** (NEW)
+   - Deterministic AST-based regression guard for case-insensitive sibling-name collisions, plus 4 in-memory fixture tests and 1 repository suite-scan test. 495 lines.
+
+2. **`tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`** (MODIFIED, +10/-16)
+   - Merged the two confirmation-token case-sensitivity `It` cases into one `-ForEach` block carrying a non-case `CaseLabel`, disambiguating the uppercased adapter IDs. Both exit-code-2 assertions preserved.
+
+3. Docs (NEW): `spec.md`, `issue.md`, `plan.2026-06-17T21-05.md`, `evidence/qa-gates/2026-06-18T01-11/qa-gate.md`.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+This is a test-only change with no production code modified. The PowerShell toolchain (format -> analyze -> test) passes clean. Coverage is satisfied: both changed files are test files (correctly excluded from the coverage denominator), and repo-wide PowerShell production line coverage is 96.8% (>= 85%). The `modified-workflow-needs-green-run` rule does not fire (no `.github/workflows/**`, `scripts/benchmarks/**`, or `.github/actions/**` paths in the diff). No evidence-location violation is introduced by this branch.
+
+**modified-workflow-needs-green-run:** NOT TRIGGERED. The branch diff contains no path matching `.github/workflows/**`, `scripts/benchmarks/**`, or `.github/actions/**`.
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- ✅ Before Making Changes / Design Principles / Module & File Structure / Naming / Toolchain / Summarize & Document.
+
+#### Language-Specific Code Change Policy (Section 3 — PowerShell)
+- ✅ Tooling & Baseline / Design & Safety / Structure & Naming / Toolchain.
+
+#### General Unit Test Policy (Section 1)
+- ✅ Core Principles / Coverage & Scenarios / Test Structure / External Dependencies / Policy Audit.
+
+#### Language-Specific Unit Test Policy (Section 4 — PowerShell)
+- ✅ Framework & Scope / Test Style & Structure / Naming & Readability / Toolchain.
+
+### Metrics Summary
+- ✅ 294/294 non-skipped tests passing on scan folders; new guard 5/5.
+- ✅ 96.8% repo-wide PowerShell production line coverage.
+- ✅ File organization mirrors the `tests/` tree.
+- ✅ All PowerShell code-quality checks passing.
+- ⚠️ Branch coverage UNVERIFIED (no Pester BRANCH counter) — not a regression, not remediation-triggering.
+
+### Recommendation
+
+**Ready for merge** (subject to AC6: CI required checks green on the PR head, which is pending PR creation and the S9 CI gate). No blocking policy findings.
+
+---
+
+## Appendix A: Test Inventory
+
+1. test-name-uniqueness adapter-ID collision guard › detection logic (in-memory fixtures) › detects two sibling It names that differ only by letter case
+2. ... › detection logic (in-memory fixtures) › detects a literal -ForEach whose rows differ only by data-value case
+3. ... › detection logic (in-memory fixtures) › reports no collision when a literal -ForEach disambiguates rows with a distinct data key
+4. ... › detection logic (in-memory fixtures) › skips a non-literal -ForEach argument without raising a collision
+5. ... › repository suite scan › reports zero folded adapter-ID collisions across all tests/**/*.Tests.ps1
+6. Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded › is case-sensitive: ConfirmToken '<ConfirmToken>' (<CaseLabel>) is rejected with code 2 [×2 expansions: uppercase, titlecase]
+
+## Appendix B: Toolchain Commands Reference
+
+**For PowerShell:**
+```powershell
+# Formatting
+Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCFormat -ScanFolders tests/scripts/claude-runtime, tests/scripts/dev-tools
+
+# Linting
+Import-Module ./scripts/powershell/PoshQC; Invoke-PoshQCAnalyze -ScanFolders tests/scripts/claude-runtime, tests/scripts/dev-tools
+
+# Testing
+Invoke-Pester -Path tests/scripts/claude-runtime, tests/scripts/dev-tools
+Invoke-Pester -Path tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1
+```
+
+**Evidence-location scan:**
+```bash
+git diff --name-only fb05bbea85d5efcf7f2f4d5b311ced644c607d9d..9eb40c16c355ecd9f50b0e6ca5501956d1037dd4 | grep -E 'artifacts/(baselines|qa|evidence|coverage)/'
+python scripts/dev_tools/validate_evidence_locations.py --root .
+```
+
+---
+
+**Audit Completed By:** feature-review agent (Claude Opus 4.8)
+**Audit Date:** 2026-06-17
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-06-17-pester-adapter-id-collision-198/spec.md
+++ b/docs/features/active/2026-06-17-pester-adapter-id-collision-198/spec.md
@@ -1,0 +1,122 @@
+# pester-adapter-id-collision (Spec)
+
+- **Issue:** #198
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-17T21-05
+- **Status:** Approved
+- **Version:** 1.0
+
+## Context
+The VS Code Test Explorer (`pspester.pester-test` adapter) reports failing or ghost Pester items for tests that pass under `Invoke-Pester`. The adapter folds discovered test IDs to uppercase during static discovery, so sibling Describe/Context/It names — including `-ForEach`/`-TestCases` expansions — that differ only by letter case collide to a single adapter ID. The adapter then drops/misreports the duplicate.
+
+Environment:
+- OS/version: Windows, VS Code with `pspester.pester-test` 2023.7.8 and `ms-vscode.PowerShell`.
+- PowerShell version: PowerShell 7 (workspace default), Pester 5.6.1.
+- Command/flags used: Test Explorer "Run Tests" (adapter invokes `Scripts/PesterInterface.ps1`).
+- Data source or fixture: `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`.
+
+Impact / Severity:
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+Rationale: the suite is green under the engine, but the Test Explorer presents false failures, which erodes trust in the local test signal and can mask real failures.
+
+## Repro & Evidence
+Steps to Reproduce:
+1. In `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`, define sibling tests whose names differ only by letter case (for example two confirmation-token cases `"YES"` and `"Yes"`).
+2. Open the VS Code Test Explorer and run the file's tests.
+3. Observe that one of the case-variant items is dropped or reported as failed/ghost.
+
+Expected:
+Each test discovered by the adapter has a distinct ID, and every test is reported with its true result.
+
+Actual:
+The adapter emits `Duplicate test item ... detected. ... The duplicate will be ignored.` for the two case-variant items because both fold to the uppercased ID ending `...CONFIRMTOKEN=YES`.
+
+Logs / Screenshots:
+- [x] Captured adapter discovery output
+- Snippet: adapter `PesterInterface.ps1 -Discovery` emits two `type:"Test"` records with the identical `id` `...IS REJECTED WITH CODE 2>>CONFIRMTOKEN=YES`.
+
+## Scope & Non-Goals
+- In scope: disambiguate the colliding case-sensitivity cases in `Invoke-FullRelease.Tests.ps1`; add a deterministic regression guard that detects case-insensitive sibling test-name collisions across the Pester suite.
+- Out of scope / non-goals: production script changes; VS Code settings changes (those are local, gitignored, and not part of this fix); changing the Pester engine or the third-party adapter.
+- Explicitly excluded: any modification to `scripts/dev-tools/Invoke-FullRelease.ps1` behavior.
+
+## Root Cause Analysis
+The `pspester.pester-test` adapter constructs test IDs from uppercased Describe/Context/It names (confirmed in the adapter's discovery output, where all IDs are uppercase). When two sibling names — or two `-ForEach` expansions — differ only by letter case, their uppercased IDs are identical. The adapter's `testItemDiscoveryHandler` treats identical IDs as duplicates and ignores one. `Invoke-Pester` itself does not fold case, so the engine reports the suite green, hiding the defect from non-adapter runs.
+
+## Proposed Fix
+
+### Design summary (what changes where):
+1. In `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`, the case-sensitivity `-ForEach` cases carry a non-case `CaseLabel` (`uppercase` / `titlecase`) that is included in the `It` name, so the uppercased IDs differ (`...(UPPERCASE)...` vs `...(TITLECASE)...`).
+2. Add a deterministic regression guard test that parses every `*.Tests.ps1` via the PowerShell AST and asserts that, within each parent scope, no two static Describe/Context/It names — and no two expansions of a literal `-ForEach`/`-TestCases` hashtable array — are equal case-insensitively.
+
+### Boundaries and invariants to preserve:
+- Both confirmation-token case-sensitivity assertions remain (each verifies a non-`yes` token is rejected with exit code 2).
+- No production behavior changes; test-only.
+- File size stays under 500 lines.
+
+### Implementation strategy (what changes, not sequencing):
+
+#### Files/modules to change:
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` (disambiguation — already applied).
+- New: `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` (regression guard).
+
+#### Functions/classes/CLI commands impacted:
+- None in production.
+
+#### Data flow and validation changes:
+- The guard reads test file contents via AST only; no external process, network, or temp files.
+
+#### Error handling and logging updates:
+- The guard fails with a clear message listing the file and the colliding (case-folded) name when a collision exists.
+
+### Technical specifications (interfaces/contracts):
+
+#### Inputs/outputs and formats:
+- Input: the set of `*.Tests.ps1` files under `tests/`.
+- Output: Pester pass when all sibling names are case-insensitively unique; fail otherwise.
+
+#### Backward-compatibility expectations:
+- The guard only adds a test; it does not alter existing tests beyond the disambiguation.
+
+## Assumptions, Constraints, Dependencies
+- Assumptions: the adapter's uppercase ID-folding is the collision mechanism (verified from adapter output).
+- Constraints: deterministic, no network/PATH/CWD/temp-file dependency (per `.claude/rules/general-unit-test.md`).
+- External dependencies: none added.
+
+## Data / API / Config Impact
+- User-facing or API changes: none.
+- Data or migration considerations: none.
+- Logging/telemetry updates: none.
+- Compatibility notes: none.
+
+## Test Strategy
+- Regression tests to add or update:
+  - The disambiguation in `Invoke-FullRelease.Tests.ps1` (applied).
+  - New guard `test-name-uniqueness.Tests.ps1` that fails on any case-insensitive sibling-name collision and passes when none exist.
+- Edge cases and negative scenarios: a literal `-ForEach` array whose expansions collide case-insensitively must be detected; non-literal `-ForEach` arguments are skipped (documented limitation).
+- Error handling verification: the guard reports the offending file and folded name.
+- Coverage impact: test-only change; no production coverage regression possible.
+- Toolchain commands to run: PoshQC format → analyze → test.
+- Manual validation: reload VS Code window; confirm the Test Explorer reports all `Invoke-FullRelease` items.
+
+## Acceptance Criteria
+- [x] AC1: The two confirmation-token case-sensitivity cases in `Invoke-FullRelease.Tests.ps1` produce distinct adapter IDs (no duplicate-item error from the adapter). Verified: adapter discovery emits distinct IDs `...(UPPERCASE)...` and `...(TITLECASE)...`.
+- [x] AC2: A new regression guard test exists that fails on a case-insensitive sibling test-name collision and passes when none exist. Path: `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1`; helper `Get-AdapterIdCollision`; 5 tests passing.
+- [x] AC3: Adapter discovery across all `tests/**/*.Tests.ps1` produces zero colliding IDs. Verified: 39 files, 608 items, 0 collisions.
+- [x] AC4: No production code changed; both case-sensitivity assertions are preserved.
+- [x] AC5: Full PowerShell toolchain passes (format → analyze → test) with zero new findings. Verified: full suite 604 passed / 0 failed / 9 skipped.
+- [ ] AC6: CI required checks are green on the PR head. Pending PR creation and S9 CI gate.
+
+## Risks & Mitigations
+- Risk: the guard's `-ForEach` expansion logic mishandles a non-literal data argument. Mitigation: skip non-literal arguments and document the limitation; the guard still covers the literal pattern that caused this bug.
+- Risk: false positives on intentionally case-distinct names. Mitigation: the comparison is scoped to siblings within one parent, matching the adapter's own ID scheme.
+
+## Rollout & Follow-up
+- Release/rollout steps: merge via PR after green CI.
+- Post-fix monitoring: none required.
+- Links: issue #198, PR (to be created), `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`.

--- a/tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1
+++ b/tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1
@@ -1,0 +1,495 @@
+Set-StrictMode -Version Latest
+
+# Regression guard for issue #198.
+#
+# The VS Code `pspester.pester-test` Test Explorer adapter folds discovered
+# test IDs to UPPERCASE during static discovery. Sibling Describe/Context/It
+# names - including `-ForEach`/`-TestCases` expansions - that differ from one
+# another only by letter case collide to a single adapter ID, and the adapter
+# drops or misreports the duplicate. `Invoke-Pester` does not fold case, so the
+# engine reports green and hides the defect.
+#
+# This file enumerates every `*.Tests.ps1` under the repository `tests/` tree,
+# parses each with the PowerShell AST, computes a per-child "adapter
+# discriminator" that mirrors how the adapter forms IDs, and asserts that no two
+# children within the same parent scope share a folded discriminator. The same
+# helper function (`Get-AdapterIdCollision`) is exercised by deterministic
+# in-memory fixtures so the detection logic is proven independently of the
+# repository suite.
+
+BeforeAll {
+    # Resolve the `tests/` root by walking up from this file's own location,
+    # not from the current working directory. This keeps the scan
+    # CWD-independent so the suite behaves identically in the terminal and the
+    # VS Code Test Explorer.
+    $script:TestsRoot = $PSScriptRoot
+    while ($null -ne $script:TestsRoot -and (Split-Path -Path $script:TestsRoot -Leaf) -ne 'tests') {
+        $script:TestsRoot = Split-Path -Path $script:TestsRoot -Parent
+    }
+    if ($null -eq $script:TestsRoot) {
+        throw "Unable to resolve the 'tests' root by walking up from '$PSScriptRoot'."
+    }
+
+    <#
+    .SYNOPSIS
+        Extracts the literal string value of an argument expression, when present.
+    .DESCRIPTION
+        Returns the literal value for a StringConstantExpressionAst or other
+        ConstantExpressionAst. Returns $null for any expression that is not a
+        literal constant (for example a variable or a sub-expression).
+    .PARAMETER Expression
+        The argument AST whose literal value is requested.
+    .OUTPUTS
+        [object] The literal value, or $null when the expression is not literal.
+    #>
+    function Get-LiteralArgumentValue {
+        param(
+            [Parameter(Mandatory = $true)]
+            [AllowNull()]
+            [System.Management.Automation.Language.Ast]$Expression
+        )
+
+        if ($Expression -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+            return $Expression.Value
+        }
+        if ($Expression -is [System.Management.Automation.Language.ConstantExpressionAst]) {
+            return $Expression.Value
+        }
+        return $null
+    }
+
+    <#
+    .SYNOPSIS
+        Converts a literal hashtable AST into an ordered dictionary of its
+        literal key/value pairs, or $null when any key/value is non-literal.
+    .PARAMETER Hashtable
+        The HashtableAst to convert.
+    #>
+    function ConvertTo-LiteralHashtableRow {
+        param(
+            [Parameter(Mandatory = $true)]
+            [System.Management.Automation.Language.HashtableAst]$Hashtable
+        )
+
+        $row = [ordered]@{}
+        foreach ($pair in $Hashtable.KeyValuePairs) {
+            $keyValue = Get-LiteralArgumentValue -Expression $pair.Item1
+            # A hashtable value is wrapped in a pipeline/command expression.
+            $valueExpression = $null
+            if ($pair.Item2 -is [System.Management.Automation.Language.PipelineAst]) {
+                $pipelineElements = $pair.Item2.PipelineElements
+                if ($pipelineElements.Count -eq 1 -and
+                    $pipelineElements[0] -is [System.Management.Automation.Language.CommandExpressionAst]) {
+                    $valueExpression = $pipelineElements[0].Expression
+                }
+            }
+            if ($null -eq $keyValue -or $null -eq $valueExpression) {
+                return $null
+            }
+            $literalValue = Get-LiteralArgumentValue -Expression $valueExpression
+            if ($null -eq $literalValue) {
+                return $null
+            }
+            $row[[string]$keyValue] = [string]$literalValue
+        }
+        return $row
+    }
+
+    <#
+    .SYNOPSIS
+        Collects the literal HashtableAst nodes from a `-ForEach`/`-TestCases`
+        argument expression, regardless of array literal shape.
+    .DESCRIPTION
+        Handles the three literal array shapes that Pester accepts: a bare
+        ArrayLiteralAst, an ArrayExpressionAst (`@( ... )`) wrapping a single
+        comma-separated ArrayLiteralAst, and an ArrayExpressionAst whose
+        SubExpression contains one statement per hashtable (the multi-line,
+        comma-free form used by the fixed Invoke-FullRelease.Tests.ps1). A single
+        HashtableAst argument is also accepted as a one-row array. Returns $null
+        for any shape that is not composed solely of literal hashtables - for
+        example a variable reference or a function-call expression.
+    .PARAMETER Argument
+        The `-ForEach`/`-TestCases` argument AST.
+    .OUTPUTS
+        [System.Collections.Generic.List[object]] of HashtableAst, or $null.
+    #>
+    function Get-LiteralHashtableElement {
+        param(
+            [Parameter(Mandatory = $true)]
+            [AllowNull()]
+            [System.Management.Automation.Language.Ast]$Argument
+        )
+
+        $hashtables = [System.Collections.Generic.List[object]]::new()
+
+        # A single literal hashtable expands to a one-row data set.
+        if ($Argument -is [System.Management.Automation.Language.HashtableAst]) {
+            $hashtables.Add($Argument)
+            return $hashtables
+        }
+
+        # A bare array literal: elements must all be literal hashtables.
+        if ($Argument -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+            foreach ($element in $Argument.Elements) {
+                if ($element -isnot [System.Management.Automation.Language.HashtableAst]) {
+                    return $null
+                }
+                $hashtables.Add($element)
+            }
+            return $hashtables
+        }
+
+        # An array expression `@( ... )`: each statement is a pipeline whose
+        # single command expression is either a comma-separated ArrayLiteralAst
+        # or one hashtable per line.
+        if ($Argument -is [System.Management.Automation.Language.ArrayExpressionAst]) {
+            foreach ($statement in $Argument.SubExpression.Statements) {
+                if ($statement -isnot [System.Management.Automation.Language.PipelineAst]) {
+                    return $null
+                }
+                $pipelineElements = $statement.PipelineElements
+                if ($pipelineElements.Count -ne 1 -or
+                    $pipelineElements[0] -isnot [System.Management.Automation.Language.CommandExpressionAst]) {
+                    return $null
+                }
+                $expression = $pipelineElements[0].Expression
+                if ($expression -is [System.Management.Automation.Language.HashtableAst]) {
+                    $hashtables.Add($expression)
+                }
+                elseif ($expression -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+                    foreach ($element in $expression.Elements) {
+                        if ($element -isnot [System.Management.Automation.Language.HashtableAst]) {
+                            return $null
+                        }
+                        $hashtables.Add($element)
+                    }
+                }
+                else {
+                    return $null
+                }
+            }
+            return $hashtables
+        }
+
+        return $null
+    }
+
+    <#
+    .SYNOPSIS
+        Parses a literal array of literal hashtables into ordered data rows.
+    .DESCRIPTION
+        Accepts the argument AST supplied to `-ForEach` or `-TestCases`. When the
+        argument is a literal array of literal hashtables (in any of the shapes
+        recognized by Get-LiteralHashtableElement) with literal keys and literal
+        values, returns a list of ordered dictionaries (one per row). Returns
+        $null for any shape that is not a literal array of literal hashtables -
+        for example a variable reference or a function-call expression. This
+        intentional limitation scopes the guard to the literal pattern that
+        caused issue #198; non-literal data is skipped, not failed.
+    .PARAMETER Argument
+        The `-ForEach`/`-TestCases` argument AST.
+    .OUTPUTS
+        [System.Collections.Generic.List[object]] of ordered dictionaries, or $null.
+    #>
+    function ConvertTo-LiteralDataRow {
+        param(
+            [Parameter(Mandatory = $true)]
+            [AllowNull()]
+            [System.Management.Automation.Language.Ast]$Argument
+        )
+
+        $hashtables = Get-LiteralHashtableElement -Argument $Argument
+        if ($null -eq $hashtables) {
+            return $null
+        }
+
+        $rows = [System.Collections.Generic.List[object]]::new()
+        # Convert each literal hashtable element into an ordered data row.
+        foreach ($hashtable in $hashtables) {
+            $row = ConvertTo-LiteralHashtableRow -Hashtable $hashtable
+            if ($null -eq $row) {
+                return $null
+            }
+            $rows.Add($row)
+        }
+        return $rows
+    }
+
+    <#
+    .SYNOPSIS
+        Computes the folded adapter discriminators for a single block invocation.
+    .DESCRIPTION
+        Mirrors the adapter's ID-formation rules. The base discriminator is the
+        block name uppercased (invariant-culture upper), with any `<Key>`
+        placeholder tokens substituted by the corresponding data value when a
+        literal `-ForEach`/`-TestCases` row is expanded. For each data row the
+        function appends, for each data key, an uppercased `KEY=VALUE` segment.
+        A plain (non-data-driven) block yields a single discriminator: its
+        uppercased name. A data-driven block yields one discriminator per row.
+    .PARAMETER Name
+        The block's positional name / `-Name` value (literal string).
+    .PARAMETER DataRows
+        Optional list of ordered dictionaries from a literal `-ForEach`/
+        `-TestCases` argument, or $null for a plain block.
+    .OUTPUTS
+        [System.Collections.Generic.List[string]] of folded discriminators.
+    #>
+    function Get-BlockDiscriminator {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$Name,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object]$DataRows
+        )
+
+        $results = [System.Collections.Generic.List[string]]::new()
+        $invariantUpper = [System.Globalization.CultureInfo]::InvariantCulture.TextInfo
+
+        # Plain block: a single discriminator equal to the uppercased name.
+        if ($null -eq $DataRows) {
+            $results.Add($invariantUpper.ToUpper($Name))
+            return $results
+        }
+
+        # Data-driven block: one discriminator per literal row.
+        foreach ($row in $DataRows) {
+            $expandedName = $Name
+            # Substitute <Key> placeholder tokens with the row's data value.
+            foreach ($key in $row.Keys) {
+                $token = '<' + $key + '>'
+                $expandedName = $expandedName.Replace($token, [string]$row[$key])
+            }
+            $segments = [System.Collections.Generic.List[string]]::new()
+            $segments.Add($invariantUpper.ToUpper($expandedName))
+            # Append an uppercased KEY=VALUE segment for each data key, in order.
+            foreach ($key in $row.Keys) {
+                $segment = $invariantUpper.ToUpper([string]$key + '=' + [string]$row[$key])
+                $segments.Add($segment)
+            }
+            $results.Add(($segments -join '>>'))
+        }
+        return $results
+    }
+
+    <#
+    .SYNOPSIS
+        Detects folded adapter-ID collisions among sibling test blocks.
+    .DESCRIPTION
+        Parses the supplied script text with the PowerShell AST, finds all
+        `Describe`/`Context`/`It` CommandAst invocations, computes each child's
+        folded adapter discriminators (using the same helpers as the suite
+        scan), and reports any case where two children within the same parent
+        scope share a discriminator. This is the single code path exercised by
+        both the in-memory fixture tests and the repository suite scan.
+    .PARAMETER ScriptText
+        The PowerShell source to analyze (parsed with `[Parser]::ParseInput`).
+    .PARAMETER SourceLabel
+        A human-readable label (file path or fixture name) included in collision
+        messages.
+    .OUTPUTS
+        [System.Collections.Generic.List[string]] of collision messages; empty
+        when no collision is found.
+    #>
+    function Get-AdapterIdCollision {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$ScriptText,
+
+            [Parameter(Mandatory = $true)]
+            [string]$SourceLabel
+        )
+
+        $tokens = $null
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            $ScriptText, [ref]$tokens, [ref]$parseErrors)
+
+        $blockCommands = @('Describe', 'Context', 'It')
+        # Find every Describe/Context/It invocation in the script.
+        $commandAsts = $ast.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $null -ne $node.GetCommandName() -and
+                $blockCommands -contains $node.GetCommandName()
+            }, $true)
+
+        # Group discriminators by their nearest enclosing Describe/Context parent.
+        $scopes = @{}
+        $collisions = [System.Collections.Generic.List[string]]::new()
+
+        foreach ($command in $commandAsts) {
+            $name = $null
+            $dataArgument = $null
+            $elements = $command.CommandElements
+
+            # The first positional string element after the command name is the
+            # block name unless an explicit -Name parameter is supplied.
+            for ($i = 1; $i -lt $elements.Count; $i++) {
+                $element = $elements[$i]
+                if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+                    $parameterName = $element.ParameterName
+                    # -Name <value>: the value is the next element.
+                    if ($parameterName -ieq 'Name' -and ($i + 1) -lt $elements.Count) {
+                        $name = Get-LiteralArgumentValue -Expression $elements[$i + 1]
+                        $i++
+                        continue
+                    }
+                    # -ForEach / -TestCases <value>: capture the data argument.
+                    if (($parameterName -ieq 'ForEach' -or $parameterName -ieq 'TestCases') -and
+                        ($i + 1) -lt $elements.Count) {
+                        $dataArgument = $elements[$i + 1]
+                        $i++
+                        continue
+                    }
+                    continue
+                }
+                # First non-parameter element is the positional name.
+                if ($null -eq $name) {
+                    $name = Get-LiteralArgumentValue -Expression $element
+                }
+            }
+
+            # Skip invocations whose name is not a literal string.
+            if ($null -eq $name) {
+                continue
+            }
+
+            # Resolve the literal data rows; non-literal data is skipped (not
+            # failed), scoping the guard to the issue-198 literal pattern.
+            $dataRows = $null
+            if ($null -ne $dataArgument) {
+                $dataRows = ConvertTo-LiteralDataRow -Argument $dataArgument
+            }
+
+            # Identify the nearest enclosing Describe/Context as the parent scope.
+            $parentScope = $command.Parent
+            while ($null -ne $parentScope) {
+                if ($parentScope -is [System.Management.Automation.Language.CommandAst] -and
+                    $null -ne $parentScope.GetCommandName() -and
+                    @('Describe', 'Context') -contains $parentScope.GetCommandName()) {
+                    break
+                }
+                $parentScope = $parentScope.Parent
+            }
+            $scopeKey = if ($null -eq $parentScope) { '<root>' } else { $parentScope.GetHashCode().ToString() }
+
+            if (-not $scopes.ContainsKey($scopeKey)) {
+                $scopes[$scopeKey] = [System.Collections.Generic.HashSet[string]]::new()
+            }
+            $seen = $scopes[$scopeKey]
+
+            # Each child contributes one or more folded discriminators.
+            $discriminators = Get-BlockDiscriminator -Name $name -DataRows $dataRows
+            foreach ($discriminator in $discriminators) {
+                if (-not $seen.Add($discriminator)) {
+                    $message = [string]::Format(
+                        "{0}: colliding folded discriminator '{1}'.", $SourceLabel, $discriminator)
+                    $collisions.Add($message)
+                }
+            }
+        }
+
+        return $collisions
+    }
+}
+
+Describe "test-name-uniqueness adapter-ID collision guard" {
+    Context "detection logic (in-memory fixtures)" {
+        It "detects two sibling It names that differ only by letter case" {
+            # Arrange: two sibling It names that fold to the same uppercased ID.
+            $fixture = @'
+Describe "outer" {
+    It "value is rejected" { $true | Should -BeTrue }
+    It "VALUE IS REJECTED" { $true | Should -BeTrue }
+}
+'@
+
+            # Act
+            $collisions = Get-AdapterIdCollision -ScriptText $fixture -SourceLabel 'case-only-fixture'
+
+            # Assert
+            $collisions.Count | Should -BeGreaterThan 0
+            ($collisions -join "`n") | Should -Match 'VALUE IS REJECTED'
+        }
+
+        It "detects a literal -ForEach whose rows differ only by data-value case" {
+            # Arrange: two -ForEach rows whose data values fold to the same value.
+            $fixture = @'
+Describe "outer" {
+    It "token <Token> is rejected" -ForEach @(
+        @{ Token = "yes" }
+        @{ Token = "YES" }
+    ) { $true | Should -BeTrue }
+}
+'@
+
+            # Act
+            $collisions = Get-AdapterIdCollision -ScriptText $fixture -SourceLabel 'foreach-case-fixture'
+
+            # Assert
+            $collisions.Count | Should -BeGreaterThan 0
+            ($collisions -join "`n") | Should -Match 'TOKEN=YES'
+        }
+
+        It "reports no collision when a literal -ForEach disambiguates rows with a distinct data key" {
+            # Arrange: ConfirmToken differs only by case but CaseLabel disambiguates,
+            # mirroring the fixed Invoke-FullRelease.Tests.ps1 pattern.
+            $fixture = @'
+Describe "outer" {
+    It "token '<ConfirmToken>' (<CaseLabel>) is rejected" -ForEach @(
+        @{ ConfirmToken = "YES"; CaseLabel = "uppercase" }
+        @{ ConfirmToken = "Yes"; CaseLabel = "titlecase" }
+    ) { $true | Should -BeTrue }
+}
+'@
+
+            # Act
+            $collisions = Get-AdapterIdCollision -ScriptText $fixture -SourceLabel 'disambiguated-fixture'
+
+            # Assert
+            $collisions.Count | Should -Be 0
+        }
+
+        It "skips a non-literal -ForEach argument without raising a collision" {
+            # Arrange: -ForEach bound to a variable is not a literal array of
+            # literal hashtables, so it is skipped (documented limitation).
+            $fixture = @'
+Describe "outer" {
+    $cases = @( @{ Token = "yes" }, @{ Token = "YES" } )
+    It "token <Token> is rejected" -ForEach $cases { $true | Should -BeTrue }
+}
+'@
+
+            # Act
+            $collisions = Get-AdapterIdCollision -ScriptText $fixture -SourceLabel 'non-literal-fixture'
+
+            # Assert
+            $collisions.Count | Should -Be 0
+        }
+    }
+
+    Context "repository suite scan" {
+        It "reports zero folded adapter-ID collisions across all tests/**/*.Tests.ps1" {
+            # Arrange: enumerate every test file under the resolved tests root.
+            $testFiles = Get-ChildItem -Path $script:TestsRoot -Recurse -Filter '*.Tests.ps1' -File
+            $testFiles | Should -Not -BeNullOrEmpty
+
+            $allCollisions = [System.Collections.Generic.List[string]]::new()
+            # Act: run the shared detection helper over each file's content.
+            foreach ($file in $testFiles) {
+                $content = Get-Content -Path $file.FullName -Raw
+                $relativePath = $file.FullName.Substring($script:TestsRoot.Length).TrimStart('\', '/')
+                $fileCollisions = Get-AdapterIdCollision -ScriptText $content -SourceLabel $relativePath
+                foreach ($collision in $fileCollisions) {
+                    $allCollisions.Add($collision)
+                }
+            }
+
+            # Assert: the fixed repository suite must have no collisions.
+            $allCollisions.Count | Should -Be 0 -Because ($allCollisions -join "`n")
+        }
+    }
+}

--- a/tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1
+++ b/tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1
@@ -55,27 +55,21 @@ Describe "Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded" {
             Should -Invoke -CommandName Invoke-GitExe -Times 0 -Exactly
         }
 
-        It "is case-sensitive: ConfirmToken 'YES' is rejected with code 2" {
+        # A non-case CaseLabel is included in the It name so the two -ForEach
+        # cases produce names that differ by something other than letter case.
+        # The VS Code Pester adapter folds discovered test IDs to uppercase
+        # during static discovery; without the label, "YES" and "Yes" would
+        # collide to a single uppercased ID and the duplicate would be dropped.
+        It "is case-sensitive: ConfirmToken '<ConfirmToken>' (<CaseLabel>) is rejected with code 2" -ForEach @(
+            @{ ConfirmToken = "YES"; CaseLabel = "uppercase" }
+            @{ ConfirmToken = "Yes"; CaseLabel = "titlecase" }
+        ) {
             Mock -CommandName Write-StderrLine -MockWith { param([string]$Message) $null = $Message }
             Mock -CommandName Invoke-NpmExe -MockWith { param([string[]]$NpmArgs) $null = $NpmArgs; throw "npm wrapper should not be invoked" }
             Mock -CommandName Invoke-PublishScript -MockWith { param([string]$ScriptPath) $null = $ScriptPath; throw "publish script should not be invoked" }
             Mock -CommandName Invoke-GitExe -MockWith { param([string[]]$GitArgs) $null = $GitArgs; throw "git wrapper should not be invoked" }
 
-            $result = Invoke-FullReleaseGuarded -ConfirmToken "YES" -RepoRoot "/repo"
-
-            $result | Should -Be 2
-            Should -Invoke -CommandName Invoke-NpmExe -Times 0 -Exactly
-            Should -Invoke -CommandName Invoke-PublishScript -Times 0 -Exactly
-            Should -Invoke -CommandName Invoke-GitExe -Times 0 -Exactly
-        }
-
-        It "is case-sensitive: ConfirmToken 'Yes' is rejected with code 2" {
-            Mock -CommandName Write-StderrLine -MockWith { param([string]$Message) $null = $Message }
-            Mock -CommandName Invoke-NpmExe -MockWith { param([string[]]$NpmArgs) $null = $NpmArgs; throw "npm wrapper should not be invoked" }
-            Mock -CommandName Invoke-PublishScript -MockWith { param([string]$ScriptPath) $null = $ScriptPath; throw "publish script should not be invoked" }
-            Mock -CommandName Invoke-GitExe -MockWith { param([string[]]$GitArgs) $null = $GitArgs; throw "git wrapper should not be invoked" }
-
-            $result = Invoke-FullReleaseGuarded -ConfirmToken "Yes" -RepoRoot "/repo"
+            $result = Invoke-FullReleaseGuarded -ConfirmToken $ConfirmToken -RepoRoot "/repo"
 
             $result | Should -Be 2
             Should -Invoke -CommandName Invoke-NpmExe -Times 0 -Exactly


### PR DESCRIPTION
# test(pester): resolve Test Explorer adapter ID collisions from case-only test names

## Summary

- Fixes the `pspester.pester-test` VS Code Test Explorer dropping/misreporting Pester items whose sibling names differ only by letter case.
- Disambiguates the confirmation-token case-sensitivity `-ForEach` cases in `Invoke-FullRelease.Tests.ps1` so their adapter IDs differ.
- Adds a deterministic AST-based regression guard (`tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1`) that fails on any case-insensitive sibling test-name collision across `tests/**`.
- Test-only change: no production code modified; both case-sensitivity assertions preserved.
- Verified locally: full suite 604 passed / 0 failed / 9 skipped; adapter discovery across 39 files / 608 items / 0 collisions.

## Why

The adapter folds discovered test IDs to uppercase during static discovery. Sibling Describe/Context/It names — including `-ForEach`/`-TestCases` expansions — that differ only by letter case collide to a single adapter ID, so the adapter ignores the duplicate. `Invoke-Pester` does not fold case, so the engine reports the suite green and the defect is invisible outside the adapter. The two confirmation-token cases (`YES` and `Yes`) both folded to the uppercased ID ending `...CONFIRMTOKEN=YES`. Root cause and environment are recorded in the feature spec (`docs/features/active/2026-06-17-pester-adapter-id-collision-198/spec.md`).

## What Changed

### Tests (core)
- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` (+10/-16): the case-sensitivity `-ForEach` cases carry a non-case `CaseLabel` (`uppercase` / `titlecase`) included in the `It` name, so the uppercased IDs differ (`...(UPPERCASE)...` vs `...(TITLECASE)...`). Both assertions retained.
- `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` (+495/-0, new): regression guard. Parses every `*.Tests.ps1` via the PowerShell AST and asserts that, within each parent scope, no two static Describe/Context/It names — and no two expansions of a literal `-ForEach`/`-TestCases` hashtable array — are equal case-insensitively. Non-literal data arguments are skipped (documented limitation).

### Docs (feature folder)
- `spec.md`, `issue.md`, `plan.2026-06-17T21-05.md`, and a QA-gate evidence artifact for the feature.

## Architecture / How It Fits Together

The guard mirrors the adapter's ID formation: it uppercases each block name (invariant culture), substitutes `<Key>` placeholders with row data for literal `-ForEach`/`-TestCases` rows, and appends uppercased `KEY=VALUE` segments per data key. It then asserts the resulting per-child discriminators are unique within each parent scope. The `tests/` root is resolved by walking up from the test's own location, so the scan is working-directory independent and behaves identically in the terminal and the Test Explorer. The shared helper `Get-AdapterIdCollision` is exercised both by in-memory fixture tests and by the repository-wide scan.

## Verification

### Completed (from context)
- `Invoke-Pester -Path tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` — EXIT_CODE 0, result pass (`docs/features/active/2026-06-17-pester-adapter-id-collision-198/evidence/qa-gates/2026-06-18T01-11/qa-gate.md`).
- Full suite: 604 passed / 0 failed / 9 skipped (Pester 5.6.1).
- PoshQC: format clean, analyze 0 findings, test green.
- Adapter discovery across all `tests/**/*.Tests.ps1`: 39 files, 608 items, 0 colliding IDs.
- Feature-review (`feature-audit.2026-06-17T21-22.md`): zero blocking findings.

### Recommended
- Reload the VS Code window (or run "Refresh Tests") so the adapter re-discovers with the new distinct IDs.

## Backward Compatibility / Migration Notes

No breaking changes. Test-only change with no production behavior impact. No renamed or removed public paths.

## Risks and Mitigations

- Risk: the guard's `-ForEach` expansion logic mishandles a non-literal data argument. Mitigation: non-literal arguments are skipped and documented; the guard still covers the literal pattern that caused this defect.
- Risk: false positives on intentionally case-distinct names. Mitigation: comparison is scoped to siblings within one parent, matching the adapter's own ID scheme.

## Review Guide

1. `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` — the focused disambiguation (10 lines).
2. `tests/scripts/claude-runtime/test-name-uniqueness.Tests.ps1` — the new guard and its fixture/negative tests.
3. `docs/features/active/2026-06-17-pester-adapter-id-collision-198/spec.md` — root cause and acceptance criteria.

## Follow-ups

- None required. The regression guard prevents recurrence of the case-only collision class.

## GitHub Auto-close

- Closes #198
