### PR TITLE
(feat(orchestration)): add routed checkpoint validation for orchestrator state

### DIFF
--- a/.github/workflows/_validate-orchestrator-state.yml
+++ b/.github/workflows/_validate-orchestrator-state.yml
@@ -1,0 +1,68 @@
+name: Validate Orchestrator State
+
+on:
+  workflow_call:
+    inputs:
+      state-path:
+        description: Repository-relative orchestrator checkpoint path.
+        required: false
+        type: string
+        default: artifacts/orchestration/orchestrator-state.json
+      require-checkpoint:
+        description: Fail when the checkpoint file is absent.
+        required: false
+        type: boolean
+        default: true
+  workflow_dispatch:
+    inputs:
+      state-path:
+        description: Repository-relative orchestrator checkpoint path.
+        required: false
+        type: string
+        default: artifacts/orchestration/orchestrator-state.json
+      require-checkpoint:
+        description: Fail when the checkpoint file is absent.
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  validate-orchestrator-state:
+    name: Validate orchestrator checkpoint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Validate checkpoint
+        env:
+          STATE_PATH: ${{ inputs.state-path }}
+          REQUIRE_CHECKPOINT: ${{ inputs.require-checkpoint }}
+        run: |
+          if [ ! -f "$STATE_PATH" ]; then
+            if [ "$REQUIRE_CHECKPOINT" = "true" ]; then
+              echo "ERROR: orchestrator checkpoint is required but was not found: $STATE_PATH" >&2
+              exit 1
+            fi
+            echo "No orchestrator checkpoint found at $STATE_PATH; validation skipped."
+            exit 0
+          fi
+
+          poetry run python -m scripts.dev_tools.validate_orchestration_artifacts \
+            orchestrator-state "$STATE_PATH" --require-complete

--- a/.github/workflows/validate-orchestrator-state.yml
+++ b/.github/workflows/validate-orchestrator-state.yml
@@ -1,0 +1,15 @@
+name: Orchestrator State Gate
+
+on:
+  pull_request:
+    branches: [main, development]
+  push:
+    branches: [main, development]
+  workflow_dispatch:
+
+jobs:
+  validate-orchestrator-state:
+    uses: ./.github/workflows/_validate-orchestrator-state.yml
+    with:
+      state-path: artifacts/orchestration/orchestrator-state.json
+      require-checkpoint: false

--- a/config/orchestration-routing.json
+++ b/config/orchestration-routing.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "routes": {
+    "small": {
+      "description": "Minor-audit path for work inside the applicable language budget.",
+      "required_agents": [
+        "atomic-planner",
+        "atomic-executor",
+        "feature-reviewer",
+        "commit-steward"
+      ],
+      "required_skills": [
+        "orchestrate",
+        "orchestrator-workflow",
+        "feature-promotion-lifecycle",
+        "repo-automation-adapter",
+        "atomic-plan-contract",
+        "acceptance-criteria-tracking",
+        "pr-context-artifacts",
+        "pr-base-branch-merge-base"
+      ],
+      "required_mcp_tools": [
+        "new_potential_entry",
+        "potential_to_issue",
+        "new_active_feature_folder",
+        "collect_commit_context",
+        "collect_pr_context",
+        "validate_orchestration_artifacts"
+      ]
+    },
+    "large": {
+      "description": "Full feature or bug path for work outside small-path budget.",
+      "required_agents": [
+        "task-researcher",
+        "prd-feature",
+        "atomic-planner",
+        "atomic-executor",
+        "feature-reviewer",
+        "commit-steward"
+      ],
+      "required_skills": [
+        "orchestrate",
+        "orchestrator-workflow",
+        "feature-promotion-lifecycle",
+        "repo-automation-adapter",
+        "atomic-plan-contract",
+        "acceptance-criteria-tracking",
+        "pr-context-artifacts",
+        "pr-base-branch-merge-base"
+      ],
+      "required_mcp_tools": [
+        "new_potential_entry",
+        "potential_to_issue",
+        "new_active_feature_folder",
+        "collect_commit_context",
+        "collect_pr_context",
+        "validate_orchestration_artifacts"
+      ]
+    },
+    "remediation": {
+      "description": "Review-triggered remediation loop.",
+      "required_agents": [
+        "atomic-planner",
+        "atomic-executor",
+        "feature-reviewer",
+        "commit-steward"
+      ],
+      "required_skills": [
+        "orchestrate",
+        "orchestrator-workflow",
+        "repo-automation-adapter",
+        "atomic-plan-contract",
+        "acceptance-criteria-tracking",
+        "pr-context-artifacts"
+      ],
+      "required_mcp_tools": [
+        "collect_commit_context",
+        "collect_pr_context",
+        "validate_orchestration_artifacts"
+      ]
+    }
+  }
+}

--- a/extensions/drm-copilot/package.json
+++ b/extensions/drm-copilot/package.json
@@ -46,6 +46,11 @@
           "type": "string",
           "default": ".claude/hooks/pre-claude-session.ps1",
           "description": "Worktree-relative path to a PowerShell script that the New Claude Worktree Session command runs immediately before 'claude'. The path is resolved relative to the worktree root. A missing script at this path is not an error; the command proceeds to 'claude'."
+        },
+        "drmCopilotExtension.newCodexWorktreeSession.postCodexScriptPath": {
+          "type": "string",
+          "default": ".codex/scripts/post-codex-worktree-session.ps1",
+          "description": "Worktree-relative path to a PowerShell script that the New Codex Worktree Session command runs after adding the worktree to Codex trusted projects and before starting 'codex'. The path is resolved relative to the worktree root. A missing script at this path is not an error; the command proceeds to 'codex'."
         }
       }
     },
@@ -145,6 +150,10 @@
       {
         "command": "drmCopilotExtension.newClaudeWorktreeSession",
         "title": "drm-copilot: New Claude Worktree Session"
+      },
+      {
+        "command": "drmCopilotExtension.newCodexWorktreeSession",
+        "title": "drm-copilot: New Codex Worktree Session"
       },
       {
         "command": "drmCopilotExtension.removeSecondaryWorktrees",

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/acceptance-criteria-tracking/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/acceptance-criteria-tracking/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: acceptance-criteria-tracking
 description: 'Track and check off acceptance criteria in requirement source files (issue.md, spec.md, user-story.md) as they are delivered. Use when executing plans, reviewing features, or validating delivery to keep AC checkboxes current.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/architecture-boundaries/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/architecture-boundaries/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: architecture-boundaries
+description: Architecture boundary enforcement rules for the No-COM architecture.
+paths:
+  - "**/*.ts"
+  - "**/*.cs"
+description: Architecture boundary enforcement rules for the No-COM architecture.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `architecture-boundaries`.
+
+# Architecture Boundaries
+
+Architecture boundary enforcement is a uniform gate across all tiers (T1–T4). Violations block PRs.
+
+## Enforcement Tools
+
+- **TypeScript:** `dependency-cruiser`. Configuration file pattern: `.dependency-cruiser.cjs`.
+- **.NET (when the backend exists):** `NetArchTest.Rules`. Test project naming pattern: `*.ArchitectureTests`.
+
+## No-COM Architecture Rules (enforceable assertions)
+
+Production code in this repository must satisfy each of the following assertions. Each assertion is enforced by `dependency-cruiser` (TypeScript) or `NetArchTest.Rules` (.NET) where applicable; legacy import utilities, when added, must satisfy the same assertions.
+
+1. New runtime code must not reference VSTO APIs (`Microsoft.Office.Tools.*`).
+2. New runtime code must not reference Outlook desktop automation APIs (`Microsoft.Office.Interop.Outlook`).
+3. New runtime code must not expose COM-visible interfaces (`[ComVisible(true)]` attribute is banned in production code).
+4. New runtime code must not use Ribbon extensibility callbacks tied to the desktop object model.
+5. New runtime code must not depend on local Outlook event streams.
+6. New runtime code must not depend on Outlook user-defined fields as the primary state store.
+7. Mailbox data must be accessed only through Office.js or Microsoft Graph.
+8. Business behavior must be implemented in the backend or in host-neutral domain or application modules.
+9. Client UI must be implemented as web UI.
+10. Legacy integration, when required, must be limited to offline data import from files or exported data.
+
+## Layer Boundary Assertions (TypeScript)
+
+- `src/taskpane/` and `src/commands/` must not import from backend internals.
+- Domain modules must not import from Office.js, Microsoft Graph SDK, or any infrastructure adapter.
+- Adapters may import from domain; domain must not import from adapters.
+
+## Layer Boundary Assertions (.NET, applies once the backend exists)
+
+- `TaskMaster.Domain` must have zero references to Outlook PIA, VSTO, or Office.js types.
+- `TaskMaster.Application` may depend on `TaskMaster.Domain` only.
+- Adapter projects may depend on `TaskMaster.Domain` and `TaskMaster.Application`; domain may not depend on adapters.
+
+## Enforcement Outcome
+
+Violations of any rule above are PR-blocking findings. CI runs the architecture-boundary stage on every PR; a non-zero violation count fails the stage and prevents merge.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/atomic-plan-contract/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/atomic-plan-contract/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite Claude skill paths to shared skill paths.
-
 ---
 name: atomic-plan-contract
 description: 'Atomic plan format and toolchain contract shared by planning and execution agents. Use when generating, validating, or executing atomic plans with Phase 0, baseline capture, and final QA loops.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/benchmark-baselines/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/benchmark-baselines/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: benchmark-baselines
+description: Benchmark baseline provenance rules for performance regression gates.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `benchmark-baselines`.
+
+# Benchmark Baseline Provenance
+
+This rule governs performance baselines used by benchmark regression gates. It exists because a baseline captured on a developer workstation was compared against a `windows-latest` runner, producing deterministic latency regressions that the benchmark gate could not survive (issue #26, PR #30).
+
+## Runner-Environment Parity (Required)
+
+Performance baselines must be captured in the same runner environment class against which they are compared. A baseline captured on a developer workstation must not be committed for comparison against a CI runner.
+
+## Prohibited: Unknown Processor
+
+A baseline whose `HostEnvironmentInfo.ProcessorName` is the literal string `"Unknown processor"` is rejected. This value indicates the baseline was captured in an environment where the processor could not be identified (typically a virtualized or developer workstation), which violates runner-environment parity.
+
+- Tooling MUST reject any baseline JSON where `HostEnvironmentInfo.ProcessorName == "Unknown processor"`.
+- The rejection is a Blocking finding; the baseline must be recaptured on the target runner class.
+
+## Required: Sibling Provenance File
+
+Every committed baseline file MUST have a sibling `baseline.provenance.json` in the same directory. The provenance file records, at minimum:
+
+- `runner_class` — the runner environment class that produced the baseline (for example `windows-latest`).
+- `host_signature` — a stable signature of the host (for example a hashed or labeled description of the CPU/core configuration).
+- `workflow_run_url` — the URL of the workflow run that produced the baseline.
+
+- Tooling MUST reject a baseline that has no sibling `baseline.provenance.json`.
+- The rejection is a Blocking finding; the baseline must be recaptured with provenance recorded.
+
+## Enforcement
+
+- The validator `scripts/benchmarks/Test-BaselineProvenance.ps1` enforces both rejection conditions above and accepts a runner-captured baseline whose `ProcessorName` is a real processor and whose sibling `baseline.provenance.json` is present.
+- The feature-review policy rule `modified-workflow-needs-green-run` (see `.agents/skills/feature-review-workflow/SKILL.md`) provides a second line of defense: a diff under `scripts/benchmarks/**` is Blocking unless a green workflow run against the branch head is present in remediation inputs.
+
+## Scope
+
+- This rule applies to any baseline consumed by a benchmark regression gate.
+- It does not change which checks are required by branch protection; it constrains the provenance of the data those checks consume.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/ci-workflows/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/ci-workflows/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: ci-workflows
+description: GitHub Actions PowerShell workflow authoring rules.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `ci-workflows`.
+
+# CI Workflow Authoring
+
+This rule governs GitHub Actions workflow steps that run PowerShell (`pwsh`). It exists because a `pwsh` step that intentionally invoked a failing nested command left `$LASTEXITCODE == 1` after its verification logic had already succeeded, leaking a failure to GitHub Actions even though the step's intent was satisfied (issue #26, PR #30).
+
+## Deliberately-Failing Nested Command Pattern (Required)
+
+A workflow step whose `run:` block intentionally invokes a command expected to fail — for example a negative-path self-validation that asserts a gate catches a synthetic regression — MUST not allow the residual non-zero exit code to propagate to GitHub Actions.
+
+For any such step, the `run:` block MUST do one of the following:
+
+1. Reset the exit code explicitly after the expected failure:
+   ```powershell
+   & ./some-tool --expect-failure
+   $LASTEXITCODE = 0
+   ```
+2. Or terminate the success path with an explicit zero exit:
+   ```powershell
+   if ($verificationSucceeded) { exit 0 } else { exit 1 }
+   ```
+
+A `pwsh` step terminates with the exit code of the last external command unless the script explicitly resets it or calls `exit`. Negative-path verification steps therefore require an explicit reset or explicit `exit 0`.
+
+## Rationale
+
+- GitHub Actions interprets a step's process exit code as the step result. A leaked `$LASTEXITCODE` from an intentionally-failing nested command causes a passing verification to report failure.
+- No local toolchain stage executes a workflow's `run:` block, so this defect is invisible to local feature-review. This textual rule is the artifact local review cites when reading workflow YAML.
+
+## Enforcement
+
+- Local feature-review cites this rule when reviewing diffs that add or modify `pwsh` steps with deliberately-failing nested commands.
+- The feature-review policy rule `modified-workflow-needs-green-run` (see `.agents/skills/feature-review-workflow/SKILL.md`) requires a green workflow run against the branch head before a workflow change can merge, which exercises the exit-code path on the runner.
+
+## Scope
+
+- This rule applies to any workflow step whose `run:` block uses `shell: pwsh` (or the repo default `pwsh`) and intentionally invokes a failing nested command.
+- It does not change required-check configuration or branch protection.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/commit-message/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/commit-message/SKILL.md
@@ -1,15 +1,6 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: commit-message
 description: Generate a conventional commit message from staged Git changes following the repository's commit message conventions.
-allowed-tools:
-  - Read
-  - "Bash(git log *)"
-  - "Bash(git diff *)"
 ---
 
 # Commit Message Skill
@@ -26,12 +17,13 @@ Generate a single conventional commit message from staged Git changes or a provi
 ## Context Gathering
 
 1. Use the supplied commit-context artifact first when present.
-2. Otherwise inspect the staged diff and commit history only:
+2. When the `drm-copilot` MCP commit-context tool is available for the workflow, collect commit context through that tool and stop if the MCP call fails.
+3. Otherwise inspect read-only staged Git state only:
    - `git diff --cached --stat`
    - `git diff --cached`
    - `git diff --cached --name-only`
    - `git log --oneline -n 20`
-3. Do not infer intent from unstaged files or unrelated commit history.
+4. Do not infer intent from unstaged files or unrelated commit history.
 
 ## Classification
 

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp-change-budget-router/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp-change-budget-router/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: csharp-change-budget-router
 description: Budget-first routing contract for C# work: estimate production-file scope, choose small vs large path, enforce orchestration-first routing for larger changes, and use the VS Code extension command surface for promotion lifecycle steps when available.
@@ -29,7 +24,7 @@ Use this skill when:
 ## Orchestrated Small-Path Requirements
 
 When routed through `csharp-orchestrator`, small path still requires lifecycle scaffolding before implementation:
-- invoke promotion/folder lifecycle steps through `vscode/runCommand` + extension access per `feature-promotion-lifecycle` when available; use script/CLI fallback only when direct extension command execution is unavailable,
+- invoke promotion/folder lifecycle steps through the `drm-copilot` MCP tools required by `repo-automation-adapter`. If the MCP server or required tool is unavailable, stop before promotion,
 - promote potential item to GitHub issue with `--work-mode minor-audit`,
 - create active feature folder with `--work-mode minor-audit`,
 - delegate minimal-audit plan creation to `atomic_planner` with `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`,

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp-orchestration-state-machine/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp-orchestration-state-machine/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: csharp-orchestration-state-machine
 description: Checkpoint schema and resume protocol for long-running C# orchestration workflows.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp-qa-gate/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp-qa-gate/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite Claude skill paths to shared skill paths.
-
 ---
 name: csharp-qa-gate
 description: Final QA gate for C# changes. Executes the full CSharpier -> .NET Analyzers -> Nullable Analysis -> MSTest toolchain, compares against a captured baseline, enforces zero-regression deltas, and produces the required reporting block before the agent declares the change complete.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/csharp/SKILL.md
@@ -1,9 +1,5 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
+name: csharp
 paths:
   - "**/*.cs"
   - "**/*.csproj"

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: evidence-and-timestamp-conventions
 description: 'Evidence storage and timestamp naming conventions for audits and remediation. Use when storing baseline/regression/QA evidence or naming audit artifacts with ISO-8601 timestamps.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/execute-hard-lock/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/execute-hard-lock/SKILL.md
@@ -1,15 +1,6 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite Claude agent manifest paths to Codex agent paths.
-- Rewrite remaining VS Code command IDs to semantic MCP tool usage.
-
 ---
 name: execute-hard-lock
 description: Place the session in atomic execution mode bound to a specific plan-of-record. Resolves the hard-lock prompt via the drm-copilot MCP tool, then delegates to the atomic-executor subagent with the resolved text. Use when a caller provides ${plan-path} and ${work-mode} and requires strict plan-following behavior.
-allowed-tools:
-  - mcp__drm-copilot__resolve_execute_hard_lock_prompt
-  - Read
 ---
 
 # Execute Hard Lock
@@ -50,7 +41,7 @@ Use the `Read` tool on the path returned in `artifacts[0]`. Treat the file conte
 
 ### 3. Delegate to atomic-executor
 
-Invoke the `atomic-executor` subagent via the Agent tool. Pass the resolved prompt text as the subagent's kickoff directive, followed by `${plan-path}` and `${work-mode}` as session context.
+Spawn the `atomic-executor` subagent from `.codex/agents/atomic-executor.toml`. Pass the resolved prompt text as the subagent's kickoff directive, followed by `${plan-path}` and `${work-mode}` as session context. If the `atomic-executor` agent is unavailable, stop with `BLOCKED: execute-hard-lock spawn_agent_unavailable`.
 
 The resolved prompt itself already instructs the subagent to perform the mandatory read-proof (`git rev-parse HEAD`, SHA-256 of the plan file, unchecked-task count), preflight validation, and `READY TO BEGIN FROM [P#-T#]` handshake before executing any task. This skill does not reissue those instructions locally — doing so would risk divergence from the canonical template.
 
@@ -84,5 +75,5 @@ The `atomic-executor` subagent at [.codex/agents/atomic-executor.toml](.codex/ag
 - Do not proceed without a successful MCP resolver response AND a successful `Read` of the artifact.
 - Do not reconstruct the hard-lock contract from any other source (not from this file nor from prior session memory).
 - Do not modify the resolved prompt text before passing it to `atomic-executor`.
-- Do not replan, reorder, or add tasks at this layer — the subagent owns that contract.
+- Do not replan, reorder, or add tasks at this layer. The subagent owns that contract.
 - Do not create or read secrets unless explicitly authorized.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/feature-promotion-lifecycle/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/feature-promotion-lifecycle/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: feature-promotion-lifecycle
 description: Deterministic promotion workflow from potential feature/bug entry to issue, branch, active feature folder, and downstream spec/research handoffs. Agent sessions must use the drm-copilot MCP tool surface and record raw promotion receipts under the canonical checkpoint namespace.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/feature-review-workflow/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/feature-review-workflow/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: feature-review-workflow
 description: 'Feature-branch review workflow for base-branch resolution, PR-context refresh, active feature folder selection, review artifact generation, validator gates, acceptance-criteria check-off, and remediation triggers. Use when authoring or executing PR-style feature reviews.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/fill-feature-docs/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/fill-feature-docs/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: fill-feature-docs
 description: Invoke the prd-feature worker to produce feature-document outputs from issue and research inputs.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/general-code-change/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/general-code-change/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: general-code-change
+description: Cross-language code change policy for all files.
+paths:
+  - "**"
+description: Cross-language code change policy. Applies to all files.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `general-code-change`.
+
+# General Code Change Policy
+
+This rule file summarizes the cross-language code change policy for this repository.
+
+## Design Principles
+
+Apply these priorities in order when designing or changing code:
+
+1. **Simplicity first** — Prefer the simplest design that works and is readable. Avoid cleverness and deep indirection.
+2. **Reusability** — Factor out logic that is clearly reusable. Avoid copy-paste; share behavior via composition or helper methods.
+3. **Extensibility** — Design public APIs so they can be extended without breaking callers. Prefer keyword-style parameters with defaults. Prefer composition over inheritance. Use interfaces/abstract types/protocols to support multiple implementations.
+4. **Separation of concerns** — Keep pure logic (transforms, calculations, parsing) separate from I/O (disk, network, DB), UI/CLI, and framework-specific glue.
+
+## Classes, Functions, and APIs
+
+- Create a class when: there is a clear domain concept with data + behavior, state and invariants must travel together, multiple implementations behind an interface are expected, or a multi-step workflow shares context.
+- Create a standalone function when: the operation is pure, stateless, and simple; it is a small helper that does not naturally belong on a domain class; or it is a simple transformation from inputs to outputs.
+- Keep methods small and focused. Avoid god objects.
+- Use interfaces/abstract types/protocols when multiple implementations are likely.
+
+## Module Rigor Tiers
+
+Module rigor tiers (T1–T4) and the uniform-versus-tier-dependent gate matrix are defined in `.agents/skills/quality-tiers.md`. Every project must be classified in `quality-tiers.yml` at repo root.
+
+## Mandatory Toolchain Loop
+
+Run the full seven-stage toolchain in this exact order and repeat until all stages pass in a single pass:
+
+1. **Formatting** (e.g., Black, Prettier, CSharpier, Invoke-Formatter)
+2. **Linting** (e.g., Ruff, ESLint, PSScriptAnalyzer, .NET analyzers)
+3. **Type checking** (e.g., Pyright, TSC, nullable analysis; skip for PowerShell)
+4. **Architecture-boundary tests** (e.g., dependency-cruiser, NetArchTest.Rules)
+5. **Unit tests** (e.g., Pytest, Vitest, MSTest, Pester) including property-based tests where applicable per `quality-tiers.md`
+6. **Contract / schema compatibility checks** (e.g., oasdiff, schema-snapshot diff)
+7. **Integration tests**
+
+**Restart from step 1** if any stage fails or auto-fixes any files. Do not stop the loop until all seven stages complete without errors in a single pass.
+
+Mutation testing and golden tests run in pre-merge or nightly pipelines, not the per-commit loop.
+
+## File Size Limit
+
+- No production code, test code, or reusable script file may exceed **500 lines**.
+- Exceptions: temporary throwaway scripts created and deleted within an agent session; raw text fixtures for language-processing test data; Markdown documentation files.
+
+## Error Handling and Logging
+
+- **Fail fast and explicitly**: raise or return clear, specific errors when invariants are violated.
+- Do not silently ignore errors. Do not use broad catch-all handlers unless you immediately re-raise or propagate with added context.
+- Use the project's established logging pattern. Log at appropriate levels (`debug`, `info`, `warning`, `error`).
+- Enforce invariants at construction/initialization time.
+- Use assertions only for internal sanity checks, not user-facing error handling.
+
+## Naming
+
+- Names must be descriptive. Abbreviations are acceptable only when they are standard (`id`, `url`, `db`).
+- Language-specific conventions: `snake_case` for Python functions/variables, `PascalCase` for Python classes, `camelCase` for TypeScript/C# locals, `PascalCase` for TypeScript/C# types and public members.
+
+## Public APIs and Compatibility
+
+- Prefer keyword-style parameters with defaults.
+- Prefer composition over inheritance when possible.
+- Avoid breaking public APIs. If a breaking change is necessary, update all callers in-repo and call it out clearly in the change description.
+
+## Dependencies
+
+- Use only libraries already approved in the project unless explicitly told to add more.
+- If adding a dependency is unavoidable, choose a well-maintained, widely used package and document why it is required.
+
+## I/O Boundaries
+
+- Isolate I/O (disk, network, APIs) into specific classes or modules.
+- Core domain logic must be testable without touching the network or filesystem.
+- Use of temporary files within tests is strictly prohibited.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/general-unit-test/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/general-unit-test/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: general-unit-test
+description: Cross-language unit test policy for all files.
+paths:
+  - "**"
+description: Cross-language unit test policy. Applies to all files.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `general-unit-test`.
+
+# General Unit Test Policy
+
+This rule file summarizes the cross-language unit test policy for this repository.
+
+## Core Principles
+
+Every unit test must satisfy all five of these properties:
+
+1. **Independence** — Tests must be able to run in any order without impacting each other.
+2. **Isolation** — Each unit test targets a single function, method, or unit of behavior so failures clearly identify the faulty unit.
+3. **Fast execution** — Tests must be fast enough to support frequent runs and rapid feedback loops.
+4. **Determinism** — Given the same inputs and environment, tests must produce the same results. Avoid flakiness.
+5. **Readability and maintainability** — Test names, structure, and assertions must be clear and easy to understand.
+
+## Coverage Requirements
+
+- **Line coverage must remain >= 85% across all tiers (T1–T4).**
+- **Branch coverage must remain >= 75% across all tiers (T1–T4).**
+- Code changes or refactors must not reduce coverage for the lines that were changed.
+- Tier-specific lower coverage thresholds are not used in this repository. See `.agents/skills/quality-tiers.md` for the full tier system.
+- Coverage is a supporting metric, not the sole quality gate. Untested critical behavior is not acceptable even if the overall percentage looks good.
+- Configure coverage tooling to exclude test files (e.g., `tests/`) so metrics reflect application code, not tests.
+- Type-only / interface-only modules with no executable behavior may be omitted from coverage measurement. Examples: Python `Protocol`-only modules consumed only under `TYPE_CHECKING`, TypeScript interface/type-only files, and C# interface-only files. Such modules legitimately report 0% executable coverage and may be excluded from measurement. This is a clarification only; it does not lower any coverage threshold.
+
+## Coverage Exclusion Policy
+
+No production file may be excluded from coverage measurement. Every production source file is in the denominator of the coverage metric, regardless of whether its lines are reachable in the test environment.
+
+The correct response to a file that contains untestable lines is to refactor it — extract all logic into host-neutral, testable modules and leave only the thinnest possible wiring in the host-bound entry point. The entry point's uncovered lines then represent a real and visible cost in the coverage metric, which creates ongoing pressure to keep those files minimal.
+
+**Permitted `exclude` entries** (non-production paths only):
+- Build output directories: `dist/**`, `lib/**`, `lib-amd/**`.
+- Test files and test infrastructure: `**/*.test.ts`, `tests/**`, `src/test-support/**`.
+- Config files that are not production code: `vitest.config.ts`, `eslint.config.mjs`, `.dependency-cruiser.cjs`, `webpack.config.js`.
+- `node_modules/**`.
+
+**Prohibited `exclude` entries:**
+- Any path under `src/` that contains production runtime code, regardless of whether it is auto-generated, host-bound, or difficult to test.
+
+**Enforcement:** Feature-review agents must treat any `exclude` entry that matches a production source path as a **Blocking** finding.
+
+## Scenario Completeness
+
+For each unit or behavior, tests must cover:
+
+- Positive flows with valid inputs
+- Negative flows for invalid or missing inputs
+- Edge cases and boundary conditions
+- Error-handling behavior
+- Concurrency behavior when relevant
+- State transitions for stateful components
+
+## Test Structure — Arrange–Act–Assert
+
+Organize each test into three sections:
+
+- **Arrange** — set up inputs, environment, and dependencies
+- **Act** — execute the behavior under test
+- **Assert** — verify outcomes via assertions
+
+Assertions must produce clear, actionable failure messages.
+
+## External Dependencies
+
+- Unit tests must not depend on external services (databases, networks, remote APIs, external processes).
+- Use mocks, stubs, or fakes to isolate the unit under test when code interacts with external systems.
+- **Creation and use of temporary files in tests is strictly prohibited.**
+- Tests must not rely on mutable global state or external configuration that can change between runs.
+
+## Test File Location
+
+Test files must live in a `tests/` directory tree that mirrors the production source structure. The test for `src/foo/bar.ts` belongs at `tests/foo/bar.test.ts`; the test for `scripts/powershell/Foo.ps1` belongs at `tests/scripts/powershell/Foo.Tests.ps1`. Language-specific rules may add further naming conventions (framework suffix, file extension) on top of this universal layout requirement.
+
+Colocation — placing test files alongside production source files in `src/` or equivalent — is not permitted. An agent that creates or moves a test file into the production source tree has violated this rule.
+
+## Documentation
+
+- Each test must clearly communicate its purpose via a descriptive name and/or a short docstring or comment summarizing the scenario and expected outcome.
+- Group related tests logically within the same file or test class.
+
+## Test Categories
+
+The following test categories apply across the repository, with tier-dependent obligations per `.agents/skills/quality-tiers.md`:
+
+- **Unit tests** — required for all tiers (T1–T4). Cover single units of behavior in isolation.
+- **Property-based tests** — required for T1 and T2 modules: at least one property test per pure function. Use `fast-check` (TypeScript) or `hypothesis` (Python) where applicable.
+- **Golden / snapshot tests** — required only for T1 classifier-output modules, tested against a versioned corpus. Snapshot tests are otherwise discouraged unless stable and intentional.
+- **Contract / schema tests** — required at every host-service boundary (e.g., Office.js, Microsoft Graph, internal API contracts).
+- **Mutation tests** — required for T1 modules: mutation score >= 75%. Run in pre-merge or nightly pipelines.
+- **Integration tests** — required where adapters interact with external systems; scoped per tier in the gate matrix.
+
+## Determinism Infrastructure
+
+All test code must be deterministic. The following infrastructure requirements apply uniformly:
+
+- **Controllable clock** — use a `Clock` interface (TypeScript) or `TimeProvider` (.NET) injected into code under test. Do not read wall-clock time directly in production code under test.
+- **Seeded RNG** — randomness must be supplied via a seedable interface; on test failure the seed must be printed so the failure is reproducible.
+- **Banned APIs in test code** — `setTimeout`, `Thread.Sleep`, `Task.Delay`, real wall-clock waits, and `Date.now()` outside the clock interface are prohibited in tests.
+- **Virtual scheduler / fake timers / `FakeTimeProvider`** — async tests must use the framework's fake-timer facility (`vi.useFakeTimers()` for Vitest, `FakeTimeProvider` for .NET) to advance simulated time deterministically.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/human-exception-runbook/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/human-exception-runbook/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: human-exception-runbook
+description: Contract for runbooks that document permitted human exceptions recorded in orchestrator state.
+---
+
+# Human-Exception Runbook
+
+Defines the contract for a human-exception runbook: the artifact the orchestrator emits when an unautomatable requirement is resolved with the `exception` response under the autonomous-execution mandate (see `.agents/skills/orchestrate/SKILL.md`).
+
+## When to Use This Skill
+
+Use this skill when:
+
+- The orchestrator detects an unautomatable (human-interaction) requirement and resolves it with the `exception` response rather than `scope_change` or `halt`.
+- A permitted exception is recorded in orchestrator state and the schema's exception-requires-runbook invariant must be satisfied (`response == "exception"` requires a non-empty `runbook_path` pointing to an existing file).
+- Authoring or reviewing a runbook that a human will follow to complete a step the workflow cannot automate.
+
+## Canonical Path
+
+A human-exception runbook is stored per-feature at:
+
+```
+<FEATURE>/runbooks/<name>.runbook.md
+```
+
+The `runbook_path` recorded in `orchestrator-state.json` (`human_interaction.requirements[].runbook_path`) is the path relative to the repo root. This path is under the feature folder but is not an `evidence/` sub-path, so it is not governed by `enforce-evidence-locations.ps1` (OD-45-6).
+
+## Required Sections
+
+Every human-exception runbook MUST contain these five sections, in this order:
+
+1. **Cue** — when to act; the event or state that triggers the runbook (for example, "the orchestrator recorded an `exception` for Global-Administrator admin consent").
+2. **Prerequisites** — what must be true before the human starts: accounts, roles, devices, tools, and any prior state.
+3. **Step-by-step Instructions** — numbered steps, including detailed third-party UI navigation where applicable. Each step is concrete and verifiable.
+4. **Verification** — how the human confirms success: the observable state, confirmation dialog, or command output that proves the step completed.
+5. **Source and Citation** — the source URL(s) and a dated capture (`updated_at`) for each cited step. Third-party UI sections record the navigation source; non-UI CLI steps record the documentation source for the command used.
+
+## Sourcing Rule (MCP-first / web-second)
+
+Third-party UI steps (for example Azure portal / Entra admin center, Outlook desktop or mobile, the Microsoft 365 admin center) MUST be sourced **MCP-first, web-second**:
+
+1. Prefer an MCP documentation source (for example a Microsoft Learn MCP query) as the primary source.
+2. Use a web source (the vendor's current published documentation) only when no MCP source is available.
+3. Training data is NOT an acceptable sole source for any third-party UI step, because vendor UIs drift and stale navigation produces incorrect instructions.
+
+Per OD-45-5, the MCP-first / web-second ordering is mandatory for third-party UI navigation. Non-UI CLI steps (for example `az` commands) do not require the UI ordering, but every step type — UI and CLI alike — MUST carry a current, dated citation in the Source-and-Citation section. A runbook step without a dated source is not contract-conformant.
+
+## Conformance
+
+A runbook is contract-conformant when:
+
+- it lives at `<FEATURE>/runbooks/<name>.runbook.md`,
+- it contains all five required sections (Cue, Prerequisites, Step-by-step Instructions, Verification, Source and Citation),
+- its Source-and-Citation section records at least one source URL and a capture date,
+- third-party UI steps were sourced MCP-first / web-second.
+
+A self-contained, conformant example is provided at `.agents/skills/human-exception-runbook/example.runbook.md`.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/human-exception-runbook/example.runbook.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/human-exception-runbook/example.runbook.md
@@ -1,0 +1,36 @@
+# Example Human-Exception Runbook — Grant Tenant-Wide Admin Consent for an Entra Application
+
+This is a self-contained, contract-conformant example runbook per `.agents/skills/human-exception-runbook/SKILL.md`. It demonstrates the required five sections and the dated-citation requirement. It does not reference any other feature folder. The values below (tenant, application name) are illustrative placeholders.
+
+## Cue
+
+Act on this runbook when the orchestrator records an `exception` response for the requirement "tenant-wide admin consent for the Entra application." Admin consent for delegated Microsoft Graph permissions that require administrator approval cannot be granted unattended without a Global-Administrator service principal in CI (declined per the autonomous-execution mandate's scope decisions), so it is resolved as a permitted exception and this runbook is the human follow-up.
+
+## Prerequisites
+
+- An account with the **Global Administrator** or **Privileged Role Administrator** role in the target Microsoft Entra tenant.
+- The application's **Application (client) ID** and the tenant's display name.
+- Access to the Microsoft Entra admin center (https://entra.microsoft.com).
+- The set of delegated permissions the application requests is already declared on the app registration (this runbook grants consent for them; it does not add them).
+
+## Step-by-step Instructions
+
+1. Sign in to the Microsoft Entra admin center at https://entra.microsoft.com with the Global Administrator account.
+2. In the left navigation, select **Identity** > **Applications** > **App registrations**.
+3. Select **All applications**, then open the application by its Application (client) ID.
+4. In the application's left menu, select **API permissions**.
+5. Review the listed permissions and confirm the requested delegated Microsoft Graph permissions are present with status "Not granted for <tenant>".
+6. Select **Grant admin consent for <tenant>** at the top of the **Configured permissions** list.
+7. In the confirmation dialog, select **Yes** to grant tenant-wide admin consent.
+
+## Verification
+
+- After step 7, each affected permission row shows the status **Granted for <tenant>** with a green check mark.
+- Re-open **API permissions** and confirm no permission remains in the "Not granted" state.
+- Optionally, confirm programmatically that the consent exists by querying the service principal's OAuth2 permission grants with the Microsoft Graph CLI or `az ad`.
+
+## Source and Citation
+
+- Step source (third-party UI navigation, sourced MCP-first): Microsoft Learn — "Grant tenant-wide admin consent to an application." Source URL: https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent — updated_at: 2026-06-01.
+- API permissions UI reference (web-second corroboration): Microsoft Learn — "Configure a client application to access a web API." Source URL: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis — updated_at: 2026-06-01.
+- Verification reference (CLI corroboration for the optional programmatic check): Microsoft Learn — "az ad app permission" command reference. Source URL: https://learn.microsoft.com/en-us/cli/azure/ad/app/permission — updated_at: 2026-06-01.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/invoke-csharp-engineer/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/invoke-csharp-engineer/SKILL.md
@@ -1,12 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite Claude skill paths to shared skill paths.
-- Rewrite Claude rule paths to shared skill paths.
-
 ---
 name: invoke-csharp-engineer
 description: Invoke the csharp-typed-engineer worker to design, implement, and verify C# changes within typed repository boundaries. Applies CSharpier -> .NET Analyzers -> Nullable Analysis -> MSTest toolchain, the 1-3 production-file small-path budget, and zero-regression quality gates.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/invoke-powershell-engineer/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/invoke-powershell-engineer/SKILL.md
@@ -1,12 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite Claude skill paths to shared skill paths.
-- Rewrite Claude rule paths to shared skill paths.
-
 ---
 name: invoke-powershell-engineer
 description: Invoke the powershell-typed-engineer worker to design, implement, and verify PowerShell changes within typed repository boundaries. Applies PoshQC format -> analyze -> test toolchain, the 1-2 production-file direct-mode budget, the 3-production + 3-test per-batch cap, and zero-regression quality gates.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/invoke-python-engineer/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/invoke-python-engineer/SKILL.md
@@ -1,12 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite Claude skill paths to shared skill paths.
-- Rewrite Claude rule paths to shared skill paths.
-
 ---
 name: invoke-python-engineer
 description: Invoke the python-typed-engineer worker to design, implement, and verify Python changes within typed repository boundaries. Applies Black -> Ruff -> Pyright -> Pytest toolchain, the 3-production + 3-test per-batch budget, and zero-regression quality gates.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/make-skill-template/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/make-skill-template/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: make-skill-template
 description: 'Create new Agent Skills for GitHub Copilot from prompts or by duplicating this template. Use when asked to "create a skill", "make a new skill", "scaffold a skill", or when building specialized AI capabilities with bundled resources. Generates SKILL.md files with proper frontmatter, directory structure, and optional scripts/references/assets folders.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md
@@ -1,10 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite Claude skill paths to shared skill paths.
-- Rewrite Claude rules-directory references to the native skill root.
-
 ---
 name: orchestrate
 description: Route a repository request through the deterministic orchestration workflow for feature, bug, research, planning, execution, and review handoffs.
@@ -30,6 +23,64 @@ On every invocation, the main session must:
 1. Read `artifacts/orchestration/orchestrator-state.json` to check for existing state.
 2. If a valid checkpoint exists with a matching objective, resume from the recorded `next_step`.
 3. If no checkpoint exists or the objective is new, begin the orchestration lifecycle from the start.
+4. Read `config/orchestration-routing.json` before route selection and copy the
+   selected route's required agents, skills, and MCP tools into checkpoint
+   state.
+
+## Hard Enforcement Boundary
+
+The hard completion boundary for Codex orchestration is the deterministic
+orchestrator-state validator exposed through the `drm-copilot` MCP server, not
+a Codex lifecycle hook. Before any DONE transition, PR creation gate, or final
+completion report, the orchestrator must validate the canonical checkpoint with
+`validate_orchestration_artifacts` on the `drm-copilot` MCP server using
+`artifact_type: "orchestrator-state"`,
+`artifact_path: "artifacts/orchestration/orchestrator-state.json"`, and
+`require_complete: true`.
+
+There is no fallback. If the MCP server or validation tool is unavailable, or
+if validation fails, the orchestrator must update blocked state and stop rather
+than reporting completion.
+
+The repository CI gate `Orchestrator State Gate` runs the same validator when a
+checkpoint is present. Branch protection should require this check for branches
+that use orchestrated completion.
+
+Completion validation requires the checkpoint to prove mandatory handoffs and
+skill use. The checkpoint must include:
+
+- `route_id`: the selected route key from `config/orchestration-routing.json`
+- `required_agents`: exactly the selected route's `required_agents`
+- `required_skills`: exactly the selected route's `required_skills`
+- `required_mcp_tools`: exactly the selected route's `required_mcp_tools`
+- `delegation_receipts`: one receipt for each required agent
+- `skill_receipts`: one required receipt for each required skill, with evidence
+- `mcp_call_receipts`: one successful receipt for each required MCP tool
+- `local_execution_overrides`: an empty list at completion
+- `delegation_bypasses`: an empty list at completion
+- `lifecycle_operations`: any lifecycle operation must record `surface: "mcp"`
+
+If any required handoff, skill receipt, MCP receipt, or empty bypass list is
+missing, `validate_orchestration_artifacts --require-complete` fails and the
+orchestrator must not report DONE.
+
+## Autonomous-Execution Mandate
+
+The orchestrator must achieve all actions agentically with no unrecorded manual
+dependency. Every unautomatable requirement must be detected early, resolved by
+exactly one of the permitted responses below, and recorded in checkpoint state
+under `human_interaction.requirements[]`.
+
+Permitted responses:
+
+- `scope_change`: change scope to remove the manual dependency.
+- `exception`: permit an exception only when a runbook exists and its path is
+  recorded in `runbook_path`.
+- `halt`: halt until further instruction. A `halt` blocks DONE while present.
+
+The checkpoint validator enforces the `human_interaction` invariants. An
+unresolved response, invalid response value, `halt`, or exception without an
+existing runbook path blocks completion.
 
 ## Delegation Model
 
@@ -38,10 +89,35 @@ After reading `artifacts/orchestration/orchestrator-state.json`, the main sessio
 - `atomic-planner` — generates phased implementation plans
 - `atomic-executor` — executes approved plans task-by-task
 - `feature-review` — produces policy, code, and feature audit artifacts
-- `commit-steward` — writes commit messages from commit-context artifacts
 - `task-researcher` — performs deep research and writes findings to `artifacts/research/`
+- `prd-feature` — produces issue, specification, and user-story artifacts when required by the selected workflow
+- `staged-review` — reviews staged changes when a pre-commit review is required
+- `epic-review` — reviews epic-level artifacts when the work item is an epic
+- `status-updater` — produces status update artifacts when the workflow requires status synchronization
+- `python-typed-engineer` — performs delegated Python implementation work
+- `powershell-typed-engineer` — performs delegated PowerShell implementation work
+- `csharp-typed-engineer` — performs delegated C# implementation work
+- `typescript-engineer` — performs delegated TypeScript implementation work
+- `commit-steward` — writes commit messages from commit-context artifacts
 
 The orchestrator does not perform deep implementation itself. It coordinates, tracks state, and enforces completion.
+
+Every worker listed above must exist as a native Codex agent under `.codex/agents/`.
+For required delegated steps, missing agent configuration, failed spawn, missing
+receipt, or missing required artifact output is a hard block. The orchestrator
+must persist blocked state and stop rather than performing that step locally.
+
+Every required skill listed in the selected route must be acknowledged in
+`skill_receipts[]` with:
+
+- `skill`
+- `required: true`
+- `acknowledged_at_phase`
+- `evidence`
+
+The evidence value must point to objective evidence: a checkpoint field, MCP
+receipt, artifact path, validator output, or test result. A bare narrative
+statement is not sufficient.
 
 ## Evidence Location Authority
 
@@ -66,6 +142,7 @@ The orchestrator must not report completion until:
 1. All required artifacts for the selected workflow path are present on disk.
 2. All validation gates (toolchain, acceptance criteria, audit artifacts) have passed.
 3. The checkpoint file at `artifacts/orchestration/orchestrator-state.json` reflects the completed state.
+4. The orchestrator-state validator passes with `--require-complete`.
 
 ## Pre-Feature-Review Commit
 
@@ -111,6 +188,13 @@ Every delegation prompt to `atomic-planner`, `atomic-executor`, and `feature-rev
 
 If a subagent artifact references a different issue number, the orchestrator rejects it, requests correction, and records the discrepancy under `artifact_errors` in the checkpoint.
 
+## CI Green Gate
+
+Before PR/DONE completion, the orchestrator must observe the live PR head SHA
+and required GitHub checks through `gh`. The checkpoint must record the checked
+head SHA and CI result. DONE is blocked unless the required checks pass for the
+current PR head SHA.
+
 ## PR Creation Gate
 
 The orchestrator must not create a PR, push a branch for PR purposes, or report work complete until all four conditions are simultaneously true:
@@ -120,6 +204,7 @@ The orchestrator must not create a PR, push a branch for PR purposes, or report 
 2. The AC verification artifact (`p14-acceptance-criteria-checkoff.md` or equivalent) confirms all acceptance criteria pass.
 3. The mandatory toolchain passed in its most recent run on the branch (no linting/type-check/test failures).
 4. The checkpoint `next_step` is `S8_create_pr`.
+5. The required CI checks pass for the current PR head SHA.
 
 This gate is non-negotiable. Each condition is independently verified before PR creation proceeds.
 

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrator-state/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrator-state/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: orchestrator-state
+description: Orchestrator-state remediation-cycle and human-interaction invariants.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `orchestrator-state`.
+
+# Orchestrator-State Remediation-Cycle and Human-Interaction Invariants
+
+This rule governs remediation-cycle records and the optional `human_interaction` block in the orchestrator-state checkpoint at `artifacts/orchestration/orchestrator-state.json`. It documents three invariants that must hold for each remediation cycle, plus three invariants for the `human_interaction` block, so that resume and review workflows do not depend on a structurally invalid checkpoint.
+
+## Foreign Schema Warning (do not copy verbatim)
+
+A hardened snapshot from another repository contains a JSON Schema for the orchestrator-state artifact whose `$id` references a foreign origin (`drmoisan.github.io/mix-calculator/`). That schema MUST NOT be copied verbatim into this repository: its `$id`, its top-level required-field set, and its cycle-level `additionalProperties: false` do not match this repository's checkpoint contract. The invariants below are re-expressed here as prose and enforced by validator logic in `scripts/dev_tools/validate_orchestrator_state.py`, not by importing a foreign schema file.
+
+This prohibition is specific to the disqualified foreign schema identified by the `drmoisan.github.io/mix-calculator/` `$id`. A schema whose `$id` is repo-local and whose required-field set and `additionalProperties` policy match this repository's checkpoint contract is not the disqualified foreign artifact; even so, the repository's enforcement mechanism remains the Python validator prose-and-logic above, not an imported schema file.
+
+## Scope and Backward Compatibility
+
+These invariants apply only when the checkpoint contains a top-level `remediation_loop` with a `cycles` array. A checkpoint with no `remediation_loop` (the existing step-based checkpoint shape) is unaffected: it validates exactly as before and produces no new errors. The invariants are additive.
+
+## Invariants (per remediation cycle)
+
+1. **Non-empty `plan_path`.** Each cycle's `plan_path` must be a non-empty string. A missing value, a non-string value, or an empty/whitespace-only string is a malformed cycle.
+
+2. **Execution requires cleared preflight.** A cycle's `execution_status` may be in `{in_progress, complete, failed}` only when that cycle's `preflight.final_status` is exactly `'clear'`. Any other preflight status with one of those execution statuses is a malformed cycle (execution was recorded before preflight cleared).
+
+3. **Exit gate requires zero blocking findings.** When a cycle's `exit_condition_met == true`, its `blocking_count` must be `0`. A non-zero `blocking_count` with `exit_condition_met == true` is a malformed cycle (the exit gate was marked satisfied while blocking findings remained).
+
+## Human-Interaction Scope and Backward Compatibility
+
+These invariants apply only when the checkpoint contains a top-level `human_interaction` block. A checkpoint with no `human_interaction` key (the existing checkpoint shape) is unaffected: it validates exactly as before and produces no new errors. The invariants are additive and support the autonomous-execution mandate documented in `.agents/skills/orchestrate/SKILL.md`.
+
+## Invariants (human_interaction block)
+
+1. **Required `requirements` list.** When `human_interaction` is present, it must be an object containing a `requirements` list. A non-object `human_interaction`, or a `requirements` value that is not a list, is a malformed block.
+
+2. **Per-requirement `response` enum membership.** Each requirement must be an object whose `response` value is one of `scope_change`, `exception`, or `halt`. A requirement that is not an object, or whose `response` is outside this enum, is a malformed requirement.
+
+3. **Exception requires `runbook_path`.** A requirement whose `response == "exception"` must carry a non-empty `runbook_path` string. A missing, non-string, or empty/whitespace-only `runbook_path` on an `exception` requirement is a malformed requirement.
+
+## Enforcement
+
+- `scripts/dev_tools/validate_orchestrator_state.py` appends one error per violated invariant when a `remediation_loop` is present, using the existing validator message style (literal, checkpoint-context prefixed). The validator returns a list of error strings and does not mutate its input.
+- `scripts/dev_tools/validate_orchestrator_state.py` likewise appends one error per violated `human_interaction` invariant when a `human_interaction` key is present, using the same literal, checkpoint-context-prefixed message style. The check does not import or read any schema file.
+- The validator is consumed by the MCP tool `validate_orchestration_artifacts`; backward compatibility for existing step-based checkpoints is preserved.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrator-workflow/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrator-workflow/SKILL.md
@@ -30,11 +30,22 @@ Use as needed:
 - Required delegated specialists:
   - `atomic-planner`
   - `atomic-executor`
+  - `feature-review`
   - `feature-reviewer`
+  - `task-researcher`
+  - `prd-feature`
+  - `staged-review`
+  - `epic-review`
+  - `status-updater`
+  - `python-typed-engineer`
+  - `powershell-typed-engineer`
+  - `csharp-typed-engineer`
+  - `typescript-engineer`
   - `commit-steward`
 - Deterministic availability rule:
-  - if the host exposes `spawn_agent`, treat all four required delegated specialists as available,
+  - if the host exposes `spawn_agent` and the required `.codex/agents/<name>.toml` file exists, treat that delegated specialist as available,
   - do not infer unavailability from missing nicknames, missing prior agent instances, or lack of a dedicated launcher alias.
+- Every required delegated specialist must exist as a native Codex agent under `.codex/agents/`. If a required agent file is missing, set `blocked_reason` to `spawn_agent_unavailable` and stop.
 - Required delegated steps MUST delegate or stop execution.
 - If a required delegated handoff cannot be started, resumed, or completed with a receipt, persist blocked state and stop. Do not perform that step directly.
 - Direct local execution is allowed only for workflow steps that are not designated below as required delegated handoffs.
@@ -43,6 +54,9 @@ Use as needed:
 
 Canonical checkpoint path:
 - `artifacts/orchestration/orchestrator-state.json`
+
+Canonical route matrix:
+- `config/orchestration-routing.json`
 
 Persist and reuse these fields exactly:
 - `objective`
@@ -73,6 +87,15 @@ Persist and reuse these fields exactly:
 - `step10_status`
 - `delegation_receipts`
 - `blocked_reason`
+- `route_id`
+- `required_agents`
+- `required_skills`
+- `required_mcp_tools`
+- `skill_receipts`
+- `mcp_call_receipts`
+- `local_execution_overrides`
+- `delegation_bypasses`
+- `lifecycle_operations`
 
 For small-path runs, also persist:
 - `bootstrap_mode`
@@ -114,6 +137,32 @@ Delegation receipt schema:
   - `completed_at`
   - `result_signal`
   - `artifact_paths`
+
+Skill receipt schema:
+- `skill_receipts` MUST be a list of objects with:
+  - `skill`
+  - `required`
+  - `acknowledged_at_phase`
+  - `evidence`
+
+MCP receipt schema:
+- `mcp_call_receipts` MUST be a list of objects with:
+  - `tool`
+  - `ok`
+  - `evidence`
+
+Completion-state invariants:
+- `route_id` MUST identify an entry in `config/orchestration-routing.json`.
+- `required_agents`, `required_skills`, and `required_mcp_tools` MUST exactly
+  match the selected route matrix entry.
+- every required agent MUST have a matching `delegation_receipts[].agent_name`.
+- every required skill MUST have a matching required `skill_receipts[].skill`
+  with non-empty evidence.
+- every required MCP tool MUST have a successful `mcp_call_receipts[].tool`
+  receipt with non-empty evidence.
+- `local_execution_overrides` and `delegation_bypasses` MUST be empty lists at
+  completion.
+- every recorded `lifecycle_operations[]` item MUST use `surface: "mcp"`.
 
 Required-delegation step map:
 - small path:
@@ -170,6 +219,9 @@ If an exact signal or required path field is missing, set the relevant step to `
 4. If the scope is primarily PowerShell, use `powershell-change-budget-router`.
 5. If the scope is mixed-language, ambiguous, or unsupported by an existing change-budget router, fail closed to the large path.
 6. Treat any request outside the applicable small-path budget as large path.
+7. Select `route_id` from `config/orchestration-routing.json` and persist the
+   exact required agent, skill, and MCP lists from the matrix before starting
+   lifecycle automation.
 
 ## Small Path
 
@@ -288,6 +340,9 @@ Do not claim mission completion until all of the following are true:
 
 - the selected path completed end to end
 - all required delegations completed with receipts
+- all required skills have `skill_receipts` with evidence
+- all required MCP tools have successful `mcp_call_receipts`
+- no local execution override or delegation bypass is recorded
 - the checkpoint is updated with the final state
 - the canonical checkpoint path was used without sidecar replacement or backup substitution
 - `${relativeFile}` is a real promoted-input path and `${issue-num}` is numeric when lifecycle setup was required
@@ -300,6 +355,8 @@ Do not claim mission completion until all of the following are true:
 - any required remediation artifacts exist on disk and the latest re-review is clean
 - any required remediation loop run also includes a remediation execution receipt, a remediation commit receipt, and a final `REVIEW_STATUS: PASS`
 - validator-backed checks for the approved plan, policy audit, code review, feature audit, and checkpoint state pass
+- the canonical checkpoint passes `validate_orchestration_artifacts` with `artifact_type: "orchestrator-state"` and `require_complete: true`
+- required GitHub checks pass for the current PR head SHA before PR/DONE completion
 
 ## Hard Constraints
 
@@ -315,4 +372,5 @@ Do not claim mission completion until all of the following are true:
 - Do not create replacement audit artifacts yourself for any required delegated review step.
 - Do not execute required delegated steps locally as a fallback.
 - Do not accept stale PR-context artifacts, unsupported checklist checkoffs, or missing required evidence as PASS outcomes.
+- Do not treat Codex lifecycle hooks as the hard completion boundary; use deterministic validator and CI gates for completion enforcement.
 - Do not claim completion without reporting the checkpoint path and the created or updated artifact paths.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/policy-audit-template-usage/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/policy-audit-template-usage/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: policy-audit-template-usage
 description: 'Policy audit template usage and output requirements. Use when creating policy-audit.<timestamp>.md artifacts from the repo templates.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/policy-compliance-order/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/policy-compliance-order/SKILL.md
@@ -1,13 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite GitHub Copilot instruction-directory references to the native skill root.
-- Rewrite Claude rule paths to shared skill paths.
-- Rewrite Claude rules-directory references to the native skill root.
-
 ---
 name: policy-compliance-order
 description: 'Repository policy compliance order and hard constraints. Use when an agent must read mandatory policy files, apply repo-wide constraints, or restate policy precedence without duplicating blocks across agents.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell-change-budget-router/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell-change-budget-router/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: powershell-change-budget-router
 description: Budget-first routing contract for PowerShell work: estimate production-file scope, choose small vs large path, enforce direct-mode escalation to orchestrator, and use the VS Code extension command surface for promotion lifecycle steps when available.
@@ -29,7 +24,7 @@ Use this skill when:
 ## Orchestrated Small-Path Requirements
 
 When routed through `powershell-orchestrator`, small path still requires lifecycle scaffolding before implementation:
-- invoke promotion/folder lifecycle steps through `vscode/runCommand` + extension access per `feature-promotion-lifecycle` when available; use script/CLI fallback only when direct extension command execution is unavailable,
+- invoke promotion/folder lifecycle steps through the `drm-copilot` MCP tools required by `repo-automation-adapter`. If the MCP server or required tool is unavailable, stop before promotion,
 - promote potential item to GitHub issue with `--work-mode minor-audit`,
 - create active feature folder with `--work-mode minor-audit`,
 - delegate minimal-audit plan creation to `atomic_planner` with `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`,

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell-orchestration-state-machine/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell-orchestration-state-machine/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: powershell-orchestration-state-machine
 description: Checkpoint schema and resume protocol for long-running PowerShell orchestration workflows.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell-qa-gate/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell-qa-gate/SKILL.md
@@ -1,9 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite Claude skill paths to shared skill paths.
-- Rewrite Claude rule paths to shared skill paths.
-
 ---
 name: powershell-qa-gate
 description: Final QA gate for PowerShell changes. Executes the full PoshQC format -> analyze -> test toolchain (with coverage where enforced), compares against a captured baseline, enforces zero-regression deltas, and produces the required reporting block before the agent declares the change complete.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/powershell/SKILL.md
@@ -1,9 +1,5 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
+name: powershell
 paths:
   - "**/*.ps1"
   - "**/*.psm1"

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/pr-author/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/pr-author/SKILL.md
@@ -1,14 +1,6 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: pr-author
 description: Write a GitHub-ready pull request body from the canonical PR-context bundle with strict verification and auto-close rules.
-allowed-tools:
-  - Read
-  - "Bash(git log *)"
 ---
 
 # PR Author Skill
@@ -52,4 +44,4 @@ Use these sections in this order:
 - Only mention an issue/PR number if it appears verbatim in the provided context.
 - Do not treat PR numbers as issues.
 - Auto-close bullets must use exactly `- Closes #NNN` format, sourced only from "Issues to autoclose" or "Author-asserted autoclose issues."
-- If GitHub validation is unavailable/unverified, do not emit `Closes`; use the fallback `None` bullet.
+- If GitHub validation is unavailable or unverified, do not emit `Closes`; use the `None` bullet.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/pr-base-branch-merge-base/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/pr-base-branch-merge-base/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: pr-base-branch-merge-base
 description: 'Resolve PRBaseBranch for mcp__drm-copilot__collect_pr_context using merge-base ancestry. Use when orchestrators or review workflows need the correct comparison base branch and must select the branch with the most recent common ancestor commit with HEAD.'
@@ -42,7 +37,7 @@ Definition of correct base:
 ## Guardrails
 
 - Do not default to `main` unless merge-base resolution fails for all candidates.
-- If all candidates fail, surface explicit error context and use repository default branch only as last-resort fallback.
+- If all candidates fail, surface explicit error context and stop unless repository metadata directly identifies the default branch.
 - Persist chosen `PRBaseBranch` in orchestration state and reuse it within the same run.
 
 ## Collector Invocation Rule

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/pr-context-artifacts/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/pr-context-artifacts/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: pr-context-artifacts
 description: 'PR context artifact locations and refresh rules. Use when generating, reading, or inlining pr_context summary/appendix artifacts.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python-change-budget-router/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python-change-budget-router/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: python-change-budget-router
 description: Budget-first routing and batch-scope contract for Python work. Estimate production-file scope, choose small vs large path, enforce the 3 production + 3 test per-batch cap, and halt the agent for scope expansion approval when the estimate exceeds the budget.
@@ -64,7 +59,7 @@ If `python-typed-engineer` is invoked directly and estimated scope is `>3` produ
 
 When routed through the orchestrator, the small path still requires lifecycle scaffolding before implementation:
 
-- invoke promotion and folder lifecycle steps through `vscode/runCommand` and extension access per `feature-promotion-lifecycle` when available. Use script or CLI fallback only when direct extension command execution is unavailable.
+- invoke promotion and folder lifecycle steps through the `drm-copilot` MCP tools required by `repo-automation-adapter`. If the MCP server or required tool is unavailable, stop before promotion.
 - promote the potential item to a GitHub issue with `--work-mode minor-audit`,
 - create the active feature folder with `--work-mode minor-audit`,
 - delegate minimal-audit plan creation to `atomic_planner` with `DIRECTIVE: MINIMAL-AUDIT PLAN REQUIRED`,

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python-qa-gate/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python-qa-gate/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite Claude skill paths to shared skill paths.
-
 ---
 name: python-qa-gate
 description: Final QA gate for Python changes. Executes the full Black -> Ruff -> Pyright -> Pytest toolchain, compares against a captured baseline, enforces zero-regression deltas, and produces the required reporting block before the agent declares the change complete.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python-suppressions/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python-suppressions/SKILL.md
@@ -1,12 +1,8 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
+name: python-suppressions
 paths:
   - "**/*.py"
-description: Pre-authorized Python Ruff and Pyright suppression patterns. Applies to Python files.
+description: Python suppression policy for linting and type-checking exceptions.
 ---
 
 # Python Suppression Policy

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/python/SKILL.md
@@ -1,9 +1,5 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
+name: python
 paths:
   - "**/*.py"
 description: Python-specific toolchain and coding standards.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/quality-tiers/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/quality-tiers/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: quality-tiers
+description: Module rigor tier system and uniform coverage thresholds.
+paths:
+  - "**"
+description: Module rigor tier system and uniform coverage thresholds.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `quality-tiers`.
+
+# Module Rigor Tiers
+
+This rule defines the T1–T4 module rigor tier system used by all CI gates in this repository. The tier system source of truth is `docs/ci.research.md` section 1; the file `quality-tiers.yml` at the repository root maps every project to a tier. Adding a project without a tier classification fails CI.
+
+## Tiers
+
+- **T1 — Critical.** Behavior bugs cause silent data loss, model drift, or security holes. Examples (No-COM architecture): classifier engines (SpamBayes, Triage), ToDo ID allocator and hierarchy operations, Graph extended-properties adapter, auth/token handling, host-agnostic command bus.
+- **T2 — Core.** Bugs cause feature regressions but not data loss. Examples: `TaskMaster.Domain`, `TaskMaster.Application`, mail-item DTOs, settings store abstraction, schema definitions.
+- **T3 — Adapters & UI.** Glue around APIs the team does not own. Examples: Outlook task pane UI, Office.js wrappers, Microsoft Graph SDK wrappers, persistence I/O.
+- **T4 — Scaffolding.** Examples: DI wiring, bootstrap, build scripts, dev tooling, generated code, manifests.
+
+## Source of Truth
+
+- `quality-tiers.yml` at repo root maps every project to one tier.
+- The CI pipeline's `tier-classification` stage validates that every project entry has a tier and that no unclassified project exists. Adding a project without a tier classification fails CI.
+
+## Uniform-vs-Tier-Dependent Gate Matrix
+
+Per Authoritative Decision #2, line and branch coverage thresholds are uniform across all tiers. Other gates remain tier-dependent.
+
+### Uniform across all tiers (T1–T4)
+
+- Format check: 100% pass.
+- Lint errors: 0.
+- Type errors: 0.
+- Architecture violations: 0.
+- Line coverage: >= 85%.
+- Branch coverage: >= 75%.
+- No regression on changed lines.
+
+### Tier-dependent
+
+| Gate | T1 | T2 | T3 | T4 |
+|---|---|---|---|---|
+| Untyped escape hatches (`any`/`dynamic`) | 0 | 0 | <= 5 per file, justified | unlimited |
+| Property test density | >= 1 per pure function | >= 1 per pure function | none | none |
+| Mutation score | >= 75% | trend-only | none | none |
+| Contract breaking changes | major bump required | major bump required | n/a | n/a |
+| Determinism (retry rate) | < 0.5% | < 1% | < 2% | n/a |
+| Golden tests | required for classifier-output modules | optional | none | none |
+| Full E2E suite scope | all critical paths | core paths | adapter smoke | none |
+
+## Rationale (uniform coverage thresholds)
+
+High test coverage is a fundamental quality-control design choice that enables autonomous agentic development and trust in the work product. For that reason, line coverage >= 85% and branch coverage >= 75% apply uniformly across T1–T4; tier-specific lower coverage floors are not used in this repository.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/remediation-handoff-atomic-planner/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/remediation-handoff-atomic-planner/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: remediation-handoff-atomic-planner
 description: 'Reusable remediation trigger and atomic_planner handoff steps. Use when audits require remediation inputs and a delegated remediation plan.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/repo-automation-adapter/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/repo-automation-adapter/SKILL.md
@@ -109,7 +109,7 @@ Required tools:
 - `potential_to_issue`
 - `new_active_feature_folder`
 
-Execute lifecycle operations as one ordered MCP chain:
+Execute these lifecycle operations as one ordered chain:
 
 1. Create the potential entry.
 2. Promote with `potential_to_issue`.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/repo-automation-adapter/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/repo-automation-adapter/SKILL.md
@@ -1,49 +1,39 @@
 ---
 name: repo-automation-adapter
-description: 'Centralize host-surface and repo-automation differences for Codex. Use when a migrated workflow previously depended on GitHub Copilot or VS Code extension commands and needs a single Codex-compatible execution or fallback rule.'
+description: 'Centralize required drm-copilot MCP execution for Codex repo automation. Use when a workflow needs promotion, PR context, commit context, customization publishing, hard-lock resolution, or orchestration validation.'
 ---
 
 # Repo Automation Adapter
 
-Use this skill to keep host-specific workflow translation in one place.
+Use this skill to keep host-specific workflow execution rules in one place.
+
+## Canonical Rule
+
+The `drm-copilot` MCP server is the only approved execution surface for canonical repository automation covered by this skill.
+
+There is no fallback. If the server is unavailable, the required tool is unavailable, or the MCP call fails, the workflow must stop, persist blocked state when an orchestrator checkpoint is active, and report the missing dependency or failed MCP operation.
+
+Do not replace a required MCP operation with local scripts, git reconstruction, direct filesystem synthesis, VS Code command IDs, or best-effort behavior.
 
 ## When to Use This Skill
 
 Use this skill when:
-- a migrated skill previously depended on `drmCopilotExtension.*` commands,
-- a workflow needs PR-context collection, issue promotion, or feature-folder creation,
-- the same fallback behavior would otherwise be repeated across multiple skills.
 
-## Canonical Rule
-
-Do not encode host-specific execution details in multiple workflow skills. Put them here and have the calling skills reference this skill.
+- a migrated workflow previously depended on `drmCopilotExtension.*` commands,
+- a workflow needs PR-context collection, issue promotion, feature-folder creation, commit-context collection, customization publishing, hard-lock prompt resolution, or orchestration-artifact validation,
+- multiple skills need the same MCP-required execution rule.
 
 ## Published Codex Automation Surface
 
-The canonical Codex automation dependency for this repo is the published MCP server:
+The required Codex automation dependency for this repo is the published MCP server:
+
 - `drm-copilot`
 
-Downstream Codex skills should depend on the MCP server name `drm-copilot`, not on raw VS Code command IDs.
-
-Declare that dependency once on this skill via `agents/openai.yaml`.
-
-## Codex Capability Model
-
-Codex in this repo can reliably use:
-- repository files,
-- shell commands,
-- git,
-- local scripts that already exist in the repository,
-- configured MCP tools when available.
-
-Codex in this repo should not assume direct access to:
-- `vscode/runCommand`,
-- `drmCopilotExtension.*` command execution,
-- GitHub issue or PR mutation unless an explicit connector or script is available.
+Downstream Codex skills must depend on the MCP server name `drm-copilot`, not on raw VS Code command IDs.
 
 ## Published MCP Tool Surface
 
-Prefer these semantic MCP tools when the server is configured:
+Use these semantic MCP tools when the corresponding operation is required:
 
 - `collect_commit_context`
 - `collect_pr_context`
@@ -54,8 +44,14 @@ Prefer these semantic MCP tools when the server is configured:
 - `potential_to_issue`
 - `new_active_feature_folder`
 - `resolve_execute_hard_lock_prompt`
+- `resolve_atomic_plan_prompt`
+- `validate_orchestration_artifacts`
+- `run_poshqc_format`
+- `run_poshqc_analyze`
+- `run_poshqc_analyze_autofix`
+- `run_poshqc_test`
 
-Legacy VS Code command IDs remain historical source material only:
+Legacy VS Code command IDs are historical source material only and must not be invoked:
 
 - `drmCopilotExtension.collectCommitContext`
 - `drmCopilotExtension.collectPrContext`
@@ -69,74 +65,97 @@ Legacy VS Code command IDs remain historical source material only:
 
 ## Adapter Preconditions
 
-Before treating the MCP path as available, assume these prerequisites:
+Before starting any workflow that depends on this skill, the orchestrator must assume these prerequisites are mandatory:
 
-- the Codex client is configured with MCP server name `drm-copilot`
-- the published extension or bridge is installed and built
-- an open workspace folder exists for workspace-targeted operations
-- `python` is on `PATH`
-- `pwsh` is preferred, with Windows PowerShell fallback when applicable
+- the Codex project is trusted so project `.codex/config.toml` loads,
+- the Codex client is configured with MCP server name `drm-copilot`,
+- the `drm-copilot` MCP server is active,
+- the required MCP tool is exposed by the active server,
+- an open workspace folder exists for workspace-targeted operations.
+
+If any prerequisite is missing, stop before mutating workflow state.
 
 ## Execution Order
 
 For any host-specific workflow step:
 
-1. Prefer the published `drm-copilot` MCP tool when it covers the requested operation.
-2. If the MCP server is unavailable, determine whether a deterministic git or filesystem fallback is sufficient.
-3. If a deterministic fallback is sufficient, use it and record that the result is a fallback artifact rather than a canonical tool-produced artifact.
-4. If no MCP path or safe fallback exists, stop and report the missing automation dependency instead of inventing behavior.
+1. Identify the required `drm-copilot` MCP tool.
+2. Call that MCP tool.
+3. Validate the MCP response according to the calling workflow's contract.
+4. If the tool is unavailable, the call fails, or the response does not satisfy the contract, stop and record blocked state. Do not execute a replacement path.
 
 ## Current Adapter Guidance
 
 ### PR context collection
 
-- Preferred: call tool `collect_pr_context` on MCP server `drm-copilot`.
+- Required tool: `collect_pr_context`.
 - When the caller already resolved a base branch, pass that base explicitly.
-- Current fallback: use deterministic git commands to reconstruct equivalent context when review workflows only need base/head, merge-base, commits, and changed files.
-- When using fallback, record the provenance in the generated review artifact.
 - For orchestrator remediation loops, PR-context refresh is mandatory after each remediation commit and before each re-review.
-- When the caller explicitly requires MCP tooling for PR-context refresh, do not silently downgrade to fallback; stop and report the dependency gap instead.
+- If the tool is unavailable or fails, stop. Do not reconstruct PR context from local git commands.
 
 ### Commit context collection
 
-- Preferred: call tool `collect_commit_context` on MCP server `drm-copilot`.
-- If the MCP server is unavailable and the workflow only needs staged-diff summary, use non-destructive git inspection as fallback and record that provenance.
+- Required tool: `collect_commit_context`.
 - For orchestrator remediation loops, collect commit context only after `git add -A` and only when staged changes exist.
-- For orchestrator remediation loops, do not continue to commit-message generation without an on-disk commit-context artifact path produced by the selected adapter path.
-- When the caller explicitly requires MCP tooling for commit-context collection, do not silently downgrade to fallback; stop and report the dependency gap instead.
+- Do not continue to commit-message generation without an on-disk commit-context artifact path produced by the MCP tool.
+- If the tool is unavailable or fails, stop. Do not replace it with staged-diff inspection.
 
 ### Feature promotion and active feature folder creation
 
-- Preferred MCP tools:
-  - `new_potential_entry`
-  - `new_potential_bug_entry`
-  - `potential_to_issue`
-  - `new_active_feature_folder`
-- Current rule: use the MCP tools as the canonical path.
-- Execute these lifecycle operations as one ordered chain:
-  - create potential entry
-  - promote with `potential_to_issue`
-  - capture numeric issue number from promotion output
-  - create or check out `${promotion-type}/${short-name}-${issue-num}`
-  - create active feature folder with `new_active_feature_folder`
-- `new_active_feature_folder` is not an allowed bootstrap substitute for missing promotion state.
-- If `${issue-num}` is missing, non-numeric, or placeholder text, stop instead of continuing.
-- If the MCP server is unavailable, surface a precise dependency gap unless the caller explicitly requests a best-effort local-only fallback.
-- Do not synthesize GitHub issue state, active-folder scaffolding, or placeholder lifecycle variables unless the user explicitly requests a best-effort local-only fallback.
-- When a local-only fallback is explicitly approved, preserve the same ordered lifecycle and verification gates; do not skip directly to folder creation.
+Required tools:
+
+- `new_potential_entry`
+- `new_potential_bug_entry`
+- `potential_to_issue`
+- `new_active_feature_folder`
+
+Execute lifecycle operations as one ordered MCP chain:
+
+1. Create the potential entry.
+2. Promote with `potential_to_issue`.
+3. Capture numeric issue number from promotion output.
+4. Create or check out `${promotion-type}/${short-name}-${issue-num}`.
+5. Create the active feature folder with `new_active_feature_folder`.
+
+`new_active_feature_folder` is not an allowed bootstrap substitute for missing promotion state. If `${issue-num}` is missing, non-numeric, or placeholder text, stop. Do not synthesize GitHub issue state, active-folder scaffolding, or placeholder lifecycle variables.
 
 ### Customization publishing and hard-lock resolution
 
-- Preferred MCP tools:
-  - `push_down_copilot_customizations`
-  - `push_down_codex_and_agents_customizations`
-  - `resolve_execute_hard_lock_prompt`
-- If the MCP server is unavailable, stop unless the caller explicitly provides an approved alternate path.
+Required tools:
+
+- `push_down_copilot_customizations`
+- `push_down_codex_and_agents_customizations`
+- `resolve_execute_hard_lock_prompt`
+- `resolve_atomic_plan_prompt`
+
+If the required tool is unavailable or fails, stop.
+
+### Orchestration artifact validation
+
+Required tool:
+
+- `validate_orchestration_artifacts`
+
+Use this tool for canonical validation of plans, policy audits, code reviews, feature audits, and orchestrator state. For orchestrator completion, call it with `artifact_type: "orchestrator-state"` and `require_complete: true`.
+
+If the tool is unavailable or fails, stop. Do not substitute direct CLI validation for canonical orchestrator completion.
+
+### PowerShell quality gates
+
+Required tools:
+
+- `run_poshqc_format`
+- `run_poshqc_analyze`
+- `run_poshqc_analyze_autofix`
+- `run_poshqc_test`
+
+When a workflow requires PoshQC execution through MCP, use only these tools. If the required tool is unavailable or fails, stop.
 
 ## Output Requirements
 
-When this skill is used, the calling workflow should report:
-- which operation required host adaptation,
-- which direct adapter or fallback path was selected,
-- whether the result is canonical or fallback-only,
-- what dependency is missing when the step is blocked.
+When this skill is used, the calling workflow must report:
+
+- which MCP operation was required,
+- which `drm-copilot` tool was called,
+- whether the MCP response satisfied the calling contract,
+- the blocked-state reason when the MCP dependency is unavailable or fails.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md
@@ -1,16 +1,6 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: research-issue
 description: Investigate the best implementation approach for a feature or bug by analyzing the codebase and external references, then writing structured findings to artifacts/research/.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - WebFetch
 ---
 
 # Research Issue Skill

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/review-epic/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/review-epic/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: review-epic
 description: Invoke the epic-review worker to produce epic-audit artifacts for an epic folder.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/review-feature/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/review-feature/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: review-feature
 description: Invoke the feature-review worker to produce feature-audit artifacts for an active feature folder.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/review-staged/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/review-staged/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: review-staged
 description: Invoke the staged-review worker to produce staged-review artifacts from the staged diff.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/self-explanatory-code-commenting/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/self-explanatory-code-commenting/SKILL.md
@@ -1,12 +1,8 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
+name: self-explanatory-code-commenting
 paths:
   - "**/*.py"
-description: Intent-first docstring and commenting standards. Applies to Python files.
+description: Intent-first docstring and commenting standards.
 ---
 
 # Code Commenting and Docstring Policy

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/skill-canonical-location-audit/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/skill-canonical-location-audit/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite Claude skill-directory references to the native skill root.
-
 ---
 name: skill-canonical-location-audit
 description: 'Audit skills for canonical-location duplication. Use when ensuring a canonical location for a given item is defined in exactly one skill and duplicates are flagged.'

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/tonality/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/tonality/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: tonality
+description: Required communication tone policy for all files and responses.
+paths:
+  - "**"
+description: Required communication tone policy. Applies to all files and responses.
+---
+
+# Converted rule
+
+Source: legacy Claude rule `tonality`.
+
+# Tonality Policy
+
+This rule file summarizes the required tone policy for all agent-authored content in this repository.
+
+## Required Professional Tone
+
+All written output must use a professional tone. Professional tone means:
+
+- Clear, direct, and factual language.
+- Neutral businesslike phrasing.
+- Measured statements that match the available evidence.
+- Concise explanations that prioritize clarity over personality.
+- Respectful wording, even when reporting defects, regressions, or disagreements.
+
+Preferred characteristics: specific rather than vague; literal rather than theatrical; calm rather than excited; precise rather than promotional.
+
+## Humor and Joking — Prohibited
+
+Do not use jokes, banter, playful remarks, sarcasm, puns, or comedic phrasing.
+
+This prohibition includes:
+- Lighthearted commentary intended to entertain.
+- Winking or self-aware jokes about tools, code, bugs, or the development process.
+- Casual filler that weakens a formal or operational message.
+- Mocking, teasing, or exaggerated "fun" framing, even when mild.
+
+When deciding between a playful sentence and a plain sentence, use the plain sentence.
+
+## Hyperbole — Prohibited
+
+Do not use hyperbolic, inflated, or sensational language. Avoid:
+
+- Claims that something is perfect, flawless, amazing, incredible, revolutionary, or world-class (unless directly quoting an authoritative source and clearly marking it as a quotation).
+- Overstated certainty that goes beyond the verified evidence.
+- Dramatic framing that overstates urgency, difficulty, simplicity, risk, or impact.
+
+Use measured alternatives: replace absolute praise with evidence-based descriptions; replace dramatic warnings with specific risks and consequences; replace sweeping claims with concrete observations.
+
+## Metaphors — Tightly Restricted
+
+Metaphor, analogy, and figurative language are not the default style. They may be used only when ALL of the following are true:
+
+1. The metaphor is strictly utilitarian.
+2. It is required to explain a technical concept that would otherwise be less clear.
+3. It improves accuracy or comprehension for the intended audience.
+4. It is brief, literal in effect, and not decorative.
+
+If a concept can be explained clearly without metaphor, do not use metaphor.
+
+## Evidence-First Wording
+
+Match the strength of the wording to the strength of the evidence:
+
+- If something was verified, say it was verified and state how.
+- If something is likely but unconfirmed, say that it is likely or appears to be the case.
+- If something is unknown, say that it is unknown.
+- Do not imply certainty, completion, safety, or correctness without support.
+
+## Difficult Messages
+
+When reporting failures, defects, or policy violations:
+- State the issue directly.
+- Describe the impact without dramatizing it.
+- Identify the next corrective action when available.
+- Avoid blame-oriented or emotionally charged wording.
+
+When giving recommendations:
+- Prefer imperative, concrete language.
+- Explain the rationale briefly when it is not obvious.
+- Avoid motivational language, sales language, or celebratory phrasing.
+
+## Final Rule
+
+When tone is uncertain, choose the more restrained phrasing. The repository default is professionalism, clarity, and accuracy — not entertainment, flourish, or hype.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-copilot-to-claude/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-copilot-to-claude/SKILL.md
@@ -1,25 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite GitHub Copilot standing guidance paths to AGENTS.md.
-- Rewrite GitHub Copilot path-scoped instructions to shared skill paths.
-- Rewrite GitHub Copilot agent manifest paths to Codex agent paths.
-- Rewrite GitHub Copilot instruction-directory references to the native skill root.
-- Rewrite GitHub Copilot skill-directory references to the native skill root.
-- Rewrite GitHub Copilot agent-directory references to the native agent root.
-- Rewrite Claude skill paths to shared skill paths.
-- Rewrite Claude agent manifest paths to Codex agent paths.
-- Rewrite Claude hook paths to Codex hook paths.
-- Rewrite Claude settings paths to Codex config paths.
-- Rewrite Claude rule paths to shared skill paths.
-- Rewrite Claude rules-directory references to the native skill root.
-- Rewrite Claude skill-directory references to the native skill root.
-- Rewrite Claude agent-directory references to the native agent root.
-- Rewrite Claude hook-directory references to the native hook root.
-- Rewrite GitHub prompt-directory references to the native shared skill root when repository prompt launchers are disabled.
-
 ---
 name: translate-copilot-to-claude
 description: Translate one or more GitHub Copilot native files (AGENTS.md, .agents/skills/*.instructions.md, .codex/agents/*.agent.md, .agents/skills/*.prompt.md, .agents/skills/<name>/SKILL.md) into the native Claude runtime. Classify each section into agent/rule/skill/hook surfaces, diff against existing .claude/ state, produce a translation plan for user approval, and then apply the plan.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/typescript-suppressions/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/typescript-suppressions/SKILL.md
@@ -1,12 +1,8 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
+name: typescript-suppressions
 paths:
   - "**/*.ts"
-description: Pre-authorized ESLint and TypeScript suppression patterns. Applies to TypeScript files.
+description: TypeScript suppression policy for linting and type-checking exceptions.
 ---
 
 # TypeScript Suppression Policy

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/typescript/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/typescript/SKILL.md
@@ -1,9 +1,5 @@
-# Converted skill
-
-Applied rewrites:
-- Rewrite Claude skill-directory references to the native skill root.
-
 ---
+name: typescript
 paths:
   - "**/*.ts"
 description: TypeScript-specific toolchain and coding standards.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/update-status/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/update-status/SKILL.md
@@ -1,8 +1,3 @@
-# Converted skill
-
-Applied rewrites:
-- None
-
 ---
 name: update-status
 description: Invoke the status-updater worker to reconcile status artifacts and synchronized status outputs.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
@@ -1,48 +1,14 @@
 name = "orchestrator"
-description = "Converted subagent"
+description = "Deterministic repository orchestrator that estimates change budget, selects a workflow path, delegates to specialist subagents, persists checkpoint state, and enforces completion gates."
+model_reasoning_effort = "high"
+default_permissions = "orchestrator-workspace"
 developer_instructions = '''
-Applied rewrites:
-- Rewrite merged standing-guidance source paths to the native AGENTS.md target.
-- Rewrite Claude rules-directory references to the native skill root.
-
-Use the following repo-local skills as the canonical workflow source:
-- orchestrator-workflow
-- feature-promotion-lifecycle
-- atomic-plan-contract
-- acceptance-criteria-tracking
-- evidence-and-timestamp-conventions
-
----
-name: orchestrator
-description: Deterministic repository orchestrator that estimates change budget, selects small or large workflow path, delegates to specialist subagents, persists checkpoint state, and enforces completion gates proactively.
-tools:
-  - "Agent(atomic-planner,atomic-executor,feature-review,task-researcher,prd-feature,staged-review,epic-review,status-updater,python-typed-engineer,powershell-typed-engineer,csharp-typed-engineer,typescript-engineer)"
-  - Read
-  - Grep
-  - Glob
-  - "Bash(git *)"
-  - "Bash(poetry run *)"
-  - "Bash(npx *)"
-  - "Bash(pwsh *)"
-  - "mcp__drm-copilot__.*"
-skills:
-  - policy-compliance-order
-  - feature-promotion-lifecycle
-  - atomic-plan-contract
-  - acceptance-criteria-tracking
-  - evidence-and-timestamp-conventions
-memory: project
-hooks:
-  Stop:
-    - matcher: ""
-      body: "Block termination unless artifacts/orchestration/orchestrator-state.json has been updated with current completed_steps and next_step, and all required artifact paths for the selected workflow path have been confirmed on disk."
----
-
 # Orchestrator Agent
 
-You are an orchestration-only agent. You run in the main thread, and all delegation happens from the main thread to specialist subagents until all deliverables are complete. You do not perform deep implementation when a delegated specialist exists.
+You are an orchestration-only agent. You run in the main thread, and all required delegation happens from the main thread to specialist subagents until all deliverables are complete. Do not perform deep implementation when a delegated specialist exists.
 
-Use the following repo-local skills as the canonical workflow source:
+Use these repo-local skills as the canonical workflow source:
+- orchestrate
 - orchestrator-workflow
 - feature-promotion-lifecycle
 - repo-automation-adapter
@@ -57,28 +23,42 @@ Use the following repo-local skills as the canonical workflow source:
 On every invocation:
 
 1. Read `AGENTS.md` for repository tone policy and architecture context.
-2. Read applicable `.agents/skills/` files for languages in scope.
+2. Read applicable `.agents/skills/` files for the languages and workflow surfaces in scope.
 3. Read `artifacts/orchestration/orchestrator-state.json` to check for existing checkpoint state.
-4. If a valid checkpoint exists with a matching objective, resume from the recorded `next_step`.
-5. If no checkpoint exists or the objective is new, begin from change-budget estimation.
+4. Read `config/orchestration-routing.json`.
+5. If a valid checkpoint exists with a matching objective, resume from the recorded `next_step`.
+6. If no checkpoint exists or the objective is new, begin from change-budget estimation.
 
 ## Change Budget Routing
 
 The first action is always to estimate the change budget by identifying likely affected production files and tests:
 
-- **Small path** (1–3 production files + corresponding tests): promotion, active folder, minimal plan, implementation, QC, small-audit review.
-- **Large path** (4+ production files or cross-cutting changes): scope, promotion, research, spec, atomic planning, atomic execution, feature review.
+- Small path: 1-3 production files plus corresponding tests.
+- Large path: 4 or more production files, cross-cutting changes, mixed-language changes, or any request the applicable router cannot clear for the small path.
+
+After selecting the path, persist `route_id`, `required_agents`, `required_skills`, and `required_mcp_tools` from `config/orchestration-routing.json`. These lists are validator-enforced. Do not hand-author a different list.
 
 ## Delegation Model
 
-Delegate exclusively through configured subagents:
+Delegate exclusively through configured subagents for required specialist steps:
 
-- `atomic-planner` — generates phased implementation plans (planning only)
-- `atomic-executor` — executes approved plans task-by-task (execution only)
-- `feature-review` — produces policy, code, and feature audit artifacts
-- `task-researcher` — performs deep research and writes findings to `artifacts/research/`
+- `atomic-planner`: planning only.
+- `atomic-executor`: preflight validation and execution only.
+- `feature-review`: policy, code, and feature audit artifacts.
+- `task-researcher`: research artifacts under `artifacts/research/`.
+- `prd-feature`: issue, specification, and user-story authoring when full feature or bug workflow requires it.
+- `staged-review`: staged-diff review when the workflow requires pre-commit inspection.
+- `epic-review`: epic-level review when the promoted work item is an epic.
+- `status-updater`: status and issue-update artifact production when the workflow requires status synchronization.
+- `python-typed-engineer`: Python implementation specialist.
+- `powershell-typed-engineer`: PowerShell implementation specialist.
+- `csharp-typed-engineer`: C# implementation specialist.
+- `typescript-engineer`: TypeScript implementation specialist.
+- `commit-steward`: commit message generation from commit-context artifacts when available.
 
-For required delegated steps, delegation is mandatory. If a handoff cannot be started, resumed, or completed, stop and report blocked state and do not perform the step locally.
+For required delegated steps, delegation is mandatory. If a handoff cannot be started, resumed, or completed with the required result contract, persist blocked state and stop. Do not perform the required delegated step locally.
+
+Every agent named above must exist as a native Codex agent under `.codex/agents/`. If any required delegated agent is missing, treat that as `spawn_agent_unavailable`, persist blocked state, and stop.
 
 ## Mandatory Delegation Gates
 
@@ -87,6 +67,8 @@ For required delegated steps, delegation is mandatory. If a handoff cannot be st
 - For planning steps, do not perform planning locally when delegation is required.
 - For delivery steps, do not perform preflight validation, execution, or post-delivery validation locally when delegation is required.
 - For review steps, do not perform post-implementation review locally when delegation is required.
+- Do not infer unavailability from missing nicknames, missing prior agent instances, or lack of a dedicated launcher alias.
+- Do not substitute local execution for a missing required delegated agent.
 - Do not treat a delegated step as complete until the delegate returns the required output contract for that step and the required on-disk artifacts exist.
 - Do not accept PASS outcomes that rely on stale PR-context artifacts, missing receipts, or missing required evidence-backed QA artifacts.
 - If the canonical checkpoint belongs to an unrelated in-progress mission, stop with `checkpoint_conflict`.
@@ -96,26 +78,71 @@ For required delegated steps, delegation is mandatory. If a handoff cannot be st
 
 ## Checkpoint Persistence
 
-Update `artifacts/orchestration/orchestrator-state.json` after every completed step with:
+Use only this checkpoint path:
 
-- `objective`, `change_budget_estimate`, `path_selected` (small or large)
-- Variables: `promotion-type`, `short-name`, `issue-num`, `feature-folder`
+- `artifacts/orchestration/orchestrator-state.json`
+
+Update it after every completed step with:
+
+- `objective`, `change_budget_estimate`, `path_selected`
+- `route_id`, `required_agents`, `required_skills`, `required_mcp_tools`
+- lifecycle variables including `promotion-type`, `short-name`, `issue-num`, `feature-folder`
 - `completed_steps`, `next_step`, `last_updated`
-- Step statuses: `step5_status` through `step10_status`
+- `step5_status` through `step10_status`
 - `delegation_receipts`, `blocked_reason`
-- Persist raw promotion MCP receipts under:
-  - `delegation_receipts.promotion.potential_entry`
-  - `delegation_receipts.promotion.issue`
-  - `delegation_receipts.promotion.feature_folder`
-- Each `delegation_receipts.promotion.*` field stores the raw MCP receipt payload from the matching promotion operation.
+- `skill_receipts`, `mcp_call_receipts`
+- `local_execution_overrides`, `delegation_bypasses`, `lifecycle_operations`
+- raw promotion MCP receipts under `delegation_receipts.promotion.potential_entry`, `delegation_receipts.promotion.issue`, and `delegation_receipts.promotion.feature_folder`
+
+Each required skill in the selected route must have a `skill_receipts[]` entry with `required = true` and non-empty `evidence`. Each required MCP tool must have an `mcp_call_receipts[]` entry with `ok = true` and non-empty `evidence`. `local_execution_overrides` and `delegation_bypasses` must remain empty at completion. Any lifecycle operation recorded in `lifecycle_operations[]` must use `surface = "mcp"`.
+
+## Native Automation Surface
+
+Use the `drm-copilot` MCP server as the preferred host automation surface. Do not call VS Code command IDs such as `drmCopilotExtension.*` directly.
+
+Required lifecycle and validation automation must use the native MCP tools when available:
+
+- `new_potential_entry`
+- `new_potential_bug_entry`
+- `potential_to_issue`
+- `new_active_feature_folder`
+- `collect_commit_context`
+- `collect_pr_context`
+- `validate_orchestration_artifacts`
+- `resolve_atomic_plan_prompt`
+- `resolve_execute_hard_lock_prompt`
+
+If the MCP server is unavailable for a step that requires it, stop and record the missing dependency instead of inventing equivalent state.
 
 ## Completion Requirements
 
 Do not report completion until:
 
 1. All required steps for the selected workflow path are complete.
-2. All validation gates (toolchain, acceptance criteria, audit artifacts) have passed.
-3. The checkpoint file reflects the completed state.
-4. Acceptance criteria in AC source files have been checked off per the `acceptance-criteria-tracking` skill.
-5. Do not claim mission completion unless all required delegations completed with receipts and the required orchestration artifacts exist on disk.
+2. All required delegations completed with receipts and required on-disk artifacts.
+3. Toolchain, acceptance criteria, audit, and review gates have passed.
+4. Acceptance criteria in AC source files have been checked off per `acceptance-criteria-tracking`.
+5. The checkpoint file reflects the final completed state.
+6. The checkpoint proves the selected routing matrix entry: all required agents have delegation receipts, all required skills have skill receipts, all required MCP tools have successful MCP receipts, and no local bypass list is populated.
+7. The deterministic MCP validator passes: `validate_orchestration_artifacts` with `artifact_type = "orchestrator-state"`, `artifact_path = "artifacts/orchestration/orchestrator-state.json"`, and `require_complete = true`.
+8. Required GitHub checks are green for the current PR head SHA before any PR/DONE transition.
+
+The MCP validator and required CI checks are the hard completion boundary. There is no fallback. If the MCP server or validation tool is unavailable, stop and persist blocked state. Codex lifecycle hooks may provide local feedback, but they are not the authoritative completion gate.
+
+Do not claim mission completion unless all required delegations completed with receipts and the required orchestration artifacts exist on disk.
 '''
+
+[mcp_servers.drm-copilot]
+enabled = true
+
+[skills.config]
+policy-compliance-order = true
+orchestrate = true
+orchestrator-workflow = true
+feature-promotion-lifecycle = true
+repo-automation-adapter = true
+atomic-plan-contract = true
+acceptance-criteria-tracking = true
+evidence-and-timestamp-conventions = true
+pr-context-artifacts = true
+pr-base-branch-merge-base = true

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
@@ -7,7 +7,7 @@ developer_instructions = '''
 
 You are an orchestration-only agent. You run in the main thread, and all required delegation happens from the main thread to specialist subagents until all deliverables are complete. Do not perform deep implementation when a delegated specialist exists.
 
-Use these repo-local skills as the canonical workflow source:
+Use the following repo-local skills as the canonical workflow source:
 - orchestrate
 - orchestrator-workflow
 - feature-promotion-lifecycle
@@ -64,6 +64,7 @@ Every agent named above must exist as a native Codex agent under `.codex/agents/
 
 - Treat `spawn_agent` availability as the mechanical availability signal for required delegated specialists.
 - For required delegated steps, you must delegate or stop execution.
+- If a required delegated step cannot complete, stop and report blocked state.
 - For planning steps, do not perform planning locally when delegation is required.
 - For delivery steps, do not perform preflight validation, execution, or post-delivery validation locally when delegation is required.
 - For review steps, do not perform post-implementation review locally when delegation is required.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/config.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/config.toml
@@ -1,137 +1,52 @@
-# Review and merge native MCP, hook, and approval settings intentionally.
+default_permissions = "orchestrator-workspace"
 
-{
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "agent": "orchestrator",
-  "permissions": {
-    "allow": [
-      "Bash(git *)",
-      "Bash(poetry run *)",
-      "Bash(pwsh *)",
-      "Read",
-      "Edit(/docs/**)",
-      "Write(/docs/**)",
-      "Write(/artifacts/**)",
-      "mcp__drm-copilot__run_poshqc_format",
-      "mcp__drm-copilot__run_poshqc_analyze",
-      "mcp__drm-copilot__run_poshqc_test",
-      "mcp__drm-copilot__run_poshqc_analyze_autofix",
-      "mcp__drm-copilot__resolve_execute_hard_lock_prompt",
-      "mcp__drm-copilot__collect_pr_context",
-      "mcp__drm-copilot__new_potential_entry",
-      "mcp__drm-copilot__new_potential_bug_entry",
-      "mcp__drm-copilot__potential_to_issue",
-      "mcp__drm-copilot__new_active_feature_folder",
-      "mcp__drm-copilot__validate_orchestration_artifacts",
-      "mcp__drm-copilot__resolve_atomic_plan_prompt",
-      "Agent(atomic-planner)",
-      "Agent(atomic-executor)",
-      "Agent(feature-review)",
-      "Agent(task-researcher)",
-      "Agent(prd-feature)",
-      "Agent(staged-review)",
-      "Agent(epic-review)",
-      "Agent(status-updater)",
-      "Agent(python-typed-engineer)",
-      "Agent(powershell-typed-engineer)",
-      "Agent(csharp-typed-engineer)",
-      "Agent(typescript-engineer)",
-      "Skill(orchestrate *)",
-      "Skill(commit-message *)",
-      "Skill(pr-author *)",
-      "Skill(research-issue *)",
-      "Skill(review-feature *)",
-      "Skill(review-staged *)",
-      "Skill(review-epic *)",
-      "Skill(update-status *)",
-      "Skill(fill-feature-docs *)",
-      "Skill(python-change-budget-router *)",
-      "Skill(python-qa-gate *)",
-      "Skill(invoke-python-engineer *)",
-      "Skill(powershell-change-budget-router *)",
-      "Skill(powershell-qa-gate *)",
-      "Skill(invoke-powershell-engineer *)",
-      "Skill(translate-copilot-to-claude *)",
-      "Skill(execute-hard-lock *)",
-      "Edit(/.agents/skills/execute-hard-lock/**)",
-      "Edit(/.agents/skills/feature-review-workflow/**)",
-      "Edit(/.agents/skills/csharp-qa-gate/**)"
-    ],
-    "deny": [
-      "Read(./.env)",
-      "Read(./.env.*)",
-      "Read(./secrets/**)",
-      "Edit(./secrets/**)",
-      "Write(./secrets/**)"
-    ],
-    "additionalDirectories": [
-      "c:\\Users\\DanMoisan\\repos\\drm-copilot\\.claude\\skills\\execute-hard-lock"
-    ]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/validate-bash.ps1"
-          },
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/enforce-promotion-mcp-only.ps1"
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/check-python-test-purity.ps1"
-          },
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/enforce-python-batch-budget.ps1"
-          },
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/check-powershell-test-purity.ps1"
-          },
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/enforce-powershell-batch-budget.ps1"
-          },
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/enforce-evidence-locations.ps1"
-          }
-        ]
-      }
-    ],
-    "SubagentStop": [
-      {
-        "matcher": "atomic-planner|atomic-executor|feature-review|task-researcher|prd-feature|staged-review|epic-review|status-updater|python-typed-engineer|powershell-typed-engineer|csharp-typed-engineer|typescript-engineer",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -Command \"$input = $env:CLAUDE_HOOK_INPUT | ConvertFrom-Json; $output = $input.output; if (-not ($output -match '(plan-path|research-path|review-artifact|PREFLIGHT|evidence/)')) { Write-Error 'Subagent stopped without required completion artifact path'; exit 1 }; exit 0\""
-          }
-        ]
-      },
-      {
-        "matcher": "feature-review",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File .codex/hooks/validate-feature-review-coverage.ps1"
-          }
-        ]
-      }
-    ]
-  },
-  "enabledPlugins": {
-    "skill-creator@claude-plugins-official": true
-  },
-  "defaultPermissionMode": "bypassPermissions"
-}
+[mcp_servers.drm-copilot]
+command = "npx"
+args = ["-y", "@danmoisan/drm-copilot-mcp"]
+required = true
+enabled_tools = [
+    "collect_commit_context",
+    "collect_pr_context",
+    "new_potential_entry",
+    "new_potential_bug_entry",
+    "potential_to_issue",
+    "new_active_feature_folder",
+    "validate_orchestration_artifacts",
+    "resolve_atomic_plan_prompt",
+    "resolve_execute_hard_lock_prompt",
+    "run_poshqc_format",
+    "run_poshqc_analyze",
+    "run_poshqc_analyze_autofix",
+    "run_poshqc_test",
+]
+default_tools_approval_mode = "prompt"
+
+[mcp_servers.drm-copilot.tools.validate_orchestration_artifacts]
+approval_mode = "approve"
+
+[features]
+multi_agent = true
+
+[permissions.orchestrator-workspace]
+description = "Workspace editing for deterministic orchestration with secret-path deny rules."
+extends = ":workspace"
+
+[permissions.orchestrator-workspace.filesystem]
+glob_scan_max_depth = 4
+
+[permissions.orchestrator-workspace.filesystem.":workspace_roots"]
+"**/.env" = "deny"
+"**/.env.*" = "deny"
+"secrets" = "deny"
+"secrets/**" = "deny"
+
+[permissions.orchestrator-workspace.network]
+enabled = true
+
+[permissions.orchestrator-workspace.network.domains]
+"github.com" = "allow"
+"api.github.com" = "allow"
+"objects.githubusercontent.com" = "allow"
+"registry.npmjs.org" = "allow"
+"pypi.org" = "allow"
+"files.pythonhosted.org" = "allow"

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/scripts/post-codex-worktree-session.ps1
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/scripts/post-codex-worktree-session.ps1
@@ -3,4 +3,3 @@ param()
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/scripts/post-codex-worktree-session.ps1
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/scripts/post-codex-worktree-session.ps1
@@ -1,0 +1,6 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.github/workflows/_validate-orchestrator-state.yml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.github/workflows/_validate-orchestrator-state.yml
@@ -1,0 +1,68 @@
+name: Validate Orchestrator State
+
+on:
+  workflow_call:
+    inputs:
+      state-path:
+        description: Repository-relative orchestrator checkpoint path.
+        required: false
+        type: string
+        default: artifacts/orchestration/orchestrator-state.json
+      require-checkpoint:
+        description: Fail when the checkpoint file is absent.
+        required: false
+        type: boolean
+        default: true
+  workflow_dispatch:
+    inputs:
+      state-path:
+        description: Repository-relative orchestrator checkpoint path.
+        required: false
+        type: string
+        default: artifacts/orchestration/orchestrator-state.json
+      require-checkpoint:
+        description: Fail when the checkpoint file is absent.
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  validate-orchestrator-state:
+    name: Validate orchestrator checkpoint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Validate checkpoint
+        env:
+          STATE_PATH: ${{ inputs.state-path }}
+          REQUIRE_CHECKPOINT: ${{ inputs.require-checkpoint }}
+        run: |
+          if [ ! -f "$STATE_PATH" ]; then
+            if [ "$REQUIRE_CHECKPOINT" = "true" ]; then
+              echo "ERROR: orchestrator checkpoint is required but was not found: $STATE_PATH" >&2
+              exit 1
+            fi
+            echo "No orchestrator checkpoint found at $STATE_PATH; validation skipped."
+            exit 0
+          fi
+
+          poetry run python -m scripts.dev_tools.validate_orchestration_artifacts \
+            orchestrator-state "$STATE_PATH" --require-complete

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.github/workflows/validate-orchestrator-state.yml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.github/workflows/validate-orchestrator-state.yml
@@ -1,0 +1,15 @@
+name: Orchestrator State Gate
+
+on:
+  pull_request:
+    branches: [main, development]
+  push:
+    branches: [main, development]
+  workflow_dispatch:
+
+jobs:
+  validate-orchestrator-state:
+    uses: ./.github/workflows/_validate-orchestrator-state.yml
+    with:
+      state-path: artifacts/orchestration/orchestrator-state.json
+      require-checkpoint: false

--- a/extensions/drm-copilot/resources/config/orchestration-routing.json
+++ b/extensions/drm-copilot/resources/config/orchestration-routing.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "routes": {
+    "small": {
+      "description": "Minor-audit path for work inside the applicable language budget.",
+      "required_agents": [
+        "atomic-planner",
+        "atomic-executor",
+        "feature-reviewer",
+        "commit-steward"
+      ],
+      "required_skills": [
+        "orchestrate",
+        "orchestrator-workflow",
+        "feature-promotion-lifecycle",
+        "repo-automation-adapter",
+        "atomic-plan-contract",
+        "acceptance-criteria-tracking",
+        "pr-context-artifacts",
+        "pr-base-branch-merge-base"
+      ],
+      "required_mcp_tools": [
+        "new_potential_entry",
+        "potential_to_issue",
+        "new_active_feature_folder",
+        "collect_commit_context",
+        "collect_pr_context",
+        "validate_orchestration_artifacts"
+      ]
+    },
+    "large": {
+      "description": "Full feature or bug path for work outside small-path budget.",
+      "required_agents": [
+        "task-researcher",
+        "prd-feature",
+        "atomic-planner",
+        "atomic-executor",
+        "feature-reviewer",
+        "commit-steward"
+      ],
+      "required_skills": [
+        "orchestrate",
+        "orchestrator-workflow",
+        "feature-promotion-lifecycle",
+        "repo-automation-adapter",
+        "atomic-plan-contract",
+        "acceptance-criteria-tracking",
+        "pr-context-artifacts",
+        "pr-base-branch-merge-base"
+      ],
+      "required_mcp_tools": [
+        "new_potential_entry",
+        "potential_to_issue",
+        "new_active_feature_folder",
+        "collect_commit_context",
+        "collect_pr_context",
+        "validate_orchestration_artifacts"
+      ]
+    },
+    "remediation": {
+      "description": "Review-triggered remediation loop.",
+      "required_agents": [
+        "atomic-planner",
+        "atomic-executor",
+        "feature-reviewer",
+        "commit-steward"
+      ],
+      "required_skills": [
+        "orchestrate",
+        "orchestrator-workflow",
+        "repo-automation-adapter",
+        "atomic-plan-contract",
+        "acceptance-criteria-tracking",
+        "pr-context-artifacts"
+      ],
+      "required_mcp_tools": [
+        "collect_commit_context",
+        "collect_pr_context",
+        "validate_orchestration_artifacts"
+      ]
+    }
+  }
+}

--- a/extensions/drm-copilot/resources/scripts/dev_tools/_orchestrator_state_routing.py
+++ b/extensions/drm-copilot/resources/scripts/dev_tools/_orchestrator_state_routing.py
@@ -1,0 +1,216 @@
+"""Routing and mandatory handoff invariants for orchestrator checkpoints."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+ROUTING_MATRIX_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "orchestration-routing.json"
+)
+
+
+def load_routing_matrix(path: Path = ROUTING_MATRIX_PATH) -> dict[str, Any]:
+    """Load the repository routing matrix from disk."""
+
+    loaded: object = json.loads(path.read_text(encoding="utf-8"))
+    return cast("dict[str, Any]", loaded)
+
+
+def _string_list(value: object) -> list[str] | None:
+    """Return a list of strings only when the value has that exact shape."""
+
+    if not isinstance(value, list):
+        return None
+    values = cast("list[object]", value)
+    if not all(isinstance(item, str) and item.strip() for item in values):
+        return None
+    return cast("list[str]", values)
+
+
+def _route_list(route: dict[str, Any], key: str) -> list[str]:
+    """Read a required string-list field from one route entry."""
+
+    value = _string_list(route.get(key))
+    return [] if value is None else value
+
+
+def _state_list(
+    state: dict[str, Any], key: str, route_id: str, expected: list[str]
+) -> list[str] | None:
+    """Validate a state list against the routing matrix list."""
+
+    value = _string_list(state.get(key))
+    if value is None:
+        return None
+    if value != expected:
+        return None
+    return value
+
+
+def _list_receipts(receipts: object) -> list[dict[str, Any]]:
+    """Return legacy list delegation receipts as typed dictionaries."""
+
+    if not isinstance(receipts, list):
+        return []
+    receipt_list = cast("list[object]", receipts)
+    return [
+        cast("dict[str, Any]", item) for item in receipt_list if isinstance(item, dict)
+    ]
+
+
+def _receipt_agents(state: dict[str, Any]) -> set[str]:
+    """Collect agent names from delegation receipts."""
+
+    agents: set[str] = set()
+    for receipt in _list_receipts(state.get("delegation_receipts")):
+        agent_name = receipt.get("agent_name")
+        if isinstance(agent_name, str) and agent_name.strip():
+            agents.add(agent_name)
+    return agents
+
+
+def _receipt_skills(state: dict[str, Any]) -> set[str]:
+    """Collect acknowledged skill names from skill receipts."""
+
+    skills: set[str] = set()
+    receipts = state.get("skill_receipts")
+    if not isinstance(receipts, list):
+        return skills
+    for receipt in cast("list[object]", receipts):
+        if not isinstance(receipt, dict):
+            continue
+        receipt_map = cast("dict[str, object]", receipt)
+        skill = receipt_map.get("skill")
+        required = receipt_map.get("required")
+        evidence = receipt_map.get("evidence")
+        if (
+            isinstance(skill, str)
+            and skill.strip()
+            and required is True
+            and isinstance(evidence, str)
+            and evidence.strip()
+        ):
+            skills.add(skill)
+    return skills
+
+
+def _mcp_tools(state: dict[str, Any]) -> set[str]:
+    """Collect successful MCP tool receipts from checkpoint state."""
+
+    tools: set[str] = set()
+    receipts = state.get("mcp_call_receipts")
+    if not isinstance(receipts, list):
+        return tools
+    for receipt in cast("list[object]", receipts):
+        if not isinstance(receipt, dict):
+            continue
+        receipt_map = cast("dict[str, object]", receipt)
+        tool = receipt_map.get("tool")
+        ok = receipt_map.get("ok")
+        evidence = receipt_map.get("evidence")
+        if (
+            isinstance(tool, str)
+            and tool.strip()
+            and ok is True
+            and isinstance(evidence, str)
+            and evidence.strip()
+        ):
+            tools.add(tool)
+    return tools
+
+
+def _validate_empty_list_field(state: dict[str, Any], key: str) -> list[str]:
+    """Require a checkpoint field to exist as an empty list."""
+
+    value = state.get(key)
+    if not isinstance(value, list):
+        return [f"Checkpoint {key} must be an empty list at completion."]
+    if value:
+        return [f"Checkpoint {key} must be empty at completion."]
+    return []
+
+
+def _validate_lifecycle_operations(state: dict[str, Any]) -> list[str]:
+    """Reject lifecycle-operation records that did not use MCP."""
+
+    operations = state.get("lifecycle_operations")
+    if operations is None:
+        return []
+    if not isinstance(operations, list):
+        return ["Checkpoint lifecycle_operations must be a list when present."]
+    errors: list[str] = []
+    for index, operation in enumerate(cast("list[object]", operations)):
+        if not isinstance(operation, dict):
+            errors.append(
+                f"Checkpoint lifecycle_operations #{index} must be an object."
+            )
+            continue
+        operation_map = cast("dict[str, object]", operation)
+        if operation_map.get("surface") != "mcp":
+            errors.append(
+                f"Checkpoint lifecycle_operations #{index} did not use MCP surface."
+            )
+    return errors
+
+
+def validate_routing_contract(
+    state: dict[str, Any], *, routing_matrix: dict[str, Any] | None = None
+) -> list[str]:
+    """Validate mandatory route, handoff, skill, and MCP completion evidence."""
+
+    matrix = routing_matrix if routing_matrix is not None else load_routing_matrix()
+    raw_routes = matrix.get("routes")
+    if not isinstance(raw_routes, dict):
+        return ["Routing matrix missing routes object."]
+    routes = cast("dict[str, object]", raw_routes)
+
+    route_id = state.get("route_id", state.get("path_selected"))
+    if not isinstance(route_id, str) or not route_id.strip():
+        return ["Checkpoint route_id or path_selected must select a route."]
+    raw_route = routes.get(route_id)
+    if not isinstance(raw_route, dict):
+        return [f"Checkpoint selected route has no routing-matrix entry: {route_id}."]
+    route_map = cast("dict[str, Any]", raw_route)
+
+    errors: list[str] = []
+    required_agents = _route_list(route_map, "required_agents")
+    required_skills = _route_list(route_map, "required_skills")
+    required_mcp_tools = _route_list(route_map, "required_mcp_tools")
+
+    if _state_list(state, "required_agents", route_id, required_agents) is None:
+        errors.append(
+            "Checkpoint required_agents must match routing matrix for route "
+            f"{route_id}."
+        )
+    if _state_list(state, "required_skills", route_id, required_skills) is None:
+        errors.append(
+            "Checkpoint required_skills must match routing matrix for route "
+            f"{route_id}."
+        )
+    if _state_list(state, "required_mcp_tools", route_id, required_mcp_tools) is None:
+        errors.append(
+            "Checkpoint required_mcp_tools must match routing matrix for route "
+            f"{route_id}."
+        )
+
+    actual_agents = _receipt_agents(state)
+    for agent in required_agents:
+        if agent not in actual_agents:
+            errors.append(f"Checkpoint missing required agent receipt: {agent}.")
+
+    actual_skills = _receipt_skills(state)
+    for skill in required_skills:
+        if skill not in actual_skills:
+            errors.append(f"Checkpoint missing required skill receipt: {skill}.")
+
+    actual_tools = _mcp_tools(state)
+    for tool in required_mcp_tools:
+        if tool not in actual_tools:
+            errors.append(f"Checkpoint missing successful MCP receipt: {tool}.")
+
+    errors.extend(_validate_empty_list_field(state, "local_execution_overrides"))
+    errors.extend(_validate_empty_list_field(state, "delegation_bypasses"))
+    errors.extend(_validate_lifecycle_operations(state))
+    return errors

--- a/extensions/drm-copilot/resources/scripts/dev_tools/validate_orchestrator_state.py
+++ b/extensions/drm-copilot/resources/scripts/dev_tools/validate_orchestrator_state.py
@@ -35,6 +35,7 @@ from dev_tools._orchestrator_state_human_interaction import (
     HUMAN_INTERACTION_KEY,
     _validate_human_interaction,
 )
+from dev_tools._orchestrator_state_routing import validate_routing_contract
 
 REQUIRED_STATE_KEYS = (
     "objective",
@@ -422,5 +423,6 @@ def validate_orchestrator_state_text(
             errors.append(
                 "Checkpoint completion validation failed: blocked_reason is not `none`."
             )
+        errors.extend(validate_routing_contract(state_map))
 
     return errors

--- a/extensions/drm-copilot/src/codex-worktree-session.ts
+++ b/extensions/drm-copilot/src/codex-worktree-session.ts
@@ -1,0 +1,101 @@
+import { quoteForPwsh } from "./claude-worktree-session";
+
+/**
+ * Inputs required to build the PowerShell commands that start a Codex worktree
+ * session in a VS Code integrated terminal.
+ */
+export interface CodexWorktreeSessionCommandInput {
+  readonly repoRoot: string;
+  readonly worktreePath: string;
+  readonly branchName: string;
+  readonly usePoetry: boolean;
+  readonly objective: string | undefined;
+  /**
+   * Worktree-relative PowerShell script path to run after Codex trust has been
+   * written and before the Codex CLI starts. Empty values emit no post command.
+   */
+  readonly postCodexScriptPath: string | undefined;
+}
+
+/**
+ * Ordered PowerShell commands that constitute a Codex worktree session.
+ */
+export interface CodexWorktreeSessionCommands {
+  readonly git: string;
+  readonly setLocation: string;
+  readonly trustCodexProject: string;
+  readonly poetryInstall: string | undefined;
+  readonly activate: string | undefined;
+  readonly postCodex: string | undefined;
+  readonly codex: string;
+}
+
+/**
+ * Builds a PowerShell command that adds the resolved worktree path to the
+ * user-level Codex trust configuration before project-local `.codex` settings
+ * are loaded by the Codex CLI.
+ *
+ * @param worktreePath The worktree path created by the preceding git command.
+ * @returns A single PowerShell command string suitable for Terminal.sendText.
+ */
+export function buildCodexTrustCommand(worktreePath: string): string {
+  const quotedPath = quoteForPwsh(worktreePath);
+  return [
+    "$codexConfig = Join-Path $HOME '.codex/config.toml'",
+    "New-Item -ItemType Directory -Force -Path (Split-Path -Parent $codexConfig) | Out-Null",
+    `if (-not (Test-Path -LiteralPath ${quotedPath})) { throw "Codex trust target does not exist: ${worktreePath.replace(/"/g, '`"')}" }`,
+    `$trustedPath = (Resolve-Path -LiteralPath ${quotedPath}).Path`,
+    '$escapedPath = $trustedPath -replace "\'", "\'\'"',
+    "$header = \"[projects.'$escapedPath']\"",
+    `$trustedLine = 'trust_level = "trusted"'`,
+    "if (-not (Test-Path -LiteralPath $codexConfig)) { Set-Content -LiteralPath $codexConfig -Value '' }",
+    "$content = Get-Content -Raw -LiteralPath $codexConfig",
+    "$sectionPattern = '(?s)' + [regex]::Escape($header) + '(?<body>.*?)(?:\\r?\\n\\[|$)'",
+    "$sectionMatch = [regex]::Match($content, $sectionPattern)",
+    'if (-not $sectionMatch.Success) { Add-Content -LiteralPath $codexConfig -Value "`r`n$header`r`n$trustedLine" }',
+    "elseif ($sectionMatch.Groups['body'].Value -notmatch 'trust_level\\s*=\\s*\"trusted\"') { throw \"Codex project trust entry exists but is not trusted: $trustedPath\" }",
+  ].join("; ");
+}
+
+/**
+ * Builds the ordered terminal commands that create the worktree, mark it as a
+ * trusted Codex project, run optional setup, and start Codex.
+ *
+ * @param input The repository root, destination worktree path, branch name,
+ *              poetry flag, optional objective, and optional post script path.
+ * @returns The commands to send as separate terminal lines.
+ */
+export function buildCodexWorktreeSessionCommands(
+  input: CodexWorktreeSessionCommandInput,
+): CodexWorktreeSessionCommands {
+  const quotedRepoRoot = quoteForPwsh(input.repoRoot);
+  const quotedPath = quoteForPwsh(input.worktreePath);
+  const quotedBranch = quoteForPwsh(input.branchName);
+
+  const trimmedObjective = input.objective?.trim() ?? "";
+  const objectiveSuffix =
+    trimmedObjective.length > 0 ? ` ${quoteForPwsh(trimmedObjective)}` : "";
+
+  const poetryInstall = input.usePoetry
+    ? "poetry install --with dev"
+    : undefined;
+  const activate = input.usePoetry
+    ? "& './.venv/Scripts/Activate.ps1'"
+    : undefined;
+
+  const trimmedPostCodexPath = input.postCodexScriptPath?.trim() ?? "";
+  const postCodex =
+    trimmedPostCodexPath.length > 0
+      ? `if (Test-Path -LiteralPath ${quoteForPwsh(trimmedPostCodexPath)}) { & ${quoteForPwsh(trimmedPostCodexPath)} }`
+      : undefined;
+
+  return {
+    git: `git -C ${quotedRepoRoot} worktree add ${quotedPath} -b ${quotedBranch}`,
+    setLocation: `Set-Location ${quotedPath}`,
+    trustCodexProject: buildCodexTrustCommand(input.worktreePath),
+    poetryInstall,
+    activate,
+    postCodex,
+    codex: `codex${objectiveSuffix}`,
+  };
+}

--- a/extensions/drm-copilot/src/extension.ts
+++ b/extensions/drm-copilot/src/extension.ts
@@ -7,6 +7,7 @@ import {
   buildWorktreeSessionCommands,
   formatWorktreeTimestamp,
 } from "./claude-worktree-session";
+import { buildCodexWorktreeSessionCommands } from "./codex-worktree-session";
 import {
   createOutputChannel,
   detectRuntime,
@@ -209,6 +210,86 @@ export function activate(context: vscode.ExtensionContext): void {
     },
   );
 
+  const newCodexWorktreeSessionDisposable = vscode.commands.registerCommand(
+    "drmCopilotExtension.newCodexWorktreeSession",
+    async () => {
+      const commandId = "drmCopilotExtension.newCodexWorktreeSession";
+
+      const objective = await vscode.window.showInputBox({
+        title: "drm-copilot: New Codex Worktree Session",
+        prompt:
+          "Enter the objective to pass to codex as a prompt. Leave blank to skip.",
+        ignoreFocusOut: true,
+      });
+      if (objective === undefined) {
+        return;
+      }
+
+      const runtime = detectRuntime("powershell");
+      const workspaceRoot = getWorkspaceRoot();
+      const repoName = path.basename(workspaceRoot);
+      const workspaceParent = path.dirname(workspaceRoot);
+      const timestamp = formatWorktreeTimestamp(new Date());
+      const worktreePath = buildWorktreePath(
+        workspaceParent,
+        timestamp,
+        repoName,
+      );
+      const branchName = buildBranchName(timestamp, repoName);
+      const usePoetry = pyprojectHasPoetry(workspaceRoot);
+      const configuredPostCodexScriptPath =
+        vscode.workspace
+          .getConfiguration("drmCopilotExtension.newCodexWorktreeSession")
+          .get<string>("postCodexScriptPath") ??
+        ".codex/scripts/post-codex-worktree-session.ps1";
+      const commands = buildCodexWorktreeSessionCommands({
+        repoRoot: workspaceRoot,
+        worktreePath,
+        branchName,
+        usePoetry,
+        objective,
+        postCodexScriptPath: configuredPostCodexScriptPath,
+      });
+
+      const terminal = vscode.window.createTerminal({
+        name: `Codex: ${branchName}`,
+        cwd: workspaceRoot,
+        shellPath: runtime.executable,
+        shellArgs: ["-NoLogo"],
+      });
+      terminal.show();
+
+      terminal.sendText(commands.git, true);
+      terminal.sendText(commands.setLocation, true);
+      terminal.sendText(commands.trustCodexProject, true);
+      if (commands.poetryInstall !== undefined) {
+        terminal.sendText(commands.poetryInstall, true);
+      }
+      if (commands.activate !== undefined) {
+        terminal.sendText(commands.activate, true);
+      }
+      if (commands.postCodex !== undefined) {
+        terminal.sendText(commands.postCodex, true);
+      }
+
+      setTimeout(() => {
+        terminal.sendText(commands.codex, true);
+      }, TERMINAL_AUTO_ACTIVATION_GRACE_MS);
+
+      const objectiveLength = objective.trim().length;
+      const poetryNote = usePoetry
+        ? "with poetry install and activation"
+        : "no poetry";
+      const postCodexNote =
+        commands.postCodex !== undefined
+          ? "post-codex script: emitted"
+          : "post-codex script: none";
+      output.appendLine(
+        `[${commandId}] opened terminal for branch ${branchName} at ${worktreePath} (objective length: ${objectiveLength}, ${poetryNote}, trust command: emitted, ${postCodexNote}); codex send deferred by ${TERMINAL_AUTO_ACTIVATION_GRACE_MS}ms`,
+      );
+    },
+  );
+
   const removeSecondaryWorktreesDisposable = vscode.commands.registerCommand(
     "drmCopilotExtension.removeSecondaryWorktrees",
     async () => {
@@ -321,6 +402,7 @@ export function activate(context: vscode.ExtensionContext): void {
     helloPythonDisposable,
     helloPowerShellDisposable,
     newClaudeWorktreeSessionDisposable,
+    newCodexWorktreeSessionDisposable,
     removeSecondaryWorktreesDisposable,
     runPoshQCSuiteDisposable,
     runPoshQCFormatDisposable,

--- a/extensions/drm-copilot/test/codex-worktree-session-command.test.ts
+++ b/extensions/drm-copilot/test/codex-worktree-session-command.test.ts
@@ -1,0 +1,206 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+import {
+  activateAndGetHandler,
+  childProcessMock,
+  createTerminalMock,
+  resetExtensionHarnessState,
+  setExecutablePresence,
+  setPostCodexScriptPathConfig,
+  setPyprojectFixture,
+  showInputBoxMock,
+} from "./extension-test-harness";
+
+describe("newCodexWorktreeSession", () => {
+  beforeEach(() => {
+    resetExtensionHarnessState();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registers the command", () => {
+    activateAndGetHandler("drmCopilotExtension.newCodexWorktreeSession");
+  });
+
+  it("sends git, Set-Location, trust, post script, and codex in order", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      setPostCodexScriptPathConfig("scripts/post-codex.ps1");
+      showInputBoxMock.mockResolvedValueOnce("Start the Codex session.");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newCodexWorktreeSession",
+      );
+      await handler();
+
+      expect(createTerminalMock).toHaveBeenCalledTimes(1);
+      const [terminalOptions] = createTerminalMock.mock.calls[0] as [
+        {
+          name: string;
+          cwd: string;
+          shellPath: string;
+          shellArgs: ReadonlyArray<string>;
+        },
+      ];
+      expect(terminalOptions.name).toMatch(/^Codex: workspace-wt-/);
+      expect(terminalOptions.cwd).toBe("C:/workspace");
+      expect(terminalOptions.shellPath).toBe("pwsh");
+      expect(terminalOptions.shellArgs).toEqual(["-NoLogo"]);
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        show: jest.Mock;
+        sendText: jest.Mock;
+      };
+      expect(terminal.show).toHaveBeenCalledTimes(1);
+
+      expect(terminal.sendText).toHaveBeenCalledTimes(4);
+      const [gitCmd] = terminal.sendText.mock.calls[0] as [string];
+      const [setLocationCmd] = terminal.sendText.mock.calls[1] as [string];
+      const [trustCmd] = terminal.sendText.mock.calls[2] as [string];
+      const [postCmd] = terminal.sendText.mock.calls[3] as [string];
+      expect(gitCmd).toContain("git -C 'C:/workspace' worktree add");
+      expect(setLocationCmd).toMatch(/^Set-Location '/);
+      expect(trustCmd).toContain(
+        "$codexConfig = Join-Path $HOME '.codex/config.toml'",
+      );
+      expect(trustCmd).toContain(
+        "Codex project trust entry exists but is not trusted",
+      );
+      expect(postCmd).toBe(
+        "if (Test-Path -LiteralPath 'scripts/post-codex.ps1') { & 'scripts/post-codex.ps1' }",
+      );
+
+      jest.advanceTimersByTime(5000);
+
+      expect(terminal.sendText).toHaveBeenCalledTimes(5);
+      const [codexCmd] = terminal.sendText.mock.calls[4] as [string];
+      expect(codexCmd).toBe("codex 'Start the Codex session.'");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("runs poetry setup before the post script when poetry is configured", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      setPyprojectFixture(
+        '[tool.poetry]\nname = "drm-copilot"\nversion = "0.1.0"\n',
+      );
+      setPostCodexScriptPathConfig("scripts/post-codex.ps1");
+      showInputBoxMock.mockResolvedValueOnce("Start the Codex session.");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newCodexWorktreeSession",
+      );
+      await handler();
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        sendText: jest.Mock;
+      };
+      expect(terminal.sendText).toHaveBeenCalledTimes(6);
+      const [poetryInstallCmd] = terminal.sendText.mock.calls[3] as [string];
+      const [activateCmd] = terminal.sendText.mock.calls[4] as [string];
+      const [postCmd] = terminal.sendText.mock.calls[5] as [string];
+      expect(poetryInstallCmd).toBe("poetry install --with dev");
+      expect(activateCmd).toBe("& './.venv/Scripts/Activate.ps1'");
+      expect(postCmd).toBe(
+        "if (Test-Path -LiteralPath 'scripts/post-codex.ps1') { & 'scripts/post-codex.ps1' }",
+      );
+
+      jest.advanceTimersByTime(5000);
+
+      expect(terminal.sendText).toHaveBeenCalledTimes(7);
+      const [codexCmd] = terminal.sendText.mock.calls[6] as [string];
+      expect(codexCmd).toBe("codex 'Start the Codex session.'");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("uses the default post-codex script path when the setting is unset", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      showInputBoxMock.mockResolvedValueOnce("Start the Codex session.");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newCodexWorktreeSession",
+      );
+      await handler();
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        sendText: jest.Mock;
+      };
+      const [postCmd] = terminal.sendText.mock.calls[3] as [string];
+      expect(postCmd).toBe(
+        "if (Test-Path -LiteralPath '.codex/scripts/post-codex-worktree-session.ps1') { & '.codex/scripts/post-codex-worktree-session.ps1' }",
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("omits the post script and objective when both are blank", async () => {
+    jest.useFakeTimers();
+    try {
+      setExecutablePresence({ pwsh: true, powershell: false });
+      setPostCodexScriptPathConfig("");
+      showInputBoxMock.mockResolvedValueOnce("   ");
+
+      const handler = activateAndGetHandler(
+        "drmCopilotExtension.newCodexWorktreeSession",
+      );
+      await handler();
+
+      const terminal = createTerminalMock.mock.results[0]?.value as {
+        sendText: jest.Mock;
+      };
+      expect(terminal.sendText).toHaveBeenCalledTimes(3);
+
+      jest.advanceTimersByTime(5000);
+
+      expect(terminal.sendText).toHaveBeenCalledTimes(4);
+      const [codexCmd] = terminal.sendText.mock.calls[3] as [string];
+      expect(codexCmd).toBe("codex");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("returns early when the objective prompt is cancelled", async () => {
+    showInputBoxMock.mockResolvedValue(undefined);
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newCodexWorktreeSession",
+    );
+    await handler();
+
+    expect(createTerminalMock).not.toHaveBeenCalled();
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a missing powershell runtime error", async () => {
+    setExecutablePresence({ pwsh: false, powershell: false });
+    showInputBoxMock.mockResolvedValueOnce("Start the Codex session.");
+
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.newCodexWorktreeSession",
+    );
+
+    await expect(handler()).rejects.toThrow(
+      "PowerShell runtime not found. Expected 'pwsh' or 'powershell' on PATH.",
+    );
+    expect(createTerminalMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/drm-copilot/test/codex-worktree-session.test.ts
+++ b/extensions/drm-copilot/test/codex-worktree-session.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  buildCodexTrustCommand,
+  buildCodexWorktreeSessionCommands,
+} from "../src/codex-worktree-session";
+
+describe("buildCodexTrustCommand", () => {
+  it("emits a command that writes a trusted Codex project entry", () => {
+    const command = buildCodexTrustCommand("C:/repos/workspace-wt");
+
+    expect(command).toContain(
+      "$codexConfig = Join-Path $HOME '.codex/config.toml'",
+    );
+    expect(command).toContain("$header = \"[projects.'$escapedPath']\"");
+    expect(command).toContain("$trustedLine = 'trust_level = \"trusted\"'");
+    expect(command).toContain("(?<body>.*?)");
+    expect(command).toContain(
+      "Codex project trust entry exists but is not trusted",
+    );
+  });
+
+  it("quotes paths with spaces and apostrophes", () => {
+    const command = buildCodexTrustCommand("C:/repos/o'connor worktree");
+
+    expect(command).toContain(
+      "Test-Path -LiteralPath 'C:/repos/o''connor worktree'",
+    );
+    expect(command).toContain(
+      "Resolve-Path -LiteralPath 'C:/repos/o''connor worktree'",
+    );
+  });
+});
+
+describe("buildCodexWorktreeSessionCommands", () => {
+  const baseInput = {
+    repoRoot: "C:/workspace",
+    worktreePath: "C:/workspace-wt-2026-04-20-09-59",
+    branchName: "workspace-wt-2026-04-20-09-59",
+    usePoetry: false,
+    objective: undefined,
+    postCodexScriptPath: undefined,
+  };
+
+  it("emits git, Set-Location, trust, and codex commands", () => {
+    const commands = buildCodexWorktreeSessionCommands(baseInput);
+
+    expect(commands.git).toBe(
+      "git -C 'C:/workspace' worktree add 'C:/workspace-wt-2026-04-20-09-59' -b 'workspace-wt-2026-04-20-09-59'",
+    );
+    expect(commands.setLocation).toBe(
+      "Set-Location 'C:/workspace-wt-2026-04-20-09-59'",
+    );
+    expect(commands.trustCodexProject).toContain(
+      "$codexConfig = Join-Path $HOME '.codex/config.toml'",
+    );
+    expect(commands.codex).toBe("codex");
+  });
+
+  it("emits codex with a quoted objective when supplied", () => {
+    const commands = buildCodexWorktreeSessionCommands({
+      ...baseInput,
+      objective: "Implement the Codex command.",
+    });
+
+    expect(commands.codex).toBe("codex 'Implement the Codex command.'");
+  });
+
+  it("returns poetry commands when the workspace uses poetry", () => {
+    const commands = buildCodexWorktreeSessionCommands({
+      ...baseInput,
+      usePoetry: true,
+    });
+
+    expect(commands.poetryInstall).toBe("poetry install --with dev");
+    expect(commands.activate).toBe("& './.venv/Scripts/Activate.ps1'");
+  });
+
+  it("emits a guarded post-codex script command when configured", () => {
+    const commands = buildCodexWorktreeSessionCommands({
+      ...baseInput,
+      postCodexScriptPath: "scripts/post-codex.ps1",
+    });
+
+    expect(commands.postCodex).toBe(
+      "if (Test-Path -LiteralPath 'scripts/post-codex.ps1') { & 'scripts/post-codex.ps1' }",
+    );
+  });
+
+  it("omits the post-codex script command when the path is blank", () => {
+    const commands = buildCodexWorktreeSessionCommands({
+      ...baseInput,
+      postCodexScriptPath: "   ",
+    });
+
+    expect(commands.postCodex).toBeUndefined();
+  });
+});

--- a/extensions/drm-copilot/test/extension-test-harness.ts
+++ b/extensions/drm-copilot/test/extension-test-harness.ts
@@ -55,6 +55,7 @@ const registerMcpServerDefinitionProviderMock = jest.fn(() => ({
 }));
 
 let preClaudeScriptPathConfig: string | undefined = undefined;
+let postCodexScriptPathConfig: string | undefined = undefined;
 
 const getConfigurationMock = jest.fn((section?: string) => ({
   get: <T>(key: string): T | undefined => {
@@ -63,6 +64,12 @@ const getConfigurationMock = jest.fn((section?: string) => ({
       key === "preClaudeScriptPath"
     ) {
       return preClaudeScriptPathConfig as T | undefined;
+    }
+    if (
+      section === "drmCopilotExtension.newCodexWorktreeSession" &&
+      key === "postCodexScriptPath"
+    ) {
+      return postCodexScriptPathConfig as T | undefined;
     }
     return undefined;
   },
@@ -263,6 +270,17 @@ export function setPreClaudeScriptPathConfig(value: string | undefined): void {
   preClaudeScriptPathConfig = value;
 }
 
+/**
+ * Controls the value returned by
+ * `vscode.workspace.getConfiguration("drmCopilotExtension.newCodexWorktreeSession").get<string>("postCodexScriptPath")`.
+ * Pass `undefined` to simulate the setting being unset.
+ *
+ * @param value The configured post-`codex` script path, or `undefined`.
+ */
+export function setPostCodexScriptPathConfig(value: string | undefined): void {
+  postCodexScriptPathConfig = value;
+}
+
 export function resetExtensionHarnessState(): void {
   process.env.PATH = "C:/bin";
   process.env.PATHEXT = ".EXE;.CMD";
@@ -272,6 +290,7 @@ export function resetExtensionHarnessState(): void {
   registerMcpServerDefinitionProviderMock.mockClear();
   getConfigurationMock.mockClear();
   preClaudeScriptPathConfig = undefined;
+  postCodexScriptPathConfig = undefined;
   childProcessMock.spawn.mockReset();
   childProcessMock.spawnSync.mockReset();
   fsMock.readFileSync.mockReset();

--- a/scripts/dev_tools/_orchestrator_state_routing.py
+++ b/scripts/dev_tools/_orchestrator_state_routing.py
@@ -1,0 +1,216 @@
+"""Routing and mandatory handoff invariants for orchestrator checkpoints."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+ROUTING_MATRIX_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "orchestration-routing.json"
+)
+
+
+def load_routing_matrix(path: Path = ROUTING_MATRIX_PATH) -> dict[str, Any]:
+    """Load the repository routing matrix from disk."""
+
+    loaded: object = json.loads(path.read_text(encoding="utf-8"))
+    return cast("dict[str, Any]", loaded)
+
+
+def _string_list(value: object) -> list[str] | None:
+    """Return a list of strings only when the value has that exact shape."""
+
+    if not isinstance(value, list):
+        return None
+    values = cast("list[object]", value)
+    if not all(isinstance(item, str) and item.strip() for item in values):
+        return None
+    return cast("list[str]", values)
+
+
+def _route_list(route: dict[str, Any], key: str) -> list[str]:
+    """Read a required string-list field from one route entry."""
+
+    value = _string_list(route.get(key))
+    return [] if value is None else value
+
+
+def _state_list(
+    state: dict[str, Any], key: str, route_id: str, expected: list[str]
+) -> list[str] | None:
+    """Validate a state list against the routing matrix list."""
+
+    value = _string_list(state.get(key))
+    if value is None:
+        return None
+    if value != expected:
+        return None
+    return value
+
+
+def _list_receipts(receipts: object) -> list[dict[str, Any]]:
+    """Return legacy list delegation receipts as typed dictionaries."""
+
+    if not isinstance(receipts, list):
+        return []
+    receipt_list = cast("list[object]", receipts)
+    return [
+        cast("dict[str, Any]", item) for item in receipt_list if isinstance(item, dict)
+    ]
+
+
+def _receipt_agents(state: dict[str, Any]) -> set[str]:
+    """Collect agent names from delegation receipts."""
+
+    agents: set[str] = set()
+    for receipt in _list_receipts(state.get("delegation_receipts")):
+        agent_name = receipt.get("agent_name")
+        if isinstance(agent_name, str) and agent_name.strip():
+            agents.add(agent_name)
+    return agents
+
+
+def _receipt_skills(state: dict[str, Any]) -> set[str]:
+    """Collect acknowledged skill names from skill receipts."""
+
+    skills: set[str] = set()
+    receipts = state.get("skill_receipts")
+    if not isinstance(receipts, list):
+        return skills
+    for receipt in cast("list[object]", receipts):
+        if not isinstance(receipt, dict):
+            continue
+        receipt_map = cast("dict[str, object]", receipt)
+        skill = receipt_map.get("skill")
+        required = receipt_map.get("required")
+        evidence = receipt_map.get("evidence")
+        if (
+            isinstance(skill, str)
+            and skill.strip()
+            and required is True
+            and isinstance(evidence, str)
+            and evidence.strip()
+        ):
+            skills.add(skill)
+    return skills
+
+
+def _mcp_tools(state: dict[str, Any]) -> set[str]:
+    """Collect successful MCP tool receipts from checkpoint state."""
+
+    tools: set[str] = set()
+    receipts = state.get("mcp_call_receipts")
+    if not isinstance(receipts, list):
+        return tools
+    for receipt in cast("list[object]", receipts):
+        if not isinstance(receipt, dict):
+            continue
+        receipt_map = cast("dict[str, object]", receipt)
+        tool = receipt_map.get("tool")
+        ok = receipt_map.get("ok")
+        evidence = receipt_map.get("evidence")
+        if (
+            isinstance(tool, str)
+            and tool.strip()
+            and ok is True
+            and isinstance(evidence, str)
+            and evidence.strip()
+        ):
+            tools.add(tool)
+    return tools
+
+
+def _validate_empty_list_field(state: dict[str, Any], key: str) -> list[str]:
+    """Require a checkpoint field to exist as an empty list."""
+
+    value = state.get(key)
+    if not isinstance(value, list):
+        return [f"Checkpoint {key} must be an empty list at completion."]
+    if value:
+        return [f"Checkpoint {key} must be empty at completion."]
+    return []
+
+
+def _validate_lifecycle_operations(state: dict[str, Any]) -> list[str]:
+    """Reject lifecycle-operation records that did not use MCP."""
+
+    operations = state.get("lifecycle_operations")
+    if operations is None:
+        return []
+    if not isinstance(operations, list):
+        return ["Checkpoint lifecycle_operations must be a list when present."]
+    errors: list[str] = []
+    for index, operation in enumerate(cast("list[object]", operations)):
+        if not isinstance(operation, dict):
+            errors.append(
+                f"Checkpoint lifecycle_operations #{index} must be an object."
+            )
+            continue
+        operation_map = cast("dict[str, object]", operation)
+        if operation_map.get("surface") != "mcp":
+            errors.append(
+                f"Checkpoint lifecycle_operations #{index} did not use MCP surface."
+            )
+    return errors
+
+
+def validate_routing_contract(
+    state: dict[str, Any], *, routing_matrix: dict[str, Any] | None = None
+) -> list[str]:
+    """Validate mandatory route, handoff, skill, and MCP completion evidence."""
+
+    matrix = routing_matrix if routing_matrix is not None else load_routing_matrix()
+    raw_routes = matrix.get("routes")
+    if not isinstance(raw_routes, dict):
+        return ["Routing matrix missing routes object."]
+    routes = cast("dict[str, object]", raw_routes)
+
+    route_id = state.get("route_id", state.get("path_selected"))
+    if not isinstance(route_id, str) or not route_id.strip():
+        return ["Checkpoint route_id or path_selected must select a route."]
+    raw_route = routes.get(route_id)
+    if not isinstance(raw_route, dict):
+        return [f"Checkpoint selected route has no routing-matrix entry: {route_id}."]
+    route_map = cast("dict[str, Any]", raw_route)
+
+    errors: list[str] = []
+    required_agents = _route_list(route_map, "required_agents")
+    required_skills = _route_list(route_map, "required_skills")
+    required_mcp_tools = _route_list(route_map, "required_mcp_tools")
+
+    if _state_list(state, "required_agents", route_id, required_agents) is None:
+        errors.append(
+            "Checkpoint required_agents must match routing matrix for route "
+            f"{route_id}."
+        )
+    if _state_list(state, "required_skills", route_id, required_skills) is None:
+        errors.append(
+            "Checkpoint required_skills must match routing matrix for route "
+            f"{route_id}."
+        )
+    if _state_list(state, "required_mcp_tools", route_id, required_mcp_tools) is None:
+        errors.append(
+            "Checkpoint required_mcp_tools must match routing matrix for route "
+            f"{route_id}."
+        )
+
+    actual_agents = _receipt_agents(state)
+    for agent in required_agents:
+        if agent not in actual_agents:
+            errors.append(f"Checkpoint missing required agent receipt: {agent}.")
+
+    actual_skills = _receipt_skills(state)
+    for skill in required_skills:
+        if skill not in actual_skills:
+            errors.append(f"Checkpoint missing required skill receipt: {skill}.")
+
+    actual_tools = _mcp_tools(state)
+    for tool in required_mcp_tools:
+        if tool not in actual_tools:
+            errors.append(f"Checkpoint missing successful MCP receipt: {tool}.")
+
+    errors.extend(_validate_empty_list_field(state, "local_execution_overrides"))
+    errors.extend(_validate_empty_list_field(state, "delegation_bypasses"))
+    errors.extend(_validate_lifecycle_operations(state))
+    return errors

--- a/scripts/dev_tools/validate_orchestrator_state.py
+++ b/scripts/dev_tools/validate_orchestrator_state.py
@@ -35,6 +35,7 @@ from scripts.dev_tools._orchestrator_state_human_interaction import (
     HUMAN_INTERACTION_KEY,
     _validate_human_interaction,
 )
+from scripts.dev_tools._orchestrator_state_routing import validate_routing_contract
 
 REQUIRED_STATE_KEYS = (
     "objective",
@@ -422,5 +423,6 @@ def validate_orchestrator_state_text(
             errors.append(
                 "Checkpoint completion validation failed: blocked_reason is not `none`."
             )
+        errors.extend(validate_routing_contract(state_map))
 
     return errors

--- a/tests/scripts/dev_tools/test_validate_orchestrator_state_routing_contract.py
+++ b/tests/scripts/dev_tools/test_validate_orchestrator_state_routing_contract.py
@@ -1,0 +1,173 @@
+"""Tests for mandatory route, handoff, skill, and MCP checkpoint evidence."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import scripts.dev_tools.validate_orchestrator_state as state_validator
+from scripts.dev_tools._orchestrator_state_routing import load_routing_matrix
+
+
+def _large_route() -> dict[str, Any]:
+    """Return the large-route entry from the repository routing matrix."""
+
+    matrix = load_routing_matrix()
+    routes = cast("dict[str, Any]", matrix["routes"])
+    return cast("dict[str, Any]", routes["large"])
+
+
+def _build_complete_large_state() -> dict[str, object]:
+    """Return a completion-safe large-path checkpoint for mutation."""
+
+    route = _large_route()
+    required_agents = cast("list[str]", route["required_agents"])
+    required_skills = cast("list[str]", route["required_skills"])
+    required_mcp_tools = cast("list[str]", route["required_mcp_tools"])
+    return {
+        "objective": "obj",
+        "change_budget_estimate": "large",
+        "route_id": "large",
+        "path_selected": "large",
+        "promotion-type": "feature",
+        "short-name": "short",
+        "relativeFile": "docs/features/potential/x.md",
+        "long-name": "feature-1",
+        "issue-num": "1",
+        "feature-folder": "docs/features/active/feature-1",
+        "work-mode": "full-feature",
+        "plan-path": "docs/features/active/feature-1/plan.md",
+        "completed_steps": ["S7", "S8", "S9"],
+        "next_step": "done",
+        "last_updated": "2026-04-07T10:00:00-04:00",
+        "step5_status": "not-applicable",
+        "step6_status": "not-applicable",
+        "step7_status": "verified",
+        "step8_status": "verified",
+        "step9_status": "verified",
+        "step10_status": "not-applicable",
+        "required_agents": required_agents,
+        "required_skills": required_skills,
+        "required_mcp_tools": required_mcp_tools,
+        "delegation_receipts": [
+            {
+                "step": f"handoff-{index}",
+                "agent_name": agent,
+                "agent_id": f"{agent}-1",
+                "skill_source": "orchestrator-workflow",
+                "started_at": "2026-04-07T09:00:00-04:00",
+                "completed_at": "2026-04-07T09:05:00-04:00",
+                "result_signal": "COMPLETE",
+                "artifact_paths": [f"artifacts/orchestration/{agent}.receipt.json"],
+            }
+            for index, agent in enumerate(required_agents, start=1)
+        ],
+        "skill_receipts": [
+            {
+                "skill": skill,
+                "required": True,
+                "acknowledged_at_phase": "completion",
+                "evidence": f"artifact:{skill}",
+            }
+            for skill in required_skills
+        ],
+        "mcp_call_receipts": [
+            {
+                "tool": tool,
+                "ok": True,
+                "evidence": f"mcp_call:{tool}",
+            }
+            for tool in required_mcp_tools
+        ],
+        "local_execution_overrides": [],
+        "delegation_bypasses": [],
+        "lifecycle_operations": [
+            {"name": tool, "surface": "mcp"} for tool in required_mcp_tools
+        ],
+        "blocked_reason": "none",
+    }
+
+
+def _validate(state: dict[str, object]) -> list[str]:
+    """Run completion validation against a serialized checkpoint."""
+
+    return state_validator.validate_orchestrator_state_text(
+        json.dumps(state), require_complete=True
+    )
+
+
+def test_complete_state_accepts_full_routing_contract_evidence() -> None:
+    """Accept a checkpoint that proves all mandatory route evidence."""
+
+    assert _validate(_build_complete_large_state()) == []
+
+
+def test_complete_state_rejects_missing_required_agent_receipt() -> None:
+    """Reject completion when a routing-matrix agent has no receipt."""
+
+    state = _build_complete_large_state()
+    state["delegation_receipts"] = cast("list[object]", state["delegation_receipts"])[
+        1:
+    ]
+
+    errors = _validate(state)
+
+    assert "Checkpoint missing required agent receipt: task-researcher." in errors
+
+
+def test_complete_state_rejects_missing_required_skill_receipt() -> None:
+    """Reject completion when a routing-matrix skill is not acknowledged."""
+
+    state = _build_complete_large_state()
+    state["skill_receipts"] = cast("list[object]", state["skill_receipts"])[1:]
+
+    errors = _validate(state)
+
+    assert "Checkpoint missing required skill receipt: orchestrate." in errors
+
+
+def test_complete_state_rejects_missing_successful_mcp_receipt() -> None:
+    """Reject completion when a required MCP tool lacks a successful receipt."""
+
+    state = _build_complete_large_state()
+    receipts = cast("list[dict[str, object]]", state["mcp_call_receipts"])
+    receipts[0] = {**receipts[0], "ok": False}
+
+    errors = _validate(state)
+
+    assert "Checkpoint missing successful MCP receipt: new_potential_entry." in errors
+
+
+def test_complete_state_rejects_required_agent_list_mismatch() -> None:
+    """Reject completion when checkpoint route requirements differ from matrix."""
+
+    state = _build_complete_large_state()
+    state["required_agents"] = ["atomic-planner"]
+
+    errors = _validate(state)
+
+    assert any("required_agents must match routing matrix" in error for error in errors)
+
+
+def test_complete_state_rejects_local_execution_override() -> None:
+    """Reject completion when local execution bypasses are recorded."""
+
+    state = _build_complete_large_state()
+    state["local_execution_overrides"] = [{"step": "S8"}]
+
+    errors = _validate(state)
+
+    assert "Checkpoint local_execution_overrides must be empty at completion." in errors
+
+
+def test_complete_state_rejects_non_mcp_lifecycle_operation() -> None:
+    """Reject completion when lifecycle evidence records a non-MCP surface."""
+
+    state = _build_complete_large_state()
+    state["lifecycle_operations"] = [
+        {"name": "new_active_feature_folder", "surface": "cli"}
+    ]
+
+    errors = _validate(state)
+
+    assert "Checkpoint lifecycle_operations #0 did not use MCP surface." in errors


### PR DESCRIPTION
# Add orchestrator routed checkpoint validation, Codex worktree session command, and bundled agent guardrails

## Summary

- Add a routing-matrix-driven orchestrator-state validation contract (`scripts/dev_tools/_orchestrator_state_routing.py`) that enforces required agents, skills, MCP-tool receipts, and no-local-bypass invariants at checkpoint completion.
- Introduce `config/orchestration-routing.json` defining `small`, `large`, and `remediation` routes with their mandatory agent, skill, and MCP-tool sets.
- Add a GitHub Actions reusable workflow (`_validate-orchestrator-state.yml`) and its caller (`validate-orchestrator-state.yml`) to run checkpoint validation in CI on `main`/`development` pull requests and pushes.
- Add a new VS Code command `drmCopilotExtension.newCodexWorktreeSession` that creates a git worktree, writes a Codex project-trust entry, runs optional Poetry setup and a post-session script, then starts the Codex CLI.
- Synchronize bundled `codex-and-agents-customizations` skills with the repository rule set: add new skill mirrors (general-code-change, general-unit-test, quality-tiers, tonality, architecture-boundaries, benchmark-baselines, ci-workflows, orchestrator-state, human-exception-runbook) and update existing skills, Codex agent/config TOML, and orchestration docs.
- Wire the routing contract into the completion gate of `validate_orchestrator_state_text` and add a routing-contract unit test.

## Why

- The orchestrator-state checkpoint previously validated structural fields and remediation/human-interaction invariants but did not enforce that the route actually used its mandatory agents, skills, and MCP tools, nor that no local-execution overrides or delegation bypasses were recorded. The routing contract closes that gap so resume and review workflows can trust that delegation occurred as required.
- A CI gate was needed so checkpoint validation runs automatically rather than only in local tooling.
- The Codex worktree session command extends the existing Claude worktree session workflow to the Codex CLI, including a project-trust step required before Codex loads project-local `.codex` settings.
- Bundled extension resources under `extensions/drm-copilot/resources/` had drifted from the canonical rule files; this PR re-synchronizes the skill mirrors.

PR Intent fields (Primary outcome, Impact, Risks) were left blank in the provided context.

## What Changed

### Core feature — orchestration routing validation
- `config/orchestration-routing.json` (new): route definitions for `small`, `large`, and `remediation`, each listing `required_agents`, `required_skills`, and `required_mcp_tools`.
- `scripts/dev_tools/_orchestrator_state_routing.py` (new, +216): `validate_routing_contract(...)` loads the routing matrix, resolves the route from `route_id`/`path_selected`, verifies the checkpoint's `required_*` lists match the matrix, confirms agent/skill/MCP receipts are present, and requires `local_execution_overrides` and `delegation_bypasses` to be empty and any `lifecycle_operations` to use the `mcp` surface.
- `scripts/dev_tools/validate_orchestrator_state.py` (+2): invokes `validate_routing_contract(state_map)` inside the `require_complete` completion gate.
- The same two files are mirrored under `extensions/drm-copilot/resources/scripts/dev_tools/`.

### Tooling / CI
- `.github/workflows/_validate-orchestrator-state.yml` (new): reusable `workflow_call` job that checks out the repo, sets up Python 3.13 and Poetry, installs dependencies, and runs `validate_orchestration_artifacts orchestrator-state` with `--require-complete`; honors `state-path` and `require-checkpoint` inputs.
- `.github/workflows/validate-orchestrator-state.yml` (new): caller wired to `pull_request`/`push` on `main` and `development`, with `require-checkpoint: false`.
- Mirrors of both workflows under `extensions/drm-copilot/resources/codex-and-agents-customizations/.github/workflows/`.

### Codex worktree session command (TypeScript)
- `extensions/drm-copilot/src/codex-worktree-session.ts` (new): `buildCodexTrustCommand(...)` and `buildCodexWorktreeSessionCommands(...)` produce the ordered PowerShell terminal commands (git worktree add, set-location, Codex trust entry, optional Poetry install/activate, optional post-codex script, codex start).
- `extensions/drm-copilot/src/extension.ts`: registers `drmCopilotExtension.newCodexWorktreeSession`, prompts for an objective, builds the worktree path/branch, sends the commands to a new terminal, and defers the `codex` start by the activation grace interval.
- `extensions/drm-copilot/package.json`: command/configuration contributions for the new command.
- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/scripts/post-codex-worktree-session.ps1` (new).

### Tests
- `tests/scripts/dev_tools/test_validate_orchestrator_state_routing_contract.py` (new, +173): routing-contract unit tests.
- `extensions/drm-copilot/test/codex-worktree-session.test.ts` (new), `extensions/drm-copilot/test/codex-worktree-session-command.test.ts` (new), and additions to `extensions/drm-copilot/test/extension-test-harness.ts`.

### Bundled skills / agents / config
- New skill mirrors: `general-code-change`, `general-unit-test`, `quality-tiers`, `tonality`, `architecture-boundaries`, `benchmark-baselines`, `ci-workflows`, `orchestrator-state`, `human-exception-runbook` (plus `example.runbook.md`).
- Updated skills include `orchestrate`, `orchestrator-workflow`, `repo-automation-adapter`, the language change-budget routers and QA gates, suppression skills, and review skills.
- `.codex/agents/orchestrator.toml` and `.codex/config.toml` updated.

## Architecture / How It Fits Together

- `validate_orchestrator_state_text` parses the checkpoint, validates required keys, step statuses, delegation receipts, and the additive remediation-loop and human-interaction invariants. When called with `require_complete=True`, it additionally calls `validate_routing_contract`, which reads `config/orchestration-routing.json` (resolved relative to the module via `parents[2]/config`).
- The routing contract correlates declared `required_agents`/`required_skills`/`required_mcp_tools` against actual `delegation_receipts`, `skill_receipts`, and `mcp_call_receipts`, and rejects any non-empty `local_execution_overrides`/`delegation_bypasses` or non-MCP `lifecycle_operations`.
- The CI caller workflow invokes the reusable workflow, which runs the same validator entrypoint (`scripts.dev_tools.validate_orchestration_artifacts`) used locally, giving a single validation surface.
- The Codex command path mirrors the existing Claude worktree session command: `extension.ts` (host wiring) calls pure command-builder functions in `codex-worktree-session.ts`, keeping terminal/UI side effects separate from the command-string logic.

## Verification

### Completed
- Not verified in this PR. The provided context reports no canonical verification evidence parsed, and CI status at HEAD is `in_progress`.

### Recommended
- Python: `poetry run black .`, `poetry run ruff check .`, `poetry run pyright`, `poetry run pytest --cov --cov-branch --cov-report=term-missing`
- TypeScript (extension): `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test`
- Confirm the `Orchestrator State Gate` workflow runs green against the branch head.
- Manually exercise `drmCopilotExtension.newCodexWorktreeSession` to confirm worktree creation, trust-entry write, and Codex start ordering.

## Backward Compatibility / Migration Notes

- The routing contract executes only under the `require_complete` completion gate; non-completion validation paths are unchanged.
- Routing validation depends on `config/orchestration-routing.json` and on the checkpoint exposing `route_id`/`path_selected`, `required_*` lists, and the corresponding receipt arrays. Checkpoints reaching the completion gate without these fields will now report errors.
- `validate-orchestrator-state.yml` uses `require-checkpoint: false`, so a missing checkpoint file does not fail the run.
- No public API removals or path renames identified in the changed-files set.

## Risks and Mitigations

- Risk: the completion gate becomes stricter and may surface errors for checkpoints that omit routing fields. Mitigation: routing validation is scoped to `require_complete`; populate `route_id`, `required_*`, and receipt fields per `config/orchestration-routing.json`.
- Risk: the routing matrix path is resolved via `parents[2]/config`; relocating the module without updating the relative path would break loading. Mitigation: the module exposes `ROUTING_MATRIX_PATH` and accepts an injected `routing_matrix` for tests.
- Risk: the Codex trust command edits `~/.codex/config.toml`; a malformed pre-existing entry raises rather than silently overwriting. Mitigation: the command throws an explicit error when an existing project entry is not trusted.
- Risk: duplicated source under `scripts/` and `extensions/drm-copilot/resources/scripts/` can drift. Mitigation: keep both copies in sync; consider a future sync check.
- Rollback: revert this PR; the new workflows, command, and routing gate are additive.

## Review Guide

Suggested order:
1. `config/orchestration-routing.json` — route definitions.
2. `scripts/dev_tools/_orchestrator_state_routing.py` — routing contract logic.
3. `scripts/dev_tools/validate_orchestrator_state.py` — completion-gate wiring (+2 lines).
4. `tests/scripts/dev_tools/test_validate_orchestrator_state_routing_contract.py` — contract coverage.
5. `.github/workflows/_validate-orchestrator-state.yml` and `validate-orchestrator-state.yml` — CI gate.
6. `extensions/drm-copilot/src/codex-worktree-session.ts`, `extension.ts`, and the two new TS tests.
7. Bundled skill/agent/config changes (largely mechanical mirrors of canonical rules; high file count, lower per-file complexity).

Noisy/mechanical: the bulk of the 73 changed files are `.md` skill mirrors and the `.codex` TOML re-formatting; the `extensions/drm-copilot/resources/scripts/...` Python files duplicate the top-level `scripts/dev_tools/...` files verbatim.

## Follow-ups

- Consider a CI check that asserts parity between `scripts/dev_tools/*` and `extensions/drm-copilot/resources/scripts/dev_tools/*`.
- Confirm CI status (currently `in_progress`) reaches green before merge.

## GitHub Auto-close

None (no verified closing issues; readiness not PASS and no author-asserted autoclose issues in context).
