### PR TITLE
Bump mcp-server to 0.0.3

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danmoisan/drm-copilot-mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Stdio MCP server exposing drm-copilot repo-automation tools.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
Bumps the MCP server package (`@danmoisan/drm-copilot-mcp`) from 0.0.2 to 0.0.3 to align package.json with the already-updated lockfile, in preparation for the `mcp-server-v0.0.3` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)