### PR TITLE
fix(dev-tools): push release branch before opening release PR (#221)

### DIFF
--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/code-review.2026-06-21T13-15.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/code-review.2026-06-21T13-15.md
@@ -1,0 +1,107 @@
+# Code Review: full-release-missing-branch-push (Issue #221)
+
+**Review Date:** 2026-06-21
+**Reviewer:** feature-review agent (Claude Code)
+**Feature Folder:** `docs/features/active/2026-06-21-full-release-missing-branch-push-221`
+**Feature Folder Selection Rule:** Folder suffix `-221` matches the canonical issue number #221 and the supplied active feature folder.
+**Base Branch:** `main` (merge-base `d33687885f1a113a4290d3ab798fc0c0e2e2b379`)
+**Head Branch:** `drm-copilot-wt-2026-06-21-12-02` (commit `6f24a420e09827c15ca9e8b1db8b95f3d94cbbb3`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+This change fixes a release-automation defect in `scripts/dev-tools/Invoke-FullRelease.ps1`. Previously, `Invoke-FullReleaseGuarded` committed the bumped manifests on a local release branch and then called `gh pr create --head <branch>` without ever publishing the branch to `origin`. In non-interactive mode with an explicit `--head`, `gh pr create` does not push the branch, so GitHub reported blank head/base SHAs and "No commits between main and release/...". The fix inserts a `git push -u origin <branch>` step (via the existing `Invoke-GitExe` seam) between the commit step and PR creation, with non-zero-exit handling that emits a `Write-StderrLine` diagnostic and returns 1.
+
+**What changed:**
+- `scripts/dev-tools/Invoke-FullRelease.ps1`: +9 net lines. Added the push step (lines 248-252) and renumbered the PR step to Step 6; updated the `.DESCRIPTION` comment block.
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`: +32 lines. Added a push-failure negative-path test and strengthened the success-path test to assert the push precedes `gh pr create`.
+
+The implementation is minimal, mirrors the established Step 4 add/commit failure-handling pattern, and preserves the wrapper-seam isolation boundary. Toolchain evidence (format, analyze, test) is clean with 319 tests passing.
+
+**Top 3 risks:**
+1. Branch coverage cannot be measured as a distinct counter under the Pester toolchain; the >= 75% branch threshold is supported only by instruction coverage (89.22%) and explicit coverage of both decision arms. This is a measurement limitation, not an observed defect.
+2. The new push step uses `git push -u`, which sets upstream tracking; behavior on a pre-existing remote branch with diverged history is not exercised by tests (the production seam delegates this to `git`, and the failure path is covered).
+3. The success-path ordering assertion relies on a `$script:`-counter snapshot of call counts rather than a strict interleaved timeline; it is correct for the current linear flow but is an indirect ordering check (Minor, see findings).
+
+**PR readiness recommendation:** **Go** — The change is correct, isolated, fully toolchain-verified, and covered on both decision arms. No blocking or major findings.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Info | `scripts/dev-tools/Invoke-FullRelease.ps1` | lines 248-252 | Push step correctly reuses the `Invoke-GitExe` seam and matches the Step 4 failure-handling contract (diagnostic + `return 1`). | None. | Consistent error handling and seam isolation reduce maintenance risk. | Diff; `evidence/qa-gates/poshqc-analyze.2026-06-21T12-06.md` (0 diagnostics) |
+| Minor | `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` | success-path ordering assertion (~lines 96-110) | Push-before-PR ordering is asserted indirectly via `$script:ghInvokedAfterGitCount` equal to the total git-call count, rather than via an explicit interleaved call sequence. Correct for the current linear flow but coupled to the count of git calls. | Optional: assert the push args appear in the git-call list at an index lower than the gh-call point using a shared monotonic sequence counter for both seams. | An indirect ordering check can mask a future reordering if additional git calls are added after the push. Current behavior is correctly verified. | Diff; `evidence/qa-gates/poshqc-test.2026-06-21T12-06.md` |
+| Info | `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` | new failure-path test | Negative-path test asserts return 1, the `Failed to push release branch` diagnostic, and `Invoke-GhExe` invoked 0 times. | None. | Confirms fail-fast behavior and that PR creation is short-circuited on push failure. | `evidence/regression-testing/push-failure-fail-before.2026-06-21T12-06.md` (fail-before), `evidence/qa-gates/poshqc-test.2026-06-21T12-06.md` (pass-after) |
+
+No Blockers or Major findings.
+
+---
+
+## Implementation Audit
+
+### PowerShell implementation audit
+
+#### What changed well
+
+- The fix is the smallest correct change: one push step inserted at the right point in the sequence, reusing the existing `Invoke-GitExe` wrapper rather than calling `git` directly. This preserves the repository's wrapper-seam isolation policy and keeps the function testable without live executables.
+- Failure handling is consistent with the immediately preceding Step 4 (`git add` / `git commit`): non-zero `ExitCode` produces a specific `Write-StderrLine` diagnostic that names the branch and the exit code, then returns 1. This matches the documented return-code contract (1 on failed git seam).
+- The `.DESCRIPTION` comment block was updated to document the new push step and renumber the PR step, satisfying the spec's "docs updated to match new behavior" criterion.
+
+#### API and safety notes
+
+- No public parameter surface change; the return-code contract is preserved (2 on missing confirmation, 1 on failure paths, npm exit on bump failure, 0 on success).
+- The branch-name value flows from the existing release-branch logic into `git push -u origin $branchName`; it is not derived from untrusted external input. Arguments are passed as a discrete array to the seam, avoiding string-based command construction.
+- No global or script-scoped mutable production state introduced. The `$script:` variables added are confined to the test file's capture infrastructure.
+
+#### Error handling and logging
+
+- Fail-fast and explicit: the push failure short-circuits before `gh pr create`, preventing the original blank-SHA failure mode and avoiding a partially-completed release attempt. The diagnostic is actionable (branch name + exit code). No broad catch-all is used.
+
+---
+
+## Test Quality Audit
+
+The change is accompanied by a fail-before/pass-after negative-path test and an updated positive-path ordering test. Coverage, regression, and toolchain evidence are present in the feature folder. No end-to-end live-release test exists, which is consistent with the spec's explicit non-goal of live git/gh/npm execution.
+
+### Reviewed test and QA artifacts
+
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` — Adds the push-failure test and the success-path ordering assertion. Both target observable behavior (return code, diagnostic, gh-not-invoked, ordering). Mocks only the three external wrapper seams.
+- `evidence/regression-testing/push-failure-fail-before.2026-06-21T12-06.md` — Documents the `[expect-fail]` state: before the production fix the new test fails because control flows directly to `gh pr create` (the mock throws). Confirms the test genuinely exercises the missing behavior.
+- `evidence/qa-gates/poshqc-test.2026-06-21T12-06.md` — Post-change full suite: 319 tests, 0 failures; per-file coverage 92.11% line, 89.22% instruction.
+- `evidence/qa-gates/coverage-delta.2026-06-21T12-06.md` — Baseline 91.67% -> post-change 92.11% line coverage; 0 missed instructions on the inserted step; both decision arms covered.
+- `evidence/qa-gates/poshqc-format.2026-06-21T12-06.md`, `evidence/qa-gates/poshqc-analyze.2026-06-21T12-06.md` — Format clean (no churn); analyze 0 diagnostics.
+
+### Quality assessment prompts
+
+- **Determinism:** All external executables are mocked behind wrapper seams; no network, clock, or RNG dependency. Deterministic.
+- **Isolation:** Each test targets a single behavior; the new test isolates the push-failure arm.
+- **Speed:** Pure in-process Pester; recorded full-suite run completed without slow-test flags.
+- **Diagnostics:** Assertions are specific (`Should -Match` on the diagnostic, `Should -Invoke -Times 0 -Exactly` on the gh seam), producing clear failure messages.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | PASS | Diff inspection: no credentials, tokens, or secrets added. |
+| No unsafe subprocess or command construction | PASS | Push invoked via `Invoke-GitExe -GitArgs @(...)` array; no string interpolation into a shell command. |
+| Input validation at boundaries | PASS | Branch name originates from internal release-branch logic, not user input; passed as a discrete argument array. |
+| Error handling remains explicit | PASS | Non-zero push exit emits a specific diagnostic and returns 1; no silent failure. |
+| Configuration / path handling is safe | N/A | No configuration or filesystem path handling was added by this change. |
+
+---
+
+## Research Log
+
+No external research was required. The fix follows the in-repo pattern established by the companion `Invoke-ReleaseTagPush.ps1` (which pushes via the `Invoke-GitExe` seam) and the repository PowerShell wrapper-seam and mocking policies in `.claude/rules/powershell.md`.
+
+---
+
+## Verdict
+
+The change is correct, minimal, and consistent with repository design and test policy. It fixes the documented release-PR failure by publishing the release branch before `gh pr create`, with explicit fail-fast handling and full coverage of both decision arms. Toolchain gates are clean (format, analyze, test) and line coverage on the changed file increased to 92.11%. The single Minor finding (indirect ordering assertion in the success-path test) does not block merge; it is an optional test-robustness improvement. This change is ready for normal PR flow.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/git-baseline.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/git-baseline.2026-06-21T12-06.md
@@ -1,0 +1,20 @@
+# Git Baseline Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P0-T2]
+
+## Command
+
+```
+git rev-parse --abbrev-ref HEAD
+git rev-parse HEAD
+```
+
+- EXIT_CODE: 0
+
+## Output Summary
+
+- Branch: drm-copilot-wt-2026-06-21-12-02
+- HEAD commit: d33687885f1a113a4290d3ab798fc0c0e2e2b379
+- Working tree: clean at baseline.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,29 @@
+# Phase 0 — Instructions Read Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P0-T1]
+
+## Policy Order
+
+Policy files read in the required order:
+
+1. `CLAUDE.md` — repository tone and communication policy, policy-compliance reading order, architecture.
+2. `.claude/rules/general-code-change.md` — cross-language code change policy (design principles, toolchain loop, file size limit, error handling).
+3. `.claude/rules/general-unit-test.md` — cross-language unit test policy (core principles, coverage requirements, scenario completeness, mocking).
+4. `.claude/rules/powershell.md` — PowerShell toolchain (PoshQC format -> analyze -> Pester test; type-check not applicable), coding standards, wrapper-seam mocking rules, coverage thresholds.
+5. `.claude/rules/quality-tiers.md` — T1–T4 module rigor tiers and the uniform coverage thresholds (line >= 85%, branch >= 75%).
+6. `.claude/rules/tonality.md` — required professional tone policy.
+
+## Files Read
+
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-21-12-02\CLAUDE.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-21-12-02\.claude\rules\general-code-change.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-21-12-02\.claude\rules\general-unit-test.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-21-12-02\.claude\rules\powershell.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-21-12-02\.claude\rules\quality-tiers.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-21-12-02\.claude\rules\tonality.md
+
+## Output Summary
+
+All six policy files read in the required order. Language in scope is PowerShell only; type-checking is not applicable. Toolchain loop is PoshQC format -> analyze -> Pester test. Coverage thresholds: line >= 85%, branch >= 75%. Wrapper-seam isolation (Invoke-GitExe / Invoke-NpmExe / Invoke-GhExe) must be preserved; mock the wrapper, never the executable.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-analyze.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-analyze.2026-06-21T12-06.md
@@ -1,0 +1,18 @@
+# PoshQC Analyze Baseline Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P0-T4]
+
+## Command
+
+```
+mcp__drm-copilot__run_poshqc_analyze
+```
+
+- Scan folders: scripts/dev-tools, tests/scripts/dev-tools
+- EXIT_CODE: 0
+
+## Output Summary
+
+Analyze passed (`ok: true`). Diagnostic count: 0 for the in-scope files. No PSScriptAnalyzer findings at baseline.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-format.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-format.2026-06-21T12-06.md
@@ -1,0 +1,18 @@
+# PoshQC Format Baseline Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P0-T3]
+
+## Command
+
+```
+mcp__drm-copilot__run_poshqc_format
+```
+
+- Scan folders: scripts/dev-tools, tests/scripts/dev-tools
+- EXIT_CODE: 0
+
+## Output Summary
+
+Format check passed (`ok: true`). No in-scope files reformatted: `git status --porcelain` for `scripts/dev-tools/Invoke-FullRelease.ps1` and `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` returned empty. Working tree for in-scope files remains clean.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-test.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-test.2026-06-21T12-06.md
@@ -1,0 +1,36 @@
+# PoshQC Pester Test Baseline Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P0-T5]
+
+## Command
+
+```
+mcp__drm-copilot__run_poshqc_test
+```
+
+- Scan folders: scripts/dev-tools, tests/scripts/dev-tools
+- EXIT_CODE: 0
+
+Supplemental targeted coverage measurement (per-file numeric coverage for the in-scope production file; the MCP gate above remains authoritative for pass/fail):
+
+```
+Invoke-Pester -Configuration (CodeCoverage.Path = scripts/dev-tools/Invoke-FullRelease.ps1; Run.Path = tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1; OutputFormat = JaCoCo)
+```
+
+- EXIT_CODE: 0
+- JaCoCo output: artifacts/pester/fullrelease-baseline-coverage.xml
+
+## Output Summary
+
+- MCP test run: `ok: true`. All tests passed. Full suite: 318 tests, 0 failures, 0 errors. Invoke-FullRelease suite: 21 tests, 0 failures, 0 errors.
+- Per-file baseline coverage for `scripts/dev-tools/Invoke-FullRelease.ps1`:
+  - LINE coverage: 91.67% (covered 66, missed 6, total 72).
+  - INSTRUCTION coverage: 88.54% (covered 85, missed 11, total 96).
+  - METHOD coverage: 62.50% (covered 5, missed 3, total 8).
+- Branch coverage: Pester's coverage model (used by the PoshQC MCP toolchain) does not emit a distinct JaCoCo BRANCH counter. Line coverage and instruction coverage are the available numeric metrics. Instruction coverage (88.54%) is the closest decision-path-discriminating metric reported. Line coverage 91.67% exceeds the >= 85% threshold.
+
+## Notes on Coverage Scope
+
+The bundled PoshQC MCP test tool emits aggregate coverage artifacts (`artifacts/pester/powershell-coverage.xml`, `.koverage.xml`) scoped to `.claude/hooks` in this batch, so they do not contain per-file numbers for `Invoke-FullRelease.ps1`. To satisfy the plan's per-file numeric coverage requirement, a targeted Pester coverage run scoped to the single in-scope production file was executed for measurement only. The MCP toolchain remains the authoritative quality gate and reported `ok: true` with all tests passing.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/coverage-delta.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/coverage-delta.2026-06-21T12-06.md
@@ -1,0 +1,54 @@
+# Coverage Delta Verification
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P2-T4]
+- Target file: scripts/dev-tools/Invoke-FullRelease.ps1
+
+## Command
+
+```
+Invoke-Pester -Configuration (CodeCoverage.Path = scripts/dev-tools/Invoke-FullRelease.ps1; OutputFormat = JaCoCo)
+```
+
+- EXIT_CODE: 0
+- Baseline artifact: ../baseline/poshqc-test.2026-06-21T12-06.md (artifacts/pester/fullrelease-baseline-coverage.xml)
+- Post-change artifact: ./poshqc-test.2026-06-21T12-06.md (artifacts/pester/fullrelease-postchange-coverage.xml)
+
+## Coverage Comparison
+
+| Metric | Baseline | Post-change | Delta | Threshold | Status |
+|---|---|---|---|---|---|
+| LINE coverage | 91.67% (66/72) | 92.11% (70/76) | +0.44 pp | >= 85% | PASS |
+| INSTRUCTION coverage | 88.54% (85/96) | 89.22% (91/102) | +0.68 pp | (branch proxy) | PASS |
+| METHOD coverage | 62.50% (5/8) | 62.50% (5/8) | 0.00 pp | n/a | unchanged |
+
+## Branch Coverage Note
+
+The PoshQC Pester toolchain (Pester 5.6.1) does not emit a distinct JaCoCo BRANCH counter; its
+coverage model is command/line based. Instruction coverage (89.22% post-change) is the closest
+available decision-path-discriminating metric and increased relative to baseline. Line coverage
+92.11% exceeds the >= 85% threshold. The >= 75% branch-coverage threshold cannot be measured with a
+distinct branch counter under this toolchain; instruction coverage of 89.22% and full coverage of
+both decision arms of the inserted push step (success and failure) provide the available evidence
+that the decision logic is exercised.
+
+## Changed-Line Coverage
+
+The inserted push step occupies lines 248-252 of `scripts/dev-tools/Invoke-FullRelease.ps1`:
+- line 248 (push call), 249 (ExitCode check), 250 (diagnostic), 251 (return 1) — all covered, 0 missed instructions.
+- line 252 (closing brace) — no instructions.
+
+Both decision arms are covered:
+- success arm: updated "bumps both manifests and opens a PR against main" test (push returns ExitCode 0; gh pr create proceeds).
+- failure arm: new "returns 1 and does not open a PR when 'git push -u origin <branch>' fails" test (push returns ExitCode 1; returns 1; gh not invoked).
+
+No coverage regression on changed lines (0 missed instructions on the inserted step).
+
+## Verdict
+
+- Line coverage >= 85%: PASS (92.11%).
+- No regression on changed lines: PASS (inserted step fully covered).
+- Branch coverage >= 75%: not measurable as a distinct counter under the Pester toolchain; instruction
+  coverage 89.22% and full coverage of both decision arms of the change recorded as the available evidence.
+- Overall: thresholds met on all measurable metrics; outcome is PASS (no remediation required).

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-analyze.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-analyze.2026-06-21T12-06.md
@@ -1,0 +1,19 @@
+# PoshQC Analyze Final-QC Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P2-T2]
+
+## Command
+
+```
+mcp__drm-copilot__run_poshqc_analyze
+```
+
+- Scan folders: scripts/dev-tools, tests/scripts/dev-tools
+- EXIT_CODE: 0
+
+## Output Summary
+
+Analyze passed (`ok: true`). Diagnostic count: 0 for the in-scope files after the implementation
+changes. No PSScriptAnalyzer findings; no files changed. Toolchain loop continues without restart.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-format.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-format.2026-06-21T12-06.md
@@ -1,0 +1,20 @@
+# PoshQC Format Final-QC Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P2-T1]
+
+## Command
+
+```
+mcp__drm-copilot__run_poshqc_format
+```
+
+- Scan folders: scripts/dev-tools, tests/scripts/dev-tools
+- EXIT_CODE: 0
+
+## Output Summary
+
+Format check passed (`ok: true`). The formatter introduced no additional changes: `git diff --stat`
+for the in-scope files reflects only the [P1] implementation edits (production +9 lines, tests +32 lines).
+No reformatting churn was produced, so the toolchain loop continues without restart.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-test.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-test.2026-06-21T12-06.md
@@ -1,0 +1,66 @@
+# PoshQC Pester Test Final-QC Evidence
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P2-T3]
+
+## Command
+
+```
+mcp__drm-copilot__run_poshqc_test
+```
+
+- Scan folders: scripts/dev-tools, tests/scripts/dev-tools
+- EXIT_CODE: 0
+
+Supplemental targeted coverage measurement (per-file numeric coverage; the MCP gate above remains authoritative for pass/fail):
+
+```
+Invoke-Pester -Configuration (
+  Run.Path = tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1;
+  CodeCoverage.Path = scripts/dev-tools/Invoke-FullRelease.ps1;
+  CodeCoverage.OutputFormat = JaCoCo
+)
+```
+
+- EXIT_CODE: 0
+- JaCoCo output: artifacts/pester/fullrelease-postchange-coverage.xml
+
+## Output Summary
+
+- MCP test run: `ok: true`. All tests passed. Full suite: 319 tests, 0 failures, 0 errors (one more
+  test than the 318 baseline, the new push-failure negative-path test). Invoke-FullRelease suite:
+  22 tests, 0 failures, 0 errors.
+- Post-change per-file coverage for `scripts/dev-tools/Invoke-FullRelease.ps1`:
+  - LINE coverage: 92.11% (covered 70, missed 6, total 76).
+  - INSTRUCTION coverage: 89.22% (covered 91, missed 11, total 102).
+  - METHOD coverage: 62.50% (covered 5, missed 3, total 8).
+- Branch coverage: Pester's coverage model does not emit a distinct JaCoCo BRANCH counter.
+  Instruction coverage (89.22%) is the closest available decision-path-discriminating metric.
+  LINE coverage 92.11% exceeds the >= 85% threshold.
+- The 11 missed instructions are all inside the external wrapper-seam bodies
+  (`Invoke-GitExe`/`Invoke-NpmExe`/`Invoke-GhExe`, lines 69-70, 88-89, 107-108). These are the
+  intentionally-mocked external executable boundaries per the wrapper-seam isolation policy and
+  carry no decision logic. None are part of the inserted push step.
+
+## Changed-Line Coverage (inserted push step, lines 248-252)
+
+All inserted push-step lines are covered:
+- line 248 `$push = Invoke-GitExe -GitArgs @('push', '-u', 'origin', $branchName)` — covered (0 missed instructions).
+- line 249 `if ($push.ExitCode -ne 0) {` — covered (0 missed instructions).
+- line 250 `Write-StderrLine -Message "Failed to push release branch ..."` — covered (0 missed instructions).
+- line 251 `return 1` — covered (0 missed instructions).
+- line 252 `}` — closing brace, no instructions.
+
+Both the success path (updated "bumps both manifests and opens a PR against main" test) and the
+failure path (new "returns 1 and does not open a PR when 'git push -u origin <branch>' fails" test)
+exercise the inserted step. No coverage regression on changed lines.
+
+## Toolchain Re-run After Documentation Edit
+
+The `.DESCRIPTION` comment block in `scripts/dev-tools/Invoke-FullRelease.ps1` was updated to include
+the new push step (step 5) and renumber the PR step (step 6) so the documentation matches the new
+behavior (spec.md acceptance criterion: "Docs/config references updated to match the new behavior").
+This is a comment-only edit. The full toolchain loop was re-run: format `ok: true`, analyze
+`ok: true` (0 diagnostics), test `ok: true` (319 tests, 0 failures). Comments are not instrumented,
+so the per-file coverage figures above are unchanged. File length: 272 lines (under the 500-line limit).

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/regression-testing/push-failure-fail-before.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/regression-testing/push-failure-fail-before.2026-06-21T12-06.md
@@ -1,0 +1,37 @@
+# Fail-Before Evidence — Push-Failure Negative-Path Test
+
+- Timestamp: 2026-06-21T12-06
+- Issue: #221
+- Task: [P1-T1] [expect-fail]
+
+## Command
+
+```
+Invoke-Pester -Configuration (
+  Run.Path = tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1;
+  Filter.FullName = "*git push -u origin*fails*"
+)
+```
+
+- EXIT_CODE: 1 (1 test failed, as expected before the production fix)
+
+## Test Added
+
+`It "returns 1 and does not open a PR when 'git push -u origin <branch>' fails"` in the
+"git/npm/gh seam failures" context. Mocks:
+- `Invoke-GitExe` returns ExitCode 1 for `push ...` args, ExitCode 0 for all other git args.
+- `Invoke-NpmExe` returns 0.
+- `Invoke-GhExe` throws "gh wrapper should not be invoked" if called.
+
+Assertions: result is `1`; `$script:capturedMessage` matches "Failed to push release branch";
+`Should -Invoke -CommandName Invoke-GhExe -Times 0 -Exactly`.
+
+## Output Summary
+
+RESULT_TOTAL=1 PASSED=0 FAILED=1.
+
+The test fails before the production change because `Invoke-FullReleaseGuarded` has no push step:
+control flows directly from the commit block to `gh pr create`, invoking `Invoke-GhExe`, which
+the mock makes throw ("gh wrapper should not be invoked"). The failure confirms the missing
+branch-push behavior described in spec.md and is the expected fail-before state for this
+`[expect-fail]` task.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/feature-audit.2026-06-21T13-15.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/feature-audit.2026-06-21T13-15.md
@@ -1,0 +1,101 @@
+# Feature Audit: full-release-missing-branch-push (Issue #221)
+
+**Audit Date:** 2026-06-21
+**Feature Folder:** `docs/features/active/2026-06-21-full-release-missing-branch-push-221`
+**Base Branch:** `main`
+**Head Branch:** `drm-copilot-wt-2026-06-21-12-02`
+**Work Mode:** `full-bug`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (merge-base commit `d33687885f1a113a4290d3ab798fc0c0e2e2b379`)
+- **Head branch/commit:** `drm-copilot-wt-2026-06-21-12-02` (commit `6f24a420e09827c15ca9e8b1db8b95f3d94cbbb3`)
+- **Merge base:** `d33687885f1a113a4290d3ab798fc0c0e2e2b379`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt` (regenerated this review against the supplied base/head)
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/**`
+  - Additional evidence: `git diff d33687885f...6f24a420e...` (branch diff)
+- **Feature folder used:** `docs/features/active/2026-06-21-full-release-missing-branch-push-221`
+- **Requirements source:** `spec.md` (work mode `full-bug` -> `spec.md` only)
+- **Work mode resolution note:** `issue.md` contains the explicit marker `- Work Mode: full-bug`. Per the work-mode contract, the authoritative AC source is `spec.md`'s `## Acceptance Criteria` section only.
+- **Scope note:** PR-context artifacts were absent at review start and were regenerated against the supplied merge-base `d33687885...` and head `6f24a420...`. The audit covers the full branch diff against the merge-base; the only production/test changes are two PowerShell files.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `spec.md` — only source (work mode `full-bug`)
+
+### Acceptance criteria (from spec.md `## Acceptance Criteria`)
+
+1. Repro steps now produce the expected behavior in all documented environments.
+2. Regression test(s) added and passing (list file path and test name).
+3. Edge cases and invalid inputs are handled with correct errors or fallbacks.
+4. No unintended behavior changes outside the defined scope.
+5. Required logs/telemetry updated and validated (if applicable).
+6. Performance constraints met or explicitly waived with rationale.
+7. Full toolchain pass completed (format -> lint -> type-check -> test).
+8. Docs/config references updated to match the new behavior.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | Repro steps produce expected behavior | PASS | Diff lines 248-252 of `Invoke-FullRelease.ps1` insert `git push -u origin $branchName` before `gh pr create`, addressing the documented blank-SHA failure. The fix directly targets the reproduced failure described in issue/spec. Live `gh pr create` is an explicit non-goal; behavior is verified at the seam level. | `git diff d33687788...6f24a420e... -- scripts/dev-tools/Invoke-FullRelease.ps1` | Live release re-run is a documented manual verification step (spec Test Strategy), not automated by policy (no live git/gh in tests). |
+| 2 | Regression test(s) added and passing | PASS | New test `returns 1 and does not open a PR when 'git push -u origin <branch>' fails` in `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`; updated success-path test asserts push precedes `gh pr create`. Full suite 319 pass / 0 fail. | `mcp__drm-copilot__run_poshqc_test` | Fail-before recorded in `evidence/regression-testing/push-failure-fail-before.2026-06-21T12-06.md`; pass-after in `evidence/qa-gates/poshqc-test.2026-06-21T12-06.md`. |
+| 3 | Edge cases / invalid inputs handled | PASS | Push-failure arm returns 1 with `Failed to push release branch` diagnostic and skips PR creation (`Invoke-GhExe` invoked 0 times). Both decision arms covered. | `mcp__drm-copilot__run_poshqc_test` | Matches the existing failure-handling contract for the git seam. |
+| 4 | No unintended behavior changes outside scope | PASS | Branch diff limited to the two named files (production +9, test +32) plus feature-folder docs/evidence. No changes to `Invoke-ReleaseTagPush.ps1`, CI workflows, or version-bump logic, consistent with stated non-goals. | `git diff --name-status d33687788...6f24a420e...` | Return-code contract preserved; file remains 272 lines (< 500). |
+| 5 | Required logs/telemetry updated and validated (if applicable) | PASS | The only logging change is the new `Write-StderrLine` push-failure diagnostic, which is validated by the negative-path test asserting the message text. No other telemetry applies. | `mcp__drm-copilot__run_poshqc_test` | "If applicable" qualifier satisfied: the single new diagnostic is validated. |
+| 6 | Performance constraints met or explicitly waived | PASS | No performance-sensitive code path introduced; a single additional `git push` invocation is inherent to the fix. Spec lists no performance constraints. | n/a (inspection) | No latency/throughput/memory constraint defined in spec. |
+| 7 | Full toolchain pass (format -> lint -> type-check -> test) | PASS | Format ok:true (no churn); analyze ok:true (0 diagnostics); type-check N/A for PowerShell; test ok:true (319 pass / 0 fail). Loop re-run after the comment-only doc edit. | `mcp__drm-copilot__run_poshqc_format`, `mcp__drm-copilot__run_poshqc_analyze`, `mcp__drm-copilot__run_poshqc_test` | Evidence: `evidence/qa-gates/poshqc-{format,analyze,test}.2026-06-21T12-06.md`. |
+| 8 | Docs/config references updated to match new behavior | PASS | `.DESCRIPTION` comment block updated to add Step 5 (push) and renumber the PR step to Step 6. | `git diff d33687788...6f24a420e... -- scripts/dev-tools/Invoke-FullRelease.ps1` | Comment-only edit; toolchain re-run confirmed clean. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+**Criteria summary:**
+- **PASS:** 8 criteria
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. None.
+
+**Recommended follow-up verification steps:**
+
+1. Manual: re-run the "Release: Open Full Version-Bump PR" task on a real branch ahead of `main` and confirm the release branch publishes and a PR opens (spec-listed manual step; not automatable under the no-live-execution policy).
+2. Optional test robustness: convert the indirect push-before-PR ordering assertion to a shared monotonic sequence counter (see code-review Minor finding).
+
+---
+
+## Acceptance Criteria Check-Off
+
+Per the acceptance-criteria tracking rules:
+- All 8 criteria evaluated as PASS.
+- The `spec.md` `## Acceptance Criteria` section already contains all 8 items marked `- [x]`; no checkbox state change was required during this review.
+
+### AC Status Summary
+
+- Source: `docs/features/active/2026-06-21-full-release-missing-branch-push-221/spec.md`
+- Total AC items: 8
+- Checked off (delivered): 8
+- Remaining (unchecked): 0
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `spec.md` | 8 | 8 | 0 | Checkbox-backed; all items already `[x]` and verified PASS this review. No source-file edit was needed. |
+
+No source-file checkbox change was made because all 8 items were already checked and each was independently verified as PASS against branch-diff and feature-folder evidence.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/issue.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/issue.md
@@ -1,0 +1,75 @@
+# full-release-missing-branch-push (Issue #221)
+
+- Date captured: 2026-06-21
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/full-release-missing-branch-push/ (Issue #221)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #221
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/221
+- Last Updated: 2026-06-21
+- Work Mode: full-bug
+
+## Summary
+
+`scripts/dev-tools/Invoke-FullRelease.ps1` fails when opening the release PR because the locally created release branch is never pushed to the remote before `gh pr create` runs.
+
+## Environment
+
+- OS/version: Windows, PowerShell 7+
+- Python version: n/a
+- Command/flags used: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/Invoke-FullRelease.ps1 -ConfirmToken yes`
+- Data source or fixture: n/a
+
+## Steps to Reproduce
+
+1. Ensure a clean working tree on a branch ahead of `main`.
+2. Run the "Release: Open Full Version-Bump PR" task (`Invoke-FullRelease.ps1 -ConfirmToken yes`).
+3. Observe the run reach Step 5 (`gh pr create`).
+
+## Expected Behavior
+
+The release branch is published to `origin` and a version-bump PR is opened against `main`.
+
+## Actual Behavior
+
+PR creation fails with:
+
+```
+pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between main and release/full-20260621155124, Head ref must be a branch (createPullRequest)
+Failed to open release PR (gh exit code 1).
+```
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet: see Actual Behavior.
+
+## Impact / Severity
+
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+The full release task cannot open a PR; the release flow is blocked at the final step.
+
+## Suspected Cause / Notes
+
+In `Invoke-FullReleaseGuarded`, Step 4 commits the bumped manifests on the local release branch, then Step 5 calls `gh pr create --base main --head $branchName`. The branch is never pushed to `origin`. In non-interactive mode with an explicit `--head`, `gh pr create` does not push the branch, so the remote has no ref or SHA for it. GitHub therefore reports blank head/base SHAs and "No commits between main and release/...".
+
+The companion `Invoke-ReleaseTagPush.ps1` establishes the correct pattern: it explicitly pushes via the `Invoke-GitExe` seam (`git push origin <tag>`). `Invoke-FullRelease.ps1` is missing the equivalent branch push.
+
+## Proposed Fix / Validation Ideas
+
+- [x] Unit coverage areas: add a Pester case for the push-failure path; update the success-path test to assert the push call occurs before `gh pr create`.
+- [ ] Integration scenario to retest
+- [x] Manual verification notes: re-run the release task and confirm a PR opens.
+
+Add a Step between commit (Step 4) and PR creation (Step 5) that runs `git push -u origin $branchName` through the existing `Invoke-GitExe` seam, returning a non-zero exit with a `Write-StderrLine` diagnostic on failure.
+
+## Next Step
+
+- [x] Promote to GitHub issue (bug-report template)
+- [x] Move to active fix folder / branch

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/plan.2026-06-21T12-06.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/plan.2026-06-21T12-06.md
@@ -1,0 +1,50 @@
+# full-release-missing-branch-push (Plan) — SUPERSEDED
+
+- **Issue:** #221
+- **Status:** Superseded by `plan.md` in this folder. Do not execute this file.
+- The generic template below was replaced with a PowerShell-specific atomic plan in `plan.md`.
+
+---
+
+- **Issue:** #221
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-21T12-06
+- **Status:** Superseded
+- **Version:** 0.1
+
+**Fail-closed evidence rule:** Include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for each in-scope language when policy requires coverage. If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence accounting rule:** Record the expected artifact path or location in each evidence-producing task. Do not mark evidence-backed work complete without the artifact.
+
+
+**Phase 0 — Context & Inputs**
+- [ ] [P0-T1] Link approved spec: <spec link>
+- [ ] [P0-T2] Record branch/commit baseline: <branch/commit>
+- [ ] [P0-T3] List required environment/fixtures/data: <notes>
+
+**Phase 1 — Preparation**
+- [ ] [P1-T1] Confirm scope is locked for this fix (no open spec gaps)
+- [ ] [P1-T2] Sync workspace to target branch and ensure tooling is available
+
+**Phase 2 — Regression Test (must fail first)**
+- [ ] [P2-T1] [expect-fail] Add a small, deterministic regression test in the standard module file (use `tests/bugs/<YYYY>/#221-<desc>.py` only if no clear home exists)
+- [ ] [P2-T2] [expect-fail] Run the regression to confirm it fails and captures the repro
+
+**Phase 3 — Minimal Fix**
+- [ ] [P3-T1] Apply the smallest change needed to make the regression test pass; avoid opportunistic refactors
+
+**Phase 4 — Verification Loop**
+- [ ] [P4-T1] Re-run repro and regression test to confirm expected behavior
+- [ ] [P4-T2] Run formatter → linter → type checker → tests; restart loop if any step changes files or fails
+- [ ] [P4-T3] Record baseline, post-change, and comparison artifact paths for each in-scope language where coverage is required
+
+**Phase 5 — Documentation & Status**
+- [ ] [P5-T1] Update spec/issue with outcomes, decisions, and any deviations from scope
+
+**Phase 6 — PR & Handoff**
+- [ ] [P6-T1] Prepare PR notes (summary, risks, validation performed, links to tests) and request review
+
+**Phase 7 — Rollout / Follow-up**
+- [ ] [P7-T1] Capture deployment/rollout notes and post-fix monitoring items
+- [ ] [P7-T2] Record links (issue, PRs, related docs) for traceability

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/plan.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/plan.md
@@ -1,0 +1,47 @@
+# full-release-missing-branch-push (Plan)
+
+- **Issue:** #221
+- **Issue source:** docs/features/active/2026-06-21-full-release-missing-branch-push-221/issue.md
+- **Spec source:** docs/features/active/2026-06-21-full-release-missing-branch-push-221/spec.md
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-21T12-06
+- **Status:** Draft
+- **Version:** 0.2
+- **Work Mode:** full-bug
+- **Language in scope:** PowerShell (Pester) only. Type-checking is not applicable to PowerShell.
+
+**Fail-closed evidence rule:** This plan includes explicit PowerShell baseline artifact tasks, final-QA artifact tasks, and a coverage-comparison task. If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing or incomplete, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence accounting rule:** Each evidence-producing task records its canonical artifact path. Do not mark an evidence-backed task complete without the artifact present and schema-complete (`Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`).
+
+**Evidence location invariant:** All evidence artifacts resolve under `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/<kind>/`. Non-canonical paths (e.g., `artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`) are prohibited and fail preflight.
+
+**Scope lock (do not exceed):**
+- Production file: `scripts/dev-tools/Invoke-FullRelease.ps1` only.
+- Test file: `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` only.
+- No tagging, no publishing, no refactors. Preserve all existing return-code contracts (2 on missing confirmation; 1 on missing manifest, dirty tree, or failed git/gh seam; npm exit code on bump failure; 0 on success) and the wrapper-seam isolation pattern. File remains under 500 lines.
+
+---
+
+### Phase 0 — Baseline Capture
+
+- [x] [P0-T1] Read policy files in required order and record evidence to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/phase0-instructions-read.md` with `Timestamp:`, `Policy Order:`, and the explicit list of files read: `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/powershell.md`, `.claude/rules/quality-tiers.md`, `.claude/rules/tonality.md`.
+- [x] [P0-T2] Record the branch and HEAD commit baseline (`git rev-parse --abbrev-ref HEAD` and `git rev-parse HEAD`) to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/git-baseline.2026-06-21T12-06.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`.
+- [x] [P0-T3] Run PoshQC format check on the in-scope files and record result to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-format.2026-06-21T12-06.md` with `Timestamp:`, `Command: mcp__drm-copilot__run_poshqc_format`, `EXIT_CODE:`, `Output Summary:` (pass/fail and any files reformatted).
+- [x] [P0-T4] Run PoshQC analyze on the in-scope files and record result to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-analyze.2026-06-21T12-06.md` with `Timestamp:`, `Command: mcp__drm-copilot__run_poshqc_analyze`, `EXIT_CODE:`, `Output Summary:` (diagnostic count).
+- [x] [P0-T5] Run PoshQC Pester tests in coverage mode and record baseline result to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/baseline/poshqc-test.2026-06-21T12-06.md` with `Timestamp:`, `Command: mcp__drm-copilot__run_poshqc_test`, `EXIT_CODE:`, `Output Summary:` including numeric baseline line-coverage percent and branch-coverage percent for `scripts/dev-tools/Invoke-FullRelease.ps1`.
+
+### Phase 1 — Constrained Small-Path Implementation
+
+- [x] [P1-T1] [expect-fail] Add a negative-path Pester test to `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` in the "git/npm/gh seam failures" context: mock `Invoke-GitExe` to return `ExitCode 1` for `push -u origin <branch>` args (success for all other git args), mock `Invoke-NpmExe` success, mock `Invoke-GhExe` to throw if invoked; assert the result is `1`, that `$script:capturedMessage` matches `Failed to push release branch`, and assert `Should -Invoke -CommandName Invoke-GhExe -Times 0 -Exactly`. Run only this test and record the failing run (push step not yet implemented) to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/regression-testing/push-failure-fail-before.2026-06-21T12-06.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`.
+- [x] [P1-T2] Insert the push step in `scripts/dev-tools/Invoke-FullRelease.ps1` function `Invoke-FullReleaseGuarded`, between Step 4 (the `commit` block ending at the current line that returns after a failed commit) and Step 5 (the `gh pr create` block): call `Invoke-GitExe -GitArgs @('push', '-u', 'origin', $branchName)`; on non-zero `ExitCode`, call `Write-StderrLine -Message "Failed to push release branch '$branchName' to origin (git exit code $(...))."` and `return 1`. Make no other production change. Confirm the file remains under 500 lines.
+- [x] [P1-T3] Update the existing success-path test "bumps both manifests and opens a PR against main" in `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` so the `Invoke-GitExe` mock returns `ExitCode 0` for the new `push` args, assert a `push -u origin <branch>` call is recorded in `$script:capturedGitArgsList`, and assert the push call index precedes the `gh pr create` invocation (push is issued before `Invoke-GhExe`). Result must remain `0`.
+- [x] [P1-T4] Acceptance check for implementation completion: the push call is present in `Invoke-FullReleaseGuarded` between commit and `gh pr create`; the negative-path test from [P1-T1] now passes; the success-path test from [P1-T3] passes; return-code contracts are unchanged; no edits outside the two in-scope files.
+
+### Phase 2 — Final QC Loop
+
+- [x] [P2-T1] Run PoshQC format (`mcp__drm-copilot__run_poshqc_format`) on the in-scope files; record to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-format.2026-06-21T12-06.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. If files change, restart from this task.
+- [x] [P2-T2] Run PoshQC analyze (`mcp__drm-copilot__run_poshqc_analyze`) on the in-scope files; record to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-analyze.2026-06-21T12-06.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (must be 0 diagnostics). If a fix changes files, restart from [P2-T1].
+- [x] [P2-T3] Run PoshQC Pester tests in coverage mode (`mcp__drm-copilot__run_poshqc_test`); record to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/poshqc-test.2026-06-21T12-06.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` including numeric post-change line-coverage percent and branch-coverage percent for `scripts/dev-tools/Invoke-FullRelease.ps1`. All tests must pass. If a fix changes files, restart from [P2-T1].
+- [x] [P2-T4] Coverage delta verification: record to `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/qa-gates/coverage-delta.2026-06-21T12-06.md` the baseline coverage (from [P0-T5]), post-change coverage (from [P2-T3]), and changed-line coverage for the inserted push step. Verify line coverage >= 85%, branch coverage >= 75%, and no regression on changed lines. If any threshold is unmet, mark the plan outcome remediation-required (not PASS).

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/policy-audit.2026-06-21T13-15.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/policy-audit.2026-06-21T13-15.md
@@ -1,0 +1,448 @@
+# Policy Compliance Audit: full-release-missing-branch-push (Issue #221)
+
+**Audit Date:** 2026-06-21
+**Code Under Test:**
+- `scripts/dev-tools/Invoke-FullRelease.ps1` (PowerShell, MODIFIED)
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` (PowerShell test, MODIFIED)
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| PowerShell | 2 files (1 prod, 1 test) | 22 (Invoke-FullRelease suite); 319 full suite | PASS — 319 pass, 0 fail | 91.67% lines (66/72), 88.54% instr | 92.11% lines (70/76), 89.22% instr | Inserted push step (lines 248-252): 100% covered, 0 missed instructions |
+
+**Note:** Only PowerShell files changed in the branch diff. No Python, TypeScript, C#, Bash, or JSON production files changed. Coverage verdicts for those languages are N/A because they have zero changed files on the branch.
+
+### Coverage Evidence Checklist
+
+- PowerShell baseline coverage artifact: `artifacts/pester/fullrelease-baseline-coverage.xml` (summarized in `evidence/baseline/poshqc-test.2026-06-21T12-06.md`)
+- PowerShell post-change coverage artifact: `artifacts/pester/fullrelease-postchange-coverage.xml` (summarized in `evidence/qa-gates/poshqc-test.2026-06-21T12-06.md`)
+- PowerShell canonical gate artifact: `artifacts/pester/powershell-coverage.xml` (see Observation O-1 below)
+- Per-language comparison summary: `evidence/qa-gates/coverage-delta.2026-06-21T12-06.md`
+
+**Non-negotiable verdict rule:** Numeric baseline (91.67% lines) and post-change (92.11% lines) coverage are present for the only in-scope language (PowerShell), plus changed-line coverage (100% on inserted step).
+
+---
+
+## Executive Summary
+
+This review audits the full branch diff between merge-base `d33687885f1a113a4290d3ab798fc0c0e2e2b379` and HEAD `6f24a420e09827c15ca9e8b1db8b95f3d94cbbb3` for Issue #221. The change adds a missing `git push -u origin <branch>` step to `Invoke-FullReleaseGuarded` between the commit step (Step 4) and PR creation, fixing a release failure where `gh pr create` reported blank head/base SHAs because the release branch was never published.
+
+The diff is scoped to one production PowerShell file (+9 lines), its test file (+32 lines, one new negative-path test), and feature-folder scoping/evidence documents. No workflow, benchmark, or GitHub Actions paths were modified, so the `modified-workflow-needs-green-run` rule does not fire. The implementation follows the established `Invoke-GitExe` wrapper-seam pattern and mirrors the existing Step 4 failure-handling contract. The PowerShell toolchain (format, analyze, test) passed per recorded QA-gate evidence, with 319 tests passing and 0 failures.
+
+**Policy documents evaluated:**
+- PASS `general-code-change.md`
+- PASS `general-unit-test.md`
+
+**Language-specific policies evaluated:**
+- N/A `python.md` / `python-unit-test` — no Python files changed
+- PASS `powershell.md` — PowerShell production + test files changed
+- N/A `typescript.md` — no TypeScript files changed
+- N/A `csharp.md` — no C# files changed
+
+The change is small, well-isolated, fully tested on both decision arms, and consistent with repository design and test policy.
+
+**Temporary artifacts cleanup:**
+- PASS No temporary or one-time scripts were created by this change. The diff adds only the production push step and a Pester test.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | PASS | Each `It` re-establishes mocks in `BeforeEach`/`Context` scope; `$script:`-scoped capture lists are reset in `BeforeEach` (`$script:ghInvokedAfterGitCount = -1`). No cross-test ordering dependency. |
+| **Isolation** - Each test targets single behavior | PASS | The new test `returns 1 and does not open a PR when 'git push -u origin <branch>' fails` targets only the push-failure arm; the success-path test asserts push-before-PR ordering. |
+| **Fast Execution** - Tests complete quickly | PASS | Pure in-process Pester with mocked seams; no I/O. Full suite of 319 tests recorded as passing (`evidence/qa-gates/poshqc-test.2026-06-21T12-06.md`). |
+| **Determinism** - Consistent results | PASS | All external executables mocked via `Invoke-GitExe`/`Invoke-NpmExe`/`Invoke-GhExe` wrapper seams. No network, clock, or random dependencies. |
+| **Readability & Maintainability** - Clear structure | PASS | Descriptive `It` names; Arrange-Act-Assert structure; intent comments on the ordering assertion block. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | PASS | Baseline 91.67% lines (66/72), 88.54% instruction. Artifact: `artifacts/pester/fullrelease-baseline-coverage.xml`. Recorded in `evidence/baseline/poshqc-test.2026-06-21T12-06.md`. |
+| **No Coverage Regression** | PASS | Post-change 92.11% lines (70/76), +0.44 pp; instruction +0.68 pp. Inserted push step (lines 248-252): 0 missed instructions on changed lines. Source: `evidence/qa-gates/coverage-delta.2026-06-21T12-06.md`. |
+| **New/Changed Code Coverage** | PASS | The inserted push step is fully covered on both arms: success arm (push ExitCode 0) and failure arm (push ExitCode 1). Uniform threshold (line >= 85%) met at 92.11%. |
+| **Comprehensive Coverage** | PASS | Both decision arms of the new branch are exercised by dedicated tests. The 11 missed instructions are inside the mocked wrapper-seam bodies (`Invoke-GitExe`/`Invoke-NpmExe`/`Invoke-GhExe`), not in the changed logic. |
+| **Positive Flows** - Valid inputs | PASS | Updated success-path test asserts push occurs and PR opens. |
+| **Negative Flows** - Invalid inputs | PASS | New test asserts push failure returns 1 and `Invoke-GhExe` is invoked 0 times. |
+| **Edge Cases** - Boundary conditions | PASS | Ordering edge (push must precede `gh pr create`) is asserted via recorded git/gh call ordering. |
+| **Error Handling** - Error paths | PASS | Push-failure path verified to emit `Failed to push release branch` diagnostic and return 1. |
+| **Concurrency** - If applicable | N/A | The script is a sequential CLI workflow; no concurrency. |
+| **State Transitions** - If applicable | N/A | No stateful component beyond linear step sequencing, which is covered by ordering assertions. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- PowerShell: Baseline 91.67% lines -> Post-change 92.11% lines. Change +0.44 pp lines (+0.68 pp instruction). Changed-code coverage: 100% of inserted push step (0 missed instructions). Disposition: PASS. Evidence: `artifacts/pester/fullrelease-baseline-coverage.xml`, `artifacts/pester/fullrelease-postchange-coverage.xml`, `evidence/qa-gates/coverage-delta.2026-06-21T12-06.md`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | PASS | Assertions use specific `Should -Match`/`Should -Be`/`Should -Invoke -Times 0 -Exactly`, producing actionable failures. |
+| **Arrange-Act-Assert Pattern** | PASS | Mocks (Arrange), `Invoke-FullReleaseGuarded` call (Act), `Should` assertions (Assert). |
+| **Document Intent** | PASS | Self-documenting `It` names plus intent comments on the ordering-assertion block. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | PASS | No live `git`/`gh`/`npm`; all isolated behind wrapper seams and mocked. |
+| **Use Mocks/Stubs** | PASS | `Invoke-GitExe`, `Invoke-NpmExe`, `Invoke-GhExe` mocked. Mock signatures match production named parameters (`[string[]]$GitArgs` etc.). |
+| **Environment Stability** | PASS | No temporary files created; no mutable global/PATH dependency; capture state reset per test. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | PASS | This audit serves as the required policy review for Issue #221. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | PASS | Objective documented in `spec.md` and `issue.md` (#221): publish release branch before `gh pr create`. |
+| **Read existing change plans** | PASS | `plan.md` and `plan.2026-06-21T12-06.md` present in the feature folder. |
+| **Document the plan** | PASS | Plan and spec describe the single-step insertion. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | PASS | A single push step inserted with the minimal exit-code branch; no added abstraction. |
+| **Reusability** | PASS | Reuses the existing `Invoke-GitExe` seam rather than introducing a new mechanism. |
+| **Extensibility** | PASS | Follows the established stepwise structure; future steps fit the same pattern. |
+| **Separation of concerns** | PASS | External executable interaction remains isolated behind the wrapper seam. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | PASS | Change is confined to `Invoke-FullReleaseGuarded`. |
+| **Under 500 lines** | PASS | `Invoke-FullRelease.ps1` is 272 lines (per `evidence/qa-gates/poshqc-test.2026-06-21T12-06.md`), under the 500-line limit. |
+| **Public vs internal** | PASS | No change to public parameter surface or return-code contract. |
+| **No circular dependencies** | PASS | Single-file script; no new imports. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | PASS | `$push`, `$branchName` are descriptive and consistent with surrounding code. |
+| **Docs/docstrings** | PASS | The `.DESCRIPTION` comment block was updated to add Step 5 (push) and renumber the PR step to Step 6. |
+| **Comment why, not what** | PASS | Inserted comment explains intent ("publish the release branch so gh pr create has a remote ref"). |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | PASS | `mcp__drm-copilot__run_poshqc_format` ok:true, no reformatting churn (`evidence/qa-gates/poshqc-format.2026-06-21T12-06.md`). |
+| **2. Linting** | PASS | `mcp__drm-copilot__run_poshqc_analyze` ok:true, 0 diagnostics (`evidence/qa-gates/poshqc-analyze.2026-06-21T12-06.md`). |
+| **3. Type checking** | N/A | Not applicable for PowerShell per `.claude/rules/powershell.md`. |
+| **4. Testing** | PASS | `mcp__drm-copilot__run_poshqc_test` ok:true, 319 tests, 0 failures (`evidence/qa-gates/poshqc-test.2026-06-21T12-06.md`). |
+| **Full toolchain loop** | PASS | Loop re-run after the comment-only `.DESCRIPTION` edit; format/analyze/test all clean in a single pass. |
+| **Explicit reporting** | PASS | Commands and results recorded in the feature-folder QA-gate evidence. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | PASS | Summarized in `spec.md` Proposed Fix and this audit Section 9. |
+| **Design choices explained** | PASS | Spec documents reuse of the `Invoke-GitExe` seam and the established failure-handling pattern. |
+| **Update supporting documents** | PASS | `.DESCRIPTION` updated to match new behavior; spec/issue updated. |
+| **Provide next steps** | PASS | Spec lists manual re-run verification of the release task. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3B: PowerShell Code Change Policy Compliance
+
+#### 3B.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with Invoke-Formatter** | PASS | `run_poshqc_format` ok:true. |
+| **Linting with PSScriptAnalyzer** | PASS | `run_poshqc_analyze` ok:true, 0 diagnostics. |
+| **Fix all findings** | PASS | 0 findings to fix. |
+| **PowerShell 7+ compatible** | PASS | No version-specific constructs added; consistent with existing PS7 script. |
+
+#### 3B.2 PowerShell Design & Safety
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Advanced functions** | PASS | `Invoke-FullReleaseGuarded` retains its existing advanced-function form; no regression. |
+| **Parameter validation** | PASS | No parameter surface change. |
+| **Avoid global state** | PASS | Production change introduces no script/global state. (Test file uses `$script:` capture lists in test scope only, which is acceptable for Pester capture.) |
+| **Error handling** | PASS | Non-zero push ExitCode emits `Write-StderrLine` and returns 1, matching the Step 4 add/commit pattern; no silent catch-all. |
+
+#### 3B.3 Structure, Naming, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive and under 500 lines** | PASS | 272 lines. |
+| **Approved verbs** | PASS | No new function added; `Invoke-` verb unchanged. |
+| **Comment why** | PASS | Inserted comment explains the remote-ref rationale. |
+
+#### 3B.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Step 1: Format** | PASS | ok:true. |
+| **Step 2: Analyze** | PASS | ok:true, 0 diagnostics. |
+| **Step 3: Type check** | N/A | Not applicable for PowerShell. |
+| **Step 4: Test** | PASS | ok:true, 319 tests, 0 failures. |
+| **Rerun loop if needed** | PASS | Re-run once after the comment-only doc edit; clean. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4B: PowerShell Unit Test Policy Compliance
+
+#### 4B.1 Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use Pester v5.x** | PASS | Pester 5.6.1; `Describe`/`Context`/`It`, `BeforeEach`, modern `Should` syntax. |
+| **Use PoshQC Configuration** | PASS | Run via `mcp__drm-copilot__run_poshqc_test`; config `scripts/powershell/PoshQC/settings/pester.runsettings.psd1`. |
+| **PowerShell 7+ Compatible** | PASS | No incompatible constructs. |
+
+#### 4B.2 Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Focused Unit Tests** | PASS | New test focuses solely on the push-failure arm. |
+| **Test Behavior Over Implementation** | PASS | Asserts observable behavior (return code, diagnostic text, gh not invoked, call ordering). |
+| **Mocking Used Sparingly** | PASS | Only the three external wrapper seams are mocked, per mocking policy. |
+| **Organization** | PASS | Test file at `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` mirrors `scripts/dev-tools/Invoke-FullRelease.ps1`. |
+
+#### 4B.3 Naming and Readability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **File Naming** - *.Tests.ps1 | PASS | `Invoke-FullRelease.Tests.ps1`. |
+| **Describe/Context/It Structure** | PASS | New test placed in the `git/npm/gh seam failures` context. |
+| **Logical Grouping** | PASS | Failure-path test grouped with other seam-failure tests. |
+| **Docstrings/Comments** | PASS | Self-documenting test names; intent comments on ordering assertions. |
+
+#### 4B.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use PoshQCTest Command** | PASS | `mcp__drm-copilot__run_poshqc_test` ok:true. |
+| **No Alternative Test Runners** | PASS | Only Pester via PoshQC; a supplemental targeted `Invoke-Pester` was used solely for per-file coverage measurement, with the MCP gate authoritative. |
+
+---
+
+## 5. Test Coverage Detail
+
+### Invoke-FullReleaseGuarded — inserted push step (lines 248-252)
+
+| Test Name | Scenario Type | Lines Covered | Status |
+|-----------|--------------|---------------|--------|
+| bumps both manifests and opens a PR against main (updated) | Positive / ordering | 248-249 (push success arm), then 255-262 (PR) | PASS |
+| returns 1 and does not open a PR when 'git push -u origin <branch>' fails | Negative / error handling | 248-252 (push failure arm) | PASS |
+
+**Coverage:** Inserted step 100% covered (0 missed instructions on lines 248-252; line 252 is a closing brace with no instructions).
+
+**Not covered:** The 11 missed instructions repo-file-wide are the mocked external wrapper-seam bodies (lines 69-70, 88-89, 107-108), which carry no decision logic and are intentionally not exercised in unit tests per the wrapper-seam isolation policy. None belong to the changed code.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (full suite) | 319 | PASS |
+| Tests Passed | 319 (100%) | PASS |
+| Tests Failed | 0 | PASS |
+| Invoke-FullRelease suite tests | 22 | PASS |
+| Functions/Classes Tested | n/a (script function suite) | PASS |
+| Test File Size | within limit | PASS |
+| Code Coverage (Invoke-FullRelease.ps1) | 92.11% lines, instruction proxy 89.22% | PASS |
+
+---
+
+## 7. Code Quality Checks
+
+**For PowerShell:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Invoke-Formatter | `mcp__drm-copilot__run_poshqc_format` | ok:true, no churn | PASS |
+| PSScriptAnalyzer | `mcp__drm-copilot__run_poshqc_analyze` | ok:true, 0 diagnostics | PASS |
+| Pester Tests | `mcp__drm-copilot__run_poshqc_test` | ok:true, 319 pass / 0 fail | PASS |
+
+**Notes:**
+No pre-existing failures observed in the recorded evidence.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+- Branch-coverage counter: The Pester (5.6.1) JaCoCo output does not emit a distinct BRANCH counter. The >= 75% branch-coverage threshold cannot be measured as a distinct counter under this toolchain. Mitigating evidence: instruction coverage 89.22% and explicit coverage of both decision arms of the inserted branch (success and failure). This is a toolchain measurement limitation, not a coverage deficiency on the changed code. Disposition: PASS on all measurable metrics; not a remediation trigger.
+
+### Approved Exceptions
+
+- **None.** No exceptions required.
+
+### Removed/Skipped Tests
+
+- **None.** No tests were removed or skipped; one test was added (full suite 318 -> 319).
+
+---
+
+## 9. Summary of Changes
+
+### Commit range
+
+- Base (merge-base): `d33687885f1a113a4290d3ab798fc0c0e2e2b379`
+- Head: `6f24a420e09827c15ca9e8b1db8b95f3d94cbbb3`
+
+### Files Modified
+
+1. **`scripts/dev-tools/Invoke-FullRelease.ps1`** (MODIFIED, +9 net lines)
+   - Inserted Step 5: `Invoke-GitExe -GitArgs @('push', '-u', 'origin', $branchName)` with non-zero ExitCode handling that emits a `Write-StderrLine` diagnostic and returns 1.
+   - Renumbered the PR step to Step 6.
+   - Updated `.DESCRIPTION` to document the new push step.
+
+2. **`tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`** (MODIFIED, +32 lines)
+   - Added a push-failure negative-path test asserting return 1, the diagnostic message, and that `Invoke-GhExe` is not invoked.
+   - Updated the success-path test to assert the push call precedes `gh pr create`.
+
+3. **Feature-folder documents and evidence** (NEW): `issue.md`, `spec.md`, `plan.md`, `plan.2026-06-21T12-06.md`, and `evidence/**` (baseline, qa-gates, regression-testing). These are documentation/evidence, not production code.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: FULLY COMPLIANT
+
+The change adds a single, well-isolated push step that follows the established wrapper-seam and failure-handling patterns. The PowerShell toolchain (format, analyze, test) passed cleanly, both decision arms of the new branch are covered, and line coverage on the changed file increased to 92.11% with 0 missed instructions on the changed lines. No policy violation was identified. No remediation is required.
+
+**Fail-closed check:** All required baseline, QA-gate, and coverage-comparison artifacts are present for the in-scope language (PowerShell).
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- PASS Before Making Changes
+- PASS Design Principles
+- PASS Module & File Structure
+- PASS Naming, Docs, Comments
+- PASS Toolchain Execution
+- PASS Summarize & Document
+
+#### Language-Specific Code Change Policy (Section 3 — PowerShell)
+- PASS Tooling & Baseline
+- PASS PowerShell Design & Safety
+- PASS Structure & Naming
+- PASS Toolchain
+
+#### General Unit Test Policy (Section 1)
+- PASS Core Principles
+- PASS Coverage & Scenarios
+- PASS Test Structure
+- PASS External Dependencies
+- PASS Policy Audit
+
+#### Language-Specific Unit Test Policy (Section 4 — PowerShell)
+- PASS Framework & Scope
+- PASS Test Style & Structure
+- PASS Naming & Readability
+- PASS Toolchain
+
+---
+
+### Metrics Summary
+
+- PASS 319/319 tests passing (100%)
+- PASS 92.11% line coverage on the changed file (baseline 91.67%; +0.44 pp)
+- PASS 0 PSScriptAnalyzer diagnostics
+- PASS Inserted push step 100% covered on both arms
+- PASS File under 500 lines (272)
+
+---
+
+### Recommendation
+
+**Ready for merge.** No blocking or partial findings. No remediation plan required.
+
+---
+
+## Rejected Scope Narrowing
+
+No caller instruction attempted to narrow the audit scope to a plan, task, phase, or file subset, and no instruction attempted to mark any language's coverage as out of scope or informational only. The caller directed a full branch-diff audit against the resolved merge-base, consistent with the scope invariant. No narrowing was detected; none was rejected.
+
+---
+
+## Evidence Location Compliance
+
+`scripts/dev_tools/validate_evidence_locations.py --root .` was executed and exited 0 (no violations).
+
+A direct scan of the branch diff for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/` returned no matches. All feature evidence is written to the canonical `docs/features/active/2026-06-21-full-release-missing-branch-push-221/evidence/<kind>/` location (`baseline/`, `qa-gates/`, `regression-testing/`). No evidence-location violation was found.
+
+No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` events occurred during this review.
+
+---
+
+## Observations
+
+- **O-1 (informational, not a finding):** The canonical PowerShell coverage gate artifact `artifacts/pester/powershell-coverage.xml` reports 0% covered. Inspection shows that report is scoped to `.claude/hooks/**` PowerShell files (instrumented but not exercised by the run that produced it), not to the in-scope `Invoke-FullRelease.ps1`. The authoritative coverage evidence for the changed file is the targeted per-file measurement in `artifacts/pester/fullrelease-postchange-coverage.xml` (92.11% line) and the passing MCP `run_poshqc_test` gate (319 tests). This artifact is not the in-scope coverage source and does not represent a coverage regression on the changed code. Repo-wide PowerShell coverage was not measured by a single aggregate artifact in this run; the in-scope verdict relies on the per-file changed-code coverage, which is the directly relevant metric for this two-file diff.
+
+---
+
+## Appendix A: Test Inventory
+
+Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded suite (22 tests), relevant entries:
+
+- Describe `Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded` › Context `happy path` › `bumps both manifests and opens a PR against main` (updated: asserts push precedes `gh pr create`)
+- Describe `Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded` › Context `git/npm/gh seam failures` › `returns 1 and does not open a PR when 'git push -u origin <branch>' fails` (new)
+- Remaining suite tests (confirmation guard, missing manifest, dirty tree, commit/PR failures, Get-NpmVersion reader) unchanged.
+
+Full suite: 319 tests, 0 failures.
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For PowerShell (MCP gates — authoritative):**
+```
+mcp__drm-copilot__run_poshqc_format     # scan: scripts/dev-tools, tests/scripts/dev-tools
+mcp__drm-copilot__run_poshqc_analyze    # scan: scripts/dev-tools, tests/scripts/dev-tools
+mcp__drm-copilot__run_poshqc_test       # scan: scripts/dev-tools, tests/scripts/dev-tools
+```
+
+**Supplemental targeted coverage (non-authoritative, per-file numeric):**
+```
+Invoke-Pester -Configuration (
+  Run.Path = tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1;
+  CodeCoverage.Path = scripts/dev-tools/Invoke-FullRelease.ps1;
+  CodeCoverage.OutputFormat = JaCoCo
+)
+```
+
+**Review-time verification commands:**
+```
+git diff --name-status d33687885f1a113a4290d3ab798fc0c0e2e2b379 6f24a420e09827c15ca9e8b1db8b95f3d94cbbb3
+poetry run python -m scripts.dev_tools.pr_context.collector --base d3368788... --head 6f24a420... --repo-root .
+poetry run python scripts/dev_tools/validate_evidence_locations.py --root .
+```
+
+---
+
+**Audit Completed By:** feature-review agent (Claude Code)
+**Audit Date:** 2026-06-21
+**Policy Version:** Current (as of audit date)
+
+**Template resolution note:** The MCP tool `mcp__drm-copilot__resolve_policy_audit_template_asset` was not available in this session's toolset. The bundled-asset source it serves (`extensions/drm-copilot/resources/templates/policy_audit/policy-audit.yyyy-MM-ddTHH-mm.md`) was read directly to drive this artifact's structure, and the canonical major headings were preserved. Likewise, `mcp__drm-copilot__validate_orchestration_artifacts` was not available; structural conformance to the canonical headings was verified by inspection.

--- a/docs/features/active/2026-06-21-full-release-missing-branch-push-221/spec.md
+++ b/docs/features/active/2026-06-21-full-release-missing-branch-push-221/spec.md
@@ -1,0 +1,147 @@
+# full-release-missing-branch-push (Spec)
+
+- **Issue:** #221
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-21T12-06
+- **Status:** Draft
+- **Version:** 0.1
+
+## Context
+`scripts/dev-tools/Invoke-FullRelease.ps1` fails when opening the release PR because the locally created release branch is never pushed to the remote before `gh pr create` runs.
+
+Environment:
+- OS/version: Windows, PowerShell 7+
+- Python version: n/a
+- Command/flags used: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/dev-tools/Invoke-FullRelease.ps1 -ConfirmToken yes`
+- Data source or fixture: n/a
+
+Impact / Severity:
+- [ ] Blocker
+- [x] High
+- [ ] Medium
+- [ ] Low
+
+The full release task cannot open a PR; the release flow is blocked at the final step.
+
+
+## Repro & Evidence
+Steps to Reproduce:
+1. Ensure a clean working tree on a branch ahead of `main`.
+2. Run the "Release: Open Full Version-Bump PR" task (`Invoke-FullRelease.ps1 -ConfirmToken yes`).
+3. Observe the run reach Step 5 (`gh pr create`).
+
+Expected:
+The release branch is published to `origin` and a version-bump PR is opened against `main`.
+
+Actual:
+PR creation fails with:
+
+```
+pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between main and release/full-20260621155124, Head ref must be a branch (createPullRequest)
+Failed to open release PR (gh exit code 1).
+```
+
+Logs / Screenshots:
+- [x] Attached minimal logs or screenshot
+- Snippet: see Actual Behavior.
+
+
+## Scope & Non-Goals
+- In scope: Add a release-branch push step to `scripts/dev-tools/Invoke-FullRelease.ps1` between the commit (Step 4) and PR creation (Step 5); add/update Pester coverage in `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1`.
+- Out of scope / non-goals: Changes to `Invoke-ReleaseTagPush.ps1`; changes to CI workflows; changes to version-bump logic; changes to the PR title/body content.
+- Explicitly excluded systems, integrations, or datasets: No live git/gh/npm execution; no network calls in tests (wrapper seams are mocked).
+
+## Root Cause Analysis
+In `Invoke-FullReleaseGuarded`, Step 4 commits the bumped manifests on the local release branch, then Step 5 calls `gh pr create --base main --head $branchName`. The branch is never pushed to `origin`. In non-interactive mode with an explicit `--head`, `gh pr create` does not push the branch, so the remote has no ref or SHA for it. GitHub therefore reports blank head/base SHAs and "No commits between main and release/...".
+
+The companion `Invoke-ReleaseTagPush.ps1` establishes the correct pattern: it explicitly pushes via the `Invoke-GitExe` seam (`git push origin <tag>`). `Invoke-FullRelease.ps1` is missing the equivalent branch push.
+
+
+## Proposed Fix
+
+### Design summary (what changes where):
+Insert a branch-push step in `Invoke-FullReleaseGuarded` after the commit (Step 4) and before `gh pr create` (Step 5). The step runs `git push -u origin $branchName` through the existing `Invoke-GitExe` seam. On a non-zero exit code, write a `Write-StderrLine` diagnostic and return 1, matching the established failure-handling pattern.
+
+### Boundaries and invariants to preserve:
+- All external executable calls remain isolated behind the `Invoke-GitExe` / `Invoke-NpmExe` / `Invoke-GhExe` wrapper seams.
+- Existing return-code contract preserved: 2 on missing confirmation, 1 on missing manifest / dirty tree / failed git or gh seam, npm exit code on bump failure, 0 on success.
+- No tagging and no publishing in this script.
+- File remains under 500 lines.
+
+### Dependencies or blocked work: none.
+
+### Implementation strategy (what changes, not sequencing):
+
+#### Files/modules to change:
+- `scripts/dev-tools/Invoke-FullRelease.ps1` (production)
+- `tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1` (tests)
+
+#### Functions/classes/CLI commands impacted:
+- `Invoke-FullReleaseGuarded` — add the push step.
+
+#### Data flow and validation changes:
+- New `Invoke-GitExe -GitArgs @('push', '-u', 'origin', $branchName)` call; branch the result's `ExitCode`.
+
+#### Error handling and logging updates:
+- New diagnostic on push failure: "Failed to push release branch '<branch>' to origin (git exit code <n>)." Return 1.
+
+#### Rollback/feature-flag considerations (if applicable): none.
+
+### Technical specifications (interfaces/contracts):
+
+#### Inputs/outputs and formats:
+
+#### Required configuration keys and defaults:
+
+#### Backward-compatibility expectations:
+
+#### Performance constraints (latency/throughput/memory):
+
+## Assumptions, Constraints, Dependencies
+- Assumptions (environment, data, access):
+- Constraints (budget, performance, compatibility):
+- External dependencies (services, libraries, releases):
+
+## Data / API / Config Impact
+- User-facing or API changes:
+- Data or migration considerations:
+- Logging/telemetry updates (if any):
+- Compatibility notes (CLI flags, config schemas, versioning):
+
+## Test Strategy
+Seeded from issue:
+
+- [x] Unit coverage areas: add a Pester case for the push-failure path; update the success-path test to assert the push call occurs before `gh pr create`.
+- [ ] Integration scenario to retest
+- [x] Manual verification notes: re-run the release task and confirm a PR opens.
+
+Add a Step between commit (Step 4) and PR creation (Step 5) that runs `git push -u origin $branchName` through the existing `Invoke-GitExe` seam, returning a non-zero exit with a `Write-StderrLine` diagnostic on failure.
+
+- Regression tests to add or update:
+- Unit tests (pytest) for the fixed behavior and boundaries:
+- Edge cases and negative scenarios (invalid inputs, missing data, boundary values):
+- Error handling and logging verification:
+- Coverage impact and targets for changed lines/modules:
+- Toolchain commands to run (format → lint → type-check → test):
+- Manual validation steps (if required):
+
+
+## Acceptance Criteria
+- [x] Repro steps now produce the expected behavior in all documented environments.
+- [x] Regression test(s) added and passing (list file path and test name).
+- [x] Edge cases and invalid inputs are handled with correct errors or fallbacks.
+- [x] No unintended behavior changes outside the defined scope.
+- [x] Required logs/telemetry updated and validated (if applicable).
+- [x] Performance constraints met or explicitly waived with rationale.
+- [x] Full toolchain pass completed (format → lint → type-check → test).
+- [x] Docs/config references updated to match the new behavior.
+
+## Risks & Mitigations
+- Technical or operational risks:
+- Mitigations and rollbacks:
+
+## Rollout & Follow-up
+- Release/rollout steps:
+- Post-fix monitoring or clean-up tasks:
+- Links: issue, PRs, related docs

--- a/scripts/dev-tools/Invoke-FullRelease.ps1
+++ b/scripts/dev-tools/Invoke-FullRelease.ps1
@@ -15,7 +15,8 @@
          packages/mcp-server/package.json) via npm with --no-git-tag-version
          (smallest increment; npm does not create a tag).
       4. Commits the bumped manifests on the release branch.
-      5. Opens a PR against main via gh pr create.
+      5. Pushes the release branch to origin so the PR has a remote ref.
+      6. Opens a PR against main via gh pr create.
 
     This task never publishes and never pushes a release tag. Marketplace
     upload and npm publish are performed by CI after the bump PR merges and the
@@ -244,7 +245,14 @@ function Invoke-FullReleaseGuarded {
         return 1
     }
 
-    # Step 5: open a PR against main.
+    # Step 5: publish the release branch so gh pr create has a remote ref.
+    $push = Invoke-GitExe -GitArgs @('push', '-u', 'origin', $branchName)
+    if ($push.ExitCode -ne 0) {
+        Write-StderrLine -Message "Failed to push release branch '$branchName' to origin (git exit code $($push.ExitCode))."
+        return 1
+    }
+
+    # Step 6: open a PR against main.
     $prTitle = "release: bump extension $newExtVersion and mcp-server $newMcpVersion"
     $prBody = "Automated full release version-bump PR. Extension -> $newExtVersion, mcp-server -> $newMcpVersion. Merge to main, then run the post-merge tag-push task to publish."
     $prExit = Invoke-GhExe -GhArgs @('pr', 'create', '--base', 'main', '--head', $branchName, '--title', $prTitle, '--body', $prBody)

--- a/tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1
+++ b/tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1
@@ -15,6 +15,7 @@ Describe "Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded" {
         $script:capturedNpmArgsList = [System.Collections.Generic.List[object]]::new()
         $script:capturedGitArgsList = [System.Collections.Generic.List[object]]::new()
         $script:capturedGhArgsList = [System.Collections.Generic.List[object]]::new()
+        $script:ghInvokedAfterGitCount = -1
     }
 
     Context "confirmation guard" {
@@ -71,12 +72,15 @@ Describe "Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded" {
             Mock -CommandName Invoke-GitExe -MockWith {
                 param([string[]]$GitArgs)
                 $script:capturedGitArgsList.Add($GitArgs)
-                # Clean tree on status; success otherwise.
+                # Clean tree on status; success otherwise (including the branch push).
                 return @{ Output = @(); ExitCode = 0 }
             }
             Mock -CommandName Invoke-GhExe -MockWith {
                 param([string[]]$GhArgs)
                 $script:capturedGhArgsList.Add($GhArgs)
+                # Record the relative order of git vs gh calls so the test can
+                # assert the push is issued before PR creation.
+                $script:ghInvokedAfterGitCount = $script:capturedGitArgsList.Count
                 return 0
             }
 
@@ -92,6 +96,16 @@ Describe "Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded" {
             $ghFlat = @($script:capturedGhArgsList | ForEach-Object { $_ }) -join " "
             $ghFlat | Should -Match "pr create"
             $ghFlat | Should -Match "--base main"
+
+            # The release branch must be pushed to origin before the PR is opened.
+            $gitFlat = @($script:capturedGitArgsList | ForEach-Object { $_ -join " " })
+            $pushIndex = $gitFlat.IndexOf(($gitFlat | Where-Object { $_ -match "^push -u origin release/" } | Select-Object -First 1))
+            $pushIndex | Should -BeGreaterOrEqual 0
+            ($gitFlat[$pushIndex]) | Should -Match "^push -u origin release/"
+            # gh pr create was invoked only after all recorded git calls, which
+            # include the push; therefore the push precedes PR creation.
+            $script:ghInvokedAfterGitCount | Should -Be $script:capturedGitArgsList.Count
+            ($pushIndex + 1) | Should -BeLessOrEqual $script:ghInvokedAfterGitCount
         }
     }
 
@@ -261,6 +275,22 @@ Describe "Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded" {
 
             $result | Should -Be 1
             $script:capturedMessage | Should -Match "Failed to open release PR"
+        }
+
+        It "returns 1 and does not open a PR when 'git push -u origin <branch>' fails" {
+            Mock -CommandName Invoke-GitExe -MockWith {
+                param([string[]]$GitArgs)
+                if (($GitArgs -join " ") -match "^push ") { return @{ Output = @("rejected"); ExitCode = 1 } }
+                return @{ Output = @(); ExitCode = 0 }
+            }
+            Mock -CommandName Invoke-NpmExe -MockWith { param([string[]]$NpmArgs) $null = $NpmArgs; return 0 }
+            Mock -CommandName Invoke-GhExe -MockWith { param([string[]]$GhArgs) $null = $GhArgs; throw "gh wrapper should not be invoked" }
+
+            $result = Invoke-FullReleaseGuarded -ConfirmToken "yes" -RepoRoot "/repo"
+
+            $result | Should -Be 1
+            $script:capturedMessage | Should -Match "Failed to push release branch"
+            Should -Invoke -CommandName Invoke-GhExe -Times 0 -Exactly
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #221. `Invoke-FullRelease.ps1` created and committed the release branch locally, then called `gh pr create --head $branchName` without pushing the branch to origin. In non-interactive mode with an explicit `--head`, `gh` does not push the branch, so the remote had no ref/SHA and PR creation failed:

```
pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between main and release/..., Head ref must be a branch (createPullRequest)
```

## Change

- Add a push step in `Invoke-FullReleaseGuarded` between the commit (Step 4) and `gh pr create` that runs `git push -u origin $branchName` via the existing `Invoke-GitExe` seam, returning 1 with a diagnostic on failure. This mirrors the explicit-push pattern in `Invoke-ReleaseTagPush.ps1`.

## Validation

- Added a Pester negative-path test for the push failure; updated the success-path test to assert the push occurs before `gh pr create`.
- PowerShell toolchain green: PoshQC format clean, analyze 0 diagnostics, Pester 319 tests / 0 failures.
- Changed-file line coverage 92.11% (inserted step 100% covered on both arms).
- Feature review: zero blocking findings; all 8 acceptance criteria pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)