### PR TITLE
fix(dev-tools): stage package-lock.json in release version-bump commit

### DIFF
--- a/scripts/dev-tools/Invoke-FullRelease.ps1
+++ b/scripts/dev-tools/Invoke-FullRelease.ps1
@@ -185,6 +185,8 @@ function Invoke-FullReleaseGuarded {
 
     $extensionManifest = Join-Path -Path $RepoRoot -ChildPath 'extensions/drm-copilot/package.json'
     $mcpManifest = Join-Path -Path $RepoRoot -ChildPath 'packages/mcp-server/package.json'
+    $extensionLockfile = Join-Path -Path $RepoRoot -ChildPath 'extensions/drm-copilot/package-lock.json'
+    $mcpLockfile = Join-Path -Path $RepoRoot -ChildPath 'packages/mcp-server/package-lock.json'
     $extensionDir = Join-Path -Path $RepoRoot -ChildPath 'extensions/drm-copilot'
     $mcpServerDir = Join-Path -Path $RepoRoot -ChildPath 'packages/mcp-server'
 
@@ -232,8 +234,10 @@ function Invoke-FullReleaseGuarded {
     $newExtVersion = Get-NpmVersion -ManifestPath $extensionManifest
     $newMcpVersion = Get-NpmVersion -ManifestPath $mcpManifest
 
-    # Step 4: commit the bumped manifests.
-    $add = Invoke-GitExe -GitArgs @('add', $extensionManifest, $mcpManifest)
+    # Step 4: commit the bumped manifests and their lockfiles. npm version
+    # (npm 7+) updates both package.json and package-lock.json, so all four
+    # files must be staged or the lockfile changes are left uncommitted.
+    $add = Invoke-GitExe -GitArgs @('add', $extensionManifest, $mcpManifest, $extensionLockfile, $mcpLockfile)
     if ($add.ExitCode -ne 0) {
         Write-StderrLine -Message "Failed to stage bumped manifests (git exit code $($add.ExitCode))."
         return 1

--- a/tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1
+++ b/tests/scripts/dev-tools/Invoke-FullRelease.Tests.ps1
@@ -97,6 +97,18 @@ Describe "Invoke-FullRelease.ps1 - Invoke-FullReleaseGuarded" {
             $ghFlat | Should -Match "pr create"
             $ghFlat | Should -Match "--base main"
 
+            # The 'git add' staging call must include both package.json manifests
+            # and both package-lock.json lockfiles. npm version (npm 7+) updates
+            # the lockfiles too, so all four paths must be staged or the lockfile
+            # changes are left uncommitted.
+            $addCall = $script:capturedGitArgsList | Where-Object { @($_)[0] -eq 'add' } | Select-Object -First 1
+            $addCall | Should -Not -BeNullOrEmpty
+            $addFlat = (@($addCall) -join " ")
+            $addFlat | Should -Match "extensions[\\/]drm-copilot[\\/]package\.json"
+            $addFlat | Should -Match "packages[\\/]mcp-server[\\/]package\.json"
+            $addFlat | Should -Match "extensions[\\/]drm-copilot[\\/]package-lock\.json"
+            $addFlat | Should -Match "packages[\\/]mcp-server[\\/]package-lock\.json"
+
             # The release branch must be pushed to origin before the PR is opened.
             $gitFlat = @($script:capturedGitArgsList | ForEach-Object { $_ -join " " })
             $pushIndex = $gitFlat.IndexOf(($gitFlat | Where-Object { $_ -match "^push -u origin release/" } | Select-Object -First 1))


### PR DESCRIPTION
## Problem
`Invoke-FullRelease.ps1` bumps versions with `npm version patch --no-git-tag-version`. In npm 7+, `npm version` updates both `package.json` and `package-lock.json`. The Step 4 staging only added the two `package.json` manifests, so the lockfile version changes were never committed. Release PRs were opened with `package.json` and `package-lock.json` disagreeing on version, which breaks `npm ci` reproducibility. Observed on PR #223 (the `0.0.5` bump), where both lockfiles were left as uncommitted working-tree changes.

## Fix
- Stage `extensions/drm-copilot/package-lock.json` and `packages/mcp-server/package-lock.json` alongside the two manifests in the Step 4 `git add`.
- Update the Pester test to assert the staging `git add` call includes both manifests and both lockfiles.

## Verification
PoshQC toolchain run via MCP: format, analyze, and test all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)