### PR TITLE
ci(deps): add npm audit gate and Dependabot for the three npm manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+
+updates:
+  # Root VS Code extension manifest.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      npm-root:
+        patterns:
+          - "*"
+
+  # Extension-side bundled workflow utilities and MCP bridge.
+  - package-ecosystem: npm
+    directory: "/extensions/drm-copilot"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      npm-extensions-drm-copilot:
+        patterns:
+          - "*"
+
+  # Stdio MCP server package.
+  - package-ecosystem: npm
+    directory: "/packages/mcp-server"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      npm-mcp-server:
+        patterns:
+          - "*"
+
+  # GitHub Actions used by the workflows in this repository.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/_npm-audit-gate.yml
+++ b/.github/workflows/_npm-audit-gate.yml
@@ -1,0 +1,54 @@
+name: npm Audit Gate (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      audit-level:
+        description: >-
+          Minimum advisory severity that fails the gate
+          (low | moderate | high | critical).
+        required: false
+        type: string
+        default: moderate
+  workflow_dispatch:
+    inputs:
+      audit-level:
+        description: >-
+          Minimum advisory severity that fails the gate
+          (low | moderate | high | critical).
+        required: false
+        type: string
+        default: moderate
+
+jobs:
+  npm-audit:
+    name: npm audit (${{ matrix.manifest }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        manifest:
+          - "."
+          - extensions/drm-copilot
+          - packages/mcp-server
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ${{ matrix.manifest }}/package-lock.json
+
+      - name: Install from lockfile (verifies lockfile/manifest sync)
+        working-directory: ${{ matrix.manifest }}
+        run: npm ci
+
+      - name: Audit dependencies
+        working-directory: ${{ matrix.manifest }}
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
+        run: npm audit --audit-level="$AUDIT_LEVEL"

--- a/.github/workflows/npm-audit-gate.yml
+++ b/.github/workflows/npm-audit-gate.yml
@@ -1,0 +1,21 @@
+name: npm Audit Gate
+
+on:
+  schedule:
+    # Weekly, Monday 07:00 UTC. Catches advisories disclosed against the
+    # committed lockfiles after they were last regenerated.
+    - cron: "0 7 * * 1"
+  pull_request:
+    branches: [main, development]
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+      - ".github/workflows/npm-audit-gate.yml"
+      - ".github/workflows/_npm-audit-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  npm-audit:
+    uses: ./.github/workflows/_npm-audit-gate.yml
+    with:
+      audit-level: moderate

--- a/docs/features/active/npm-audit-gate-and-dependabot/issue.md
+++ b/docs/features/active/npm-audit-gate-and-dependabot/issue.md
@@ -1,0 +1,71 @@
+# npm-audit-gate-and-dependabot
+
+- Work Mode: minor-audit
+
+## Problem / Why
+
+Follow-up to PR #209 (`fix(deps): eliminate npm audit vulnerabilities`). That work
+revealed the repository has three independently installed npm manifests (root,
+`extensions/drm-copilot`, `packages/mcp-server`), each with its own lockfile. The
+sub-manifest lockfiles had drifted to stale, vulnerable transitive pins independently
+of the root. Without an automated gate, that staleness can silently reintroduce
+vulnerabilities, and newly disclosed advisories against the committed lockfiles would
+go unnoticed between manual installs.
+
+## Implementation Intent
+
+Add two complementary, automated mechanisms:
+
+1. A reusable `npm audit` gate (`_npm-audit-gate.yml`) that runs `npm ci` (verifying
+   lockfile/manifest sync) and `npm audit --audit-level=moderate` across all three
+   manifests via a matrix. A thin caller (`npm-audit-gate.yml`) runs it weekly on a
+   schedule, on pull requests that touch any `package.json` / `package-lock.json` or
+   the gate workflows, and on manual dispatch.
+2. Dependabot configuration (`.github/dependabot.yml`) for weekly grouped npm version
+   updates across the three manifest directories plus the `github-actions` ecosystem.
+   This is the lockfile-refresh mechanism: Dependabot opens PRs to bump dependencies,
+   which the audit gate then validates.
+
+Follows the repository reusable-workflow convention: callee `_<name>.yml` declares
+`workflow_call` + `workflow_dispatch`; the caller wires triggers and references the
+callee via `uses: ./.github/workflows/_npm-audit-gate.yml`.
+
+## Acceptance Criteria
+
+- [x] `_npm-audit-gate.yml` declares both `workflow_call` and `workflow_dispatch` and audits all three manifests via matrix.
+- [x] `npm-audit-gate.yml` triggers on `schedule`, path-filtered `pull_request`, and `workflow_dispatch`, and calls the reusable workflow.
+- [x] The gate runs `npm ci` (lockfile sync check) before `npm audit` for each manifest.
+- [x] `.github/dependabot.yml` configures weekly grouped npm updates for `/`, `/extensions/drm-copilot`, `/packages/mcp-server`, and github-actions.
+- [x] All workflow YAML passes `actionlint` and parses as valid YAML.
+- [x] The gate passes against the current (remediated) lockfiles: `npm audit --audit-level=moderate` exits 0 for all three manifests.
+- [ ] A green run of the new gate is observed on the PR (satisfies `modified-workflow-needs-green-run`).
+
+## Dependencies / Risks
+
+- The PR's `pull_request` path filter includes the gate workflow files, so the PR that
+  adds the gate triggers a real run, providing the required green workflow run.
+- `audit-level` defaults to `moderate` (blocks moderate/high/critical — the severity
+  classes from the PR #209 incident) and is exposed as a workflow input so it can be
+  tightened to `low` if desired. This avoids excessive PR friction from frequently
+  disclosed low-severity advisories in dev tooling.
+- Dependabot will open grouped PRs weekly; `open-pull-requests-limit` is capped at 5
+  per ecosystem to bound noise.
+
+## Verification Steps
+
+1. `python -c "import yaml; ..."` parses all three files.
+2. `actionlint .github/workflows/_npm-audit-gate.yml .github/workflows/npm-audit-gate.yml` exits 0.
+3. For each manifest: `npm audit --audit-level=moderate` exits 0.
+4. Observe the `npm Audit Gate` checks pass on the PR.
+
+## Evidence Checklist
+
+- [x] baseline — PR #209 established 0 vulnerabilities across all three manifests.
+- [x] targeted verification — YAML parse, actionlint exit 0, local audit exit 0 per manifest.
+- [ ] end-state — green `npm Audit Gate` run observed on the PR.
+
+## References
+
+- Prior PR: https://github.com/drmoisan/drm-copilot/pull/209
+- Reusable-workflow convention: `.claude/skills/orchestrate/SKILL.md` (GitHub Actions Reusable Workflows)
+- CI workflow authoring rule: `.claude/rules/ci-workflows.md`

--- a/docs/features/active/npm-audit-gate-and-dependabot/plan.2026-06-19T20-37.md
+++ b/docs/features/active/npm-audit-gate-and-dependabot/plan.2026-06-19T20-37.md
@@ -1,0 +1,53 @@
+# npm-audit-gate-and-dependabot - Plan
+
+- **Issue:** TBD
+- **Parent (optional):** none
+- **Owner:** TBD
+- **Last Updated:** 2026-06-19T20-37
+- **Status:** Draft
+- **Version:** 0.1
+
+## Required References
+
+- General Coding Standards: [`.github/instructions/general-code-change.instructions.md`](../../../../.github/instructions/general-code-change.instructions.md)
+- General Unit Test Policy: [`.github/instructions/general-unit-test.instructions.md`](../../../../.github/instructions/general-unit-test.instructions.md)
+- (Add language-specific policies as needed, e.g. `python-code-change.instructions.md`)
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Implementation Plan (Atomic Tasks)
+
+> **Instructions for this section:**
+> - Break work into **Phases** (broad buckets) and **Atomic Tasks** (binary, 5-30 min units).
+> - Use `- [ ] [P#-T#]` for every task.
+> - Start every task with a **strong verb** (Implement, Create, Update, Verify).
+> - No "bucket" tasks like "Refactor module" or "Write tests"; split them into specific, verifiable steps.
+> - **Self-Validating Phases:** Include necessary test creation/update tasks *within* the phase that implements the code. Do not defer verification to a final "Testing" phase.
+> - Include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for every language in scope when policy requires coverage.
+> - Name the expected artifact path or location in each evidence-producing task's acceptance criteria.
+> - If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+### Phase 0: Compliance & Context
+- [ ] [P0-T1] Confirm alignment with repo policies by reading `.github/instructions/general-code-change.instructions.md`, `.github/instructions/python-code-change.instructions.md`, `.github/instructions/general-unit-test.instructions.md`, and `.github/instructions/python-unit-test.instructions.md` before touching code
+  - Acceptance: Development log contains policy review timestamp prior to Phase 1 commits
+
+### Phase 1: <Phase Name>
+- [ ] [P1-T1] <Atomic task with strong verb>
+- [ ] [P1-T2] <Atomic task>
+  - Preconditions: <optional>
+  - Acceptance: <optional>
+
+### Phase 2: <Phase Name>
+- [ ] [P2-T1] <Atomic task>
+- [ ] [P2-T2] <Atomic task>
+
+## Test Plan
+
+- Unit: ...
+- Integration: ...
+- Manual/CLI: ...
+- Coverage evidence: list baseline artifact paths, post-change artifact paths, and comparison artifact paths for each in-scope language
+
+## Open Questions / Notes
+
+- ...


### PR DESCRIPTION
# ci(deps): add npm audit gate and Dependabot for the three npm manifests

## Summary

- Adds an automated guard against npm lockfile staleness reintroducing vulnerabilities across the three independently installed manifests (root, `extensions/drm-copilot`, `packages/mcp-server`). Follow-up to #209.
- New reusable workflow `_npm-audit-gate.yml` runs `npm ci` (lockfile/manifest sync check) and `npm audit --audit-level=moderate` for each manifest via a matrix.
- New caller `npm-audit-gate.yml` runs the gate weekly on a schedule, on pull requests touching any `package.json`/`package-lock.json` or the gate workflows, and on manual dispatch.
- New `.github/dependabot.yml` provides weekly grouped npm version updates for the three manifest directories plus the `github-actions` ecosystem (the lockfile-refresh mechanism).
- CI infrastructure only; no production source changed.

## Why

#209 found that the sub-manifest lockfiles had drifted to stale, vulnerable transitive pins independently of the root, and that newly disclosed advisories against committed lockfiles go unnoticed between manual installs. This PR closes that gap with detection (audit gate) plus refresh (Dependabot).

## What Changed

**Audit gate (detection)**
- `.github/workflows/_npm-audit-gate.yml` — reusable callee declaring `workflow_call` + `workflow_dispatch`, per the repository reusable-workflow convention. Matrix over `.`, `extensions/drm-copilot`, `packages/mcp-server`. `audit-level` is a configurable input (default `moderate`).
- `.github/workflows/npm-audit-gate.yml` — caller wiring `schedule` (weekly), path-filtered `pull_request`, and `workflow_dispatch`; references the callee via `uses: ./.github/workflows/_npm-audit-gate.yml`.

**Dependabot (refresh)**
- `.github/dependabot.yml` — weekly grouped updates for `/`, `/extensions/drm-copilot`, `/packages/mcp-server`, and `github-actions`; `open-pull-requests-limit: 5` per ecosystem.

## Verification

**Completed**
- All three YAML files parse (`yaml.safe_load`).
- `actionlint` exits 0 on both workflows.
- `npm audit --audit-level=moderate` exits 0 for all three manifests against the current lockfiles.
- Feature review: code-review Go (1 Minor, 2 Informational); the one blocking finding is `modified-workflow-needs-green-run`, discharged by this PR's own gate run (see below).

**Produced by this PR**
- The caller's `pull_request` path filter includes the gate workflow files, so this PR self-triggers `npm Audit Gate`. A green run on this PR satisfies `modified-workflow-needs-green-run`.

## Backward Compatibility / Migration Notes

- Additive only. No existing workflow, production source, or public API changed.
- `audit-level` defaults to `moderate` (blocks moderate/high/critical — the severity classes from the #209 incident) and can be tightened to `low` via the workflow input.

## Risks and Mitigations

- Dependabot opens grouped PRs weekly; capped at 5 open PRs per ecosystem to bound noise.
- A scheduled audit failure is the intended alert when a new advisory is disclosed against the committed lockfiles; remediation is a lockfile refresh (manual or via the Dependabot PR).

## Review Guide

1. `_npm-audit-gate.yml` — confirm `workflow_call` + `workflow_dispatch` and the matrix.
2. `npm-audit-gate.yml` — confirm triggers and the `uses:` reference.
3. `.github/dependabot.yml` — confirm the four ecosystems/directories.

## GitHub Auto-close

- None (no verified closing issue is associated with this branch).
