### PR TITLE
fix(activate): tolerate null console background in the venv-aware prompt

### DIFF
--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/code-review.2026-06-18T09-32.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/code-review.2026-06-18T09-32.md
@@ -1,0 +1,103 @@
+# Code Review: activate-prompt-null-background (#202)
+
+**Review Date:** 2026-06-18
+**Reviewer:** feature-review agent
+**Feature Folder:** `docs/features/active/2026-06-18-activate-prompt-null-background-202`
+**Feature Folder Selection Rule:** Selected by issue-number suffix `-202` matching the branch's autoclose issue #202; it is the only active folder with material scoping-doc changes in the diff.
+**Base Branch:** `main` (`origin/main` @ `db3d528ea9c8fb87e9ec21a4d96e4c263d347651`)
+**Head Branch:** `fix/activate-prompt-null-background` @ `34176ed1ed82c1353443667dbcb10bff60541deb`
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+The branch makes `Get-VenvAwarePrompt -BackgroundColor` null-tolerant so the installed `global:prompt` shim does not throw in hosts that report a null console background (for example the VS Code Pester test adapter). The change is small and localized: the parameter is relaxed from mandatory non-nullable `[System.ConsoleColor]` to optional `[AllowNull()] [System.Nullable[System.ConsoleColor]]`, and a null guard renders the prompt uncolored instead of binding null into the non-nullable dark-background predicate. A deterministic regression test is added that supplies `$null` explicitly, removing the prior ambient-host dependence.
+
+**What changed:**
+- `scripts/dev-tools/activate.ps1` (+18/-4): parameter contract widened; null guard added around `Test-IsDarkBackground`; comment-help updated.
+- `tests/scripts/dev-tools/activate.Tests.ps1` (+12/-0): one new `It` asserting the null-background path returns the uncolored prompt.
+- Three feature-scoping docs added (spec, issue, plan).
+
+No production behavior changes when a valid background color is supplied: dark -> green-wrapped, non-dark -> plain (verified by retained parameterized tests). `Test-IsDarkBackground` and `Get-ColorizedPrompt` are unchanged.
+
+**Top 3 risks:**
+1. A host reporting a non-null but invalid background (for example integer `-1`) is not handled; the spec explicitly scopes this out and documents it as a follow-up. Low risk given the observed defect is null only.
+2. Repo coverage configuration (`pester.runsettings.psd1`) does not include `activate.ps1`, so the standing coverage artifact does not exercise this file; coverage was verified by a scoped run during review. Configuration follow-up, not a code defect.
+3. CI required-checks green on the PR head (AC6) is unverified because no PR exists yet for this branch.
+
+**PR readiness recommendation:** **Go** — The change is minimal, correct, deterministic, and passes the full PowerShell toolchain with high coverage on the changed file. The only outstanding item (CI green on PR head) is a downstream gate, not a code defect.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Info | `scripts/powershell/PoshQC/settings/pester.runsettings.psd1` | `CodeCoverage.Path` | The standing coverage scope excludes `scripts/dev-tools/activate.ps1`, so the repo coverage artifact provides no coverage for the changed file. | Consider widening coverage scope to include `scripts/dev-tools/**` in a follow-up so standing CI coverage exercises this file. | The change is verified here by a scoped run, but the standing gate will not track regressions on this file. | `pester.runsettings.psd1` lines for `CodeCoverage.Path`; `artifacts/pester/powershell-coverage.xml` contains only `.claude/hooks` classes. |
+| Info | `scripts/dev-tools/activate.ps1` | `Get-VenvAwarePrompt` null guard | Non-null but invalid background values (e.g. `-1`) are not normalized. | None required for this fix; tracked as spec follow-up. | Out of scope for the observed null defect; documented in spec Risks & Mitigations. | `spec.md` Risks & Mitigations. |
+
+No Blocker or Major findings.
+
+---
+
+## Implementation Audit
+
+### PowerShell implementation audit
+
+#### What changed well
+
+- The fix is the minimal correct change: it widens one parameter and adds one guard, preserving the existing decision pipeline (`Test-IsDarkBackground` -> `Get-ColorizedPrompt`) untouched.
+- The null path is implemented as an explicit `if ($null -ne $BackgroundColor) { ... } else { $false }` expression rather than swallowing an exception, so the failure mode is now defined behavior rather than a caught throw.
+- The parameter contract uses `[System.Nullable[System.ConsoleColor]]` with `[AllowNull()]`, which is the idiomatic way to accept null for a value-type parameter in PowerShell, and matches the spec design.
+
+#### API and safety notes
+
+- The parameter change from mandatory non-nullable to optional nullable is a widening change: existing callers that pass a valid `[System.ConsoleColor]` continue to bind and behave identically. No in-repo caller is broken.
+- `[CmdletBinding()]`, `[OutputType([string])]`, and `-CurrentPath`'s `[ValidateNotNullOrEmpty()]` are retained. Approved verb `Get` is used.
+
+#### Error handling and logging
+
+- The change converts a parameter-bind exception into a deterministic uncolored render. No logging is needed for this pure decision function; failing fast is not appropriate here because a null background is a legitimate host condition, not an invariant violation.
+
+---
+
+## Test Quality Audit
+
+The added test is deterministic and isolated. It supplies `-BackgroundColor $null` explicitly, which removes the ambient-host dependence that the spec identifies as the root cause of the original masked defect (the prior suite read the live host background, which is non-null on CI/terminal and null only in the adapter host). The assertion checks the exact uncolored prompt string, so a regression to colored output or a re-introduced throw would fail clearly.
+
+### Reviewed test and QA artifacts
+
+- `tests/scripts/dev-tools/activate.Tests.ps1` — Adds the null-background `It`; retains parameterized dark/non-dark coverage for `Test-IsDarkBackground` and the Black -> green-wrapped case for `Get-VenvAwarePrompt`. 53/53 tests pass.
+- `docs/features/active/2026-06-18-activate-prompt-null-background-202/evidence/coverage/activate-coverage.xml` — JaCoCo coverage for `scripts/dev-tools/activate.ps1`: 98.21% commands, 98.1% lines, all changed lines covered (generated during this review).
+
+### Quality assessment prompts
+
+- **Determinism:** The new test passes `$null` directly; no clock, RNG, network, or ambient host dependence.
+- **Isolation:** Each `It` targets a single behavior; the null case is independent of dark/light cases.
+- **Speed:** Full suite 0.985s for 53 tests.
+- **Diagnostics:** `Should -Be` on the prompt string yields explicit expected-vs-actual output on failure.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | PASS | Diff contains no credentials or tokens. |
+| No unsafe subprocess or command construction | PASS | No `Invoke-Expression` or external command construction in the change. |
+| Input validation at boundaries | PASS | `-BackgroundColor` now explicitly accepts null via `[AllowNull()]`; `-CurrentPath` retains `[ValidateNotNullOrEmpty()]`. |
+| Error handling remains explicit | PASS | Null handled by explicit branch, not a swallowed exception. |
+| Configuration / path handling is safe | PASS | No path or config handling changed. |
+
+---
+
+## Research Log
+
+No external research was required. The change is fully specified by `spec.md` and verifiable against repository policy and the local PowerShell toolchain.
+
+---
+
+## Verdict
+
+The change is ready for normal PR flow. It is a minimal, correct, deterministic null-tolerance fix with high coverage on the changed production file and a clean PowerShell toolchain pass (format, analyze, test). The two recorded findings are Info-level: a standing coverage-scope configuration limitation (compensated during review) and an explicitly out-of-scope non-null-invalid-value case documented as a spec follow-up. The only readiness item outside the code is confirmation of green CI on the PR head, which is a downstream gate. Recommendation: **Go**.

--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/feature-audit.2026-06-18T09-32.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/feature-audit.2026-06-18T09-32.md
@@ -1,0 +1,93 @@
+# Feature Audit: activate-prompt-null-background (#202)
+
+**Audit Date:** 2026-06-18
+**Feature Folder:** `docs/features/active/2026-06-18-activate-prompt-null-background-202`
+**Base Branch:** `main`
+**Head Branch:** `fix/activate-prompt-null-background`
+**Work Mode:** `full-bug`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (`origin/main` @ `db3d528ea9c8fb87e9ec21a4d96e4c263d347651`)
+- **Head branch/commit:** `fix/activate-prompt-null-background` @ `34176ed1ed82c1353443667dbcb10bff60541deb`
+- **Merge base:** `db3d528ea9c8fb87e9ec21a4d96e4c263d347651`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-06-18-activate-prompt-null-background-202/evidence/coverage/activate-coverage.xml`
+  - Additional evidence: `git diff db3d528..34176ed`; Pester/PSScriptAnalyzer/Invoke-Formatter output captured during review.
+- **Feature folder used:** `docs/features/active/2026-06-18-activate-prompt-null-background-202`
+- **Requirements source:** `spec.md` (`## Acceptance Criteria`)
+- **Work mode resolution note:** `issue.md` carries `- Work Mode: full-bug`. Per the work-mode contract, `full-bug` resolves the AC source to `spec.md` only.
+- **Scope note:** The audit scope is the full feature-vs-base diff (`db3d528..34176ed`), which contains exactly one production PowerShell file, one PowerShell test file, and three feature-scoping docs. No caller narrowing was accepted.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md` — only source (work mode `full-bug`)
+
+### Acceptance criteria
+
+1. AC1: `Get-VenvAwarePrompt -BackgroundColor $null` returns the uncolored prompt and does not throw.
+2. AC2: A valid background color is unchanged in behavior (dark -> green-wrapped, light/non-dark -> plain).
+3. AC3: A deterministic regression test for the null-background case exists and passes without depending on the ambient host.
+4. AC4: `tests/scripts/dev-tools/activate.Tests.ps1` passes in full (no failures).
+5. AC5: Full PowerShell toolchain passes (format -> analyze -> test) with zero new findings.
+6. AC6: CI required checks are green on the PR head.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | `Get-VenvAwarePrompt -BackgroundColor $null` returns uncolored prompt, no throw | PASS | New `It` passes asserting `Should -Be '(mix-calculator)> '`; null guard at `activate.ps1` lines 301-306 renders uncolored. 53/53 tests pass. | `Invoke-Pester` on `tests/scripts/dev-tools/activate.Tests.ps1` | Null path (else `$false`, line 305) is covered. |
+| 2 | Valid background unchanged (dark -> green, non-dark -> plain) | PASS | Parameter change is a widening; `Test-IsDarkBackground` and `Get-ColorizedPrompt` unchanged in diff. Retained tests cover Black -> green-wrapped and non-dark -> plain; `Test-IsDarkBackground` parameterized over all dark/non-dark colors all pass. | `git diff db3d528..34176ed -- scripts/dev-tools/activate.ps1`; `Invoke-Pester` | No behavior change for valid colors confirmed by diff inspection plus passing tests. |
+| 3 | Deterministic null-background regression test exists, host-independent | PASS | The added `It` supplies `$null` explicitly (no ambient host read), with a comment documenting Test Explorer host parity. | `git diff db3d528..34176ed -- tests/scripts/dev-tools/activate.Tests.ps1` | Removes the ambient-host determinism violation noted in spec Root Cause Analysis. |
+| 4 | `activate.Tests.ps1` passes in full | PASS | 53 passed, 0 failed, 0 skipped. | `Invoke-Pester -Configuration <activate suite>` | Execution 0.985s. |
+| 5 | Full PowerShell toolchain passes (format -> analyze -> test), zero new findings | PASS | FORMAT_CLEAN (Invoke-Formatter, no diff), ANALYZE_CLEAN (PSScriptAnalyzer with repo `pssa.settings.psd1`, zero findings), 53/53 tests pass. | `Invoke-Formatter`; `Invoke-ScriptAnalyzer -Settings scripts/powershell/PoshQC/settings/pssa.settings.psd1`; `Invoke-Pester` | All stages clean in a single pass. |
+| 6 | CI required checks green on PR head | UNVERIFIED | No PR exists for this branch (PR digests: none; CI status HEAD: not available in PR context). | n/a | Cannot be verified locally; downstream orchestrator CI gate must confirm. Not a code defect. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS (pending downstream CI confirmation for AC6)
+
+**Criteria summary:**
+- **PASS:** 5 criteria (AC1-AC5)
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 1 criterion (AC6)
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. AC6 (CI green on PR head) is UNVERIFIED because no PR exists yet for this branch. This is a downstream gate, not a local defect; it does not require remediation.
+
+**Recommended follow-up verification steps:**
+
+1. Open the PR for `fix/activate-prompt-null-background` and confirm required CI checks are green on head `34176ed` to satisfy AC6.
+2. Optionally widen `pester.runsettings.psd1` coverage scope to include `scripts/dev-tools/**` so the standing coverage gate tracks `activate.ps1`.
+
+---
+
+## Acceptance Criteria Check-Off
+
+Per the acceptance-criteria tracking rules, AC1-AC5 are evaluated PASS and are checked off in the authoritative source file `spec.md`. AC6 is UNVERIFIED and remains unchecked.
+
+### AC Status Summary
+
+- Source: `docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md`
+- Total AC items: 6
+- Checked off (delivered): 5 (AC1-AC5)
+- Remaining (unchecked): 1
+- Items remaining: AC6: CI required checks are green on the PR head.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `spec.md` | 6 | 5 | 1 | Checkbox-backed; AC6 left unchecked pending downstream CI on the PR head. |

--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/issue.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/issue.md
@@ -1,0 +1,64 @@
+# activate-prompt-null-background (Issue #202)
+
+- Date captured: 2026-06-18
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/activate-prompt-null-background/ (Issue #202)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #202
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/202
+- Last Updated: 2026-06-18
+- Work Mode: full-bug
+
+## Summary
+
+One or two sentences on what is broken.
+
+## Environment
+
+- OS/version:
+- Python version:
+- Command/flags used:
+- Data source or fixture:
+
+## Steps to Reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened (include key error text).
+
+## Logs / Screenshots
+
+- [ ] Attached minimal logs or screenshot
+- Snippet:
+
+## Impact / Severity
+
+- [ ] Blocker
+- [ ] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+Optional early hunches, related changes, or files to inspect.
+
+## Proposed Fix / Validation Ideas
+
+- [ ] Unit coverage areas
+- [ ] Integration scenario to retest
+- [ ] Manual verification notes
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/plan.2026-06-18T09-25.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/plan.2026-06-18T09-25.md
@@ -1,0 +1,43 @@
+# activate-prompt-null-background (Plan)
+
+- **Issue:** #202
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-18T09-25
+- **Status:** Active
+- **Version:** 1.0
+
+**Fail-closed evidence rule:** This change touches one production PowerShell file (`activate.ps1`, Tier T4) and its test. Coverage must not regress on changed lines; the new null-background test covers the changed branch.
+
+**Evidence accounting rule:** Record the expected artifact path or location in each evidence-producing task.
+
+**Phase 0 — Context & Inputs**
+- [x] [P0-T1] Link approved spec: `docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md`
+- [x] [P0-T2] Record branch/commit baseline: branch `fix/activate-prompt-null-background` off `main` (`db3d528`)
+- [x] [P0-T3] Reproduce the failure deterministically: `Get-VenvAwarePrompt -BackgroundColor $null` throws the ConsoleColor cast error
+
+**Phase 1 — Preparation**
+- [x] [P1-T1] Scope locked: null-tolerant `-BackgroundColor` + deterministic regression test; no other behavior changes
+- [x] [P1-T2] Workspace on branch; PoshQC toolchain available
+
+**Phase 2 — Regression Test (must fail first)**
+- [x] [P2-T1] [expect-fail] Add a unit test asserting `Get-VenvAwarePrompt -BackgroundColor $null` returns the uncolored prompt
+- [x] [P2-T2] [expect-fail] Confirm the test fails against the pre-fix code (null bind throws) and passes after the fix
+
+**Phase 3 — Minimal Fix**
+- [x] [P3-T1] Make `Get-VenvAwarePrompt -BackgroundColor` optional/`[AllowNull()]`/`[System.Nullable[System.ConsoleColor]]`; treat null as not-dark; leave `Test-IsDarkBackground` unchanged
+
+**Phase 4 — Verification Loop**
+- [x] [P4-T1] Re-run repro: null -> uncolored prompt; dark -> green; light -> plain
+- [x] [P4-T2] Run PoshQC format -> analyze -> test; restart loop on any change/failure (BOM/non-ASCII finding fixed; re-ran clean)
+- [x] [P4-T3] Full `activate.Tests.ps1`: 53 passed / 0 failed / 0 skipped (Pester 5.6.1)
+
+**Phase 5 — Documentation & Status**
+- [x] [P5-T1] Update spec/issue with root cause, fix, and AC
+
+**Phase 6 — PR & Handoff**
+- [ ] [P6-T1] Pre-review commit; feature-review; PR with summary, risks, validation, links to issue #202
+
+**Phase 7 — Rollout / Follow-up**
+- [ ] [P7-T1] S9 CI green gate on PR head; remediate until green
+- [ ] [P7-T2] Record links (issue #202, PR) for traceability

--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/policy-audit.2026-06-18T09-32.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/policy-audit.2026-06-18T09-32.md
@@ -1,0 +1,435 @@
+# Policy Compliance Audit: activate-prompt-null-background (Issue #202)
+
+**Audit Date:** 2026-06-18
+**Code Under Test:** `scripts/dev-tools/activate.ps1` (production, modified), `tests/scripts/dev-tools/activate.Tests.ps1` (test, modified)
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| PowerShell | 1 prod + 1 test | 53 tests | PASS 53 pass, 0 fail | Not separately captured (see note) | 98.21% commands, 98.1% lines (52/53) on `activate.ps1` | All 8 changed lines covered |
+
+**Note:** Both changed files are modifications of pre-existing files (not new files). No language other than PowerShell has changed files in the branch diff (`db3d528..34176ed`). TypeScript, Python, and C# coverage verdicts are N/A because those languages have zero changed files on the branch.
+
+### Coverage Evidence Checklist
+
+- PowerShell post-change coverage artifact (changed production file): `docs/features/active/2026-06-18-activate-prompt-null-background-202/evidence/coverage/activate-coverage.xml` (generated during this review by a Pester run scoped to `scripts/dev-tools/activate.ps1`).
+- Pre-existing repo coverage artifact `artifacts/pester/powershell-coverage.xml`: present but scopes `CodeCoverage.Path` to five `.claude/hooks` files only and does NOT include `scripts/dev-tools/activate.ps1`. It therefore provides no coverage evidence for the changed production file. See Section 8.
+- Per-language comparison summary: Section 1.2.1.
+
+**Verdict rule applied:** PowerShell coverage verdict is explicit PASS based on numeric post-change coverage of the changed production file (98.21% commands, 98.1% lines), with all changed lines covered.
+
+---
+
+## Executive Summary
+
+The branch implements the null-tolerant `-BackgroundColor` fix for `Get-VenvAwarePrompt` in `scripts/dev-tools/activate.ps1` and adds a deterministic regression test in `tests/scripts/dev-tools/activate.Tests.ps1`. The diff against the resolved base (`origin/main` @ `db3d528`) is limited to one production PowerShell file, one test PowerShell file, and three feature-scoping docs. No workflow, benchmark, or action files are touched.
+
+The PowerShell toolchain (format -> analyze -> test) was executed during this review and passed cleanly. All 53 tests in the activate suite pass. Coverage on the changed production file is 98.21% commands / 98.1% lines, with every changed line covered.
+
+**Policy documents evaluated:**
+- PASS `general-code-change.md` (cross-language code change policy)
+- PASS `general-unit-test.md` (cross-language unit test policy)
+- PASS `powershell.md` (PowerShell toolchain and standards)
+- PASS `quality-tiers.md` (uniform coverage thresholds)
+
+**Language-specific policies evaluated:**
+- N/A Python (no changed files)
+- PASS PowerShell (`powershell-code-change` + `powershell-unit-test`)
+- N/A Bash (no changed files)
+- N/A JSON (no changed files)
+
+**Temporary artifacts cleanup:**
+- PASS No temporary or one-time scripts were created during this review. The coverage artifact written to the feature evidence folder is a durable review artifact in the canonical location.
+
+---
+
+## Evidence Location Compliance
+
+The branch diff (`db3d528..34176ed`) was scanned for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`.
+
+- Branch-diff scan result: **NONE**. No file in this branch's diff is written to a non-canonical evidence path.
+- `validate_evidence_locations.py --root .` exited 0. It reported pre-existing violations under `artifacts/evidence/baseline/**` and `artifacts/evidence/post-change/**` dated 2026-04-18 and 2026-04-25. These files are NOT part of this branch's diff and are not attributable to this feature; they are out of audit scope (the scope is the feature-vs-base diff). No FAIL finding is recorded against this feature for them.
+- The coverage evidence this review produced was written to the canonical `<FEATURE>/evidence/coverage/` path (`docs/features/active/2026-06-18-activate-prompt-null-background-202/evidence/coverage/activate-coverage.xml`). No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` was required; no caller instruction specified a non-canonical evidence path.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | PASS | Tests use `BeforeAll` to import functions via AST/ScriptBlock dot-source; each `It` is self-contained with no shared mutable state. The full suite ran successfully in a single Invoke-Pester pass. |
+| **Isolation** - Each test targets single behavior | PASS | Each `It` exercises one function/behavior (e.g., `Test-IsDarkBackground` per-color cases, `Get-VenvAwarePrompt` per-scenario). The new null-background test targets exactly the null path. |
+| **Fast Execution** - Tests complete quickly | PASS | Full activate suite (53 tests) completed in 985 ms (discovery 147 ms). |
+| **Determinism** - Consistent results | PASS | The new test supplies `-BackgroundColor $null` explicitly rather than reading the ambient host, removing the determinism violation called out in spec Root Cause Analysis. Dark/light cases use literal `[System.ConsoleColor]` values. |
+| **Readability & Maintainability** - Clear structure | PASS | Descriptive `It` names; the new test includes a rationale comment explaining Test Explorer host parity. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | PARTIAL | A baseline coverage figure for `activate.ps1` was not separately captured before the change because the repo `pester.runsettings.psd1` does not include `activate.ps1` in coverage scope. Post-change coverage was measured directly: 98.21% commands. Disposition does not block since changed-line coverage is verified at 100%. |
+| **No Coverage Regression** | PASS | All 8 changed production lines (288, 289, 292, 293, 301, 302, 305, 307) are covered (`ci>=1`, `mi=0`). No regression on changed lines. |
+| **New Code Coverage >= 85%/>=90%** | PASS | The changed file is a modified file (not new). Line coverage 98.1% (52/53), command coverage 98.21% (55/56), exceeding the >= 85% line threshold. The single uncovered command is unrelated to the change. |
+| **Comprehensive Coverage** | PASS | `Get-VenvAwarePrompt` is covered for venv-active, default, dark, light, and null-background paths. The new null path (`$false` else branch, line 305) is covered. |
+| **Positive Flows** | PASS | Valid background colors (Black -> green; non-dark -> plain) and valid venv path are tested. |
+| **Negative Flows** | PASS | Null background (`-BackgroundColor $null`) is the negative/edge input for the fix and is tested deterministically. |
+| **Edge Cases** | PASS | Null background, empty venv, and per-color boundary cases are covered. |
+| **Error Handling** | PASS | The fix converts a parameter-bind throw into a defined uncolored-render path; the test asserts no throw and the expected uncolored output. |
+| **Concurrency** | N/A | Not applicable to a pure prompt-decision function. |
+| **State Transitions** | N/A | The function under test is pure with no state. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- PowerShell: Baseline: not separately captured (repo coverage scope excludes `activate.ps1`) -> Post-change: 98.21% commands / 98.1% lines on `scripts/dev-tools/activate.ps1`. Changed-line coverage: 100% (8/8 changed lines covered). Disposition: PASS. Evidence: `docs/features/active/2026-06-18-activate-prompt-null-background-202/evidence/coverage/activate-coverage.xml`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | PASS | `Should -Be` assertions produce explicit expected-vs-actual messages on the prompt string. |
+| **Arrange-Act-Assert Pattern** | PASS | Each `It` arranges inputs as parameters, acts by invoking the function, and asserts on the returned string. |
+| **Document Intent** | PASS | The new test name and inline comment document the Test Explorer host-parity scenario. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | PASS | The activate tests exercise pure functions imported via AST; no network, DB, or live executable. |
+| **Use Mocks/Stubs** | PASS | The new test requires no mocks; it passes `$null` directly. No prohibited direct executable mocking introduced. |
+| **Environment Stability** | PASS | No temporary files; the new test does not read ambient host state, satisfying Terminal/Test Explorer parity. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | PASS | This audit constitutes the required policy review prior to PR. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | PASS | Objective documented in `spec.md` (Issue #202): make `Get-VenvAwarePrompt -BackgroundColor` null-tolerant. |
+| **Read existing change plans** | PASS | `plan.2026-06-18T09-25.md` present with recorded P0-P4 tasks. |
+| **Document the plan** | PASS | Plan and spec recorded in the feature folder. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | PASS | The fix adds a single null guard around the existing `Test-IsDarkBackground` call; no new abstractions. |
+| **Reusability** | PASS | `Test-IsDarkBackground` and `Get-ColorizedPrompt` are unchanged and reused. |
+| **Extensibility** | PASS | `-BackgroundColor` is now optional with `[AllowNull()]`; future invalid-value normalization is noted as follow-up in spec Risks. |
+| **Separation of concerns** | PASS | Pure decision logic remains separate from host access; the shim continues to supply the host value. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | PASS | Change is localized to one function in the existing cohesive script. |
+| **Under 500 lines** | PASS | `activate.ps1` = 434 lines; `activate.Tests.ps1` = 417 lines. |
+| **Public vs internal** | PASS | `-BackgroundColor` parameter contract relaxed from mandatory non-nullable to optional nullable; this is a widening (non-breaking) change. |
+| **No circular dependencies** | PASS | No new dependencies introduced. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | PASS | Parameter and function names unchanged and descriptive. |
+| **Docs/docstrings** | PASS | The `.PARAMETER BackgroundColor` comment-help was updated to document the null case. |
+| **Comment why, not what** | PASS | The inline comment at the null guard explains the rationale (redirected/non-interactive host reports null) rather than restating the code. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | PASS | `Invoke-Formatter` on both changed files returned no diff (FORMAT_CLEAN). |
+| **2. Linting** | PASS | `Invoke-ScriptAnalyzer -Settings scripts/powershell/PoshQC/settings/pssa.settings.psd1` returned zero findings on both files (ANALYZE_CLEAN). |
+| **3. Type checking** | N/A | Not applicable for PowerShell. |
+| **4. Testing** | PASS | Invoke-Pester on the activate suite: 53 passed, 0 failed, 0 skipped. |
+| **Full toolchain loop** | PASS | Format, analyze, and test all passed in a single pass during this review. |
+| **Explicit reporting** | PASS | Commands and results recorded in this audit (Section 7, Appendix B). |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | PASS | Documented in spec Proposed Fix and commit `34176ed`. |
+| **Design choices explained** | PASS | Null-as-not-dark rationale documented in spec and inline comment. |
+| **Update supporting documents** | PASS | spec.md, issue.md, plan present. |
+| **Provide next steps** | PASS | spec Rollout notes merge via PR after green CI. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3B: PowerShell Code Change Policy Compliance
+
+#### 3B.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with Invoke-Formatter** | PASS | FORMAT_CLEAN on both files. |
+| **Linting with PSScriptAnalyzer** | PASS | ANALYZE_CLEAN on both files with repo `pssa.settings.psd1`. |
+| **Fix all findings** | PASS | No findings to fix. |
+| **PowerShell 7+ compatible** | PASS | `[System.Nullable[System.ConsoleColor]]` and ternary-style `if` expression are PowerShell 7 compatible; the spec environment is PowerShell 7. |
+
+#### 3B.2 PowerShell Design & Safety
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Advanced functions** | PASS | `Get-VenvAwarePrompt` retains `[CmdletBinding()]` and `[OutputType([string])]`. |
+| **Parameter validation** | PASS | `-BackgroundColor` uses `[Parameter()] [AllowNull()] [System.Nullable[System.ConsoleColor]]`; `-CurrentPath` retains `[ValidateNotNullOrEmpty()]`. |
+| **Avoid global state** | PASS | No global/script-scoped mutable state introduced. |
+| **Error handling** | PASS | The null guard replaces a bind-time throw with explicit branching; failure mode is now defined. |
+
+#### 3B.3 Structure, Naming, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive and under 500 lines** | PASS | 434 lines. |
+| **Approved verbs** | PASS | `Get-VenvAwarePrompt` uses the approved verb `Get`. |
+| **Comment why** | PASS | The guard comment explains the host-null rationale. |
+
+#### 3B.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Step 1: Format** | PASS | FORMAT_CLEAN. |
+| **Step 2: Analyze** | PASS | ANALYZE_CLEAN. |
+| **Step 3: Type check** | N/A | Not applicable for PowerShell. |
+| **Step 4: Test** | PASS | 53/53 passed. |
+| **Rerun loop if needed** | PASS | Single clean pass; no rerun required during review. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4B: PowerShell Unit Test Policy Compliance
+
+#### 4B.1 Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use Pester v5.x** | PASS | Pester 5.6.1; suite uses `Describe`/`Context`/`It` and modern `Should -Be`. |
+| **Use PoshQC Configuration** | PASS | Repo config `scripts/powershell/PoshQC/settings/pester.runsettings.psd1` exists; for changed-file coverage the review ran a scoped Pester configuration targeting `activate.ps1` because the repo runsettings scope excludes it (see Section 8). |
+| **PowerShell 7+ Compatible** | PASS | Tests run under PowerShell 7 / Pester 5.6.1. |
+
+#### 4B.2 Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Focused Unit Tests** | PASS | One behavior per `It`. |
+| **Test Behavior Over Implementation** | PASS | Tests assert returned prompt strings, not internals. |
+| **Mocking Used Sparingly** | PASS | The new test uses no mocks. |
+| **Organization** | PASS | Test file `tests/scripts/dev-tools/activate.Tests.ps1` mirrors `scripts/dev-tools/activate.ps1`. |
+
+#### 4B.3 Naming and Readability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **File Naming - *.Tests.ps1** | PASS | `activate.Tests.ps1`. |
+| **Describe/Context/It Structure** | PASS | Grouped under `Describe 'Get-VenvAwarePrompt ...'`. |
+| **Logical Grouping** | PASS | Null case grouped with the other `Get-VenvAwarePrompt` cases. |
+| **Docstrings/Comments** | PASS | New test name and comment self-document the scenario. |
+
+#### 4B.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use Pester** | PASS | Invoke-Pester via repo Pester 5.6.1. |
+| **No Alternative Test Runners** | PASS | Only Pester used. |
+
+---
+
+## 5. Test Coverage Detail
+
+### Get-VenvAwarePrompt (focus of the change)
+
+| Test Name | Scenario Type | Lines Covered | Status |
+|-----------|--------------|---------------|--------|
+| renders the prompt uncolored when the host background is null (Test Explorer host parity) | Edge/Negative (null) | 285, 288-289 or 292-293, 301, 305, 307 | PASS |
+| wraps the prompt in green for a dark background (Black) | Positive (dark) | 285, 301-302, 307 | PASS |
+| leaves the prompt plain for a non-dark background | Positive (light) | 285, 301-302, 307 | PASS |
+
+**Coverage:** `scripts/dev-tools/activate.ps1` 98.21% commands (55/56), 98.1% lines (52/53). All changed lines covered.
+
+**Not covered:** One command/line unrelated to this change remains uncovered (1 missed of 56). The changed region is fully covered.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests | 53 | PASS |
+| Tests Passed | 53 (100%) | PASS |
+| Tests Failed | 0 | PASS |
+| Execution Time | 0.985s total | PASS Fast |
+| Discovery Time | 147ms | PASS |
+| Test File Size | 417 lines | PASS Maintainable |
+| Code Coverage (changed prod file) | 98.21% commands, 98.1% lines; branch coverage UNVERIFIED (Pester JaCoCo emits no branch counter) | PASS (line/command) |
+
+---
+
+## 7. Code Quality Checks
+
+**For PowerShell:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Invoke-Formatter | `Invoke-Formatter -ScriptDefinition <file>` | No diff on both files | PASS |
+| PSScriptAnalyzer | `Invoke-ScriptAnalyzer -Path <file> -Settings scripts/powershell/PoshQC/settings/pssa.settings.psd1` | Zero findings on both files | PASS |
+| Pester Tests | `Invoke-Pester` (activate suite, coverage scoped to `activate.ps1`) | 53 passed / 0 failed; 98.21% command coverage | PASS |
+
+**Notes:**
+The repo `pester.runsettings.psd1` scopes coverage to `.claude/hooks` files only; the changed production file `scripts/dev-tools/activate.ps1` is not in that scope. To verify coverage for the changed file as required, this review executed a Pester run with `CodeCoverage.Path = scripts/dev-tools/activate.ps1`. See Section 8.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+- **Repo coverage configuration excludes the changed production file.** `scripts/powershell/PoshQC/settings/pester.runsettings.psd1` sets `CodeCoverage.Path` to five `.claude/hooks` files only. Consequently the pre-existing artifact `artifacts/pester/powershell-coverage.xml` contains no coverage data for `scripts/dev-tools/activate.ps1`. This is a configuration limitation, not a defect introduced by this branch. This review compensated by running a scoped coverage measurement directly on the changed file (98.21% commands, all changed lines covered). This gap is informational and does not block the feature; it is recorded so the coverage configuration can be widened in a follow-up if the team wants `activate.ps1` in the standing coverage scope.
+- **Branch coverage UNVERIFIED.** Pester's JaCoCo output emits no BRANCH counter (`mb`/`cb` are zero across all lines). Branch coverage for the new null/not-null decision cannot be read numerically from the artifact. The decision's both arms are exercised by the test suite (null path -> uncolored; valid color -> dark/light), so the new branch is behaviorally covered even though the numeric branch metric is unavailable. This matches the known PowerShell branch-coverage limitation.
+
+### Approved Exceptions
+
+- **None.** No policy exceptions were required.
+
+### Removed/Skipped Tests
+
+- **None.** No tests were removed or skipped.
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This PR/Branch
+
+1. **34176ed** - fix(activate): tolerate null console background in venv-aware prompt (#202)
+
+(Range `db3d528..34176ed`.)
+
+### Files Modified
+
+1. **scripts/dev-tools/activate.ps1** (MODIFIED, +18/-4)
+   - `Get-VenvAwarePrompt -BackgroundColor` changed from `[Parameter(Mandatory)] [System.ConsoleColor]` to `[Parameter()] [AllowNull()] [System.Nullable[System.ConsoleColor]]`.
+   - Added a null guard: when `$BackgroundColor` is `$null`, treat as not-dark (`$false`) and render uncolored; otherwise call `Test-IsDarkBackground` unchanged.
+   - Updated `.PARAMETER BackgroundColor` comment-help.
+
+2. **tests/scripts/dev-tools/activate.Tests.ps1** (MODIFIED, +12/-0)
+   - Added a deterministic `It` asserting `Get-VenvAwarePrompt -BackgroundColor $null` returns `'(mix-calculator)> '` (uncolored).
+
+3. **docs/features/active/2026-06-18-activate-prompt-null-background-202/{spec.md,issue.md,plan.2026-06-18T09-25.md}** (NEW scoping docs).
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: FULLY COMPLIANT
+
+The change is a minimal, well-scoped null-tolerance fix with a deterministic regression test. The PowerShell toolchain (format -> analyze -> test) passes cleanly. Coverage on the changed production file is 98.21% commands with all changed lines covered. The only recorded gaps are a repo coverage-scope configuration limitation (compensated by a scoped run during this review) and the structural absence of a numeric PowerShell branch counter (the new branch is behaviorally covered). Neither gap is a FAIL.
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- PASS Before Making Changes
+- PASS Design Principles
+- PASS Module & File Structure
+- PASS Naming, Docs, Comments
+- PASS Toolchain Execution
+- PASS Summarize & Document
+
+#### Language-Specific Code Change Policy (Section 3)
+**For PowerShell:**
+- PASS Tooling & Baseline
+- PASS PowerShell Design & Safety
+- PASS Structure & Naming
+- PASS Toolchain
+
+#### General Unit Test Policy (Section 1)
+- PASS Core Principles
+- PASS Coverage & Scenarios (Baseline documentation PARTIAL, non-blocking)
+- PASS Test Structure
+- PASS External Dependencies
+- PASS Policy Audit
+
+#### Language-Specific Unit Test Policy (Section 4)
+**For PowerShell:**
+- PASS Framework & Scope
+- PASS Test Style & Structure
+- PASS Naming & Readability
+- PASS Toolchain
+
+### Metrics Summary
+
+- PASS 53/53 tests passing (100%)
+- PASS 98.21% command coverage / 98.1% line coverage on the changed production file
+- PASS All 8 changed production lines covered
+- PASS All code quality checks passing (format, analyze, test)
+- PASS Test execution time 0.985s (fast)
+- UNVERIFIED branch coverage (no Pester branch counter; new branch behaviorally covered)
+
+### Recommendation
+
+**Ready for merge** with respect to local policy and toolchain. CI required-checks green on the PR head (AC6) remains to be confirmed by the orchestrator's CI gate, since no PR currently exists for this branch.
+
+---
+
+## Rejected Scope Narrowing
+
+No caller instruction attempted to narrow the audit scope to a plan subset, a file subset, or to mark any language's coverage as out of scope. The caller explicitly directed full feature-vs-base review and application of the PowerShell coverage and toolchain gates. No rejection was required.
+
+---
+
+## Appendix A: Test Inventory
+
+Activate suite top-level groups (53 tests total) include:
+- `Get-VenvAwarePrompt (prompt decision used by the shim)` — including the new `renders the prompt uncolored when the host background is null (Test Explorer host parity)`.
+- `Test-IsDarkBackground (dark-color predicate)` — parameterized over all dark and non-dark `[System.ConsoleColor]` values.
+- `Get-ColorizedPrompt`, `Get-DefaultPrompt`, `Get-RepoRelativePrompt`, `Resolve-RepoRoot`, `Test-IsDotSourced`, and prompt-shim installation cases.
+
+(Full enumeration available via `Invoke-Pester -Output Detailed` on `tests/scripts/dev-tools/activate.Tests.ps1`.)
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For PowerShell (commands executed during this review):**
+```powershell
+# Formatting (check-only via Invoke-Formatter diff)
+Invoke-Formatter -ScriptDefinition (Get-Content -Raw scripts/dev-tools/activate.ps1)
+Invoke-Formatter -ScriptDefinition (Get-Content -Raw tests/scripts/dev-tools/activate.Tests.ps1)
+
+# Linting
+Invoke-ScriptAnalyzer -Path scripts/dev-tools/activate.ps1 -Settings scripts/powershell/PoshQC/settings/pssa.settings.psd1
+Invoke-ScriptAnalyzer -Path tests/scripts/dev-tools/activate.Tests.ps1 -Settings scripts/powershell/PoshQC/settings/pssa.settings.psd1
+
+# Testing with coverage scoped to the changed production file
+$cfg = New-PesterConfiguration
+$cfg.Run.Path = 'tests/scripts/dev-tools/activate.Tests.ps1'
+$cfg.CodeCoverage.Enabled = $true
+$cfg.CodeCoverage.Path = 'scripts/dev-tools/activate.ps1'
+$cfg.CodeCoverage.OutputFormat = 'JaCoCo'
+$cfg.CodeCoverage.OutputPath = 'docs/features/active/2026-06-18-activate-prompt-null-background-202/evidence/coverage/activate-coverage.xml'
+Invoke-Pester -Configuration $cfg
+```
+
+**Evidence-location validator:**
+```bash
+python scripts/dev_tools/validate_evidence_locations.py --root .
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-06-18
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md
@@ -67,11 +67,11 @@ Logs / Screenshots:
 - Manual validation: in the VS Code Test Explorer, the `activate.Tests.ps1` items pass after reload.
 
 ## Acceptance Criteria
-- [ ] AC1: `Get-VenvAwarePrompt -BackgroundColor $null` returns the uncolored prompt and does not throw.
-- [ ] AC2: A valid background color is unchanged in behavior (dark -> green-wrapped, light/non-dark -> plain).
-- [ ] AC3: A deterministic regression test for the null-background case exists and passes without depending on the ambient host.
-- [ ] AC4: `tests/scripts/dev-tools/activate.Tests.ps1` passes in full (no failures).
-- [ ] AC5: Full PowerShell toolchain passes (format -> analyze -> test) with zero new findings.
+- [x] AC1: `Get-VenvAwarePrompt -BackgroundColor $null` returns the uncolored prompt and does not throw.
+- [x] AC2: A valid background color is unchanged in behavior (dark -> green-wrapped, light/non-dark -> plain).
+- [x] AC3: A deterministic regression test for the null-background case exists and passes without depending on the ambient host.
+- [x] AC4: `tests/scripts/dev-tools/activate.Tests.ps1` passes in full (no failures).
+- [x] AC5: Full PowerShell toolchain passes (format -> analyze -> test) with zero new findings.
 - [ ] AC6: CI required checks are green on the PR head.
 
 ## Risks & Mitigations

--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md
@@ -1,0 +1,82 @@
+# activate-prompt-null-background (Spec)
+
+- **Issue:** #202
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-18T09-25
+- **Status:** Approved
+- **Version:** 1.0
+
+## Context
+The `global:prompt` installed by `scripts/dev-tools/activate.ps1` throws in any host that does not expose a console background color. `Get-VenvAwarePrompt` declares `-BackgroundColor` as a mandatory, non-nullable `[System.ConsoleColor]`; the shim passes `$Host.UI.RawUI.BackgroundColor`, which is `$null` in non-interactive/redirected hosts such as the VS Code `pspester.pester-test` Test Explorer adapter. Binding `$null` to a non-nullable `[ConsoleColor]` fails at parameter-bind time.
+
+Environment:
+- OS/version: Windows, VS Code with `pspester.pester-test` 2023.7.8.
+- PowerShell version: PowerShell 7, Pester 5.6.1.
+- Command/flags used: Test Explorer "Run Tests" (adapter invokes `PesterInterface.ps1`).
+- Data source or fixture: `tests/scripts/dev-tools/activate.Tests.ps1`.
+
+Impact / Severity:
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+## Repro & Evidence
+Steps to Reproduce:
+1. Run `tests/scripts/dev-tools/activate.Tests.ps1` in a host whose `$Host.UI.RawUI.BackgroundColor` is `$null` (the VS Code Test Explorer adapter host).
+2. The test "installs a prompt that delegates to the venv-aware builder" invokes the real `prompt`, which calls `Get-VenvAwarePrompt -BackgroundColor $null`.
+3. Binding fails with a `ConsoleColor` cast error.
+
+Expected:
+A null/unknown console background renders the prompt uncolored without throwing.
+
+Actual:
+`ParameterBindingArgumentTransformationException: Cannot process argument transformation on parameter 'BackgroundColor'. Cannot convert null to type "System.ConsoleColor"` at `scripts/dev-tools/activate.ps1:403`.
+
+Logs / Screenshots:
+- [x] Captured the adapter failure and reproduced it deterministically via AST-imported `Get-VenvAwarePrompt -BackgroundColor $null`.
+
+## Scope & Non-Goals
+- In scope: make `Get-VenvAwarePrompt -BackgroundColor` null-tolerant; add a deterministic null-background regression test.
+- Out of scope: changing the prompt's visual design; refactoring unrelated functions; the third-party adapter.
+- Explicitly excluded: any behavior change when a valid background color is supplied.
+
+## Root Cause Analysis
+`Get-VenvAwarePrompt`'s `-BackgroundColor` was `[Parameter(Mandatory)] [System.ConsoleColor]`. The host shim supplies `$Host.UI.RawUI.BackgroundColor`, which some hosts report as `$null`. A non-nullable value-type parameter cannot bind `$null`, so the call throws before any logic runs. The failing test masked the defect on CI/terminal because it reads the ambient host background, which is a valid color there (a determinism violation per `.claude/rules/powershell.md`).
+
+## Proposed Fix
+
+### Design summary (what changes where):
+1. `scripts/dev-tools/activate.ps1` — `Get-VenvAwarePrompt`: change `-BackgroundColor` to optional, `[AllowNull()]`, `[System.Nullable[System.ConsoleColor]]`. When the value is `$null`, treat the background as not-dark (render uncolored); otherwise call `Test-IsDarkBackground` unchanged.
+2. `tests/scripts/dev-tools/activate.Tests.ps1` — add a deterministic test asserting `Get-VenvAwarePrompt -BackgroundColor $null` returns the uncolored prompt. The null value is supplied explicitly (no ambient host dependence).
+
+### Boundaries and invariants to preserve:
+- A valid background color yields identical output to before (dark -> green, light -> plain).
+- `Test-IsDarkBackground` and `Get-ColorizedPrompt` are unchanged.
+- No entrypoint/side-effect behavior changes.
+
+### Files/modules to change:
+- `scripts/dev-tools/activate.ps1` (production, 1 file).
+- `tests/scripts/dev-tools/activate.Tests.ps1` (test, 1 file).
+
+## Test Strategy
+- Add a unit test for the null-background path (uncolored output).
+- Retain existing dark/light coverage.
+- Toolchain: PoshQC format -> analyze -> test.
+- Manual validation: in the VS Code Test Explorer, the `activate.Tests.ps1` items pass after reload.
+
+## Acceptance Criteria
+- [ ] AC1: `Get-VenvAwarePrompt -BackgroundColor $null` returns the uncolored prompt and does not throw.
+- [ ] AC2: A valid background color is unchanged in behavior (dark -> green-wrapped, light/non-dark -> plain).
+- [ ] AC3: A deterministic regression test for the null-background case exists and passes without depending on the ambient host.
+- [ ] AC4: `tests/scripts/dev-tools/activate.Tests.ps1` passes in full (no failures).
+- [ ] AC5: Full PowerShell toolchain passes (format -> analyze -> test) with zero new findings.
+- [ ] AC6: CI required checks are green on the PR head.
+
+## Risks & Mitigations
+- Risk: a host reporting a non-null but invalid background (for example integer -1) would still fail. Mitigation: out of scope for the observed defect (null); the guard covers the reported condition. A follow-up can normalize other invalid values if observed.
+
+## Rollout & Follow-up
+- Merge via PR after green CI.
+- Links: issue #202, PR (to be created), `scripts/dev-tools/activate.ps1`.

--- a/docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md
+++ b/docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md
@@ -72,7 +72,7 @@ Logs / Screenshots:
 - [x] AC3: A deterministic regression test for the null-background case exists and passes without depending on the ambient host.
 - [x] AC4: `tests/scripts/dev-tools/activate.Tests.ps1` passes in full (no failures).
 - [x] AC5: Full PowerShell toolchain passes (format -> analyze -> test) with zero new findings.
-- [ ] AC6: CI required checks are green on the PR head.
+- [x] AC6: CI required checks are green on the PR head. Verified: 11/11 required checks pass on head 3fe3b21 (run 27763492993; PowerShell QC passed after re-running a transient NuGet tooling-install flake).
 
 ## Risks & Mitigations
 - Risk: a host reporting a non-null but invalid background (for example integer -1) would still fail. Mitigation: out of scope for the observed defect (null); the guard covers the reported condition. A follow-up can normalize other invalid values if observed.

--- a/scripts/dev-tools/activate.ps1
+++ b/scripts/dev-tools/activate.ps1
@@ -263,7 +263,10 @@ function Get-VenvAwarePrompt {
     .PARAMETER BackgroundColor
         The console background color used to decide whether to render the prompt in
         green. Supplied by the shim from $Host.UI.RawUI.BackgroundColor so this
-        pure function performs no host access.
+        pure function performs no host access. May be $null when the host does not
+        expose a console background (for example a non-interactive or redirected
+        host such as the VS Code Pester test adapter); a null background is treated
+        as unknown and the prompt is rendered without color.
     #>
     [CmdletBinding()]
     [OutputType([string])]
@@ -277,8 +280,9 @@ function Get-VenvAwarePrompt {
         [AllowNull()]
         [string] $VenvEnv,
 
-        [Parameter(Mandatory)]
-        [System.ConsoleColor] $BackgroundColor
+        [Parameter()]
+        [AllowNull()]
+        [System.Nullable[System.ConsoleColor]] $BackgroundColor
     )
 
     if ([string]::IsNullOrEmpty($VenvEnv)) {
@@ -289,7 +293,17 @@ function Get-VenvAwarePrompt {
         $promptText = Get-RepoRelativePrompt -CurrentPath $CurrentPath -VenvRoot $venvRoot
     }
 
-    $isDark = Test-IsDarkBackground -BackgroundColor $BackgroundColor
+    # A host that does not expose a console background (for example a
+    # non-interactive or redirected host such as the VS Code Pester test adapter)
+    # reports a null background color. Treat an unknown background as not-dark so
+    # the prompt renders without color instead of failing to bind a null into the
+    # non-nullable dark-background predicate.
+    $isDark = if ($null -ne $BackgroundColor) {
+        Test-IsDarkBackground -BackgroundColor $BackgroundColor
+    }
+    else {
+        $false
+    }
     return Get-ColorizedPrompt -PromptText $promptText -IsDarkBackground $isDark
 }
 

--- a/tests/scripts/dev-tools/activate.Tests.ps1
+++ b/tests/scripts/dev-tools/activate.Tests.ps1
@@ -218,6 +218,18 @@ Describe 'Get-VenvAwarePrompt (prompt decision used by the shim)' {
             -BackgroundColor ([System.ConsoleColor]::Black) |
             Should -Be "$script:Green(mix-calculator)> $script:Reset"
     }
+
+    It 'renders the prompt uncolored when the host background is null (Test Explorer host parity)' {
+        # A non-interactive or redirected host (for example the VS Code Pester
+        # test adapter) reports a null console background. The pure function must
+        # accept null and render the prompt without color rather than failing to
+        # bind, so the installed shim does not throw when
+        # $Host.UI.RawUI.BackgroundColor is null. Deterministic: the null value is
+        # supplied explicitly and does not depend on the ambient host.
+        Get-VenvAwarePrompt -CurrentPath 'C:\repo\mix-calculator' -VenvEnv 'C:\repo\mix-calculator\.venv' `
+            -BackgroundColor $null |
+            Should -Be '(mix-calculator)> '
+    }
 }
 
 Describe 'Resolve-RepoRoot (depth-robust ancestor walk)' {


### PR DESCRIPTION
# fix(activate): tolerate null console background in the venv-aware prompt

## Summary

- Fixes the `global:prompt` from `scripts/dev-tools/activate.ps1` throwing a `ConsoleColor` cast error in hosts that report a null console background (the VS Code `pspester.pester-test` Test Explorer adapter).
- Makes `Get-VenvAwarePrompt -BackgroundColor` null-tolerant; a null/unknown background renders the prompt uncolored instead of failing to bind.
- Adds a deterministic regression test that supplies a null background explicitly, removing the prior reliance on the ambient host color.
- Behavior with a valid background color is unchanged: dark → green-wrapped, non-dark → plain.

## Why

`Get-VenvAwarePrompt` declared `-BackgroundColor` as a mandatory, non-nullable `[System.ConsoleColor]`. The shim supplies `$Host.UI.RawUI.BackgroundColor`, which is `$null` in non-interactive/redirected hosts. Binding `$null` to a non-nullable value-type parameter throws at parameter-bind time before any logic runs. The previously failing test invoked the real `prompt`, which reads the ambient host background — a valid color on CI and in a terminal, but `$null` in the Test Explorer adapter host. That ambient dependence both caused the user-visible failure and hid it from CI. Root cause and environment are recorded in `docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md`.

## What Changed

### Production
- `scripts/dev-tools/activate.ps1` (+18/-4): `Get-VenvAwarePrompt` `-BackgroundColor` is now `[Parameter()]`, `[AllowNull()]`, `[System.Nullable[System.ConsoleColor]]`. When null, the dark-background predicate is skipped and the prompt renders uncolored; otherwise `Test-IsDarkBackground` is called exactly as before.

### Tests
- `tests/scripts/dev-tools/activate.Tests.ps1` (+12/-0): a deterministic test asserting `Get-VenvAwarePrompt -BackgroundColor $null` returns the uncolored prompt, with no dependence on the ambient host.

### Docs (feature folder)
- `spec.md`, `issue.md`, `plan.2026-06-18T09-25.md`, and the policy/code/feature audit artifacts.

## Architecture / How It Fits Together

The shim remains the only host-access point; it reads `$Host.UI.RawUI.BackgroundColor` and passes it to the pure builder. The builder now accepts the legitimate null host state and degrades to uncolored output, keeping `Test-IsDarkBackground` and `Get-ColorizedPrompt` unchanged and the pure functions string-in/string-out.

## Verification

### Completed (from context)
- Reproduced the failure deterministically: `Get-VenvAwarePrompt -BackgroundColor $null` threw the exact `ConsoleColor` cast error before the fix; returns the uncolored prompt after.
- `tests/scripts/dev-tools/activate.Tests.ps1`: 53 passed / 0 failed / 0 skipped (Pester 5.6.1).
- PoshQC: format clean, analyze 0 findings, test green.
- Feature-review: zero blocking findings (Go).

### Recommended
- After merge, reload the VS Code window (or run "Refresh Tests") so the adapter re-discovers; the `activate.Tests.ps1` items should report green.

## Backward Compatibility / Migration Notes

No breaking changes. Output for any valid background color is identical to before; only the previously-crashing null case changes (now uncolored instead of an exception).

## Risks and Mitigations

- Risk: a host reporting a non-null but invalid background (for example integer `-1`) would still fail. Mitigation: out of scope for the observed null defect; the guard covers the reported condition, and a follow-up can normalize other invalid values if they are observed.

## Review Guide

1. `scripts/dev-tools/activate.ps1` — the parameter-type change and the null guard in `Get-VenvAwarePrompt`.
2. `tests/scripts/dev-tools/activate.Tests.ps1` — the new null-background test.
3. `docs/features/active/2026-06-18-activate-prompt-null-background-202/spec.md` — root cause and acceptance criteria.

## Follow-ups

- Consider making the failing-style ambient-host test fully host-independent, and normalizing non-null invalid background values, if such hosts appear.

## GitHub Auto-close

- Closes #202
