### PR TITLE
refactor(research): relocate canonical research output to tracked docs paths

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -69,7 +69,7 @@ Delegate exclusively through configured subagents:
 - `atomic-planner` — generates phased implementation plans (planning only)
 - `atomic-executor` — executes approved plans task-by-task (execution only)
 - `feature-review` — produces policy, code, and feature audit artifacts
-- `task-researcher` — performs deep research and writes findings to `artifacts/research/`
+- `task-researcher` — performs deep research and writes findings to the research path the orchestrator resolves before delegating: `docs/features/<feature>/research/` when an active `feature-folder` is in scope in `orchestrator-state.json`, otherwise `docs/research/` for one-off research. The orchestrator passes the resolved path in the delegation prompt.
 
 For required delegated steps, delegation is mandatory. If a handoff cannot be started, resumed, or completed, stop execution and record blocked state. Do not perform the step locally.
 

--- a/.claude/agents/task-researcher.md
+++ b/.claude/agents/task-researcher.md
@@ -1,13 +1,14 @@
 ---
 name: task-researcher
-description: Research specialist that performs deep investigation and writes structured findings exclusively to artifacts/research/.
+description: Research specialist that performs deep investigation and writes structured findings to the orchestrator-supplied research path under docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).
 model: sonnet
 tools:
   - Read
   - Grep
   - Glob
   - WebFetch
-  - "Write(/artifacts/research/**)"
+  - "Write(/docs/features/**/research/**)"
+  - "Write(/docs/research/**)"
   - evidence-and-timestamp-conventions
 memory: project
 hooks:
@@ -20,13 +21,16 @@ hooks:
 
 # Task Researcher Agent
 
-You are a research-only specialist. You perform deep analysis for task planning and write structured research notes. You do not make changes to source code, configurations, or project files outside `artifacts/research/`.
+You are a research-only specialist. You perform deep analysis for task planning and write structured research notes. You do not make changes to source code, configurations, or project files outside the research root the orchestrator supplies.
 
 ## Output Location
 
-Write all research artifacts to `artifacts/research/` using the filename convention:
+Write each research artifact to the research path the orchestrator supplies in the delegation prompt. There are two tracked research roots:
 
-- `artifacts/research/<timestamp>-<short-name>-research.md`
+- Feature-associated research: `docs/features/<feature>/research/<timestamp>-<short-name>-research.md` (for example `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`).
+- One-off research not tied to a feature: `docs/research/<timestamp>-<short-name>-research.md`.
+
+The orchestrator resolves which root to use from whether an active feature folder is in scope and passes the exact path in the delegation prompt; do not infer the feature folder independently. The filename convention `<timestamp>-<short-name>-research.md` is unchanged.
 
 ## Core Principles
 
@@ -67,7 +71,7 @@ Write all research artifacts to `artifacts/research/` using the filename convent
 
 ## Constraints
 
-- Write only to `artifacts/research/`. Do not modify source code or configurations.
+- Write only to the orchestrator-supplied research path under `docs/features/<feature>/research/` (feature-associated) or `docs/research/` (one-off). Do not modify source code or configurations.
 - Ground all findings in verified evidence.
 - Keep discussion of non-selected approaches brief.
 - Do not claim nested worker delegation.

--- a/.claude/hooks/enforce-evidence-locations.ps1
+++ b/.claude/hooks/enforce-evidence-locations.ps1
@@ -137,18 +137,40 @@ function Invoke-EvidenceLocationDecision {
     return [ordered]@{ decision = 'allow' }
 }
 
+function Invoke-EvidenceLocationEntryPoint {
+    <#
+    .SYNOPSIS
+        Runs the evidence-location decision and returns the process exit code.
+    .DESCRIPTION
+        Wraps the dispatch logic that the hook entry point performs so it can be
+        exercised by unit tests. On success it writes the compact JSON decision to
+        the output stream and returns 0. On a hard failure (malformed JSON) it
+        writes the error record and returns 1. This function does not call exit;
+        the thin entry-point wiring converts the returned code into a process exit.
+    .PARAMETER ToolInputRaw
+        The raw JSON string from $env:CLAUDE_TOOL_INPUT.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [string] $ToolInputRaw = $env:CLAUDE_TOOL_INPUT
+    )
+
+    try {
+        $decision = Invoke-EvidenceLocationDecision -ToolInputRaw $ToolInputRaw
+    } catch {
+        Write-Error $_
+        return 1
+    }
+
+    $decision | ConvertTo-Json -Compress | Write-Output
+
+    return 0
+}
+
 # Guard allows dot-sourcing in tests without executing the entrypoint.
 if ($MyInvocation.InvocationName -eq '.') {
     return
 }
 
-try {
-    $decision = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
-} catch {
-    Write-Error $_
-    exit 1
-}
-
-$decision | ConvertTo-Json -Compress | Write-Output
-
-exit 0
+exit (Invoke-EvidenceLocationEntryPoint)

--- a/.claude/hooks/enforce-evidence-locations.ps1
+++ b/.claude/hooks/enforce-evidence-locations.ps1
@@ -17,12 +17,15 @@
       - artifacts/evidence/
       - artifacts/regression-testing/
       - artifacts/post-change/
+      - artifacts/research/
 
     All other paths pass through, including canonical evidence paths of the form
     <FEATURE>/evidence/<kind>/ and permitted artifacts/ sub-paths such as
-    artifacts/orchestration/, artifacts/research/, artifacts/pr_context,
-    artifacts/reviews/, artifacts/status/, artifacts/python/, artifacts/pester/,
-    and artifacts/csharp/.
+    artifacts/orchestration/, artifacts/pr_context, artifacts/reviews/,
+    artifacts/status/, artifacts/python/, artifacts/pester/, and
+    artifacts/csharp/. Research output is no longer an artifacts/ sub-path; it
+    is written to the tracked roots docs/features/<feature>/research/
+    (feature-associated) or docs/research/ (one-off).
 
     If the file_path resolves to a forbidden prefix, the script writes a JSON response
     to stdout with 'decision': 'block' and exits with code 0 so Claude Code surfaces
@@ -61,7 +64,8 @@ function Test-EvidenceLocationForbidden {
         'artifacts/coverage/',
         'artifacts/evidence/',
         'artifacts/regression-testing/',
-        'artifacts/post-change/'
+        'artifacts/post-change/',
+        'artifacts/research/'
     )
 
     # Match the prefix either at the start of the string or after any directory separator,

--- a/.claude/hooks/validate-task-researcher-output.ps1
+++ b/.claude/hooks/validate-task-researcher-output.ps1
@@ -5,8 +5,10 @@
 .DESCRIPTION
     Blocks termination of the task-researcher subagent unless the agent's
     final output advertises a `research-path` token, the path is rooted
-    under artifacts/research/, matches the documented filename convention,
-    and the file exists on disk.
+    under one of the two tracked research roots
+    (docs/features/<feature>/research/ for feature-associated research, or
+    docs/research/ for one-off research), matches the documented filename
+    convention, and the file exists on disk.
 
 .NOTES
     Reads the hook payload from CLAUDE_HOOK_INPUT as JSON. Exits 0 to allow
@@ -64,7 +66,20 @@ function Test-IsUnderResearchRoot {
     )
 
     $normalized = $Path -replace '\\', '/'
-    return $normalized.StartsWith('artifacts/research/', [System.StringComparison]::OrdinalIgnoreCase)
+
+    # Accept either of the two tracked research roots:
+    #   - feature-associated research: docs/features/<...>/research/<file>
+    #     (a feature-folder path that contains a /research/ segment), or
+    #   - one-off research: docs/research/<file>.
+    # The /research/ segment requirement distinguishes feature research from
+    # other files under docs/features/ (for example spec.md or plan files).
+    $isFeatureResearch =
+    $normalized.StartsWith('docs/features/', [System.StringComparison]::OrdinalIgnoreCase) -and
+    $normalized.IndexOf('/research/', [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    $isOneOffResearch =
+    $normalized.StartsWith('docs/research/', [System.StringComparison]::OrdinalIgnoreCase)
+
+    return ($isFeatureResearch -or $isOneOffResearch)
 }
 
 function Test-IsValidResearchFileName {
@@ -174,15 +189,15 @@ function Invoke-TaskResearcherOutputValidation {
 
     $researchPath = Get-ResearchPathFromOutput -AgentOutput $agentOutput
     if ($null -eq $researchPath) {
-        return @{ Ok = $false; Message = 'task-researcher hook: agent output does not advertise a research-path. Researcher must report `research-path: <path>` pointing to artifacts/research/.' }
+        return @{ Ok = $false; Message = 'task-researcher hook: agent output does not advertise a research-path. Researcher must report `research-path: <path>` pointing to docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).' }
     }
 
     if (-not (Test-IsUnderResearchRoot -Path $researchPath)) {
-        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' is not under artifacts/research/. All research artifacts must be written to artifacts/research/." }
+        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' is not under a tracked research root. All research artifacts must be written to docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off)." }
     }
 
     if (-not (Test-IsValidResearchFileName -Path $researchPath)) {
-        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' does not match the required filename convention `artifacts/research/<timestamp>-<short-name>-research.md`." }
+        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' does not match the required filename convention `<timestamp>-<short-name>-research.md` under docs/features/<feature>/research/ or docs/research/." }
     }
 
     if (-not (Test-ResearchFile -Path $researchPath)) {
@@ -208,3 +223,4 @@ if (-not $result.Ok) {
 }
 
 exit 0
+

--- a/.claude/skills/evidence-and-timestamp-conventions/SKILL.md
+++ b/.claude/skills/evidence-and-timestamp-conventions/SKILL.md
@@ -31,7 +31,6 @@ The following sub-paths under `artifacts/` are FORBIDDEN for evidence output:
 
 Allowed `artifacts/` sub-paths (non-evidence orchestration use only):
 - `artifacts/orchestration/`
-- `artifacts/research/`
 
 No delegation prompt, plan task, or upstream agent instruction may override this scheme. If a caller supplies a non-canonical path, the receiving agent MUST reject it, substitute the canonical path, and record `EVIDENCE_LOCATION_OVERRIDE_REJECTED: <supplied path> replaced with <canonical path>`.
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -61,7 +61,7 @@ After reading `artifacts/orchestration/orchestrator-state.json`, the main sessio
 - `atomic-planner` — generates phased implementation plans
 - `atomic-executor` — executes approved plans task-by-task
 - `feature-review` — produces policy, code, and feature audit artifacts
-- `task-researcher` — performs deep research and writes findings to `artifacts/research/`
+- `task-researcher` — performs deep research and writes findings to the research path the orchestrator resolves before delegating: `docs/features/<feature>/research/` when an active `feature-folder` is in scope in `orchestrator-state.json`, otherwise `docs/research/` for one-off research. The orchestrator passes the resolved path in the delegation prompt.
 
 The orchestrator does not perform deep implementation itself. It coordinates, tracks state, and enforces completion.
 
@@ -71,7 +71,6 @@ All evidence artifacts produced during orchestration MUST comply with the canoni
 
 Permitted `artifacts/`-rooted sub-paths (non-evidence orchestration use only):
 - `artifacts/orchestration/` — orchestrator state and checkpoints
-- `artifacts/research/` — research outputs from task-researcher
 - `artifacts/pr_context` — PR context artifacts
 - `artifacts/reviews/` — review staging artifacts
 - `artifacts/status/` — status update artifacts

--- a/.claude/skills/research-issue/SKILL.md
+++ b/.claude/skills/research-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-issue
-description: Investigate the best implementation approach for a feature or bug by analyzing the codebase and external references, then writing structured findings to artifacts/research/.
+description: Investigate the best implementation approach for a feature or bug by analyzing the codebase and external references, then writing structured findings to the resolved research path under docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).
 allowed-tools:
   - Read
   - Grep
@@ -22,9 +22,11 @@ Accept one or more feature documents as context:
 
 ## Output
 
-Create or update a single research file:
+Create or update a single research file at one of the two tracked research roots:
 
-- Path: `artifacts/research/<timestamp>-<short-name>-research.md`
+- Feature-associated research: `docs/features/<feature>/research/<timestamp>-<short-name>-research.md` (for example `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`).
+- One-off research not tied to a feature: `docs/research/<timestamp>-<short-name>-research.md`.
+- Routing rule: write to the feature research root when an active feature folder is in scope (the orchestrator supplies the resolved path from `feature-folder` in `orchestrator-state.json`); otherwise write to `docs/research/`. The filename convention `<timestamp>-<short-name>-research.md` is unchanged.
 - Use the Task Researcher template from the repository exactly.
 - Place rejected-alternatives summaries inside `## Recommended Approach`, not as a separate top-level header.
 

--- a/.github/agents/task-researcher.agent.md
+++ b/.github/agents/task-researcher.agent.md
@@ -8,13 +8,13 @@ tools: [vscode/getProjectSetupInfo, vscode/installExtension, vscode/newWorkspace
 
 ## Role Definition
 
-You are a research-only specialist who performs deep, comprehensive analysis for task planning. Your sole responsibility is to write transient research notes in the untracked scratch area `artifacts/research/`. You MUST NOT make changes to any other files, code, or configurations.
+You are a research-only specialist who performs deep, comprehensive analysis for task planning. Your sole responsibility is to write research notes to one of the two tracked research roots: `docs/features/<feature>/research/` for feature-associated research, or `docs/research/` for one-off research not tied to a feature. The orchestrator resolves which root to use and supplies the path; do not infer the feature folder independently. You MUST NOT make changes to any other files, code, or configurations.
 
 ## Core Research Principles
 
 You MUST operate under these constraints:
 
-- You WILL ONLY do deep research using ALL available tools and create/edit files in `artifacts/research/` (intentionally untracked scratch space) without modifying source code or configurations
+- You WILL ONLY do deep research using ALL available tools and create/edit files in the orchestrator-supplied research root (`docs/features/<feature>/research/` for feature-associated research, or `docs/research/` for one-off research) without modifying source code or configurations
 - You WILL document ONLY verified findings from actual tool usage, never assumptions, ensuring all research is backed by concrete evidence
 - You MUST cross-reference findings across multiple authoritative sources to validate accuracy
 - You WILL understand underlying principles and implementation rationale beyond surface-level patterns
@@ -71,7 +71,7 @@ In the final research document, "remove alternatives" means:
 
 ## Operational Constraints
 
-You WILL use read tools throughout the entire workspace and external sources. You MUST create and edit files ONLY in `artifacts/research/`. You MUST NOT modify any source code, configurations, or other project files.
+You WILL use read tools throughout the entire workspace and external sources. You MUST create and edit files ONLY in the orchestrator-supplied research root: `docs/features/<feature>/research/` (feature-associated) or `docs/research/` (one-off). You MUST NOT modify any source code, configurations, or other project files.
 
 You WILL provide brief, focused updates without overwhelming details. You WILL present discoveries and guide user toward single solution selection. You WILL keep all conversation focused on research activities and findings. You WILL NEVER repeat information already documented in research files.
 
@@ -205,7 +205,7 @@ For each research activity, you MUST:
 
 You MUST maintain research files as living documents:
 
-1. Search for existing research files in `artifacts/research/`
+1. Search for existing research files in the orchestrator-supplied research root (`docs/features/<feature>/research/` for feature-associated research, or `docs/research/` for one-off research)
 2. Create new research file if none exists for the topic
 3. Initialize with comprehensive research template structure
 

--- a/.github/prompts/fillout-prd-feature.prompt.md
+++ b/.github/prompts/fillout-prd-feature.prompt.md
@@ -18,7 +18,7 @@ Use this prompt when invoking the prd_feature agent via `/fillout-prd-feature <p
 
 1. Load each supplied path in order; note missing or unreadable files explicitly.
 2. Extract available details (issue number, owner, status, story statements, constraints, inputs/outputs, CLI flags, personas, risks, acceptance criteria, non-goals).
-3. If research exists under `artifacts/research`, the caller must include the specific research file paths in the `/fillout-prd-feature` command; the agent must read each provided research file before writing.
+3. If research exists under `docs/features/<feature>/research/` (feature-associated) or `docs/research/` (one-off), the caller must include the specific research file paths in the `/fillout-prd-feature` command; the agent must read each provided research file before writing.
 4. Identify gaps; if the research document is insufficient to populate required sections, delegate additional research to the Task Researcher Agent and pause drafting until that research is complete.
 5. Before writing, run a technical completeness check: confirm Proposed Fix, Assumptions, Data/Config Impact, Test Strategy, and Acceptance Criteria can be filled with domain-specific, testable details (no placeholders).
 6. Apply the prd_feature agent’s section guidance when filling content:

--- a/.github/prompts/research-issue.prompt.md
+++ b/.github/prompts/research-issue.prompt.md
@@ -16,7 +16,7 @@ Your output must be actionable for an engineer/agent to implement, and must be g
 
 ## Scope and operating rules
 
-Follow the operating rules in your agent definition (research-only, write to `artifacts/research/`, evidence-based). Do not restate those rules in the research notes; apply them.
+Follow the operating rules in your agent definition (research-only; write to the orchestrator-supplied research root under `docs/features/<feature>/research/` for feature-associated research or `docs/research/` for one-off research; evidence-based). Do not restate those rules in the research notes; apply them.
 
 ## Inputs / Context (authoritative)
 
@@ -31,11 +31,12 @@ Also identify (from the feature docs) the **implementation target files** in the
 
 ## Research Outputs (required)
 
-Create (or update) a single research file under `artifacts/research/` using the Task Researcher template exactly.
+Create (or update) a single research file under the orchestrator-supplied research root using the Task Researcher template exactly. The two tracked research roots are `docs/features/<feature>/research/` (feature-associated; for example `docs/features/active/<feature>/research/`) and `docs/research/` (one-off, not tied to a feature). Routing rule: use the feature research root when an active feature folder is in scope (the orchestrator supplies the resolved path from `feature-folder` in `orchestrator-state.json`); otherwise use `docs/research/`.
 
 Filename convention:
 
-- `artifacts/research/YYYYMMDD-<short-feature-name>-implementation-research.md`
+- `docs/features/<feature>/research/YYYYMMDD-<short-feature-name>-implementation-research.md` (feature-associated), or
+- `docs/research/YYYYMMDD-<short-feature-name>-implementation-research.md` (one-off)
 
 In the research file, keep any discussion of non-selected approaches *brief and non-exhaustive*. After selecting a recommendation, remove detailed notes for other approaches and keep only a short “Rejected alternatives” summary (what was rejected and why).
 

--- a/coverage.xml
+++ b/coverage.xml
@@ -1,80 +1,123 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
-<report name="Pester (06/24/2026 14:11:45)">
-  <sessioninfo id="this" start="1782310304870" dump="1782310305494" />
+<report name="Pester (06/24/2026 14:16:50)">
+  <sessioninfo id="this" start="1782310610135" dump="1782310610894" />
   <package name="hooks">
-    <class name="hooks/enforce-evidence-locations" sourcefilename="enforce-evidence-locations.ps1">
-      <method name="Test-EvidenceLocationForbidden" desc="()" line="57">
-        <counter type="INSTRUCTION" missed="0" covered="8" />
-        <counter type="LINE" missed="0" covered="8" />
+    <class name="hooks/validate-task-researcher-output" sourcefilename="validate-task-researcher-output.ps1">
+      <method name="&lt;script&gt;" desc="()" line="23">
+        <counter type="INSTRUCTION" missed="5" covered="3" />
+        <counter type="LINE" missed="5" covered="3" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <method name="Get-EvidenceLocationBlockDecision" desc="()" line="97">
+      <method name="Test-ResearchFile" desc="()" line="34">
+        <counter type="INSTRUCTION" missed="2" covered="0" />
+        <counter type="LINE" missed="1" covered="0" />
+        <counter type="METHOD" missed="1" covered="0" />
+      </method>
+      <method name="Get-ResearchPathFromOutput" desc="()" line="45">
+        <counter type="INSTRUCTION" missed="1" covered="10" />
+        <counter type="LINE" missed="1" covered="8" />
+        <counter type="METHOD" missed="0" covered="1" />
+      </method>
+      <method name="Test-IsUnderResearchRoot" desc="()" line="68">
+        <counter type="INSTRUCTION" missed="0" covered="5" />
+        <counter type="LINE" missed="0" covered="4" />
+        <counter type="METHOD" missed="0" covered="1" />
+      </method>
+      <method name="Test-IsValidResearchFileName" desc="()" line="93">
         <counter type="INSTRUCTION" missed="0" covered="3" />
         <counter type="LINE" missed="0" covered="3" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <method name="Invoke-EvidenceLocationDecision" desc="()" line="117">
-        <counter type="INSTRUCTION" missed="0" covered="14" />
-        <counter type="LINE" missed="0" covered="10" />
+      <method name="Test-AutomationFeasibilitySection" desc="()" line="133">
+        <counter type="INSTRUCTION" missed="0" covered="24" />
+        <counter type="LINE" missed="0" covered="14" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <method name="Invoke-EvidenceLocationEntryPoint" desc="()" line="160">
-        <counter type="INSTRUCTION" missed="0" covered="7" />
-        <counter type="LINE" missed="0" covered="5" />
+      <method name="Invoke-TaskResearcherOutputValidation" desc="()" line="171">
+        <counter type="INSTRUCTION" missed="0" covered="45" />
+        <counter type="LINE" missed="0" covered="22" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <method name="&lt;script&gt;" desc="()" line="172">
-        <counter type="INSTRUCTION" missed="2" covered="1" />
-        <counter type="LINE" missed="1" covered="1" />
-        <counter type="METHOD" missed="0" covered="1" />
-      </method>
-      <counter type="INSTRUCTION" missed="2" covered="33" />
-      <counter type="LINE" missed="1" covered="27" />
-      <counter type="METHOD" missed="0" covered="5" />
+      <counter type="INSTRUCTION" missed="8" covered="90" />
+      <counter type="LINE" missed="7" covered="54" />
+      <counter type="METHOD" missed="1" covered="6" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
-    <sourcefile name="enforce-evidence-locations.ps1">
+    <sourcefile name="validate-task-researcher-output.ps1">
+      <line nr="23" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="24" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="34" mi="2" ci="0" mb="0" cb="0" />
+      <line nr="45" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="46" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="47" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="48" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="51" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="52" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="53" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="54" mi="1" ci="0" mb="0" cb="0" />
       <line nr="57" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="59" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="60" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="73" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="74" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="75" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="76" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="68" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="77" mi="0" ci="1" mb="0" cb="0" />
       <line nr="80" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="97" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="98" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="99" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="117" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="118" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="122" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="125" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="128" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="129" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="130" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="82" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="93" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="94" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="95" mi="0" ci="1" mb="0" cb="0" />
       <line nr="133" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="134" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="136" mi="0" ci="1" mb="0" cb="0" />
       <line nr="137" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="160" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="162" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="163" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="166" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="168" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="172" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="176" mi="2" ci="0" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="2" covered="33" />
-      <counter type="LINE" missed="1" covered="27" />
-      <counter type="METHOD" missed="0" covered="5" />
+      <line nr="139" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="140" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="142" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="143" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="146" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="147" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="148" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="151" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="157" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="158" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="161" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="171" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="172" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="176" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="179" mi="0" ci="4" mb="0" cb="0" />
+      <line nr="182" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="183" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="184" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="186" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="187" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="190" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="191" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="192" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="195" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="196" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="199" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="200" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="203" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="204" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="207" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="208" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="209" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="212" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="215" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="219" mi="1" ci="0" mb="0" cb="0" />
+      <line nr="220" mi="1" ci="0" mb="0" cb="0" />
+      <line nr="221" mi="1" ci="0" mb="0" cb="0" />
+      <line nr="222" mi="1" ci="0" mb="0" cb="0" />
+      <line nr="225" mi="1" ci="0" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="8" covered="90" />
+      <counter type="LINE" missed="7" covered="54" />
+      <counter type="METHOD" missed="1" covered="6" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="2" covered="33" />
-    <counter type="LINE" missed="1" covered="27" />
-    <counter type="METHOD" missed="0" covered="5" />
+    <counter type="INSTRUCTION" missed="8" covered="90" />
+    <counter type="LINE" missed="7" covered="54" />
+    <counter type="METHOD" missed="1" covered="6" />
     <counter type="CLASS" missed="0" covered="1" />
   </package>
-  <counter type="INSTRUCTION" missed="2" covered="33" />
-  <counter type="LINE" missed="1" covered="27" />
-  <counter type="METHOD" missed="0" covered="5" />
+  <counter type="INSTRUCTION" missed="8" covered="90" />
+  <counter type="LINE" missed="7" covered="54" />
+  <counter type="METHOD" missed="1" covered="6" />
   <counter type="CLASS" missed="0" covered="1" />
 </report>

--- a/coverage.xml
+++ b/coverage.xml
@@ -1,178 +1,80 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
-<report name="Pester (06/19/2026 22:07:34)">
-  <sessioninfo id="this" start="1781906853381" dump="1781906854801" />
-  <package name="powershell">
-    <class name="powershell/Publish-DrmCopilotExtension" sourcefilename="Publish-DrmCopilotExtension.ps1">
-      <method name="&lt;script&gt;" desc="()" line="63">
-        <counter type="INSTRUCTION" missed="3" covered="18" />
-        <counter type="LINE" missed="2" covered="15" />
+<report name="Pester (06/24/2026 14:11:45)">
+  <sessioninfo id="this" start="1782310304870" dump="1782310305494" />
+  <package name="hooks">
+    <class name="hooks/enforce-evidence-locations" sourcefilename="enforce-evidence-locations.ps1">
+      <method name="Test-EvidenceLocationForbidden" desc="()" line="57">
+        <counter type="INSTRUCTION" missed="0" covered="8" />
+        <counter type="LINE" missed="0" covered="8" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <method name="Invoke-NpmExe" desc="()" line="82">
-        <counter type="INSTRUCTION" missed="3" covered="0" />
-        <counter type="LINE" missed="2" covered="0" />
-        <counter type="METHOD" missed="1" covered="0" />
-      </method>
-      <method name="Invoke-VsceExe" desc="()" line="101">
-        <counter type="INSTRUCTION" missed="3" covered="0" />
-        <counter type="LINE" missed="2" covered="0" />
-        <counter type="METHOD" missed="1" covered="0" />
-      </method>
-      <method name="Get-VsceListing" desc="()" line="116">
-        <counter type="INSTRUCTION" missed="2" covered="0" />
-        <counter type="LINE" missed="1" covered="0" />
-        <counter type="METHOD" missed="1" covered="0" />
-      </method>
-      <method name="Test-ExtensionManifest" desc="()" line="136">
-        <counter type="INSTRUCTION" missed="1" covered="47" />
-        <counter type="LINE" missed="0" covered="38" />
-        <counter type="METHOD" missed="0" covered="1" />
-      </method>
-      <method name="Get-ForbiddenPackagedFile" desc="()" line="217">
-        <counter type="INSTRUCTION" missed="0" covered="9" />
+      <method name="Get-EvidenceLocationBlockDecision" desc="()" line="97">
+        <counter type="INSTRUCTION" missed="0" covered="3" />
         <counter type="LINE" missed="0" covered="3" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <method name="Invoke-ExtensionPackage" desc="()" line="246">
-        <counter type="INSTRUCTION" missed="0" covered="70" />
-        <counter type="LINE" missed="0" covered="53" />
+      <method name="Invoke-EvidenceLocationDecision" desc="()" line="117">
+        <counter type="INSTRUCTION" missed="0" covered="14" />
+        <counter type="LINE" missed="0" covered="10" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="12" covered="144" />
-      <counter type="LINE" missed="7" covered="109" />
-      <counter type="METHOD" missed="3" covered="4" />
+      <method name="Invoke-EvidenceLocationEntryPoint" desc="()" line="160">
+        <counter type="INSTRUCTION" missed="0" covered="7" />
+        <counter type="LINE" missed="0" covered="5" />
+        <counter type="METHOD" missed="0" covered="1" />
+      </method>
+      <method name="&lt;script&gt;" desc="()" line="172">
+        <counter type="INSTRUCTION" missed="2" covered="1" />
+        <counter type="LINE" missed="1" covered="1" />
+        <counter type="METHOD" missed="0" covered="1" />
+      </method>
+      <counter type="INSTRUCTION" missed="2" covered="33" />
+      <counter type="LINE" missed="1" covered="27" />
+      <counter type="METHOD" missed="0" covered="5" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
-    <sourcefile name="Publish-DrmCopilotExtension.ps1">
-      <line nr="63" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="64" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="65" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="82" mi="2" ci="0" mb="0" cb="0" />
-      <line nr="83" mi="1" ci="0" mb="0" cb="0" />
-      <line nr="101" mi="2" ci="0" mb="0" cb="0" />
-      <line nr="102" mi="1" ci="0" mb="0" cb="0" />
-      <line nr="116" mi="2" ci="0" mb="0" cb="0" />
-      <line nr="136" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="137" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="140" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="142" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="143" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="144" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="145" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="146" mi="1" ci="2" mb="0" cb="0" />
-      <line nr="147" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="148" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="149" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="152" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="153" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="154" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="155" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="159" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="160" mi="0" ci="2" mb="0" cb="0" />
+    <sourcefile name="enforce-evidence-locations.ps1">
+      <line nr="57" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="59" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="60" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="73" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="74" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="75" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="76" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="80" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="97" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="98" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="99" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="117" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="118" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="122" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="125" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="128" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="129" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="130" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="133" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="134" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="137" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="160" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="162" mi="0" ci="1" mb="0" cb="0" />
       <line nr="163" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="164" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="165" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="166" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="169" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="170" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="171" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="172" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="173" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="177" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="178" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="181" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="182" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="183" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="186" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="187" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="188" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="191" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="192" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="193" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="196" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="217" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="218" mi="0" ci="5" mb="0" cb="0" />
-      <line nr="219" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="246" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="247" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="248" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="250" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="251" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="252" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="253" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="254" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="255" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="257" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="258" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="259" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="261" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="262" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="263" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="264" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="266" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="267" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="268" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="271" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="273" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="276" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="277" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="280" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="281" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="283" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="284" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="285" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="286" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="287" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="288" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="289" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="293" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="295" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="297" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="298" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="299" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="300" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="301" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="304" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="305" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="306" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="308" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="309" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="311" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="312" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="315" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="317" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="319" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="320" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="321" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="322" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="323" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="327" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="328" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="329" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="330" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="331" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="333" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="334" mi="2" ci="0" mb="0" cb="0" />
-      <line nr="337" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="338" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="339" mi="1" ci="0" mb="0" cb="0" />
-      <line nr="342" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="343" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="344" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="345" mi="0" ci="1" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="12" covered="144" />
-      <counter type="LINE" missed="7" covered="109" />
-      <counter type="METHOD" missed="3" covered="4" />
+      <line nr="166" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="168" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="172" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="176" mi="2" ci="0" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="2" covered="33" />
+      <counter type="LINE" missed="1" covered="27" />
+      <counter type="METHOD" missed="0" covered="5" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="12" covered="144" />
-    <counter type="LINE" missed="7" covered="109" />
-    <counter type="METHOD" missed="3" covered="4" />
+    <counter type="INSTRUCTION" missed="2" covered="33" />
+    <counter type="LINE" missed="1" covered="27" />
+    <counter type="METHOD" missed="0" covered="5" />
     <counter type="CLASS" missed="0" covered="1" />
   </package>
-  <counter type="INSTRUCTION" missed="12" covered="144" />
-  <counter type="LINE" missed="7" covered="109" />
-  <counter type="METHOD" missed="3" covered="4" />
+  <counter type="INSTRUCTION" missed="2" covered="33" />
+  <counter type="LINE" missed="1" covered="27" />
+  <counter type="METHOD" missed="0" covered="5" />
   <counter type="CLASS" missed="0" covered="1" />
 </report>

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/code-review.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/code-review.2026-06-24T13-55.md
@@ -1,0 +1,42 @@
+# Code Review — relocate-research-canonical-location (Issue #227)
+
+- **Timestamp:** 2026-06-24T13-55
+- **Base branch (resolved):** origin/main @ ea94a068e0a071940858a0694c47e204244c09af
+- **Head:** d200d8961843f8b9d040f6c847b8ae186035dc90
+- **Scope:** full branch diff vs merge-base.
+
+## Executive Summary
+
+The change relocates the canonical research output path from the untracked `artifacts/research/` to two git-tracked roots (`docs/features/<feature>/research/` and `docs/research/`) across the Claude, Codex, and GitHub Copilot ecosystems and their bundled extension copies. The implementation is consistent and minimal:
+
+- `Test-IsUnderResearchRoot` in `validate-task-researcher-output.ps1` was rewritten to accept the two roots using a forward-slash-normalized prefix-and-segment check; the filename regex was left unchanged as required by the spec invariant.
+- `enforce-evidence-locations.ps1` and `validate_evidence_locations.py` add `artifacts/research/` to their forbidden-prefix sets, keeping the existing exclusion-only model intact.
+- Three hard-coded error messages and the hook docstring were updated to name both new roots.
+- Tests in all three test files were updated and extended for new-root acceptance and old-path rejection.
+- Root files and their bundled mirrors are byte-identical; Codex translations carry the equivalent text.
+
+The change follows the design principles in general-code-change.md (simplicity, separation of pure logic from I/O, fail-fast error messages with specific guidance). Toolchain stages (format, lint, type, test) pass. No source-code behavioral defects were identified.
+
+One coverage threshold is not met: `enforce-evidence-locations.ps1` modified-file line coverage is 81.5%, below the uniform 85% threshold. The uncovered region is the pre-existing entry-point execution block, not the changed line. This is recorded as a Blocking coverage finding in the policy audit and remediation inputs.
+
+A second observation is a low-severity whitespace artifact: a trailing blank line with a mixed line ending was added at the end of `validate-task-researcher-output.ps1`. It is byte-identical in the bundled mirror, passes Invoke-Formatter, and has no behavioral effect.
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Blocking | .claude/hooks/enforce-evidence-locations.ps1 | entry-point block, lines 146-154 | Modified-file line coverage 81.5% is below the uniform 85% threshold. Uncovered lines are the dot-source-guarded entry-point execution block; the changed forbidden-prefix line is itself covered. | Add a process-level/integration test that executes the script as a process to cover the entry-point dispatch block, or refactor the entry-point wiring so the dispatch is exercised by the unit tests. Until then the threshold remains unmet. | quality-tiers.md and general-unit-test.md set a uniform 85% line floor for modified files; the file does not meet it. | coverage-delta.2026-06-24T13-09.md (81.5%, 22/27); reviewer Pester re-run (uncovered lines 146,148,149,152,154) |
+| Low | .claude/hooks/validate-task-researcher-output.ps1 | end of file (after `exit 0`) | A trailing blank line with a mixed line ending (`\n\r\n`) was added by the diff. No behavioral effect; byte-identical in the bundled mirror; passes Invoke-Formatter. | Remove the trailing blank line for cleanliness on the next edit. Not required for merge. | Minor whitespace hygiene; not a policy violation. | `tail -c 40` shows `exit 0\n\r\n`; git diff shows a `+` blank line after `exit 0` |
+| Info | .claude/hooks/validate-task-researcher-output.ps1 | Test-IsUnderResearchRoot (lines 66-83) | Dual-root acceptance logic correctly normalizes separators and requires a `/research/` segment for feature paths, distinguishing research files from spec.md/plan files under docs/features/. Case-insensitive comparisons used throughout. | None. Implementation matches the spec acceptance/rejection matrix. | Confirms the enforcement was not weakened by accepting two roots. | spec.md "Hook acceptance/rejection logic"; tests pass 32/32 including negative cases |
+| Info | scripts/dev_tools/validate_evidence_locations.py | _FORBIDDEN_PREFIX_TO_CANONICAL (line 38) | Single-line addition of `artifacts/research/` with a canonical suggestion naming both new roots. Pure dict-data change; 100% line and branch coverage retained. | None. | Minimal, well-scoped, fully tested. | final-python.2026-06-24T13-09.md; reviewer pytest 100% coverage |
+| Info | extensions/.../codex-and-agents-customizations/.codex/agents/task-researcher.toml | embedded frontmatter, body, stop hook | Write allowlist updated to the two-root glob form; body prose and stop-hook text updated to name both roots. Translation is consistent with the Claude source. | None. | Codex translation completeness confirmed. | git diff of task-researcher.toml |
+
+## Typed-Python Review
+
+`scripts/dev_tools/validate_evidence_locations.py` change is a one-line addition to a typed module-level dict `_FORBIDDEN_PREFIX_TO_CANONICAL: dict[str, str]`. Pyright reports 0 errors/warnings. No `Any`, no untyped escape hatch, no new function. The test addition `test_artifacts_research_is_forbidden` uses `MagicMock(spec=Path)` consistently with the existing test style, asserts exactly one violation, and verifies the canonical suggestion names both roots. No determinism, I/O-boundary, or typing concerns.
+
+## Test Quality Notes
+
+- The PowerShell test files add positive cases for both new roots, a negative case for the retired `artifacts/research/` path (asserting the new message text), a negative case for a feature path lacking a `/research/` segment, and a negative case for a non-conforming filename under a valid root. This matches the spec Test Strategy.
+- The `enforce-evidence-locations.Tests.ps1` change converts the former allow-test for `artifacts/research/` into a block-test asserting `EVIDENCE_LOCATION_BLOCKED`, and adds allow-tests for the two new roots.
+- Tests are deterministic, isolated, and follow Arrange-Act-Assert. No temporary files are created. No banned timing APIs.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/code-review.2026-06-24T14-18.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/code-review.2026-06-24T14-18.md
@@ -1,0 +1,39 @@
+# Code Review — relocate-research-canonical-location (Issue #227)
+
+- **Timestamp:** 2026-06-24T14-18
+- **Base branch (resolved):** origin/main @ ea94a068e0a071940858a0694c47e204244c09af
+- **Head:** drm-copilot-wt-2026-06-24-13-02 @ eb85c8789cd99907cac8363a95c3c9043341d995
+- **Scope:** full branch diff vs merge-base (two commits: relocation + coverage remediation)
+- **Review type:** Re-audit after remediation
+
+## Executive Summary
+
+The change relocates the canonical research-output path from the git-ignored `artifacts/research/` to two tracked roots (`docs/features/<feature>/research/` and `docs/research/`) across the Claude, Codex, and GitHub Copilot ecosystems and their bundled copies. The remediation commit (`eb85c87`) extracted the `enforce-evidence-locations.ps1` entry-point dispatch into a testable `Invoke-EvidenceLocationEntryPoint` function and added three dispatch tests, raising that hook's line coverage from 81.5% to 96.43%.
+
+Code quality is consistent with repository policy. PowerShell functions use `CmdletBinding()`, named/validated parameters, and `[OutputType]`; the dot-source guard preserves the exclusion-only model and the testable-wiring seam. The Python validator is fully type-annotated, Pyright-clean, and 100% covered. Tests follow Arrange-Act-Assert with descriptive names and no temporary-file usage or external dependencies. Cross-ecosystem mirrors are byte-identical where required. No blocking code-quality findings.
+
+The remediation introduced a clean design seam: the dispatch logic now returns an exit code from a unit-testable function, and only a single thin `exit (...)` statement remains in the host-bound entry point. This is the refactor approach the general-unit-test coverage-exclusion policy prescribes (push logic into testable host-neutral code; keep the host-bound wiring minimal and visible in the denominator). No coverage exclusion was added.
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Info | .claude/hooks/enforce-evidence-locations.ps1 | L140-169, L176 | Dispatch logic extracted into `Invoke-EvidenceLocationEntryPoint` (returns int exit code); a single thin `exit (Invoke-EvidenceLocationEntryPoint)` wiring statement remains in the host-bound entry point. Clean seam; function is fully exercised by three new tests. | None. Consistent with the coverage-exclusion refactor policy. | The only uncovered line (176) is the structurally unreachable `exit` wiring; no exclusion was introduced, keeping the line in the denominator (96.43% line coverage). | Reviewer Pester re-run (13 tests, 94.29% command cov, only L176 missed); coverage-threshold-verification.2026-06-24T13-55.md |
+| Info | tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1 | L126-170 | New `entry-point dispatch` context adds three tests covering allow-output, malformed-JSON error (asserts exit 1 and error record), and block-output paths. AAA structure, deterministic, no temp files. | None. | Directly closes the prior coverage gap with behavioral assertions on the decision-to-output mapping. | Reviewer Pester run; final-pester-coverage.2026-06-24T13-55.md |
+| Info | scripts/dev_tools/validate_evidence_locations.py | L38 | Added `artifacts/research/` to `_FORBIDDEN_PREFIX_TO_CANONICAL` with a canonical suggestion naming both new roots. Single-line additive change; module remains 100% line/branch covered. | None. | Fully type-annotated, Pyright-clean; matched by the new `test_artifacts_research_is_forbidden` test asserting both new roots in the suggestion. | pytest 7 passed, 100%/100% coverage; ruff/pyright clean |
+| Info | .claude/hooks/validate-task-researcher-output.ps1 | L60-83, L190-200 | `Test-IsUnderResearchRoot` rewritten for dual-root acceptance (feature path with `/research/` segment, or `docs/research/`); three error messages updated to cite both new roots. | None. | Logic is explicit and case-insensitive; negative paths (no `/research/` segment, retired path) covered by tests. | Reviewer Pester run (22 tests, 91.84% command cov) |
+| Low | coverage.xml | repo root | Regenerated generated JaCoCo coverage report committed in the diff (net -98 lines). | Optional: exclude regenerated coverage.xml from feature commits. | Generated output is out of scope per spec Non-Goals; incidental churn, not a path violation. | git diff --stat; spec.md Non-Goals |
+| Low | extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-claude-to-codex/SKILL.md | L24, L175 | References `artifacts/research/codex-native-ecosystem.2026-06-16T13-32.md` as a historical input artifact the skill consumes. | None required; optional accuracy update on next touch of this skill. | This is a pointer to a specific historical research input, not the research-output-path contract; file is outside the spec's in-scope inventory and out of scope per Non-Goals. | Grep; spec.md In-Scope File Inventory |
+| Low | .claude/hooks/enforce-evidence-locations.ps1 | EOF | Mixed line endings reported by a direct `Invoke-Formatter -ScriptDefinition` call; authoritative PoshQC format gate passes (EXIT 0). | Optional cleanup on next edit. | Cosmetic; PSScriptAnalyzer reports 0 findings. Carried over from prior review. | Reviewer Invoke-Formatter probe; final-poshqc-format.2026-06-24T13-55.md |
+
+## Design and Standards Assessment
+
+- **Simplicity / separation of concerns:** The relocation is a path-contract change with no behavioral re-architecture, matching the spec's stated intent. The remediation seam adds one small function plus thin wiring — the minimal change that makes the dispatch path testable.
+- **Error handling:** Both hooks fail fast (malformed JSON throws / returns exit 1 with `Write-Error`); the Python validator exits 1 on violations and 0 when clean. No broad catch-all handlers.
+- **Documentation:** Python functions and the PowerShell functions carry contract-oriented docstrings; the new `Invoke-EvidenceLocationEntryPoint` docstring explains why the wrapper exists (testability) and that it does not call `exit`. Consistent with self-explanatory-code-commenting policy.
+- **Testing standards:** Tests are independent, isolated, deterministic, and free of temporary files and external dependencies. Mocking in the Python tests patches `rglob`/`find_forbidden_paths` at the import location used by the unit under test, per python.md.
+- **File-size limit:** All changed source and test files are well under 500 lines.
+
+## Conclusion
+
+No blocking or actionable code-quality findings. The remediation is correct, minimal, and consistent with repository policy. Three Low/Info observations are non-gating.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/pester.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/pester.2026-06-24T13-09.md
@@ -1,0 +1,17 @@
+# Baseline — PoshQC Pester (coverage mode)
+
+Timestamp: 2026-06-24T13-09
+Command:
+- mcp__drm-copilot__run_poshqc_test (scan_folders: ["tests/scripts/claude-hooks"]) — full claude-hooks suite, includes both target test files.
+- Targeted per-hook coverage measured directly via Pester (CodeCoverage.Path scoped to the two hooks), because the bundled PoshQC coverage scope in scripts/powershell/PoshQC/settings/pester.runsettings.psd1 does not instrument these two hooks. Pester invocation: Invoke-Pester with Run.Path = the two hook test files, CodeCoverage.Path = .claude/hooks/validate-task-researcher-output.ps1 and .claude/hooks/enforce-evidence-locations.ps1, OutputFormat JaCoCo.
+EXIT_CODE: 0
+
+Output Summary:
+- Full claude-hooks suite (PoshQC): tests=248, failures=0, errors=0.
+- Target test suites: validate-task-researcher-output.Tests.ps1 = 17 tests, 0 failures; enforce-evidence-locations.Tests.ps1 = 5 tests, 0 failures.
+- Targeted coverage run: Total=22, Passed=22, Failed=0.
+- Numeric line coverage (JaCoCo, baseline):
+  - validate-task-researcher-output.ps1: LINE 52/59 = 88.1%
+  - enforce-evidence-locations.ps1: LINE 19/27 = 70.4%
+- Branch coverage: Pester's PowerShell coverage engine emits no BRANCH counters (command/line coverage only); branch coverage is not measured by this toolchain. The repository PowerShell policy thresholds are evaluated against the available line/command coverage; BRANCH is not produced for PowerShell.
+- Note on enforce-evidence-locations.ps1 baseline (70.4%): the 8 uncovered lines are the entry-point block (the dot-source guard at line 137 and the script-execution tail at lines 141-150) which executes only when the script is invoked as an entry point, not when dot-sourced by tests. The tested logic function Test-EvidenceLocationForbidden (where this feature's changed lines live) is covered. This is the pre-change baseline; post-change coverage and changed-line coverage are evaluated in P9-T4.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/pester.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/pester.2026-06-24T13-55.md
@@ -1,0 +1,30 @@
+# Baseline — Targeted Pester Coverage for enforce-evidence-locations.ps1 (Issue #227)
+
+Timestamp: 2026-06-24T13-55
+
+Command: Scoped Pester run (New-PesterConfiguration) over tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1 with CodeCoverage.OutputFormat='JaCoCo' and CodeCoverage.Path scoped to the root hook (.claude/hooks/enforce-evidence-locations.ps1) and the Claude mirror (extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1). Run via Pester 5.6.1.
+
+Note on scope: the bundled mcp__drm-copilot__run_poshqc_test coverage scope
+(scripts/powershell/PoshQC/settings/pester.runsettings.psd1) does NOT instrument
+enforce-evidence-locations.ps1. A scoped New-PesterConfiguration run is therefore
+required to obtain per-file numeric line coverage for this hook. Pester's coverage
+engine emits LINE/INSTRUCTION counters only; JaCoCo BRANCH counters are not produced
+for PowerShell, so branch coverage is unavailable and only line coverage is reported.
+
+EXIT_CODE: 0
+
+Output Summary:
+- Pester result: TotalCount=10, Passed=10, Failed=0, Skipped=0. Suite is green.
+- Baseline LINE coverage for .claude/hooks/enforce-evidence-locations.ps1:
+  covered=22, missed=5, total=27 => 81.48% (matches plan-stated 81.5%, 22/27).
+- Uncovered (missed) lines: 146, 148, 149, 152, 154 — the entry-point dispatch
+  block (try/catch around Invoke-EvidenceLocationDecision; Write-Error/exit 1;
+  ConvertTo-Json/Write-Output; exit 0). These are unreachable from dot-sourced
+  unit tests because the dot-source guard returns before the dispatch tail.
+- Branch coverage: not produced by Pester for PowerShell (line coverage only).
+- The Claude mirror shows 0% in the same run because the test dot-sources only the
+  root path; the mirror's coverage is validated indirectly through byte-equality
+  with the root file (P3-T5).
+
+Baseline determination: 81.48% line coverage, below the uniform 85% threshold —
+this is Finding 1, the blocking shortfall this remediation resolves.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-analyze.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-analyze.2026-06-24T13-09.md
@@ -1,0 +1,6 @@
+# Baseline — PoshQC Analyze (PSScriptAnalyzer)
+
+Timestamp: 2026-06-24T13-09
+Command: mcp__drm-copilot__run_poshqc_analyze (scan_folders: [".claude/hooks", "tests/scripts/claude-hooks"])
+EXIT_CODE: 0
+Output Summary: PoshQC analyze returned ok:true for the two scan folders covering validate-task-researcher-output.ps1, enforce-evidence-locations.ps1, and their two hook test files. No analyzer findings surfaced (analyzer findings count: 0). Pre-change analyze state: clean.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-analyze.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-analyze.2026-06-24T13-55.md
@@ -1,0 +1,11 @@
+# Baseline — PoshQC Analyze (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+Command: mcp__drm-copilot__run_poshqc_analyze (scan folders: .claude/hooks, extensions/drm-copilot/resources/claude-customizations/.claude/hooks, extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks, tests/scripts/claude-hooks)
+
+EXIT_CODE: 0
+
+Output Summary: Analyzer run completed successfully (ok=true). No analyzer
+findings reported for the three production hook files and the claude-hooks test
+file. Finding count: 0. Baseline analyze state: PASS.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-format.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-format.2026-06-24T13-09.md
@@ -1,0 +1,6 @@
+# Baseline — PoshQC Format (check)
+
+Timestamp: 2026-06-24T13-09
+Command: mcp__drm-copilot__run_poshqc_format (scan_folders: [".claude/hooks", "tests/scripts/claude-hooks"])
+EXIT_CODE: 0
+Output Summary: PoshQC format ran successfully against the two scan folders containing validate-task-researcher-output.ps1, enforce-evidence-locations.ps1, and their two hook test files. `git status --short` after the run showed no modifications to any PowerShell file (only the untracked feature evidence folder). Pre-change format state: clean (no reformatting needed).

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-format.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-format.2026-06-24T13-55.md
@@ -1,0 +1,12 @@
+# Baseline — PoshQC Format (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+Command: mcp__drm-copilot__run_poshqc_format (scan folders: .claude/hooks, extensions/drm-copilot/resources/claude-customizations/.claude/hooks, extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks, tests/scripts/claude-hooks)
+
+EXIT_CODE: 0
+
+Output Summary: Format run completed successfully (ok=true) against the three
+production hook files and the claude-hooks test file. No format-induced changes
+to the four target PowerShell files (git status shows no modifications to the
+.ps1 files in scope). Baseline format state: PASS.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/python.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/python.2026-06-24T13-09.md
@@ -1,0 +1,24 @@
+# Baseline — Python (Black / Ruff / Pyright / Pytest)
+
+Timestamp: 2026-06-24T13-09
+
+Stage 1 — Black
+Command: poetry run black --check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: 2 files would be left unchanged. Already formatted.
+
+Stage 2 — Ruff
+Command: poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: All checks passed.
+
+Stage 3 — Pyright
+Command: poetry run pyright scripts/dev_tools/validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: 0 errors, 0 warnings, 0 informations.
+
+Stage 4 — Pytest (coverage)
+Command: poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts.dev_tools.validate_evidence_locations --cov-branch --cov-report=term-missing
+Note: The plan lists --cov=scripts/dev_tools/validate_evidence_locations (slash form). That slash form yields "module never imported / no data" because the test imports the dotted module scripts.dev_tools.validate_evidence_locations. The dotted-module --cov target is the mechanically equivalent form that matches the test's import and is used here and in P9.
+EXIT_CODE: 0
+Output Summary: 6 passed. Coverage for scripts/dev_tools/validate_evidence_locations.py: Stmts=28, Miss=0, Branch=12, BrPart=0, Cover=100% (line 100%, branch 100%).

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/residual-references.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/residual-references.2026-06-24T13-09.md
@@ -1,0 +1,61 @@
+# Baseline — Residual `artifacts/research` References
+
+Timestamp: 2026-06-24T13-09
+Command: Grep pattern `artifacts[/\\]research` across the repository (content/files mode, unlimited)
+EXIT_CODE: 0
+Output Summary: 96 files match the pattern. They fall into two classes.
+
+## Operational / enforcement / instruction files (must reach zero by P9-T7)
+
+Claude ecosystem (root):
+- .claude/hooks/validate-task-researcher-output.ps1
+- .claude/hooks/enforce-evidence-locations.ps1
+- .claude/agents/task-researcher.md
+- .claude/agents/orchestrator.md
+- .claude/skills/research-issue/SKILL.md
+- .claude/skills/orchestrate/SKILL.md
+- .claude/skills/evidence-and-timestamp-conventions/SKILL.md
+
+Claude ecosystem (bundled):
+- extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1
+- extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1
+- extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md
+- extensions/drm-copilot/resources/claude-customizations/.claude/agents/orchestrator.md
+- extensions/drm-copilot/resources/claude-customizations/.claude/skills/research-issue/SKILL.md
+- extensions/drm-copilot/resources/claude-customizations/.claude/skills/orchestrate/SKILL.md
+- extensions/drm-copilot/resources/claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md
+
+Codex ecosystem (bundled):
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md
+
+GitHub Copilot ecosystem (root):
+- .github/prompts/research-issue.prompt.md
+- .github/prompts/fillout-prd-feature.prompt.md
+- .github/agents/task-researcher.agent.md
+
+GitHub Copilot ecosystem (bundled):
+- extensions/drm-copilot/resources/customizations/.github/prompts/research-issue.prompt.md
+- extensions/drm-copilot/resources/customizations/.github/prompts/fillout-prd-feature.prompt.md
+- extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md
+
+Tests (updated by Phases 1-3):
+- tests/scripts/dev_tools/test_validate_evidence_locations.py
+- tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1
+- tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1
+
+Documentation accuracy (P8-T3):
+- docs/engineering/claude-code-architecture.md (note: not in the 96-match grep list above; verify during P8-T3)
+
+## Allowed (historical / generated / out-of-scope) — expected to remain
+
+- testResults.xml (generated)
+- This feature's own plan/spec/issue under docs/features/active/2026-06-24-relocate-research-canonical-location-227/ (the spec/plan reference the retired path as context; this feature's research relocates in P8-T1)
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-claude-to-codex/SKILL.md (historical research-basis reference; out of scope per plan Open Questions)
+- All historical feature documents under docs/features/active/* and docs/features/archive/* (plan/spec/issue/research/audit/feature-audit/policy-audit/code-review/user-story/baseline records). These are historical records, not enforcement/instruction files (spec Non-Goals).
+
+The pre-change reference set above is the comparison baseline for the P9-T7 residual-reference grep. After implementation, the operational set must reach zero `artifacts/research` matches (test files updated, hooks/validators/prose updated); the allowed set is expected to still match.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/other/phase0-instructions-read.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/other/phase0-instructions-read.2026-06-24T13-09.md
@@ -1,0 +1,20 @@
+# Phase 0 — Policy Instructions Read
+
+Timestamp: 2026-06-24T13-09
+
+Policy Order: CLAUDE.md -> .claude/rules/general-code-change.md -> .claude/rules/general-unit-test.md -> language-specific (PowerShell, Python) -> supporting rules
+
+Files read (in order):
+- CLAUDE.md (standing instructions, auto-loaded)
+- .claude/rules/general-code-change.md (cross-language code change policy)
+- .claude/rules/general-unit-test.md (cross-language unit test policy)
+- .claude/rules/powershell.md (PowerShell toolchain and coding standards)
+- .claude/rules/python.md (Python toolchain and coding standards)
+- .claude/rules/python-suppressions.md (Python suppression authorization policy)
+- .claude/rules/self-explanatory-code-commenting.md (commenting and docstring policy)
+- .claude/rules/quality-tiers.md (T1-T4 rigor tier system; uniform coverage thresholds)
+
+Notes:
+- Languages in scope for this feature: PowerShell (hooks + tests) and Python (validator + tests). Remaining edits are prose/instruction/allowlist text in Markdown and TOML.
+- Coverage thresholds (uniform across tiers): line >= 85%, branch >= 75%; no regression on changed lines.
+- Mandatory toolchain order — PowerShell: PoshQC format -> analyze -> Pester; Python: Black -> Ruff -> Pyright -> Pytest.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/other/phase0-instructions-read.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/other/phase0-instructions-read.2026-06-24T13-55.md
@@ -1,0 +1,24 @@
+# Phase 0 — Policy Instructions Read (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+Policy Order:
+1. CLAUDE.md (standing instructions; always loaded)
+2. .claude/rules/general-code-change.md (cross-language code change policy)
+3. .claude/rules/general-unit-test.md (cross-language unit test policy)
+4. .claude/rules/quality-tiers.md (T1–T4 tier system; uniform coverage thresholds)
+5. .claude/rules/powershell.md (PowerShell toolchain and coding standards)
+
+Files Read:
+- CLAUDE.md
+- .claude/rules/general-code-change.md
+- .claude/rules/general-unit-test.md
+- .claude/rules/quality-tiers.md
+- .claude/rules/powershell.md
+
+Output Summary: All five policy files read in the required order. Key constraints
+confirmed for this remediation: line coverage >= 85% and branch coverage >= 75%
+uniform across tiers; no coverage exclusions permitted (refactor untestable lines
+into testable functions rather than excluding); no assertion weakening; PowerShell
+toolchain order is format -> analyze -> test (type-check N/A); per-batch cap 3
+production + 3 test files; all files must remain under 500 lines.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/codex-equivalence.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/codex-equivalence.2026-06-24T13-09.md
@@ -1,0 +1,16 @@
+# Codex Translation Equivalence (P9-T6)
+
+Timestamp: 2026-06-24T13-09
+Command: grep counts for new-root references and `artifacts[/\\]research` matches across the six Codex files.
+EXIT_CODE: 0
+
+| Codex file | New-root refs | artifacts/research matches | Confirmed change |
+|---|---|---|---|
+| .codex/agents/task-researcher.toml | 7 | 0 | Embedded write-allowlist replaced with the two new Write globs (P5-T3); description, body output-location prose, constraint, and stop-hook body reference both new roots and the routing rule (P7-T1). No operational artifacts/research reference. |
+| .codex/agents/orchestrator.toml | 1 | 0 | developer_instructions delegation prose references both new roots and the orchestrator routing rule (P7-T2). No artifacts/research reference. |
+| .codex/hooks/enforce-evidence-locations.ps1 | 2 | 2 | 'artifacts/research/' added to the forbidden-prefix array and the docstring forbidden list (P4-T3); removed from the permitted list; docstring names the two new tracked roots. The 2 artifacts/research matches are the forbidden-prefix references (line 23 docstring forbidden list, line 71 $forbiddenPrefixes array) — correct operational rejection state, identical intent to the root hook. No permitted/routing artifacts/research reference remains. |
+| .agents/skills/research-issue/SKILL.md | 4 | 0 | Output-path prose and description reference both new roots and the routing rule (P7-T3). No artifacts/research reference. |
+| .agents/skills/orchestrate/SKILL.md | 1 | 0 | Delegation prose references both new roots and the routing rule; permitted-sub-path list no longer contains artifacts/research/ (P7-T4). No artifacts/research reference. |
+| .agents/skills/evidence-and-timestamp-conventions/SKILL.md | 0 | 0 | artifacts/research/ removed from the allowed list (P7-T5). This file describes the allowed-path list only (not research routing), so it has no new-root reference by design; artifacts/orchestration/ remains. No artifacts/research reference. |
+
+Acceptance: each Codex file reflects the new contract; no operational `artifacts/research/` path-routing reference remains. The only residual `artifacts/research/` strings (in the Codex enforce hook) are the intended forbidden-prefix entries that implement the rejection of the retired path, matching the root hook.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/coverage-delta.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/coverage-delta.2026-06-24T13-09.md
@@ -1,0 +1,21 @@
+# Coverage Delta (P9-T4)
+
+Timestamp: 2026-06-24T13-09
+
+Compares baseline coverage (P0-T4 PowerShell, P0-T5 Python) against post-change coverage (P9-T1 PowerShell, P9-T2 Python). PowerShell coverage is line/command coverage (JaCoCo via Pester); Pester's PowerShell coverage engine does not emit BRANCH counters, so branch coverage is reported only for Python.
+
+| Module | Baseline line cov | Post-change line cov | Baseline branch cov | Post-change branch cov | Changed-line cov | Regression on changed lines |
+|---|---|---|---|---|---|---|
+| validate-task-researcher-output.ps1 | 88.1% (52/59) | 88.5% (54/61) | n/a (not emitted) | n/a (not emitted) | covered | none |
+| enforce-evidence-locations.ps1 | 70.4% (19/27) | 81.5% (22/27) | n/a (not emitted) | n/a (not emitted) | covered | none |
+| validate_evidence_locations.py | 100% (28/28 stmts) | 100% (28/28 stmts) | 100% (12/12) | 100% (12/12) | covered | none |
+
+## Threshold disposition
+
+- validate-task-researcher-output.ps1: 88.5% line >= 85%. PASS.
+- validate_evidence_locations.py: 100% line >= 85%, 100% branch >= 75%. PASS.
+- enforce-evidence-locations.ps1: 81.5% line, below the 85% line threshold. Coverage improved +11.1 points from the 70.4% baseline by adding tests for the previously-uncovered empty-input, missing-file_path, and malformed-JSON logic branches. The only remaining uncovered lines (146, 148, 149, 152, 154) are the script entry-point execution block, which is unreachable when the script is dot-sourced by unit tests (the dot-source guard returns first). This is a pre-existing structural condition for this small (27-line) entry-point-bound file; reaching >= 85% would require refactoring the entry-point wiring (outside this plan's scope) or an integration test that executes the script as a process. The feature's changed line (the added 'artifacts/research/' forbidden prefix) is inside the fully-covered Test-EvidenceLocationForbidden function. No regression on changed lines.
+
+## Conclusion
+
+No regression on changed lines for any of the three modules. Two of three modules meet the absolute 85%/75% thresholds. enforce-evidence-locations.ps1 line coverage (81.5%) is below the 85% line threshold due to a pre-existing untestable entry-point block; this is recorded transparently rather than reported as a threshold PASS. The changed lines introduced by this feature are covered in all three modules.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/coverage-threshold-verification.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/coverage-threshold-verification.2026-06-24T13-55.md
@@ -1,0 +1,49 @@
+# Coverage Threshold and No-Regression Verification (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+## Coverage values (enforce-evidence-locations.ps1, root file)
+
+| Metric | Value | Source |
+|---|---|---|
+| Baseline line coverage | 81.48% (22/27) | evidence/baseline/pester.2026-06-24T13-55.md |
+| Post-change line coverage | 96.43% (27/28) | evidence/qa-gates/final-pester-coverage.2026-06-24T13-55.md |
+| Delta | +14.95 pp | computed |
+| Threshold (uniform, all tiers) | >= 85% | .claude/rules/quality-tiers.md |
+
+Branch coverage: not produced by Pester for PowerShell (LINE/INSTRUCTION counters
+only). Only line coverage is applicable and is reported above.
+
+## Threshold determination
+
+Post-change line coverage 96.43% >= 85% threshold. PASS.
+
+## No-regression on changed lines
+
+The previously-changed line is the `'artifacts/research/'` forbidden prefix entry
+in the `Test-EvidenceLocationForbidden` forbidden-prefix array (root file line 68).
+
+Verification: the Pester command-level CommandsMissed set for the root file
+contains only line 176 (`exit (Invoke-EvidenceLocationEntryPoint)`). Line 68 is
+not in the missed set. It is exercised by two passing tests:
+- pre-existing: "blocks writes to artifacts/research/ (retired research path)"
+- new (P2-T3): "returns exit code 0 and emits block JSON for a forbidden path"
+  using `{"file_path":"artifacts/research/notes.md"}`.
+
+Both tests require the `artifacts/research/` prefix to match to produce a block
+decision; both pass. The changed line remains covered. NO REGRESSION on changed
+lines.
+
+## Residual uncovered line
+
+Line 176, `exit (Invoke-EvidenceLocationEntryPoint)`, is the single thin
+entry-point wiring statement. It is structurally unreachable from dot-sourced
+unit tests (the dot-source guard returns before it) and cannot be executed
+in-process under Pester because `exit` terminates the test host. No coverage
+exclusion was introduced; the line remains in the denominator (27/28 -> 96.43%),
+consistent with the no-exclusion policy in general-unit-test.md.
+
+## Overall determination: PASS
+
+Line coverage 96.43% >= 85% with no regression on changed lines. No return to
+Phase 1/2 required.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/cross-ecosystem-equality.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/cross-ecosystem-equality.2026-06-24T13-09.md
@@ -1,0 +1,22 @@
+# Cross-Ecosystem Content Equality (P9-T5)
+
+Timestamp: 2026-06-24T13-09
+Command: diff -q for each root-vs-bundled pair (Claude and GitHub Copilot ecosystems)
+EXIT_CODE: 0 (all pairs identical)
+
+| # | Root file | Bundled mirror | Result |
+|---|---|---|---|
+| 1 | .claude/hooks/validate-task-researcher-output.ps1 | claude-customizations/.claude/hooks/validate-task-researcher-output.ps1 | IDENTICAL |
+| 2 | .claude/hooks/enforce-evidence-locations.ps1 | claude-customizations/.claude/hooks/enforce-evidence-locations.ps1 | IDENTICAL |
+| 3 | .claude/agents/task-researcher.md | claude-customizations/.claude/agents/task-researcher.md | IDENTICAL |
+| 4 | .claude/agents/orchestrator.md | claude-customizations/.claude/agents/orchestrator.md | IDENTICAL |
+| 5 | .claude/skills/research-issue/SKILL.md | claude-customizations/.claude/skills/research-issue/SKILL.md | IDENTICAL |
+| 6 | .claude/skills/orchestrate/SKILL.md | claude-customizations/.claude/skills/orchestrate/SKILL.md | IDENTICAL |
+| 7 | .claude/skills/evidence-and-timestamp-conventions/SKILL.md | claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md | IDENTICAL |
+| 8 | .github/agents/task-researcher.agent.md | customizations/.github/agents/task-researcher.agent.md | IDENTICAL |
+| 9 | .github/prompts/research-issue.prompt.md | customizations/.github/prompts/research-issue.prompt.md | IDENTICAL |
+| 10 | .github/prompts/fillout-prd-feature.prompt.md | customizations/.github/prompts/fillout-prd-feature.prompt.md | IDENTICAL |
+
+Count note: the plan task text states "11 root-vs-bundled file pairs". The enumerated set resolves to 10 pairs: the two logic-bearing root hooks that have Claude bundled mirrors (validate-task-researcher-output.ps1 and enforce-evidence-locations.ps1 — the third logic-bearing file, the Python validator scripts/dev_tools/validate_evidence_locations.py, has no bundled copy), the five Claude prose files, and the three GitHub Copilot prose files. All 10 enumerated pairs report no content differences. The Codex translations are verified separately in P9-T6 (codex-equivalence artifact).
+
+Acceptance: each root-vs-bundled pair reports no content differences.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/cross-ecosystem-equality.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/cross-ecosystem-equality.2026-06-24T13-55.md
@@ -1,0 +1,38 @@
+# Cross-Ecosystem Parity Verification (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+## Root vs Claude mirror — byte comparison
+
+- Root: .claude/hooks/enforce-evidence-locations.ps1
+- Claude mirror: extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1
+- `cmp -s` result: BYTE-IDENTICAL (no differences).
+- md5 (both): 0722c5227ffe8cc4cd4874b247abe516.
+
+Determination: root and Claude mirror are byte-identical. PASS.
+
+## Codex translation parity
+
+- Codex copy: extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1
+- md5: 8509d82009bbd4d0e84a27e0be3d4059 (intentionally differs from root: banner + SKILL.md path).
+
+Parity checks:
+- Converted-header banner intact: line 1 `# Converted hook`, line 2
+  `# Review the generated hook behavior before enabling it.`
+- Contains the `Invoke-EvidenceLocationEntryPoint` function: yes (1 match).
+- Contains the thin wiring `exit (Invoke-EvidenceLocationEntryPoint)`: yes (1 match).
+- Retains the `.agents/skills/evidence-and-timestamp-conventions/SKILL.md` path in
+  the block reason: yes (1 match).
+- No `.claude/skills/` path leak from the root copy: confirmed (0 matches).
+- The refactored function block plus wiring is character-for-character identical
+  between the root and Codex files (diff of the `Invoke-EvidenceLocationEntryPoint`
+  ... `exit (Invoke-EvidenceLocationEntryPoint)` span reports no differences).
+
+Determination: Codex copy contains the equivalent dispatch logic (identical
+function and wiring) while retaining its translation-specific banner and
+`.agents/skills/...` SKILL.md path. PASS.
+
+## Overall determination: PASS
+
+Root and Claude mirror byte-identical; Codex copy has equivalent dispatch logic
+with its translation-specific differences intact.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-pester-coverage.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-pester-coverage.2026-06-24T13-55.md
@@ -1,0 +1,36 @@
+# Final QA — Pester Suite and Coverage (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+Command:
+1. mcp__drm-copilot__run_poshqc_test (scan folder: tests/scripts/claude-hooks) — full claude-hooks suite.
+2. Scoped Pester run (New-PesterConfiguration) over tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1 with CodeCoverage.OutputFormat='JaCoCo' and CodeCoverage.Path scoped to the root hook (.claude/hooks/enforce-evidence-locations.ps1) and the Claude mirror (extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1). Pester 5.6.1.
+
+EXIT_CODE: 0
+
+Note on coverage scope: the bundled mcp__drm-copilot__run_poshqc_test coverage
+scope (pester.runsettings.psd1) does not instrument enforce-evidence-locations.ps1.
+A scoped New-PesterConfiguration run is therefore used for numeric per-file line
+coverage. Pester emits LINE/INSTRUCTION counters only; branch coverage is not
+produced for PowerShell.
+
+Output Summary:
+- Full claude-hooks suite (bundled MCP run): 261 tests, 0 failures, 0 errors,
+  0 skipped. Suite is green. No production or test files modified by the run.
+- enforce-evidence-locations.Tests.ps1 scoped run: TotalCount=13, Passed=13,
+  Failed=0, Skipped=0 (10 pre-existing + 3 new entry-point dispatch tests).
+- Post-change LINE coverage for .claude/hooks/enforce-evidence-locations.ps1:
+  covered=27, missed=1, total=28 => 96.43%.
+- Baseline (pre-change) coverage for delta context: 81.48% (22/27).
+- Delta: +14.95 percentage points (81.48% -> 96.43%).
+- New-code coverage: the added Invoke-EvidenceLocationEntryPoint function body
+  (try / Invoke-EvidenceLocationDecision / catch / Write-Error / return 1 /
+  ConvertTo-Json | Write-Output / return 0) is fully exercised by the three new
+  tests (allow-output path, malformed-JSON error path, block-output path). The
+  only uncovered line is 176, `exit (Invoke-EvidenceLocationEntryPoint)`, the
+  single thin wiring statement that is structurally unreachable from dot-sourced
+  unit tests.
+- The Claude mirror shows 0% in this scoped run because the test dot-sources only
+  the root path; the mirror is validated through byte-equality (P3-T5).
+
+Determination: full suite green (exit 0); post-change line coverage 96.43% >= 85%.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc-analyze.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc-analyze.2026-06-24T13-55.md
@@ -1,0 +1,14 @@
+# Final QA — PoshQC Analyze (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+Command: mcp__drm-copilot__run_poshqc_analyze (scan folders: .claude/hooks, extensions/drm-copilot/resources/claude-customizations/.claude/hooks, extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks, tests/scripts/claude-hooks)
+
+EXIT_CODE: 0
+
+Output Summary: Analyzer run completed successfully (ok=true). Finding count: 0.
+No PSScriptAnalyzer findings for the three production hook files (including the
+new Invoke-EvidenceLocationEntryPoint advanced function, which uses an approved
+verb/noun, CmdletBinding, and OutputType) or the claude-hooks test file. Analyze
+did not modify any file (md5 hashes unchanged from the post-format state). Final
+analyze: PASS.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc-format.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc-format.2026-06-24T13-55.md
@@ -1,0 +1,13 @@
+# Final QA — PoshQC Format (Issue #227 remediation)
+
+Timestamp: 2026-06-24T13-55
+
+Command: mcp__drm-copilot__run_poshqc_format (scan folders: .claude/hooks, extensions/drm-copilot/resources/claude-customizations/.claude/hooks, extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks, tests/scripts/claude-hooks)
+
+EXIT_CODE: 0
+
+Output Summary: Format run completed successfully (ok=true). Two consecutive
+format runs produced byte-identical files (md5 unchanged across runs), confirming
+the formatted state is stable with no residual changes. Root and Claude mirror
+remain byte-identical after formatting. Final format check: PASS, no residual
+changes.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc.2026-06-24T13-09.md
@@ -1,0 +1,32 @@
+# Final QA Gate — PowerShell (full loop)
+
+Timestamp: 2026-06-24T13-09
+
+Scope: all edited PowerShell files (.claude/hooks/validate-task-researcher-output.ps1, .claude/hooks/enforce-evidence-locations.ps1, the two Claude bundled mirrors, the Codex enforce-evidence-locations.ps1) plus the two hook test files.
+
+Stage 1 — Format
+Command: mcp__drm-copilot__run_poshqc_format (scan_folders: 4 folders covering root hooks, tests, Claude bundled hooks, Codex hooks)
+EXIT_CODE: 0
+Output Summary: ok:true. Bundled Claude hook mirrors reconfirmed byte-identical to root after format (diff IDENTICAL for both).
+
+Stage 2 — Analyze
+Command: mcp__drm-copilot__run_poshqc_analyze (same 4 folders)
+EXIT_CODE: 0
+Output Summary: ok:true. Zero analyzer findings.
+
+Stage 3 — Pester (coverage)
+Command:
+- mcp__drm-copilot__run_poshqc_test (scan_folders: ["tests/scripts/claude-hooks"]) — full claude-hooks suite.
+- Targeted per-hook coverage via direct Invoke-Pester scoped to the two hooks.
+EXIT_CODE: 0
+Output Summary:
+- Full claude-hooks suite: tests=258, failures=0, errors=0.
+- validate-task-researcher-output.Tests.ps1: 22 tests, 0 failures.
+- enforce-evidence-locations.Tests.ps1: 10 tests, 0 failures.
+- Targeted coverage run: Total=32, Passed=32, Failed=0.
+- Numeric line coverage (JaCoCo):
+  - validate-task-researcher-output.ps1: LINE 54/61 = 88.5% (>= 85%).
+  - enforce-evidence-locations.ps1: LINE 22/27 = 81.5% (see coverage note in phase2-poshqc.2026-06-24T13-09.md and coverage-delta artifact).
+- Branch coverage: not emitted by Pester's PowerShell coverage engine (line/command coverage only).
+
+Single-pass result: format, analyze, and test all clean in a single pass. No regression on changed lines.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-python.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-python.2026-06-24T13-09.md
@@ -1,0 +1,25 @@
+# Final QA Gate — Python (full loop)
+
+Timestamp: 2026-06-24T13-09
+
+Stage 1 — Black
+Command: poetry run black scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: 2 files left unchanged.
+
+Stage 2 — Ruff
+Command: poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: All checks passed.
+
+Stage 3 — Pyright
+Command: poetry run pyright scripts/dev_tools/validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: 0 errors, 0 warnings, 0 informations.
+
+Stage 4 — Pytest (coverage)
+Command: poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts.dev_tools.validate_evidence_locations --cov-branch --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: 7 passed. Coverage for scripts/dev_tools/validate_evidence_locations.py: Stmts=28, Miss=0, Branch=12, BrPart=0, Cover=100% (line 100% >= 85%, branch 100% >= 75%).
+
+Single-pass result: all four stages clean in a single pass.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase1-poshqc.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase1-poshqc.2026-06-24T13-09.md
@@ -1,0 +1,30 @@
+# Phase 1 QA Gate — PoshQC (validate-task-researcher-output)
+
+Timestamp: 2026-06-24T13-09
+
+Stage 1 — Format
+Command: mcp__drm-copilot__run_poshqc_format (scan_folders: [".claude/hooks", "tests/scripts/claude-hooks"])
+EXIT_CODE: 0
+Output Summary: ok:true. Formatter reindented the multi-line boolean continuation in Test-IsUnderResearchRoot (style only). No functional change.
+
+Stage 2 — Analyze
+Command: mcp__drm-copilot__run_poshqc_analyze (scan_folders: [".claude/hooks", "tests/scripts/claude-hooks"])
+EXIT_CODE: 0
+Output Summary: ok:true. Zero analyzer findings.
+
+Stage 3 — Pester (coverage)
+Command:
+- mcp__drm-copilot__run_poshqc_test (scan_folders: ["tests/scripts/claude-hooks"]) — full claude-hooks suite.
+- Targeted per-hook coverage via direct Invoke-Pester (CodeCoverage.Path scoped to the two hooks).
+EXIT_CODE: 0
+Output Summary:
+- Full claude-hooks suite: tests=253, failures=0, errors=0 (was 248; +5 new It blocks from P1-T5).
+- validate-task-researcher-output.Tests.ps1 suite: 22 tests, 0 failures (was 17; +5).
+- Targeted coverage run: Total=27, Passed=27, Failed=0.
+- Numeric line coverage (JaCoCo, post-Phase-1):
+  - validate-task-researcher-output.ps1: LINE 54/61 = 88.5% (baseline 88.1%; no regression on changed lines — the rewritten Test-IsUnderResearchRoot body and three updated messages are all exercised by new/updated tests).
+- Branch coverage: not emitted by Pester's PowerShell coverage engine (line/command coverage only).
+- Note: the ~7 uncovered lines are the pre-existing entry-point block (dot-source guard + script-execution tail), unchanged by this feature.
+
+Single-pass result: format, analyze, and test all clean in a single pass; no stage changed files in a way requiring a restart (formatter style reindent applied at the format stage, after which analyze and test passed).
+Acceptance: validate-task-researcher-output.ps1 line coverage 88.5% >= 85%; changed lines covered; no regression.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase2-poshqc.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase2-poshqc.2026-06-24T13-09.md
@@ -1,0 +1,35 @@
+# Phase 2 QA Gate — PoshQC (enforce-evidence-locations)
+
+Timestamp: 2026-06-24T13-09
+
+Stage 1 — Format
+Command: mcp__drm-copilot__run_poshqc_format (scan_folders: [".claude/hooks", "tests/scripts/claude-hooks"]) and a follow-up format after adding logic-branch tests.
+EXIT_CODE: 0
+Output Summary: ok:true. No production reformatting required.
+
+Stage 2 — Analyze
+Command: mcp__drm-copilot__run_poshqc_analyze (scan_folders: [".claude/hooks", "tests/scripts/claude-hooks"])
+EXIT_CODE: 0
+Output Summary: ok:true. Zero analyzer findings.
+
+Stage 3 — Pester (coverage)
+Command:
+- mcp__drm-copilot__run_poshqc_test (scan_folders: ["tests/scripts/claude-hooks"]) — full claude-hooks suite.
+- Targeted per-hook coverage via direct Invoke-Pester (CodeCoverage.Path scoped to the two hooks).
+EXIT_CODE: 0
+Output Summary:
+- Full claude-hooks suite: tests=258, failures=0, errors=0 (was 248 at baseline; +5 from Phase 1, +2 from P2-T4 allow tests, +3 from added logic-branch tests).
+- enforce-evidence-locations.Tests.ps1 suite: 10 tests, 0 failures (was 5).
+- Targeted coverage run: Total=32, Passed=32, Failed=0.
+- Numeric line coverage (JaCoCo, post-Phase-2):
+  - enforce-evidence-locations.ps1: LINE 22/27 = 81.5% (baseline 70.4%; +11.1 points).
+  - validate-task-researcher-output.ps1: LINE 54/61 = 88.5% (unchanged from Phase 1).
+- Branch coverage: not emitted by Pester's PowerShell coverage engine (line/command coverage only).
+
+Changed-line coverage (P2 changes):
+- The added forbidden prefix 'artifacts/research/' lives inside Test-EvidenceLocationForbidden, which is fully covered. The docstring change is comment text (not counted). No regression on changed lines.
+
+Coverage threshold note (enforce-evidence-locations.ps1 at 81.5%, below the 85% line threshold):
+- The five remaining uncovered lines are 146, 148, 149, 152, 154 — the script entry-point execution block (Invoke-EvidenceLocationDecision call, error handler, ConvertTo-Json output, exit). This block is unreachable when the script is dot-sourced by tests because the dot-source guard at lines 141-142 returns first. It executes only when the script runs as a real PreToolUse process entry point.
+- This is a pre-existing structural condition. The file is small (27 analyzed lines); the fixed ~5-line entry-point overhead caps dot-source-test coverage below 85% even with all logic branches covered. Phase 2 raised coverage from the 70.4% baseline to 81.5% by adding tests for the previously-uncovered empty-input, missing-file_path, and malformed-JSON logic branches (lines 117-118, 128-130, 121-125).
+- Reaching >= 85% would require either refactoring the entry-point wiring (outside this plan's task scope) or executing the script as a process (an integration test, not a unit test). The changed lines for this feature are covered and there is no regression. This is recorded as a coverage note, not a PASS of the absolute 85% file threshold for this entry-point-bound file.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase3-python.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase3-python.2026-06-24T13-09.md
@@ -1,0 +1,29 @@
+# Phase 3 QA Gate — Python (validate_evidence_locations)
+
+Timestamp: 2026-06-24T13-09
+
+Stage 1 — Black
+Command: poetry run black scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: 2 files left unchanged. Already formatted.
+
+Stage 2 — Ruff
+Command: poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: All checks passed.
+
+Stage 3 — Pyright
+Command: poetry run pyright scripts/dev_tools/validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: 0 errors, 0 warnings, 0 informations.
+
+Stage 4 — Pytest (coverage)
+Command: poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts.dev_tools.validate_evidence_locations --cov-branch --cov-report=term-missing
+EXIT_CODE: 0
+Output Summary: 7 passed (was 6; +1 test_artifacts_research_is_forbidden). Coverage for scripts/dev_tools/validate_evidence_locations.py: Stmts=28, Miss=0, Branch=12, BrPart=0, Cover=100% (line 100% >= 85%, branch 100% >= 75%).
+
+Changed-line coverage: the added _FORBIDDEN_PREFIX_TO_CANONICAL entry "artifacts/research/" is exercised by test_artifacts_research_is_forbidden (asserts exactly one violation and that the suggestion names both new roots). No regression on changed lines.
+
+P3-T2 disposition: not-applicable. The module docstring describes the scheme generally ("any file found under a forbidden artifacts/ sub-path is reported as a violation") and does not enumerate individual forbidden prefixes nor claim research under artifacts/ is permitted. No docstring edit was required.
+
+Single-pass result: all four stages clean in a single pass.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase4-poshqc.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/phase4-poshqc.2026-06-24T13-09.md
@@ -1,0 +1,25 @@
+# Phase 4 QA Gate — PoshQC (bundled-copy synchronization)
+
+Timestamp: 2026-06-24T13-09
+
+Files in scope:
+- extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1 (byte-identical copy of root, P4-T1)
+- extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1 (byte-identical copy of root, P4-T2)
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1 (translation-equivalent edit, P4-T3)
+
+Stage 1 — Format
+Command: mcp__drm-copilot__run_poshqc_format (scan_folders: [".../claude-customizations/.claude/hooks", ".../codex-and-agents-customizations/.codex/hooks"])
+EXIT_CODE: 0
+Output Summary: ok:true. Byte-identity of the two Claude mirrors against root reconfirmed after format (diff: IDENTICAL for both).
+
+Stage 2 — Analyze
+Command: mcp__drm-copilot__run_poshqc_analyze (same two scan folders)
+EXIT_CODE: 0
+Output Summary: ok:true. Zero analyzer findings.
+
+Verification:
+- diff .claude/hooks/validate-task-researcher-output.ps1 vs bundled mirror: IDENTICAL.
+- diff .claude/hooks/enforce-evidence-locations.ps1 vs bundled mirror: IDENTICAL.
+- Codex enforce-evidence-locations.ps1: 'artifacts/research/' present in the forbidden-prefix array (line 71) and the forbidden-prefix docstring list (line 23); no permitted reference remains. Codex-specific header ("Converted hook") and the .agents/skills/ SKILL.md path reference are preserved (translation equivalence, not byte-identity).
+
+No dedicated test files target the bundled/Codex copies; the root copies are the tested source. Format and analyze clean for the three files in a single pass.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/residual-reference-final.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/residual-reference-final.2026-06-24T13-09.md
@@ -1,0 +1,37 @@
+# Final Residual-Reference Grep (P9-T7)
+
+Timestamp: 2026-06-24T13-09
+Command: grep -rnE 'artifacts[/\\]research' across the repository, classified against the P0-T6 baseline.
+EXIT_CODE: 0
+
+## Result: zero operational routing/permitted matches remain.
+
+Every remaining `artifacts/research` match falls into an allowed class (forbidden-prefix rejection logic, deliberate test assertions, historical out-of-scope reference, this feature's own docs, or generated files). No operational/enforcement/instruction file still treats `artifacts/research/` as a permitted or canonical research-output routing target.
+
+### Class A — Required forbidden-prefix entries (rejection logic; intended)
+- .claude/hooks/enforce-evidence-locations.ps1 (lines 20, 68)
+- extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1 (lines 20, 68)
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1 (lines 23, 71)
+- scripts/dev_tools/validate_evidence_locations.py (line 38, _FORBIDDEN_PREFIX_TO_CANONICAL key)
+These implement the rejection of the retired path and are required by the feature contract.
+
+### Class B — Deliberate test assertions (verify rejection; intended)
+- tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1 (block-decision test for artifacts/research/notes.md)
+- tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1 (rejects-retired-path test)
+- tests/scripts/dev_tools/test_validate_evidence_locations.py (test_artifacts_research_is_forbidden + docstring)
+
+### Class C — Historical reference, explicitly out of scope (plan Open Questions)
+- extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-claude-to-codex/SKILL.md (lines 24, 175): research-basis reference to a specific historical artifact artifacts/research/codex-native-ecosystem.2026-06-16T13-32.md, not a routing rule. Out of scope per plan Open Questions / research.
+
+### Class D — This feature's own documents (historical/feature-doc; allowed)
+- docs/features/active/2026-06-24-relocate-research-canonical-location-227/ : plan, spec, issue, research artifact (relocated), and evidence artifacts that reference the retired path as context or record the migration. These are feature records, not enforcement/instruction files (spec Non-Goals).
+
+### Class E — Generated files (allowed)
+- testResults.xml (generated)
+- *.pyc bytecode under __pycache__ (generated)
+- artifacts/pester/*, artifacts/orchestration/* generated outputs
+
+## Comparison to P0-T6 baseline
+The P0-T6 baseline enumerated the operational set (Claude/Codex/GitHub Copilot hooks, validators, agent frontmatter/body, skill prose, prompts — root and bundled) that referenced the old path as a routing/permitted target. After implementation, that operational routing/permitted set is now zero: a targeted grep of .claude and .github excluding the enforce-evidence-locations.ps1 forbidden-prefix entries returns no matches, and the Codex equivalence check (P9-T6) confirms the Codex files carry no routing/permitted artifacts/research reference. The only residual matches in operational files are the intended forbidden-prefix entries (Class A) that implement the rejection.
+
+Acceptance: zero operational routing/permitted matches remain; all remaining matches are classified Class A (required rejection logic), B (test assertions), C (historical out-of-scope), D (feature docs), or E (generated).

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/validator-run.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/validator-run.2026-06-24T13-09.md
@@ -1,0 +1,18 @@
+# QA Gate — Evidence-Location Validator Run (P9-T3)
+
+Timestamp: 2026-06-24T13-09
+
+## Run 1 — repository root (clean tree)
+Command: poetry run python scripts/dev_tools/validate_evidence_locations.py
+EXIT_CODE: 0
+Output Summary: No violations. The relocated feature research file at docs/features/active/2026-06-24-relocate-research-canonical-location-227/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md is NOT flagged (it is under docs/, not a forbidden artifacts/ prefix). Validator exits 0 on the clean tree.
+
+## Run 2 — scratch tree with seeded artifacts/research/ and a new-root file
+Command: poetry run python scripts/dev_tools/validate_evidence_locations.py --root <scratch-tree>
+Scratch tree contents:
+- artifacts/research/seeded.md (seeded forbidden path)
+- docs/features/active/feat/research/2026-06-24T13-02-foo-research.md (new canonical root)
+EXIT_CODE: 1
+Output Summary: Exactly one VIOLATION reported for artifacts/research/seeded.md with suggestion "use docs/features/active/<feature>/research/ or docs/research/ instead". The new-root file under docs/features/.../research/ is NOT flagged. This confirms: (a) artifacts/research/ is now rejected, (b) the new canonical research location is accepted, (c) the canonical suggestion names both new roots.
+
+Acceptance: validator exits 0 on the clean tree; the new research location is not flagged; a seeded artifacts/research/ file is reported as a violation.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/feature-audit.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/feature-audit.2026-06-24T13-55.md
@@ -1,0 +1,61 @@
+# Feature Audit — relocate-research-canonical-location (Issue #227)
+
+- **Timestamp:** 2026-06-24T13-55
+- **Work mode:** full-feature
+
+## Scope and Baseline
+
+- **Base branch (resolved):** origin/main @ ea94a068e0a071940858a0694c47e204244c09af
+- **Head:** drm-copilot-wt-2026-06-24-13-02 @ d200d8961843f8b9d040f6c847b8ae186035dc90
+- **Merge base:** ea94a068e0a071940858a0694c47e204244c09af
+- **Range:** ea94a068e0a071940858a0694c47e204244c09af..d200d8961843f8b9d040f6c847b8ae186035dc90
+- **AC source resolution:** Work mode `full-feature` resolves AC sources to `spec.md` and `user-story.md`. `user-story.md` is absent from the feature folder (folder contains only issue.md, spec.md, plan, evidence/, research/). The authoritative AC checklist is the `## Acceptance Criteria` section of `spec.md`, which mirrors the issue #227 acceptance criteria. The absence of `user-story.md` is recorded as an assumption; evaluation proceeds against `spec.md`.
+
+## Acceptance Criteria Inventory
+
+Source: docs/features/active/2026-06-24-relocate-research-canonical-location-227/spec.md, `## Acceptance Criteria` (7 items), plus `## Seeded Test Conditions` (3 items).
+
+| ID | Criterion |
+|---|---|
+| AC1 | Feature-associated research written to `<FEATURE>/research/<timestamp>-<short-name>-research.md` and one-off research to `docs/research/<timestamp>-<short-name>-research.md`; `artifacts/research/` is no longer the canonical target. |
+| AC2 | Claude ecosystem (root `.claude/` and bundled `claude-customizations`) reflects the new contract in task-researcher.md, orchestrator.md, research-issue/SKILL.md, orchestrate/SKILL.md, evidence-and-timestamp-conventions/SKILL.md, and both hooks. |
+| AC3 | Codex ecosystem (bundled `codex-and-agents-customizations`) reflects the new contract in task-researcher.toml (embedded frontmatter, body, stop hook), orchestrator.toml, the three mirrored skills, and the enforce-evidence-locations.ps1 docstring. |
+| AC4 | GitHub Copilot ecosystem (root `.github/` and bundled `customizations`) reflects the new contract in task-researcher.agent.md, research-issue.prompt.md, and fillout-prd-feature.prompt.md. |
+| AC5 | validate-task-researcher-output.ps1 accepts both new tracked roots and rejects `artifacts/research/`, with three error messages updated; enforce-evidence-locations.ps1 and validate_evidence_locations.py reject `artifacts/research/`; tests updated in all three test files. |
+| AC6 | Both tracked research locations resolve to git-tracked paths (under `docs/`, not under the ignored `artifacts/` tree); no `.gitignore` change. |
+| AC7 | Root copies and their bundled mirrors are content-identical after the change; Codex translations contain the equivalent text changes. |
+| STC1 | Hook unit tests for accepted (feature and one-off) and rejected research paths. |
+| STC2 | Filename-convention validation preserved under the new roots. |
+| STC3 | Evidence-location enforcement unaffected for non-research paths. |
+
+## Acceptance Criteria Evaluation
+
+| ID | Verdict | Evidence |
+|---|---|---|
+| AC1 | PASS | Spec and all instruction surfaces define the two new roots; `artifacts/research/` removed from permitted lists and added to forbidden-prefix sets. Validator run on repo root exits 0 with the relocated feature research file under docs/ not flagged (validator-run.2026-06-24T13-09.md). |
+| AC2 | PASS | git diff confirms changes in .claude/agents/task-researcher.md (frontmatter tools, description, body), .claude/agents/orchestrator.md, research-issue/orchestrate/evidence-and-timestamp-conventions SKILL.md, and both hooks; all root vs Claude-bundled mirrors verified IDENTICAL. |
+| AC3 | PASS | git diff confirms task-researcher.toml (embedded write allowlist `Write(/docs/features/**/research/**)` + `Write(/docs/research/**)`, body, stop-hook text), orchestrator.toml, the three .agents/skills/ files, and the Codex enforce-evidence-locations.ps1 forbidden-prefix entry (lines 23, 71). |
+| AC4 | PASS | git diff confirms .github/agents/task-researcher.agent.md, .github/prompts/research-issue.prompt.md, .github/prompts/fillout-prd-feature.prompt.md updated; root vs Copilot-bundled mirrors verified IDENTICAL. |
+| AC5 | PASS | Test-IsUnderResearchRoot rewritten for dual-root acceptance; three error messages updated (no `artifacts/research/` substring remains in them); forbidden prefix added to both PowerShell hook and Python validator. All three test files updated; Pester 32/32 pass, pytest 7/7 pass. |
+| AC6 | PASS | Both roots are under `docs/` (tracked). No .gitignore change in the branch diff. The relocated feature research file is committed under docs/features/.../research/ and is tracked. |
+| AC7 | PASS | All seven Claude root/bundled pairs and three Copilot root/bundled pairs verified byte-IDENTICAL by diff. Codex translations carry the equivalent relocation text (verified by diff). |
+| STC1 | PASS | Positive tests for feature-root and one-off-root acceptance; negative tests for retired path, missing `/research/` segment, and non-conforming filename. |
+| STC2 | PASS | Filename regex left unchanged (spec invariant); filename-convention test asserts a non-conforming name under a valid root is rejected. |
+| STC3 | PASS | enforce-evidence-locations exclusion-only model unchanged; non-research evidence paths unaffected; reviewer ran validate_evidence_locations.py --root . with exit 0. |
+
+## Summary
+
+All 7 acceptance criteria and 3 seeded test conditions evaluate PASS. The feature delivers the relocation contract consistently across the three ecosystems and their bundled copies, preserves the filename-convention and exclusion-only invariants, and updates the test suites accordingly.
+
+One quality gate outside the acceptance-criteria set is not met: modified-file line coverage for `enforce-evidence-locations.ps1` is 81.5%, below the uniform 85% threshold (see policy-audit.2026-06-24T13-55.md and remediation-inputs.2026-06-24T13-55.md). This does not invalidate any acceptance criterion — the changed line is covered and there is no regression on changed lines — but it is a Blocking coverage finding under the SKILL coverage contract and routes to remediation. PR readiness is therefore no-go until the coverage finding is resolved.
+
+## Acceptance Criteria Check-off
+
+All AC items in spec.md are already marked `[x]` (checked off during execution) and the reviewer evaluation confirms PASS for each; no change to the checkbox state is required. No items require flipping from `[ ]` to `[x]`. The issue.md early-draft AC list remains `[ ]` (early-draft section, not the authoritative full-feature AC source) and is left unchanged per acceptance-criteria-tracking (reviewers do not author or alter draft AC sections).
+
+### Acceptance Criteria Status
+- Source: docs/features/active/2026-06-24-relocate-research-canonical-location-227/spec.md (authoritative); user-story.md absent (documented assumption)
+- Total AC items: 7 (plus 3 seeded test conditions)
+- Checked off (delivered): 7 (already `[x]` in spec.md; all confirmed PASS)
+- Remaining (unchecked): 0
+- Items remaining: none

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/feature-audit.2026-06-24T14-18.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/feature-audit.2026-06-24T14-18.md
@@ -1,0 +1,67 @@
+# Feature Audit — relocate-research-canonical-location (Issue #227)
+
+- **Timestamp:** 2026-06-24T14-18
+- **Review type:** Re-audit after remediation
+
+## Scope and Baseline
+
+- **Base branch (resolved):** origin/main @ ea94a068e0a071940858a0694c47e204244c09af
+- **Head:** drm-copilot-wt-2026-06-24-13-02 @ eb85c8789cd99907cac8363a95c3c9043341d995
+- **Merge base:** ea94a068e0a071940858a0694c47e204244c09af
+- **Range:** ea94a068e0a071940858a0694c47e204244c09af..eb85c8789cd99907cac8363a95c3c9043341d995
+- **Work mode:** full-feature (marker in issue.md: `- Work Mode: full-feature`)
+- **AC sources (per full-feature):** `spec.md` and `user-story.md`.
+  - `spec.md` is present and is the authoritative AC source (7 mapped acceptance criteria plus 3 seeded test conditions).
+  - `user-story.md` does NOT exist in the feature folder. Documented gap: the work-mode contract names `user-story.md` as a secondary AC source for full-feature, but none was authored for this refactor. No additional acceptance criteria are lost: the issue.md acceptance criteria are fully mapped into spec.md, which serves as the complete AC inventory. This is recorded as an assumption, not a blocker.
+- **Scope evaluated:** full branch diff vs merge-base, both commits (`d200d89` relocation, `eb85c87` coverage remediation).
+
+## Acceptance Criteria Inventory
+
+Source: `docs/features/active/2026-06-24-relocate-research-canonical-location-227/spec.md` (## Acceptance Criteria), plus Seeded Test Conditions.
+
+| # | Criterion |
+|---|---|
+| AC1 | Feature-associated research written to `<FEATURE>/research/<timestamp>-<short-name>-research.md` and one-off research to `docs/research/<timestamp>-<short-name>-research.md`; `artifacts/research/` no longer the canonical target. |
+| AC2 | Claude ecosystem (root `.claude/` and bundled `claude-customizations`) reflects the contract in `task-researcher.md` (frontmatter `tools`, description, body), `orchestrator.md`, `research-issue/SKILL.md`, `orchestrate/SKILL.md`, `evidence-and-timestamp-conventions/SKILL.md`, and both hooks. |
+| AC3 | Codex ecosystem (bundled `codex-and-agents-customizations`) reflects the contract in `task-researcher.toml` (embedded frontmatter, body, stop hook), `orchestrator.toml`, the three mirrored skills, and the `enforce-evidence-locations.ps1` docstring. |
+| AC4 | GitHub Copilot ecosystem (root `.github/` and bundled `customizations`) reflects the contract in `task-researcher.agent.md`, `research-issue.prompt.md`, and `fillout-prd-feature.prompt.md`. |
+| AC5 | `validate-task-researcher-output.ps1` accepts both new roots and rejects `artifacts/research/`, three error messages updated; `enforce-evidence-locations.ps1` and `validate_evidence_locations.py` reject `artifacts/research/`; tests updated in all three test files. |
+| AC6 | Both tracked research locations resolve to git-tracked paths (under `docs/`, not under ignored `artifacts/`); no `.gitignore` change. |
+| AC7 | Root copies and their bundled mirrors are content-identical; Codex translations contain equivalent text changes. |
+| STC1 | Hook unit tests for accepted (feature and one-off) and rejected research paths. |
+| STC2 | Filename-convention validation preserved under the new roots. |
+| STC3 | Evidence-location enforcement unaffected for non-research paths. |
+
+## Acceptance Criteria Evaluation
+
+| # | Verdict | Evidence |
+|---|---|---|
+| AC1 | PASS | `Test-IsUnderResearchRoot` (validate-task-researcher-output.ps1 L60-83) accepts feature `/research/` paths and `docs/research/`; `Test-EvidenceLocationForbidden` and `_FORBIDDEN_PREFIX_TO_CANONICAL` block `artifacts/research/`. Feature research is physically written to `docs/features/active/2026-06-24-.../research/2026-06-24T13-02-...-research.md` in the diff. |
+| AC2 | PASS | Root vs Claude bundled mirror IDENTICAL for task-researcher.md, orchestrator.md, research-issue/SKILL.md, orchestrate/SKILL.md, evidence-and-timestamp-conventions/SKILL.md, and both hooks (diff verified). task-researcher.md frontmatter shows the two new `Write(...)` allowlist forms; no residual `artifacts/research` in the agent. |
+| AC3 | PASS | Codex task-researcher.toml and orchestrator.toml carry the equivalent relocation text; the Codex enforce-evidence-locations.ps1 contains the `artifacts/research/` forbidden prefix and updated docstring. Codex/root divergence is limited to translation conventions (converted-hook header, `.agents/skills/` path). codex-equivalence.2026-06-24T13-09.md EXIT 0. |
+| AC4 | PASS | Root vs Copilot bundled mirror IDENTICAL for task-researcher.agent.md, research-issue.prompt.md, fillout-prd-feature.prompt.md (diff verified). |
+| AC5 | PASS | Reviewer re-ran both Pester suites (35 tests, 0 failures) and the Python suite (7 tests incl. new `test_artifacts_research_is_forbidden`, 100% cov). The retired-path rejection test and dual-root acceptance tests pass. Three error messages updated to cite both new roots (L192, L196, L200). |
+| AC6 | PASS | Both roots are under `docs/` (tracked). `git diff --stat` shows no `.gitignore` change. The feature research file at `docs/features/active/.../research/...` is tracked in the diff. |
+| AC7 | PASS | All root/Claude and root/Copilot mirror pairs byte-identical (diff). Remediation refactor applied to both root and Claude-bundled enforce-evidence-locations.ps1, still IDENTICAL. Codex translations carry equivalent text. cross-ecosystem-equality.2026-06-24T13-55.md. |
+| STC1 | PASS | enforce-evidence-locations.Tests.ps1 covers allow (feature research, one-off research, canonical evidence, source) and block (artifacts/research retired path); validate-task-researcher-output.Tests.ps1 covers dual-root acceptance and rejection of retired/malformed paths. |
+| STC2 | PASS | `Test-IsValidResearchFileName` regex unchanged (L95-98); filename-convention tests assert enforcement under the new roots. |
+| STC3 | PASS | Non-research forbidden prefixes (baselines, qa, coverage, evidence, etc.) unchanged in both the hook and the Python validator; allowed artifacts sub-paths (orchestration) still pass. Verified by passing tests and `validate_evidence_locations.py --root .` EXIT 0. |
+
+## Summary
+
+All 7 acceptance criteria and 3 seeded test conditions evaluate PASS. The prior review's single Blocking item (enforce-evidence-locations.ps1 coverage below 85%) is resolved: line coverage is 96.43% (was 81.5%), verified by independent reviewer Pester re-run. The feature is functionally complete, policy-compliant, and cross-ecosystem-consistent.
+
+Documented gap (non-blocking): `user-story.md` is absent for this full-feature work mode. The issue.md acceptance criteria are fully mapped into spec.md, which serves as the complete AC inventory, so no acceptance criterion is unaccounted for.
+
+**Go / No-Go: GO for PR.** No blocking findings remain.
+
+## Acceptance Criteria Check-off
+
+All 7 AC items in `spec.md` (## Acceptance Criteria) and the 3 Seeded Test Conditions are already marked `- [x]` and all evaluate PASS in this re-audit. No checkbox state change is required; the existing checked state is corroborated by the evidence above. The `issue.md` (## Acceptance Criteria — early draft) items remain `- [ ]`; they are an early draft superseded by the spec.md AC inventory per the work-mode contract and are not the authoritative tracking surface for full-feature mode.
+
+### Acceptance Criteria Status
+- Source: docs/features/active/2026-06-24-relocate-research-canonical-location-227/spec.md (user-story.md absent — documented gap)
+- Total AC items: 7 (plus 3 seeded test conditions)
+- Checked off (delivered): 7 of 7 AC + 3 of 3 STC
+- Remaining (unchecked): 0
+- Items remaining: none

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/issue.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/issue.md
@@ -1,0 +1,49 @@
+# relocate-research-canonical-location (Issue #227)
+
+- Date captured: 2026-06-24
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/relocate-research-canonical-location/ (Issue #227)
+
+- Issue: #227
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/227
+- Last Updated: 2026-06-24
+- Work Mode: full-feature
+
+## Problem / Why
+
+The research step of orchestration writes research files to `artifacts/research/`. The repository `.gitignore` ignores `artifacts` (line 6), so research output is never tracked in version control. The research artifacts contain substantive findings (current-state analysis, candidate approaches, requirements mapping) that are valuable to retain alongside the feature they support. Discarding them on every clean checkout is suboptimal.
+
+## Proposed Behavior
+
+Change the canonical research output location across all three customization ecosystems (Claude, Codex, GitHub Copilot), including bundled extension copies, so research is persisted in tracked locations:
+
+- When research is associated with an orchestration / feature, write it inside the active feature folder, e.g. `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`.
+- When research is one-off and not associated with a feature, write it to a general `docs/research/<timestamp>-<short-name>-research.md` folder.
+
+The validation hooks, agent write-path allowlists, skills, prompts, and tests that currently assume `artifacts/research/` must be updated to the new contract consistently across ecosystems.
+
+## Acceptance Criteria (early draft)
+
+- [ ] Feature-associated research is written to `<FEATURE>/research/` and one-off research to `docs/research/`; `artifacts/research/` is no longer the canonical target.
+- [ ] The Claude ecosystem (root `.claude/` and bundled `claude-customizations`) reflects the new contract in agents, skills, and hooks.
+- [ ] The Codex ecosystem (bundled `codex-and-agents-customizations`) reflects the new contract in agents, skills, and hooks.
+- [ ] The GitHub Copilot ecosystem (root `.github/` and bundled `customizations`) reflects the new contract in prompts and agents.
+- [ ] `validate-task-researcher-output` and `enforce-evidence-locations` hooks accept the new tracked locations and reject the old untracked location, with tests updated accordingly.
+- [ ] Both tracked research locations resolve to git-tracked paths (not under the ignored `artifacts` tree).
+
+## Constraints & Risks
+
+- The change is contract-wide and must remain consistent across the three ecosystems and their bundled copies; divergence is a regression.
+- Hook regexes and agent write-path allowlists must accept two distinct roots without weakening evidence-location enforcement.
+- Backward compatibility: existing archived research under `artifacts/research/` is historical and is not migrated by this change.
+
+## Test Conditions to Consider
+
+- [ ] Hook unit tests for accepted (feature and one-off) and rejected research paths.
+- [ ] Filename-convention validation preserved under the new roots.
+- [ ] Evidence-location enforcement unaffected for non-research paths.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (refactor template)
+- [ ] Create `docs/features/active/relocate-research-canonical-location/` folder from the template

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/plan.2026-06-24T13-09.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/plan.2026-06-24T13-09.md
@@ -1,0 +1,188 @@
+# relocate-research-canonical-location - Refactor Plan (Atomic)
+
+- **Issue:** #227
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-24T13-09
+- **Status:** Draft
+- **Version:** 1.0
+- **Work Mode:** full-feature
+
+## Required References (read, do not restate)
+
+- Spec: `docs/features/active/2026-06-24-relocate-research-canonical-location-227/spec.md`
+- Research: `docs/features/active/2026-06-24-relocate-research-canonical-location-227/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md` (relocated from `artifacts/research/` by Phase 8 P8-T1)
+- Issue: `docs/features/active/2026-06-24-relocate-research-canonical-location-227/issue.md`
+- Policy reading order: `.claude/skills/policy-compliance-order/SKILL.md`
+- Atomic plan contract: `.claude/skills/atomic-plan-contract/SKILL.md`
+- Evidence conventions: `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`
+
+## Strategy
+
+Direct substitution with dual-root acceptance (per research Recommended Approach). The change relocates a path contract from `artifacts/research/` to two git-tracked roots: `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md` (feature-associated) and `docs/research/<timestamp>-<short-name>-research.md` (one-off).
+
+Only three files carry logic changes; each has a root copy plus bundled/translated copies that must change identically:
+- `validate-task-researcher-output.ps1` — rewrite `Test-IsUnderResearchRoot` to accept both new roots; update three hard-coded error messages; filename regex unchanged.
+- `enforce-evidence-locations.ps1` — add `artifacts/research/` to the forbidden-prefix array; update docstring.
+- `scripts/dev_tools/validate_evidence_locations.py` — add `artifacts/research/` to `_FORBIDDEN_PREFIX_TO_CANONICAL`.
+
+All other in-scope edits are write-path allowlist forms and prose/instruction text across the Claude, Codex, and GitHub Copilot ecosystems and their bundled copies.
+
+Phase ordering by concern:
+- Phase 0 — baseline capture.
+- Phase 1 — logic-bearing PowerShell hook (validate-task-researcher-output) + its tests, root copy.
+- Phase 2 — logic-bearing PowerShell hook (enforce-evidence-locations) + its tests, root copy.
+- Phase 3 — Python validator + its tests.
+- Phase 4 — bundled-copy synchronization for all logic-bearing files (PowerShell hooks: Claude bundled mirror + Codex bundled copy).
+- Phase 5 — agent write-path allowlist edits (Claude `.md` frontmatter + Codex `.toml`, root + bundled).
+- Phase 6 — prose/instruction edits, Claude ecosystem (root + bundled).
+- Phase 7 — prose/instruction edits, Codex and GitHub Copilot ecosystems (bundled + root).
+- Phase 8 — relocate this feature's own research artifact; documentation accuracy.
+- Phase 9 — final QA loop, consistency verification, and residual-reference grep.
+
+Fail-closed evidence rule: each evidence-producing task records its canonical artifact path under `<FEATURE>/evidence/<kind>/`. Missing baseline, QA, or coverage artifacts force a BLOCKED/INCOMPLETE verdict, never PASS.
+
+Constraints honored:
+- PowerShell per-batch cap: at most 3 production + 3 test files per batch. Phases 1, 2, 4 are each scoped under the cap.
+- 500-line file limit: every edited file remains under 500 lines; no file is expanded past the limit.
+- Mandatory toolchain order — PowerShell: PoshQC format -> analyze -> Pester; Python: Black -> Ruff -> Pyright -> Pytest.
+
+EVIDENCE_LOCATION_OVERRIDE_REJECTED: none. Spec and delegation reference `artifacts/research/` only as the contract being retired (not as an evidence path); all plan evidence resolves to `<FEATURE>/evidence/<kind>/`.
+
+`<FEATURE>` = `docs/features/active/2026-06-24-relocate-research-canonical-location-227`
+
+---
+
+### Phase 0 — Baseline Capture
+
+- [x] [P0-T1] Read the policy files in required order and record a Phase 0 evidence artifact at `<FEATURE>/evidence/other/phase0-instructions-read.2026-06-24T13-09.md` containing `Timestamp:`, `Policy Order:`, and the explicit list of files read: `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/powershell.md`, `.claude/rules/python.md`, `.claude/rules/python-suppressions.md`, `.claude/rules/self-explanatory-code-commenting.md`, `.claude/rules/quality-tiers.md`. Acceptance: artifact exists with all three fields populated.
+- [x] [P0-T2] Capture PowerShell format baseline by running `mcp__drm-copilot__run_poshqc_format` (check mode) over `.claude/hooks/validate-task-researcher-output.ps1`, `.claude/hooks/enforce-evidence-locations.ps1`, and the two hook test files. Write artifact `<FEATURE>/evidence/baseline/poshqc-format.2026-06-24T13-09.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: artifact records the pre-change format state.
+- [x] [P0-T3] Capture PowerShell analyze baseline by running `mcp__drm-copilot__run_poshqc_analyze` over the same four files. Write artifact `<FEATURE>/evidence/baseline/poshqc-analyze.2026-06-24T13-09.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: artifact records analyzer findings count.
+- [x] [P0-T4] Capture PowerShell Pester baseline (coverage mode) by running `mcp__drm-copilot__run_poshqc_test` for `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1` and `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`. Write artifact `<FEATURE>/evidence/baseline/pester.2026-06-24T13-09.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` including numeric line-coverage and branch-coverage headline values for the two hooks under test. Acceptance: artifact records pass count and numeric coverage values (no placeholders).
+- [x] [P0-T5] Capture Python baseline by running `poetry run black --check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`, `poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`, `poetry run pyright scripts/dev_tools/validate_evidence_locations.py`, and `poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts/dev_tools/validate_evidence_locations --cov-branch --cov-report=term-missing`. Write artifact `<FEATURE>/evidence/baseline/python.2026-06-24T13-09.md` with `Timestamp:`, `Command:` (one per stage), `EXIT_CODE:` (per stage), `Output Summary:` including numeric line and branch coverage for `validate_evidence_locations.py`. Acceptance: artifact records four stage results and numeric coverage values (no placeholders).
+- [x] [P0-T6] Capture residual-reference baseline by running a content search for `artifacts[/\\]research` across the repository (Grep, content mode). Write artifact `<FEATURE>/evidence/baseline/residual-references.2026-06-24T13-09.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` listing the operational/enforcement files that match (distinct from historical feature-doc references). Acceptance: artifact enumerates the current matching operational files as the pre-change reference set.
+
+---
+
+### Phase 1 — Logic: validate-task-researcher-output (root copy) + tests
+
+Batch scope: 1 production file + 1 test file (within PowerShell per-batch cap).
+
+- [x] [P1-T1] In `.claude/hooks/validate-task-researcher-output.ps1`, rewrite the `Test-IsUnderResearchRoot` function body so it normalizes the path to forward slashes and returns `$true` when the path `StartsWith('docs/features/', OrdinalIgnoreCase)` AND contains a `/research/` segment, OR when the path `StartsWith('docs/research/', OrdinalIgnoreCase)`; otherwise returns `$false`. Leave `Test-IsValidResearchFileName` and its regex unchanged. Acceptance: function accepts `docs/features/active/x/research/<file>` and `docs/research/<file>`, rejects `artifacts/research/<file>` and `docs/features/active/x/<file>` (no `/research/` segment).
+- [x] [P1-T2] In `.claude/hooks/validate-task-researcher-output.ps1`, update the three hard-coded `artifacts/research/` error messages: (a) the missing `research-path` guidance message (currently "pointing to artifacts/research/"), (b) the root-mismatch message (currently "is not under artifacts/research/. All research artifacts must be written to artifacts/research/."), and (c) the filename-convention message (currently "artifacts/research/<timestamp>-<short-name>-research.md"). Each updated message must reference the two new roots `docs/features/<feature>/research/` and `docs/research/`. Acceptance: no `artifacts/research/` substring remains in the three messages; each cites both new roots.
+- [x] [P1-T3] In `.claude/hooks/validate-task-researcher-output.ps1`, update the `.DESCRIPTION` SYNOPSIS block (currently "rooted under artifacts/research/") to describe the dual-root contract. Acceptance: docstring references both new roots and contains no `artifacts/research/` substring.
+- [x] [P1-T4] In `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1`, update the existing tests that assert the old root, old error-message text, and `artifacts/research/...` example paths: the root-check test (`blocks when the research-path is not under artifacts/research/`), the valid-path termination test, the missing-file block test, the quoted-path extraction test, and the `Test-AutomationFeasibilitySection` tests, to use valid paths under the new roots (e.g., `docs/features/active/my-feature/research/2026-05-04T00-00-hook-contract-research.md`). Acceptance: no updated test references `artifacts/research/`; assertions check new-root acceptance and new message text.
+- [x] [P1-T5] In `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1`, add five new `It` cases: (a) feature-folder path accepted (`docs/features/active/some-feature-227/research/2026-06-24T13-02-some-feature-research.md`), (b) one-off path accepted (`docs/research/2026-06-24T13-02-some-topic-research.md`), (c) old path rejected (`artifacts/research/2026-06-24T13-02-some-topic-research.md`) with a message referencing the new roots, (d) feature path without a `/research/` segment rejected (`docs/features/active/some-feature/2026-06-24T13-02-some-feature-research.md`), (e) feature path with a `/research/` segment but non-conforming filename rejected (`docs/features/active/some-feature/research/bad-name.md`) with the filename-convention message. Acceptance: five new `It` blocks present, each asserting the stated outcome.
+- [x] [P1-T6] Run the PowerShell toolchain for the Phase 1 batch: `mcp__drm-copilot__run_poshqc_format`, then `mcp__drm-copilot__run_poshqc_analyze`, then `mcp__drm-copilot__run_poshqc_test` for `validate-task-researcher-output.Tests.ps1` (coverage mode). Restart from format if any stage changes files or fails. Write artifact `<FEATURE>/evidence/qa-gates/phase1-poshqc.2026-06-24T13-09.md` with `Timestamp:`, `Command:` per stage, `EXIT_CODE:` per stage, `Output Summary:` including pass count and numeric coverage for `validate-task-researcher-output.ps1`. Acceptance: all stages clean in a single pass; coverage >= 85% line and >= 75% branch with no regression on changed lines.
+
+---
+
+### Phase 2 — Logic: enforce-evidence-locations (root copy) + tests
+
+Batch scope: 1 production file + 1 test file (within PowerShell per-batch cap).
+
+- [x] [P2-T1] In `.claude/hooks/enforce-evidence-locations.ps1`, add `'artifacts/research/'` to the `$forbiddenPrefixes` array inside `Test-EvidenceLocationForbidden`. Do not change the exclusion-only model or any other prefix. Acceptance: `artifacts/research/` is a member of the forbidden-prefix array; all eight existing prefixes remain.
+- [x] [P2-T2] In `.claude/hooks/enforce-evidence-locations.ps1`, update the `.DESCRIPTION` docstring: add `artifacts/research/` to the "Forbidden path prefixes" list and remove `artifacts/research/` from the "permitted artifacts/ sub-paths" enumeration. Acceptance: docstring lists `artifacts/research/` as forbidden and no longer lists it as permitted.
+- [x] [P2-T3] In `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`, change the existing `It` block `'allows writes to artifacts/research/ (permitted research path)'` into a rejection test: path `artifacts/research/notes.md` must produce `decision: block` with a reason containing `EVIDENCE_LOCATION_BLOCKED`. Acceptance: the previously-allowing test now asserts a block decision.
+- [x] [P2-T4] In `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`, add two allow `It` blocks: (a) `'allows writes to docs/features/ research subfolder (new canonical feature research path)'` with path `docs/features/active/my-feature/research/2026-06-24T13-02-foo-research.md` -> `decision: allow`; (b) `'allows writes to docs/research/ (new canonical one-off research path)'` with path `docs/research/2026-06-24T13-02-foo-research.md` -> `decision: allow`. Acceptance: two new allow `It` blocks present asserting the stated outcomes.
+- [x] [P2-T5] Run the PowerShell toolchain for the Phase 2 batch: `mcp__drm-copilot__run_poshqc_format`, then `mcp__drm-copilot__run_poshqc_analyze`, then `mcp__drm-copilot__run_poshqc_test` for `enforce-evidence-locations.Tests.ps1` (coverage mode). Restart from format if any stage changes files or fails. Write artifact `<FEATURE>/evidence/qa-gates/phase2-poshqc.2026-06-24T13-09.md` with `Timestamp:`, `Command:` per stage, `EXIT_CODE:` per stage, `Output Summary:` including pass count and numeric coverage for `enforce-evidence-locations.ps1`. Acceptance: all stages clean in a single pass; coverage >= 85% line and >= 75% branch with no regression on changed lines.
+
+---
+
+### Phase 3 — Logic: Python validator + tests
+
+- [x] [P3-T1] In `scripts/dev_tools/validate_evidence_locations.py`, add the entry `"artifacts/research/": "docs/features/active/<feature>/research/ or docs/research/"` to the `_FORBIDDEN_PREFIX_TO_CANONICAL` dict. The canonical suggestion must reference both new roots. Acceptance: dict contains the new key with a value naming both new roots; existing entries unchanged.
+- [x] [P3-T2] In `scripts/dev_tools/validate_evidence_locations.py`, update the module docstring if it enumerates forbidden prefixes so it reflects the added `artifacts/research/` prefix. Acceptance: docstring is consistent with the dict; no stale claim that research under `artifacts/` is permitted. (If the docstring does not enumerate prefixes, record this task as not-applicable with a note; no edit required.)
+- [x] [P3-T3] In `tests/scripts/dev_tools/test_validate_evidence_locations.py`, in `test_clean_tree_exits_zero` replace the allowed path `Path("/fake/repo/artifacts/research/notes.md")` with a new-root path such as `Path("/fake/repo/docs/features/active/my-feature/research/note.md")`. Acceptance: the clean-tree test no longer seeds an `artifacts/research/` path and passes.
+- [x] [P3-T4] In `tests/scripts/dev_tools/test_validate_evidence_locations.py`, add `test_artifacts_research_is_forbidden`: seed a file at `artifacts/research/seeded.md` under the fake root and assert `find_forbidden_paths` yields exactly one violation whose canonical suggestion references the new paths. Acceptance: new test present and asserts exactly one violation with a suggestion naming the new roots.
+- [x] [P3-T5] Run the Python toolchain for the Phase 3 batch in order: `poetry run black scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`, `poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`, `poetry run pyright scripts/dev_tools/validate_evidence_locations.py`, `poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts/dev_tools/validate_evidence_locations --cov-branch --cov-report=term-missing`. Restart from format if any stage changes files or fails. Write artifact `<FEATURE>/evidence/qa-gates/phase3-python.2026-06-24T13-09.md` with `Timestamp:`, `Command:` per stage, `EXIT_CODE:` per stage, `Output Summary:` including numeric line and branch coverage for `validate_evidence_locations.py`. Acceptance: all four stages clean in a single pass; coverage >= 85% line and >= 75% branch with no regression on changed lines.
+
+---
+
+### Phase 4 — Bundled-copy synchronization for logic-bearing hooks
+
+Batch scope: 3 production PowerShell files (within PowerShell per-batch cap); no test files in this batch.
+
+- [x] [P4-T1] Overwrite `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1` so it is byte-for-byte identical to the root `.claude/hooks/validate-task-researcher-output.ps1` after Phase 1. Acceptance: a content diff between the root and bundled file reports no differences.
+- [x] [P4-T2] Overwrite `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1` so it is byte-for-byte identical to the root `.claude/hooks/enforce-evidence-locations.ps1` after Phase 2. Acceptance: a content diff between the root and bundled file reports no differences.
+- [x] [P4-T3] In `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1`, apply the equivalent docstring update from Phase 2 (add `artifacts/research/` to forbidden list; remove it from permitted list) and the equivalent forbidden-prefix change. Acceptance: the Codex copy reflects the same forbidden-prefix membership and docstring text as the root hook (translation equivalence, not necessarily byte-identical if the Codex header differs).
+- [x] [P4-T4] Run the PowerShell toolchain over the three Phase 4 files: `mcp__drm-copilot__run_poshqc_format`, then `mcp__drm-copilot__run_poshqc_analyze`. (No dedicated test files target the bundled/Codex copies; the root copies are the tested source.) Restart from format if a stage changes files. Write artifact `<FEATURE>/evidence/qa-gates/phase4-poshqc.2026-06-24T13-09.md` with `Timestamp:`, `Command:` per stage, `EXIT_CODE:` per stage, `Output Summary:`. Acceptance: format and analyze clean for the three files in a single pass.
+
+---
+
+### Phase 5 — Agent write-path allowlist edits (Claude .md + Codex .toml)
+
+- [x] [P5-T1] In `.claude/agents/task-researcher.md` frontmatter `tools:` list, replace the entry `"Write(/artifacts/research/**)"` with the two entries `"Write(/docs/features/**/research/**)"` and `"Write(/docs/research/**)"`. Acceptance: frontmatter contains both new Write globs and no `Write(/artifacts/research/**)` entry.
+- [x] [P5-T2] In `extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md` frontmatter, apply the identical `tools:` allowlist change from P5-T1. Acceptance: bundled frontmatter matches the root frontmatter allowlist exactly.
+- [x] [P5-T3] In `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml`, replace the embedded write-allowlist entry `"Write(/artifacts/research/**)"` with `"Write(/docs/features/**/research/**)"` and `"Write(/docs/research/**)"` (preserving TOML array/string syntax). Acceptance: the embedded allowlist contains both new globs and no `artifacts/research` write glob.
+
+---
+
+### Phase 6 — Prose/instruction edits: Claude ecosystem (root + bundled)
+
+- [x] [P6-T1] In `.claude/agents/task-researcher.md`, update the description metadata (currently "writes structured findings exclusively to artifacts/research/") and the body output-location prose (the "Write all research artifacts to `artifacts/research/`" statement and the "Write only to `artifacts/research/`" constraint) to describe the two new roots and the orchestrator-supplied routing rule (feature-folder research path vs. `docs/research/`). Acceptance: no `artifacts/research/` substring remains; both roots and the routing rule are described.
+- [x] [P6-T2] In `.claude/agents/orchestrator.md`, update the delegation prose (currently "task-researcher — performs deep research and writes findings to `artifacts/research/`") to reference the two new roots and the routing rule (orchestrator resolves the output path from `feature-folder` in `orchestrator-state.json`). Acceptance: no `artifacts/research/` substring remains in the delegation prose; routing rule documented.
+- [x] [P6-T3] In `.claude/skills/research-issue/SKILL.md`, update the output-path prose (currently "Path: `artifacts/research/<timestamp>-<short-name>-research.md`") and the description metadata (currently "writing structured findings to artifacts/research/") to document both roots and the routing rule. Acceptance: no `artifacts/research/` substring remains; both roots and routing rule documented; filename convention preserved.
+- [x] [P6-T4] In `.claude/skills/orchestrate/SKILL.md`, update the delegation prose and remove/replace the `"artifacts/research/ — research outputs from task-researcher"` entry in the Evidence Location Authority permitted-sub-path list, reflecting that research is no longer an `artifacts/` sub-path. Acceptance: permitted-sub-path list no longer contains `artifacts/research/`; delegation prose references both new roots.
+- [x] [P6-T5] In `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`, remove `artifacts/research/` from the "Allowed `artifacts/` sub-paths" list. Acceptance: the allowed list no longer contains `artifacts/research/`; `artifacts/orchestration/` remains.
+- [x] [P6-T6] Apply the identical edits from P6-T1 through P6-T5 to the bundled mirrors: `extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md`, `.../agents/orchestrator.md`, `.../skills/research-issue/SKILL.md`, `.../skills/orchestrate/SKILL.md`, `.../skills/evidence-and-timestamp-conventions/SKILL.md`. Acceptance: each bundled file is content-identical to its root counterpart after the edits.
+
+---
+
+### Phase 7 — Prose/instruction edits: Codex + GitHub Copilot ecosystems
+
+- [x] [P7-T1] In `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml`, update the embedded body prose (mirrors the Claude agent) and the stop-hook text (currently "Block termination unless research artifact path has been confirmed on disk under artifacts/research/.") to reference the two new roots and the routing rule. Acceptance: no `artifacts/research/` substring remains in the body prose or stop-hook text; both roots documented.
+- [x] [P7-T2] In `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml`, update the `developer_instructions` delegation prose (currently "task-researcher: research artifacts under `artifacts/research/`") to reference the two new roots and the routing rule. Acceptance: no `artifacts/research/` substring remains in the delegation prose.
+- [x] [P7-T3] In `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md`, apply the equivalent text changes made to the Claude `research-issue/SKILL.md` in P6-T3. Acceptance: file mirrors the Claude counterpart's research-path prose; no `artifacts/research/` substring remains.
+- [x] [P7-T4] In `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md`, apply the equivalent text changes made to the Claude `orchestrate/SKILL.md` in P6-T4. Acceptance: file mirrors the Claude counterpart; permitted-sub-path list no longer contains `artifacts/research/`.
+- [x] [P7-T5] In `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md`, apply the equivalent change made in P6-T5 (remove `artifacts/research/` from the allowed list). Acceptance: file mirrors the Claude counterpart; allowed list no longer contains `artifacts/research/`.
+- [x] [P7-T6] In `.github/agents/task-researcher.agent.md`, update the role-definition prose (currently "Your sole responsibility is to write transient research notes in the untracked scratch area `artifacts/research/`"), the operational constraint (currently "You MUST create and edit files ONLY in `artifacts/research/`"), and the collaborative-process reference (currently "Search for existing research files in `artifacts/research/`") to describe the two new tracked roots and the routing rule. Remove the "untracked scratch area" framing since research is now tracked. Acceptance: no `artifacts/research/` substring remains; both roots documented; tracked-location framing used.
+- [x] [P7-T7] In `.github/prompts/research-issue.prompt.md`, update the output-path prose (currently "Path: `artifacts/research/<timestamp>-<short-name>-research.md`"), the filename-convention example, and the operating-rules reference (currently "write to `artifacts/research/`, evidence-based") to document both new roots and the routing rule. Acceptance: no `artifacts/research/` substring remains; both roots and routing rule documented; filename convention preserved.
+- [x] [P7-T8] In `.github/prompts/fillout-prd-feature.prompt.md`, update the research-path reference (currently "If research exists under `artifacts/research`, the caller must include the specific research file paths") to reference both new roots. Acceptance: no `artifacts/research` substring remains in the reference; both roots named.
+- [x] [P7-T9] Apply the identical edits from P7-T6 through P7-T8 to the GitHub Copilot bundled mirrors: `extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md`, `.../prompts/research-issue.prompt.md`, `.../prompts/fillout-prd-feature.prompt.md`. Acceptance: each bundled file is content-identical to its root counterpart after the edits.
+
+---
+
+### Phase 8 — Relocate feature research artifact + documentation accuracy
+
+- [x] [P8-T1] Create the destination directory and relocate this feature's research artifact from `artifacts/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md` to `docs/features/active/2026-06-24-relocate-research-canonical-location-227/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md`, preserving the filename and content verbatim. This exercises the new contract after the hooks accept the new location (Phases 1, 2, 4 complete). Acceptance: the file exists at the new `docs/features/.../research/` path with identical content; it no longer needs to be read from `artifacts/research/` for this feature. (Historical `artifacts/research/` copies for other features are not migrated, per spec Non-Goals.)
+- [x] [P8-T2] Update the `Required References` line at the top of this plan and the spec's research reference to point at the relocated `docs/features/.../research/...` path. Acceptance: plan and spec reference the new research path.
+- [x] [P8-T3] In `docs/engineering/claude-code-architecture.md`, update the architectural description that references `artifacts/research/` to reflect the two new tracked roots, for documentation accuracy. Acceptance: the architectural description names the new roots; no enforcement claim depends on `artifacts/research/`. (Non-blocking accuracy edit per spec Dependencies/Touchpoints.)
+
+---
+
+### Phase 9 — Final QA Loop, Consistency Verification, and Residual-Reference Grep
+
+- [x] [P9-T1] Run the full PowerShell QA loop over all edited PowerShell files (`.claude/hooks/validate-task-researcher-output.ps1`, `.claude/hooks/enforce-evidence-locations.ps1`, the two Claude bundled mirrors, and the Codex `enforce-evidence-locations.ps1`) plus the two hook test files, in order: `mcp__drm-copilot__run_poshqc_format`, `mcp__drm-copilot__run_poshqc_analyze`, `mcp__drm-copilot__run_poshqc_test` (coverage mode) for both hook test files. Restart from format if any stage changes files or fails. Write artifact `<FEATURE>/evidence/qa-gates/final-poshqc.2026-06-24T13-09.md` with `Timestamp:`, `Command:` per stage, `EXIT_CODE:` per stage, `Output Summary:` including pass count and numeric line/branch coverage for both hooks. Acceptance: all stages clean in a single pass; coverage >= 85% line and >= 75% branch.
+- [x] [P9-T2] Run the full Python QA loop in order: `poetry run black scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`, `poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`, `poetry run pyright scripts/dev_tools/validate_evidence_locations.py`, `poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts/dev_tools/validate_evidence_locations --cov-branch --cov-report=term-missing`. Restart from format if any stage changes files or fails. Write artifact `<FEATURE>/evidence/qa-gates/final-python.2026-06-24T13-09.md` with `Timestamp:`, `Command:` per stage, `EXIT_CODE:` per stage, `Output Summary:` including numeric line/branch coverage for `validate_evidence_locations.py`. Acceptance: all four stages clean in a single pass; coverage >= 85% line and >= 75% branch.
+- [x] [P9-T3] Run `poetry run python scripts/dev_tools/validate_evidence_locations.py` against the repository root and confirm it does not report the relocated feature research file at `docs/features/.../research/...` as a violation, and would report a seeded `artifacts/research/` file as a violation. Write artifact `<FEATURE>/evidence/qa-gates/validator-run.2026-06-24T13-09.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: validator exits 0 on the clean tree; the new research location is not flagged.
+- [x] [P9-T4] Verify coverage delta: compare baseline coverage (P0-T4, P0-T5) against post-change coverage (P9-T1, P9-T2) for `validate-task-researcher-output.ps1`, `enforce-evidence-locations.ps1`, and `validate_evidence_locations.py`. Write artifact `<FEATURE>/evidence/qa-gates/coverage-delta.2026-06-24T13-09.md` reporting baseline coverage, post-change coverage, and changed-code coverage for each module. Acceptance: no regression on changed lines; all modules retain >= 85% line and >= 75% branch coverage.
+- [x] [P9-T5] Verify cross-ecosystem content equality for every root/bundled pair: run a content diff for each of the 11 root-vs-bundled file pairs (the three logic-bearing root hooks vs. their two Claude bundled mirrors; `task-researcher.md`, `orchestrator.md`, `research-issue/SKILL.md`, `orchestrate/SKILL.md`, `evidence-and-timestamp-conventions/SKILL.md` Claude root vs. bundled; the three GitHub Copilot root prompts/agent vs. bundled). Write artifact `<FEATURE>/evidence/qa-gates/cross-ecosystem-equality.2026-06-24T13-09.md` listing each pair and its diff result. Acceptance: each pair reports no content differences (the Codex translations are verified for equivalence separately in P9-T6).
+- [x] [P9-T6] Verify Codex translation equivalence: confirm the Codex files (`task-researcher.toml`, `orchestrator.toml`, `enforce-evidence-locations.ps1`, the three `.agents/skills/` SKILL.md files) contain the equivalent text changes (both new roots; no `artifacts/research/` path-routing references; updated stop-hook text). Write artifact `<FEATURE>/evidence/qa-gates/codex-equivalence.2026-06-24T13-09.md` enumerating each Codex file and the confirmed change. Acceptance: each Codex file reflects the new contract; no operational `artifacts/research/` reference remains.
+- [x] [P9-T7] Run a residual-reference grep for `artifacts[/\\]research` across the repository and confirm that no operational/enforcement/instruction file (hooks, validators, agent frontmatter/body, skill prose, prompts — root and bundled, all three ecosystems) still references the old path. Compare against the P0-T6 baseline. Historical feature-doc references (plan/audit/archive documents under `docs/features/`), the `translate-claude-to-codex` historical research-basis reference, and generated `testResults.xml` are expected and excluded. Write artifact `<FEATURE>/evidence/qa-gates/residual-reference-final.2026-06-24T13-09.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` listing remaining matches and classifying each as historical/generated (allowed) or operational (must be zero). Acceptance: zero operational matches remain; all remaining matches are classified historical or generated.
+
+---
+
+## Acceptance-Criteria Mapping
+
+| Spec Acceptance Criterion | Plan Tasks |
+|---|---|
+| Feature-associated research -> `<FEATURE>/research/`; one-off -> `docs/research/`; `artifacts/research/` no longer canonical | P1-T1..T3, P5-T1..T3, P6-T1, P6-T3, P7-T6, P7-T7, P8-T1 |
+| Claude ecosystem reflects new contract (agents, skills, both hooks) | P1-T1..T3, P2-T1..T2, P5-T1, P5-T2, P6-T1..T6, P4-T1, P4-T2 |
+| Codex ecosystem reflects new contract (toml agents, three skills, enforce hook docstring) | P5-T3, P4-T3, P7-T1..T5 |
+| GitHub Copilot ecosystem reflects new contract (agent + two prompts, root + bundled) | P7-T6..T9 |
+| `validate-task-researcher-output.ps1` accepts new roots, rejects old, 3 messages updated; `enforce-evidence-locations.ps1` + `validate_evidence_locations.py` reject `artifacts/research/`; tests updated in all three test files | P1-T1..T5, P2-T1..T4, P3-T1..T4 |
+| Both tracked locations resolve to git-tracked paths; no `.gitignore` change | P8-T1, P9-T3 (no `.gitignore` task by design) |
+| Root copies content-identical to bundled mirrors; Codex translations equivalent | P4-T1..T3, P6-T6, P7-T9, P9-T5, P9-T6 |
+| Filename convention preserved (regex unchanged) | P1-T1 (leaves regex unchanged), P1-T5(e) |
+| Non-research evidence enforcement unchanged | P2-T1 (additive prefix only), P3-T1 (additive key only), P9-T3 |
+
+## Rollback / Contingency
+
+All changes are text edits to customization/enforcement files plus one file relocation. Rollback: revert the branch. The file relocation in P8-T1 is a copy-then-delete; if any hook regression is detected after relocation, restore the artifact at `artifacts/research/` from git history and re-run validation. No external consumers depend on the research output path (spec Dependencies/Touchpoints: "No CI/CD configuration or release tooling depends on the research output path").
+
+## Open Questions / Notes
+
+- The `enforce-evidence-locations` exclusion-only model is preserved; only forbidden-prefix membership and docstrings change (spec Invariants).
+- `.claude/settings.json` requires no functional change (the `research-path` SubagentStop token and `Write(/artifacts/**)` orchestrator allowlist are unaffected); no task edits it. If a descriptive comment referencing `artifacts/research/` is found there during execution, treat it as a P7-class prose edit and record it; otherwise no change.
+- `translate-claude-to-codex/SKILL.md` historical research-basis path reference is out of scope (it points to a specific historical artifact, not a routing rule), per research.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/policy-audit.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/policy-audit.2026-06-24T13-55.md
@@ -1,0 +1,156 @@
+# Policy Compliance Audit — relocate-research-canonical-location (Issue #227)
+
+- **Timestamp:** 2026-06-24T13-55
+- **Feature folder:** docs/features/active/2026-06-24-relocate-research-canonical-location-227
+- **Base branch (resolved):** origin/main @ ea94a068e0a071940858a0694c47e204244c09af
+- **Head:** drm-copilot-wt-2026-06-24-13-02 @ d200d8961843f8b9d040f6c847b8ae186035dc90
+- **Merge base:** ea94a068e0a071940858a0694c47e204244c09af
+- **Range:** ea94a068e0a071940858a0694c47e204244c09af..d200d8961843f8b9d040f6c847b8ae186035dc90
+- **Work mode:** full-feature (marker in issue.md: `- Work Mode: full-feature`)
+- **Scope:** full branch diff vs merge-base (feature-vs-base). 51 changed files.
+
+## Policy Reading Order Applied
+
+1. CLAUDE.md (standing instructions)
+2. .claude/rules/general-code-change.md
+3. .claude/rules/general-unit-test.md
+4. Language-specific rules in scope:
+   - .claude/rules/powershell.md (PowerShell hooks and tests changed)
+   - .claude/rules/python.md, .claude/rules/python-suppressions.md (Python validator and test changed)
+   - .claude/rules/quality-tiers.md (coverage thresholds)
+   - .claude/rules/tonality.md (instruction-surface prose changes)
+
+## Rejected Scope Narrowing
+
+No caller instruction attempted to narrow scope below the full feature-vs-base diff. The audit covered every language with changed files in the branch diff (PowerShell, Python, and Markdown/TOML documentation). No narrowing to reject.
+
+## Languages With Changed Files (scope determination)
+
+| Language | Changed files (representative) | In coverage scope |
+|---|---|---|
+| PowerShell | .claude/hooks/validate-task-researcher-output.ps1, .claude/hooks/enforce-evidence-locations.ps1, two Claude bundled mirrors, Codex enforce-evidence-locations.ps1, two hook test files | Yes |
+| Python | scripts/dev_tools/validate_evidence_locations.py, tests/scripts/dev_tools/test_validate_evidence_locations.py | Yes |
+| Markdown / TOML (docs, prompts, agents, skills) | task-researcher.md/.agent.md/.toml, orchestrator.md/.toml, research-issue/orchestrate/evidence-and-timestamp-conventions SKILL.md, prompts | No executable code; no coverage instrument applies |
+
+## Toolchain Results
+
+### Python (independently re-run by reviewer)
+
+| Stage | Command | Exit | Verdict |
+|---|---|---|---|
+| Format | `poetry run black --check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py` | 0 | PASS (2 files unchanged) |
+| Lint | `poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py` | 0 | PASS (All checks passed) |
+| Type | `poetry run pyright scripts/dev_tools/validate_evidence_locations.py` | 0 | PASS (0 errors/warnings) |
+| Test+coverage | `poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts.dev_tools.validate_evidence_locations --cov-branch --cov-report=term-missing` | 0 | PASS (7 passed) |
+
+### PowerShell (independently re-run by reviewer)
+
+| Stage | Command | Result | Verdict |
+|---|---|---|---|
+| Format | mcp__drm-copilot__run_poshqc_format (executor evidence: final-poshqc.2026-06-24T13-09.md) | ok:true | PASS |
+| Analyze | mcp__drm-copilot__run_poshqc_analyze (executor evidence) | ok:true, 0 findings | PASS |
+| Test | Invoke-Pester on validate-task-researcher-output.Tests.ps1 + enforce-evidence-locations.Tests.ps1 | Total=32, Passed=32, Failed=0 | PASS |
+
+## Coverage Verification
+
+Reviewer inspected the existing coverage artifacts and independently re-ran the targeted Pester coverage and pytest coverage. Coverage thresholds are uniform per quality-tiers.md: line >= 85%, branch >= 75%, no regression on changed lines.
+
+### Python — artifact: artifacts/python/lcov.info
+
+| File | Type | Line cov | Branch cov | Verdict |
+|---|---|---|---|---|
+| scripts/dev_tools/validate_evidence_locations.py | modified | 100% (28/28) | 100% (12/12) | PASS |
+
+Repo-wide per language (Python validator module under test): 100% line, 100% branch. PASS.
+
+### PowerShell — artifact: artifacts/pester/powershell-coverage.xml (repo-wide JaCoCo) plus targeted per-hook coverage
+
+Note: The repo-wide artifact at artifacts/pester/powershell-coverage.xml was produced over the `.claude/hooks`, `scripts/dev-tools`, and `scripts/powershell` packages and reports 46.8% repo-wide line coverage (LINE missed=313 covered=275). It does not contain the two changed hooks as named source files. The reviewer therefore re-ran targeted Pester coverage scoped to the two changed hooks; the per-file values below are from that re-run and corroborate the executor's coverage-delta.2026-06-24T13-09.md evidence.
+
+| File | Type | Line cov | Threshold | Verdict |
+|---|---|---|---|---|
+| .claude/hooks/validate-task-researcher-output.ps1 | modified | 88.5% (54/61, executor) / 91.8% command-cov (reviewer) | >= 85% | PASS |
+| .claude/hooks/enforce-evidence-locations.ps1 | modified | 81.5% (22/27, executor) / 78.8% command-cov (reviewer) | >= 85% | **FAIL** |
+
+Branch coverage for PowerShell: Pester's PowerShell coverage engine emits line/command coverage only; branch counters are not produced. This is a tooling limitation, not a regression. Documented in coverage-delta.2026-06-24T13-09.md.
+
+Repo-wide PowerShell coverage from the existing repo-wide artifact (46.8% line) is below the 85% repo-wide threshold. This artifact aggregates many unchanged files unrelated to this feature and predates a clean repo-wide PowerShell coverage run; it is recorded here as observed. The feature-scoped determination is the per-file modified-file result above. The blocking finding is the per-file enforce-evidence-locations.ps1 result.
+
+**Coverage FAIL summary:** `.claude/hooks/enforce-evidence-locations.ps1` (modified file) is at 81.5% line coverage, below the uniform 85% line threshold. The uncovered lines (146, 148, 149, 152, 154) are the script entry-point execution block, unreachable when the script is dot-sourced by unit tests. The feature's changed line (added `artifacts/research/` forbidden prefix) is inside the fully covered `Test-EvidenceLocationForbidden` function, and there is no regression on changed lines. The threshold is nonetheless not met, which is a FAIL per the SKILL coverage contract and routes to remediation.
+
+### Markdown / TOML
+
+No executable code; no coverage instrument applies. Not a language with executable changed files for coverage purposes. Verdict: not applicable to coverage (zero executable changed lines).
+
+## Evidence Location Compliance
+
+Command: `poetry run python scripts/dev_tools/validate_evidence_locations.py --root .` — EXIT 0 (no violations).
+
+Branch-diff scan for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`: none found. All feature evidence is written to the canonical `<FEATURE>/evidence/<kind>/` path (baseline/, qa-gates/, other/). No evidence-location violations.
+
+| Check | Result |
+|---|---|
+| Files under artifacts/baselines/ | none — PASS |
+| Files under artifacts/qa/ | none — PASS |
+| Files under artifacts/evidence/ | none — PASS |
+| Files under artifacts/coverage/ | none — PASS |
+| validate_evidence_locations.py --root . | exit 0 — PASS |
+
+## modified-workflow-needs-green-run
+
+Branch diff scanned for paths matching `.github/workflows/**`, `scripts/benchmarks/**`, `.github/actions/**`. No matching paths changed. Rule does not fire. PASS.
+
+## Cross-Ecosystem Consistency (root vs bundled mirror)
+
+| File pair | Result |
+|---|---|
+| validate-task-researcher-output.ps1 (root vs Claude bundled) | IDENTICAL — PASS |
+| enforce-evidence-locations.ps1 (root vs Claude bundled) | IDENTICAL — PASS |
+| task-researcher.md (root vs Claude bundled) | IDENTICAL — PASS |
+| orchestrator.md (root vs Claude bundled) | IDENTICAL — PASS |
+| research-issue/SKILL.md (root vs Claude bundled) | IDENTICAL — PASS |
+| orchestrate/SKILL.md (root vs Claude bundled) | IDENTICAL — PASS |
+| evidence-and-timestamp-conventions/SKILL.md (root vs Claude bundled) | IDENTICAL — PASS |
+| task-researcher.agent.md (root vs Copilot bundled) | IDENTICAL — PASS |
+| research-issue.prompt.md (root vs Copilot bundled) | IDENTICAL — PASS |
+| fillout-prd-feature.prompt.md (root vs Copilot bundled) | IDENTICAL — PASS |
+| enforce-evidence-locations.ps1 (root vs Codex bundled) | DIVERGENT — expected (Codex translation: converted-hook header and `.agents/skills/` path); the `artifacts/research/` forbidden prefix change is present at lines 23 and 71 — PASS for the relocation change |
+| Codex task-researcher.toml / orchestrator.toml / three .agents/skills | equivalent relocation text present — PASS |
+
+The Codex `.agents/skills/` files carry substantial pre-existing translation differences (AGENTS.md vs CLAUDE.md, `.agents/skills/` paths, differing orchestration content). These predate this feature. The spec requires only the equivalent research-relocation text changes in the Codex translations; those are present and verified.
+
+## Residual Reference Scan
+
+Command: content search for `artifacts[/\\]research` across .claude, .github, scripts, extensions, tests (excluding docs/features historical records).
+
+All remaining matches are intentional: forbidden-prefix list entries in the three `enforce-evidence-locations.ps1` copies (the relocation's purpose) and test assertions that exercise rejection of the retired path. No operational/instruction file still treats `artifacts/research/` as a canonical or permitted research target. PASS.
+
+## Verdict Summary
+
+| Area | Verdict |
+|---|---|
+| Python toolchain | PASS |
+| PowerShell toolchain | PASS |
+| Python coverage | PASS |
+| PowerShell coverage (validate-task-researcher-output.ps1) | PASS |
+| PowerShell coverage (enforce-evidence-locations.ps1) | **FAIL** (81.5% < 85% line) |
+| Markdown/TOML coverage | N/A (zero executable changed lines) |
+| Evidence-location compliance | PASS |
+| modified-workflow-needs-green-run | PASS (does not fire) |
+| Cross-ecosystem consistency | PASS |
+| Residual reference scan | PASS |
+| Tonality (instruction prose) | PASS |
+
+**Overall policy verdict: PARTIAL.** One coverage threshold FAIL (enforce-evidence-locations.ps1) triggers remediation. All other policy areas PASS.
+
+## Appendix B — Command Reference
+
+- `git diff --stat ea94a068e0a071940858a0694c47e204244c09af..d200d8961843f8b9d040f6c847b8ae186035dc90`
+- `poetry run black --check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`
+- `poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`
+- `poetry run pyright scripts/dev_tools/validate_evidence_locations.py`
+- `poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts.dev_tools.validate_evidence_locations --cov-branch --cov-report=term-missing`
+- `Invoke-Pester -Configuration <cfg>` scoped to the two hook test files with CodeCoverage on the two hooks
+- `poetry run python scripts/dev_tools/validate_evidence_locations.py --root .`
+- `diff <root file> <bundled mirror>` for each cross-ecosystem pair
+- content search for `artifacts[/\\]research` across operational directories

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/policy-audit.2026-06-24T14-18.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/policy-audit.2026-06-24T14-18.md
@@ -1,0 +1,170 @@
+# Policy Compliance Audit — relocate-research-canonical-location (Issue #227)
+
+- **Timestamp:** 2026-06-24T14-18
+- **Feature folder:** docs/features/active/2026-06-24-relocate-research-canonical-location-227
+- **Base branch (resolved):** origin/main @ ea94a068e0a071940858a0694c47e204244c09af
+- **Head:** drm-copilot-wt-2026-06-24-13-02 @ eb85c8789cd99907cac8363a95c3c9043341d995
+- **Merge base:** ea94a068e0a071940858a0694c47e204244c09af
+- **Range:** ea94a068e0a071940858a0694c47e204244c09af..eb85c8789cd99907cac8363a95c3c9043341d995
+- **Work mode:** full-feature (marker in issue.md: `- Work Mode: full-feature`)
+- **Scope:** full branch diff vs merge-base (feature-vs-base). 66 changed files across two commits (`d200d89` relocation, `eb85c87` coverage remediation).
+- **Review type:** Re-audit after remediation. Prior review (2026-06-24T13-55) recorded a single Blocking finding: `enforce-evidence-locations.ps1` line coverage below 85%.
+
+## Policy Reading Order Applied
+
+1. CLAUDE.md (standing instructions)
+2. .claude/rules/general-code-change.md
+3. .claude/rules/general-unit-test.md
+4. Language-specific rules in scope:
+   - .claude/rules/powershell.md (PowerShell hooks and tests changed)
+   - .claude/rules/python.md, .claude/rules/python-suppressions.md (Python validator and test changed)
+   - .claude/rules/self-explanatory-code-commenting.md (Python docstring/comment policy)
+   - .claude/rules/quality-tiers.md (coverage thresholds)
+   - .claude/rules/tonality.md (instruction-surface prose changes)
+
+## Rejected Scope Narrowing
+
+No caller instruction attempted to narrow scope below the full feature-vs-base diff. The delegation prompt explicitly directed review of the complete branch diff across both commits and the full toolchain/coverage expectations for every language with changed files. The audit covered every language with changed files in the branch diff (PowerShell, Python, and Markdown/TOML documentation). No narrowing to reject.
+
+## Languages With Changed Files (scope determination)
+
+| Language | Changed files (representative) | In coverage scope |
+|---|---|---|
+| PowerShell | .claude/hooks/validate-task-researcher-output.ps1, .claude/hooks/enforce-evidence-locations.ps1, two Claude bundled mirrors, Codex enforce-evidence-locations.ps1, two hook test files | Yes |
+| Python | scripts/dev_tools/validate_evidence_locations.py, tests/scripts/dev_tools/test_validate_evidence_locations.py | Yes |
+| Markdown / TOML (docs, prompts, agents, skills) | task-researcher.md/.agent.md/.toml, orchestrator.md/.toml, research-issue/orchestrate/evidence-and-timestamp-conventions SKILL.md, prompts | No executable code; no coverage instrument applies |
+
+## Toolchain Results
+
+### Python (independently re-run by reviewer)
+
+| Stage | Command | Exit | Verdict |
+|---|---|---|---|
+| Format | `poetry run black --check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py` | 0 | PASS (2 files unchanged) |
+| Lint | `poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py` | 0 | PASS (All checks passed) |
+| Type | `poetry run pyright scripts/dev_tools/validate_evidence_locations.py` | 0 | PASS (0 errors/warnings) |
+| Test+coverage | `poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts.dev_tools.validate_evidence_locations --cov-branch --cov-report=term-missing` | 0 | PASS (7 passed) |
+
+### PowerShell (independently re-run by reviewer)
+
+| Stage | Command | Result | Verdict |
+|---|---|---|---|
+| Format | Invoke-Formatter / PoshQC format (executor evidence: final-poshqc-format.2026-06-24T13-55.md, EXIT 0) | ok:true | PASS |
+| Analyze | Invoke-ScriptAnalyzer over the six PowerShell files (reviewer re-run) | 0 findings on every file | PASS |
+| Test | Invoke-Pester on validate-task-researcher-output.Tests.ps1 (22) + enforce-evidence-locations.Tests.ps1 (13) | Total=35, Passed=35, Failed=0 | PASS |
+
+Note on format: a direct `Invoke-Formatter -ScriptDefinition` call against the raw text of `enforce-evidence-locations.ps1` reports "mixed line endings." The authoritative repo format gate (PoshQC MCP run in executor evidence final-poshqc-format.2026-06-24T13-55.md) reports EXIT 0. The mixed-line-ending condition is a known cosmetic artifact tolerated by the PoshQC formatter and recorded below as a non-blocking observation; PSScriptAnalyzer reports 0 findings.
+
+## Coverage Verification
+
+Reviewer inspected the existing coverage artifacts and independently re-ran the targeted Pester coverage and pytest coverage. Coverage thresholds are uniform per quality-tiers.md: line >= 85%, branch >= 75%, no regression on changed lines.
+
+### Python — artifact: artifacts/python/lcov.info
+
+| File | Type | Line cov | Branch cov | Verdict |
+|---|---|---|---|---|
+| scripts/dev_tools/validate_evidence_locations.py | modified | 100% (28/28) | 100% (12/12) | PASS |
+
+Repo-wide per language (Python validator module under test): 100% line, 100% branch. PASS.
+
+### PowerShell — targeted per-hook coverage (reviewer re-run; corroborates executor evidence)
+
+| File | Type | Line / command cov | Threshold | Verdict |
+|---|---|---|---|---|
+| .claude/hooks/enforce-evidence-locations.ps1 | modified | 96.43% line (27/28, executor) / 94.29% command (33/35, reviewer) | >= 85% | PASS |
+| .claude/hooks/validate-task-researcher-output.ps1 | modified | 91.84% command (90/98, reviewer) | >= 85% | PASS |
+
+Reviewer Pester command (New-PesterConfiguration, CodeCoverage scoped to the named hook):
+- enforce-evidence-locations.Tests.ps1: 13 tests, 13 passed, 0 failed. Command coverage 94.29%; the only uncovered statement is line 176 `exit (Invoke-EvidenceLocationEntryPoint)`, the thin process-exit wiring that is structurally unreachable when the script is dot-sourced by unit tests.
+- validate-task-researcher-output.Tests.ps1: 22 tests, 22 passed, 0 failed. Command coverage 91.84%; uncovered statements are the entry-point dispatch block (lines 219-225) plus two minor branches.
+
+Remediation confirmation: the prior Blocking finding (enforce-evidence-locations.ps1 at 81.5% line coverage) is RESOLVED. The remediation commit `eb85c87` extracted the dispatch logic into a testable `Invoke-EvidenceLocationEntryPoint` function and added three entry-point dispatch tests (allow-output, malformed-JSON error, block-output). Post-change line coverage 96.43% >= 85% with no coverage exclusion introduced (line 176 remains in the denominator) and no regression on the changed line (the `'artifacts/research/'` forbidden prefix in `Test-EvidenceLocationForbidden`, fully covered by two passing tests).
+
+Branch coverage for PowerShell: Pester's PowerShell coverage engine emits line/command counters only; branch counters are not produced. This is a documented tooling limitation (coverage-threshold-verification.2026-06-24T13-55.md), not a regression. Line coverage is the applicable PowerShell metric and meets threshold.
+
+### Markdown / TOML
+
+No executable code; no coverage instrument applies. Not a language with executable changed lines for coverage purposes. Verdict: not applicable to coverage (zero executable changed lines).
+
+## Evidence Location Compliance
+
+Command: `poetry run python scripts/dev_tools/validate_evidence_locations.py --root .` — EXIT 0 (no violations).
+
+Branch-diff scan for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, `artifacts/coverage/`, or `artifacts/research/`: none found (`git diff --name-only <range> | grep -E '^artifacts/...'` returned no matches). All feature evidence is written to the canonical `<FEATURE>/evidence/<kind>/` path (baseline/, qa-gates/, other/). No evidence-location violations.
+
+| Check | Result |
+|---|---|
+| Files under artifacts/baselines/ in diff | none — PASS |
+| Files under artifacts/qa/ in diff | none — PASS |
+| Files under artifacts/evidence/ in diff | none — PASS |
+| Files under artifacts/coverage/ in diff | none — PASS |
+| Files under artifacts/research/ in diff | none — PASS |
+| validate_evidence_locations.py --root . | exit 0 — PASS |
+
+## modified-workflow-needs-green-run
+
+Branch diff scanned for paths matching `.github/workflows/**`, `scripts/benchmarks/**`, `.github/actions/**`. No matching paths changed. Rule does not fire. PASS.
+
+## Cross-Ecosystem Consistency (root vs bundled mirror)
+
+| File pair | Result |
+|---|---|
+| validate-task-researcher-output.ps1 (root vs Claude bundled) | IDENTICAL — PASS |
+| enforce-evidence-locations.ps1 (root vs Claude bundled) | IDENTICAL — PASS |
+| task-researcher.md (root vs Claude bundled) | IDENTICAL — PASS |
+| orchestrator.md (root vs Claude bundled) | IDENTICAL — PASS |
+| research-issue/SKILL.md (root vs Claude bundled) | IDENTICAL — PASS |
+| orchestrate/SKILL.md (root vs Claude bundled) | IDENTICAL — PASS |
+| evidence-and-timestamp-conventions/SKILL.md (root vs Claude bundled) | IDENTICAL — PASS |
+| task-researcher.agent.md (root vs Copilot bundled) | IDENTICAL — PASS |
+| research-issue.prompt.md (root vs Copilot bundled) | IDENTICAL — PASS |
+| fillout-prd-feature.prompt.md (root vs Copilot bundled) | IDENTICAL — PASS |
+| enforce-evidence-locations.ps1 (root vs Codex bundled) | DIVERGENT — expected (Codex translation: `# Converted hook` header banner and `.agents/skills/` path in the block reason); the `artifacts/research/` forbidden prefix change is present — PASS for the relocation change |
+| Codex task-researcher.toml / orchestrator.toml / three .agents/skills | equivalent relocation text present — PASS |
+
+The remediation refactor (extracting `Invoke-EvidenceLocationEntryPoint`) was applied to both the root hook and the Claude bundled mirror, which remain byte-identical (verified by `diff`). The Codex bundled hook is a translation; the only diffs versus root are the converted-hook header and the skills-path reference, both pre-existing translation conventions consistent with the spec.
+
+## Residual Reference Scan
+
+Command: content search for `artifacts[/\\]research` across .claude, .github, scripts, extensions, tests (excluding docs/features historical records and this feature's own docs).
+
+All remaining matches in operational/instruction files are intentional: forbidden-prefix list entries and docstrings in the three `enforce-evidence-locations.ps1` copies (the relocation's purpose), the forbidden-prefix entry in `validate_evidence_locations.py`, and test assertions that exercise rejection of the retired path. `.claude/agents/task-researcher.md` and the Codex `task-researcher.toml` contain no residual `artifacts/research` references (verified). No operational/instruction file still treats `artifacts/research/` as a canonical or permitted research target. PASS.
+
+One match outside the in-scope inventory: `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-claude-to-codex/SKILL.md` references `artifacts/research/codex-native-ecosystem.2026-06-16T13-32.md` as a specific historical input artifact the skill consumes, not as the canonical research-output path contract. This file is not in the spec's in-scope inventory and the reference is a historical input pointer, out of scope per spec Non-Goals. Recorded as a non-blocking observation.
+
+## Verdict Summary
+
+| Area | Verdict |
+|---|---|
+| Python toolchain | PASS |
+| PowerShell toolchain | PASS |
+| Python coverage | PASS |
+| PowerShell coverage (validate-task-researcher-output.ps1) | PASS |
+| PowerShell coverage (enforce-evidence-locations.ps1) | PASS (resolved; 96.43% line, was 81.5%) |
+| Markdown/TOML coverage | N/A (zero executable changed lines) |
+| Evidence-location compliance | PASS |
+| modified-workflow-needs-green-run | PASS (does not fire) |
+| Cross-ecosystem consistency | PASS |
+| Residual reference scan | PASS |
+| Tonality (instruction prose) | PASS |
+
+**Overall policy verdict: PASS.** The single prior Blocking finding (enforce-evidence-locations.ps1 coverage) is resolved. No FAIL or PARTIAL results remain. No remediation triggered.
+
+## Non-Blocking Observations
+
+- Low: `coverage.xml` at repo root (a tracked, generated JaCoCo Pester report) was regenerated and committed in the branch diff (net -98 lines). Generated coverage output is out of scope per spec Non-Goals ("testResults.xml and similar generated outputs are not authored and are out of scope"). Committing regenerated generated output is incidental churn; not a path violation (root path, not under a forbidden prefix). Optional: avoid committing regenerated coverage.xml.
+- Low: `enforce-evidence-locations.ps1` reports "mixed line endings" under a direct `Invoke-Formatter -ScriptDefinition` call, while the authoritative PoshQC format gate passes (EXIT 0). Cosmetic; carried over from the prior review. Optional cleanup on next edit.
+
+## Appendix B — Command Reference
+
+- `git diff --stat ea94a068e0a071940858a0694c47e204244c09af..eb85c8789cd99907cac8363a95c3c9043341d995`
+- `git log --oneline ea94a068e0a071940858a0694c47e204244c09af..eb85c8789cd99907cac8363a95c3c9043341d995`
+- `poetry run black --check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`
+- `poetry run ruff check scripts/dev_tools/validate_evidence_locations.py tests/scripts/dev_tools/test_validate_evidence_locations.py`
+- `poetry run pyright scripts/dev_tools/validate_evidence_locations.py`
+- `poetry run pytest tests/scripts/dev_tools/test_validate_evidence_locations.py --cov=scripts.dev_tools.validate_evidence_locations --cov-branch --cov-report=term-missing`
+- `Invoke-Pester -Configuration <cfg>` scoped to each hook test file with CodeCoverage on the corresponding hook
+- `Invoke-ScriptAnalyzer -Path <file> -Severity Warning,Error` over the six PowerShell files
+- `poetry run python scripts/dev_tools/validate_evidence_locations.py --root .`
+- `diff <root file> <bundled mirror>` for each cross-ecosystem pair
+- content search for `artifacts[/\\]research` across operational directories

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/remediation-inputs.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/remediation-inputs.2026-06-24T13-55.md
@@ -1,0 +1,41 @@
+# Remediation Inputs — relocate-research-canonical-location (Issue #227)
+
+- **Timestamp:** 2026-06-24T13-55
+- **Base branch (resolved):** origin/main @ ea94a068e0a071940858a0694c47e204244c09af
+- **Head:** d200d8961843f8b9d040f6c847b8ae186035dc90
+- **Source artifacts:**
+  - policy-audit: docs/features/active/2026-06-24-relocate-research-canonical-location-227/policy-audit.2026-06-24T13-55.md
+  - code-review: docs/features/active/2026-06-24-relocate-research-canonical-location-227/code-review.2026-06-24T13-55.md
+  - feature-audit: docs/features/active/2026-06-24-relocate-research-canonical-location-227/feature-audit.2026-06-24T13-55.md
+
+## Remediation Trigger
+
+Coverage threshold not met for a modified file. Per the feature-review-workflow SKILL coverage contract, modified files must reach line coverage >= 85%. `enforce-evidence-locations.ps1` is at 81.5% line coverage.
+
+## Blocking Findings
+
+### Finding 1 — enforce-evidence-locations.ps1 line coverage below threshold
+
+- **Severity: Blocking**
+- **File:** .claude/hooks/enforce-evidence-locations.ps1 (and its byte-identical Claude bundled mirror at extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1)
+- **Location:** entry-point execution block, lines 146, 148, 149, 152, 154
+- **Measurement:** Modified-file line coverage 81.5% (22/27 lines), below the uniform 85% line threshold (quality-tiers.md, general-unit-test.md). Reviewer Pester re-run corroborates: the only uncovered commands are the script entry-point dispatch block, unreachable when the script is dot-sourced by the unit tests.
+- **Context:** The feature's changed line (the added `'artifacts/research/'` forbidden prefix) is inside the fully covered `Test-EvidenceLocationForbidden` function. There is no regression on changed lines. The shortfall is in the pre-existing entry-point wiring, not in the feature change. Coverage improved +11.1 points from the 70.4% baseline.
+- **Evidence:** docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/coverage-delta.2026-06-24T13-09.md; reviewer-run Invoke-Pester with CodeCoverage scoped to the two hooks (uncovered lines 146,148,149,152,154).
+- **Required remediation:** Bring `enforce-evidence-locations.ps1` line coverage to >= 85% by one of:
+  1. Adding a process-level/integration test that invokes the script as a separate process with a representative `CLAUDE_TOOL_INPUT`, exercising the entry-point dispatch block (lines 146-154); or
+  2. Refactoring the entry-point wiring so the dispatch path is invokable and asserted by the existing dot-sourced unit tests (extract the entry-point block into a thin, testable function and assert its decision-to-output mapping).
+  Apply the same change to the byte-identical Claude bundled mirror to preserve cross-ecosystem equality (AC7). The Codex bundled copy is a translation; mirror the testable-wiring change if it affects shared logic.
+- **Acceptance for closure:** Re-run targeted Pester coverage for enforce-evidence-locations.ps1; line coverage >= 85% with no regression on changed lines; root and Claude-bundled mirror remain byte-identical; full claude-hooks Pester suite remains green.
+
+## Non-Blocking Observations (not gating)
+
+- Low: trailing blank line with mixed line ending at end of validate-task-researcher-output.ps1. Cosmetic; passes Invoke-Formatter; byte-identical in mirror. Optional cleanup on next edit.
+
+## Acceptance Criteria Status
+
+All 7 acceptance criteria and 3 seeded test conditions evaluate PASS (see feature-audit.2026-06-24T13-55.md). No acceptance criterion is blocked. The only Blocking item is the coverage threshold above.
+
+## Go / No-Go
+
+No-go for PR until Finding 1 is resolved. All functional acceptance criteria are met; the single gating item is the modified-file coverage threshold.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/remediation-plan.2026-06-24T13-55.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/remediation-plan.2026-06-24T13-55.md
@@ -1,0 +1,103 @@
+# Remediation Plan — enforce-evidence-locations.ps1 coverage shortfall (Issue #227)
+
+- **Timestamp:** 2026-06-24T13-55
+- **Feature folder:** docs/features/active/2026-06-24-relocate-research-canonical-location-227
+- **Remediation inputs:** docs/features/active/2026-06-24-relocate-research-canonical-location-227/remediation-inputs.2026-06-24T13-55.md
+- **Blocking finding addressed:** Finding 1 — `enforce-evidence-locations.ps1` line coverage 81.5% (22/27), below the uniform 85% line threshold. Uncovered region is the entry-point dispatch block (lines 145-154), unreachable from dot-sourced unit tests.
+
+## Objective
+
+Bring `enforce-evidence-locations.ps1` line coverage to >= 85% with no regression on changed lines, by refactoring the untestable entry-point dispatch into a testable function and adding Pester coverage for the success-output path and the malformed-JSON error path. No coverage exclusions and no assertion weakening are permitted.
+
+## Chosen Approach (verified against current file structure)
+
+The current file (verified at this timestamp) ends with:
+
+```
+# Guard allows dot-sourcing in tests without executing the entrypoint.
+if ($MyInvocation.InvocationName -eq '.') {
+    return
+}
+
+try {
+    $decision = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
+} catch {
+    Write-Error $_
+    exit 1
+}
+
+$decision | ConvertTo-Json -Compress | Write-Output
+
+exit 0
+```
+
+The uncovered lines (146, 148, 149, 152, 154) are inside this block. `exit` cannot be executed in-process under Pester without terminating the test host, so the dispatch logic is extracted into a new advanced function `Invoke-EvidenceLocationEntryPoint` that:
+
+- accepts the raw tool input as a parameter (default `$env:CLAUDE_TOOL_INPUT`),
+- calls `Invoke-EvidenceLocationDecision`,
+- on success: writes the compact JSON to the output stream and returns exit code `0`,
+- on failure (malformed JSON): writes the error via `Write-Error` and returns exit code `1`,
+- returns the integer exit code rather than calling `exit` itself.
+
+The thin dot-source guard then becomes only:
+
+```
+if ($MyInvocation.InvocationName -eq '.') {
+    return
+}
+
+exit (Invoke-EvidenceLocationEntryPoint)
+```
+
+This makes the JSON-output path and the malformed-JSON error path unit-testable through the new function. Only the single `exit (...)` wiring line and the dot-source guard remain outside unit reach; both are within the residual tolerance for the 85% threshold once the dispatch body is covered. This approach complies with the no-exclusion policy (`general-unit-test.md` Coverage Exclusion Policy) by extracting logic into a testable function rather than excluding lines.
+
+### Parity scope
+
+The fix applies to three production files. The root and Claude-bundled mirror are byte-identical and must remain so. The Codex copy shares the same entry-point dispatch logic (differing only in its converted-header banner and the SKILL.md path inside the block reason); the dispatch refactor is shared logic and must be mirrored there to preserve translation parity (AC7).
+
+- Root: `.claude/hooks/enforce-evidence-locations.ps1`
+- Claude mirror (byte-identical to root): `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1`
+- Codex translation (parity, not byte-identical): `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1`
+- Test: `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`
+
+### Batch-cap compliance
+
+3 production files + 1 test file. Within the PowerShell per-batch cap (max 3 production, 3 test). All four files remain well under the 500-line limit.
+
+---
+
+### Phase 0 — Baseline capture and policy reads
+
+- [x] [P0-T1] Read policy files in required order and record an evidence artifact at `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/other/phase0-instructions-read.2026-06-24T13-55.md` containing `Timestamp:`, `Policy Order:`, and the explicit list of files read: `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/quality-tiers.md`, `.claude/rules/powershell.md`. Acceptance: artifact exists with all three required fields and the five listed files.
+- [x] [P0-T2] Capture baseline PoshQC format state for the three production hook files and the test file by running `mcp__drm-copilot__run_poshqc_format` (check mode). Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-format.2026-06-24T13-55.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: artifact records exit code and pass/fail signal.
+- [x] [P0-T3] Capture baseline PoshQC analyze state by running `mcp__drm-copilot__run_poshqc_analyze`. Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/poshqc-analyze.2026-06-24T13-55.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (analyzer finding count). Acceptance: artifact records exit code and finding count.
+- [x] [P0-T4] Capture baseline targeted Pester coverage for `enforce-evidence-locations.ps1` by running `mcp__drm-copilot__run_poshqc_test` with CodeCoverage scoped to the root and Claude-mirror hook files and the claude-hooks test path. Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/baseline/pester.2026-06-24T13-55.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` including the numeric baseline line-coverage headline for `enforce-evidence-locations.ps1` (expected 81.5%, 22/27) and the uncovered line numbers. Acceptance: artifact records the numeric baseline coverage value and uncovered lines.
+
+### Phase 1 — Refactor entry-point dispatch into a testable function (all three production files)
+
+- [x] [P1-T1] In `.claude/hooks/enforce-evidence-locations.ps1`, add a new advanced function `Invoke-EvidenceLocationEntryPoint` (with `[CmdletBinding()]`, `[OutputType([int])]`, and an optional `[string] $ToolInputRaw = $env:CLAUDE_TOOL_INPUT` parameter) that: calls `Invoke-EvidenceLocationDecision -ToolInputRaw $ToolInputRaw` inside a try/catch; on catch writes `Write-Error $_` and returns `1`; on success writes `$decision | ConvertTo-Json -Compress | Write-Output` and returns `0`. Acceptance: function is defined above the dot-source guard, returns an `[int]` exit code, and does not call `exit` itself.
+- [x] [P1-T2] In `.claude/hooks/enforce-evidence-locations.ps1`, replace the existing `try { ... } catch { ... } ; $decision | ConvertTo-Json ... ; exit 0` block (current lines 145-154) with the thin wiring `exit (Invoke-EvidenceLocationEntryPoint)` placed after the dot-source guard. Acceptance: the only post-guard statement is the single `exit (Invoke-EvidenceLocationEntryPoint)` line; no dispatch logic remains inline; file remains under 500 lines.
+- [x] [P1-T3] Apply the identical edits from P1-T1 and P1-T2 to the Claude bundled mirror `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1`, preserving byte-for-byte equality with the root file. Acceptance: a byte-comparison of the root file and the Claude mirror reports identical content.
+- [x] [P1-T4] Apply the equivalent dispatch refactor (new `Invoke-EvidenceLocationEntryPoint` function plus thin `exit (Invoke-EvidenceLocationEntryPoint)` wiring) to the Codex translation `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1`, preserving its converted-header banner and its existing `.agents/skills/...` SKILL.md path in the block reason (do not copy the `.claude/skills/...` path from the root). Acceptance: the Codex file contains the same `Invoke-EvidenceLocationEntryPoint` function and thin wiring as the root, while its banner and SKILL.md path remain unchanged from the pre-edit Codex copy.
+
+### Phase 2 — Add Pester coverage for the extracted entry-point function
+
+- [x] [P2-T1] In `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`, add a `Context 'entry-point dispatch'` block with an `It` test (Arrange-Act-Assert) that sets a representative allowed `file_path` JSON, calls `Invoke-EvidenceLocationEntryPoint -ToolInputRaw <allowed-json>`, captures the function's output and returned code, and asserts the returned code is `0` and the captured stdout is the compact JSON containing `"decision":"allow"`. Acceptance: test exercises the success-output path of `Invoke-EvidenceLocationEntryPoint` and asserts both the exit code and the emitted JSON content without weakening any assertion.
+- [x] [P2-T2] In the same test file, add an `It` test (Arrange-Act-Assert) that calls `Invoke-EvidenceLocationEntryPoint -ToolInputRaw '{ not valid json'` with `-ErrorAction SilentlyContinue` (capturing the error) and asserts the returned code is `1` and that an error record matching `*malformed JSON*` was written. Acceptance: test exercises the malformed-JSON error path of `Invoke-EvidenceLocationEntryPoint`, asserts the exit code is `1`, and asserts the error message, without temporary files or external dependencies.
+- [x] [P2-T3] In the same test file, add an `It` test for a forbidden path that calls `Invoke-EvidenceLocationEntryPoint -ToolInputRaw '{"file_path":"artifacts/research/notes.md"}'` and asserts the returned code is `0` and the emitted JSON contains `"decision":"block"` and `EVIDENCE_LOCATION_BLOCKED`. Acceptance: test exercises the block-decision output path through the entry-point function and asserts the JSON content and exit code.
+
+### Phase 3 — Final QA loop (PowerShell) and coverage re-verification
+
+- [x] [P3-T1] Run `mcp__drm-copilot__run_poshqc_format` over the three production files and the test file. If it changes any file, restart the loop from this step. Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc-format.2026-06-24T13-55.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: format check passes with exit code 0 and no residual changes.
+- [x] [P3-T2] Run `mcp__drm-copilot__run_poshqc_analyze`. If it fails or changes files, fix and restart from P3-T1. Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-poshqc-analyze.2026-06-24T13-55.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (analyzer finding count, expected 0). Acceptance: analyzer reports zero findings, exit code 0.
+- [x] [P3-T3] Run `mcp__drm-copilot__run_poshqc_test` for the full claude-hooks Pester suite with CodeCoverage scoped to the root and Claude-mirror `enforce-evidence-locations.ps1` files. If it fails or changes files, fix and restart from P3-T1. Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/final-pester-coverage.2026-06-24T13-55.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` including the post-change numeric line-coverage value for `enforce-evidence-locations.ps1`, the new-code coverage for the added function, and the baseline value (81.5%) for delta context. Acceptance: full claude-hooks suite passes (exit code 0) and the artifact records post-change coverage, new-code coverage, and baseline coverage.
+- [x] [P3-T4] Verify the coverage threshold and no-regression condition: confirm the post-change line coverage for `enforce-evidence-locations.ps1` recorded in P3-T3 is >= 85% and that the previously-changed line (the `'artifacts/research/'` forbidden prefix in `Test-EvidenceLocationForbidden`) remains covered. Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/coverage-threshold-verification.2026-06-24T13-55.md` recording baseline coverage, post-change coverage, the delta, new/changed-code coverage, and a PASS/FAIL determination. Acceptance: artifact shows line coverage >= 85% with no regression on changed lines; FAIL determination requires returning to Phase 1/2.
+- [x] [P3-T5] Verify cross-ecosystem parity: confirm the root file `.claude/hooks/enforce-evidence-locations.ps1` and the Claude mirror `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1` are byte-identical, and confirm the Codex copy contains the equivalent `Invoke-EvidenceLocationEntryPoint` function and thin wiring while retaining its banner and `.agents/skills/...` SKILL.md path. Write `docs/features/active/2026-06-24-relocate-research-canonical-location-227/evidence/qa-gates/cross-ecosystem-equality.2026-06-24T13-55.md` with `Timestamp:`, the byte-comparison result for root vs Claude mirror, and the Codex parity confirmation. Acceptance: root and Claude mirror are byte-identical; Codex copy has equivalent dispatch logic with its translation-specific differences intact.
+
+## Closure Criteria
+
+- `enforce-evidence-locations.ps1` line coverage >= 85% (recorded numerically in P3-T3 and P3-T4 artifacts).
+- No regression on changed lines.
+- Root and Claude bundled mirror remain byte-identical; Codex copy retains parity.
+- Full claude-hooks Pester suite is green.
+- No coverage exclusions introduced; no assertions weakened.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md
@@ -1,0 +1,494 @@
+# Task Research Notes: relocate-research-canonical-location (Issue #227)
+
+## Research Executed
+
+### File Analysis
+
+All files listed in the task inventory were read end-to-end. Confirmed complete
+coverage for the following sources:
+
+**Claude ecosystem (root):**
+- `.claude/agents/task-researcher.md`
+- `.claude/agents/orchestrator.md`
+- `.claude/skills/research-issue/SKILL.md`
+- `.claude/skills/orchestrate/SKILL.md`
+- `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`
+- `.claude/hooks/validate-task-researcher-output.ps1`
+- `.claude/hooks/enforce-evidence-locations.ps1`
+- `.claude/settings.json`
+
+**Claude ecosystem (bundled copy — confirmed byte-for-byte identical content):**
+- `extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/agents/orchestrator.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/skills/research-issue/SKILL.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/skills/orchestrate/SKILL.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/settings.json`
+
+**Codex ecosystem (bundled):**
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-claude-to-codex/SKILL.md`
+
+**GitHub Copilot ecosystem (root):**
+- `.github/agents/task-researcher.agent.md`
+- `.github/prompts/research-issue.prompt.md`
+- `.github/prompts/fillout-prd-feature.prompt.md`
+
+**GitHub Copilot ecosystem (bundled copy — confirmed identical content):**
+- `extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md`
+- `extensions/drm-copilot/resources/customizations/.github/prompts/research-issue.prompt.md`
+- `extensions/drm-copilot/resources/customizations/.github/prompts/fillout-prd-feature.prompt.md`
+
+**Tests:**
+- `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1`
+- `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`
+- `tests/scripts/dev_tools/test_validate_evidence_locations.py`
+
+**Tooling:**
+- `scripts/dev_tools/validate_evidence_locations.py`
+- `.gitignore`
+
+### Code Search Results
+
+- `artifacts[/\\]research` grep across repo returned 95 matching files.
+  Operational hits (files that actually enforce or instruct on the path, as
+  opposed to historical plan/evidence docs that merely reference the path as
+  context) are enumerated in the per-file inventory below.
+- `research-path` grep returned 9 files: the hook, the bundled hook,
+  `settings.json` (two copies), two feature evidence files (historical, not
+  enforcement), and `docs/engineering/claude-code-architecture.md`.
+
+### Project Conventions
+
+- `.gitignore` line 6: `artifacts` — entire `artifacts/` tree is excluded from
+  version control (bare entry with no trailing slash, matching any depth).
+- The enforce-evidence-locations hook and the Python validator both use an
+  explicit allowlist of forbidden prefixes; they do NOT contain a blocklist of
+  allowed paths. Paths not on the forbidden list pass through.
+- `docs/` is tracked; `docs/features/active/<feature>/` is the established home
+  for all per-feature versioned artifacts.
+- No existing `docs/research/` directory exists in the repo. It would need to
+  be created (`.gitkeep` or first research file).
+
+---
+
+## Current-State Analysis
+
+### How `artifacts/research/` is referenced across operational files
+
+The table below covers only enforcement/instruction files — not historical
+feature-doc references that happen to mention the path.
+
+| File | Reference type | Exact text / logic | Required change |
+|---|---|---|---|
+| `.claude/agents/task-researcher.md` (frontmatter) | Write allowlist | `"Write(/artifacts/research/**)"` in `tools:` list | Replace with two new roots |
+| `.claude/agents/task-researcher.md` (body) | Output-location prose | `Write all research artifacts to \`artifacts/research/\`` and constraint `Write only to \`artifacts/research/\`` | Update prose to describe two new roots and routing rule |
+| `.claude/agents/task-researcher.md` (description) | Metadata prose | `"writes structured findings exclusively to artifacts/research/"` | Update description |
+| `.claude/agents/orchestrator.md` (body) | Delegation prose | `"task-researcher — performs deep research and writes findings to \`artifacts/research/\`"` | Update |
+| `.claude/skills/research-issue/SKILL.md` (body) | Output path prose | `Path: \`artifacts/research/<timestamp>-<short-name>-research.md\`` | Update to new routing rule |
+| `.claude/skills/research-issue/SKILL.md` (description) | Metadata prose | `"writing structured findings to artifacts/research/"` | Update |
+| `.claude/skills/orchestrate/SKILL.md` (body) | Delegation prose | `"task-researcher — performs deep research and writes findings to \`artifacts/research/\`"` | Update |
+| `.claude/skills/orchestrate/SKILL.md` (Evidence Location Authority) | Permitted sub-path prose | `"artifacts/research/ — research outputs from task-researcher"` listed as permitted sub-path | Remove or replace: this path is no longer a permitted artifacts/ sub-path |
+| `.claude/skills/evidence-and-timestamp-conventions/SKILL.md` | Permitted sub-path list | `"artifacts/research/"` in `Allowed artifacts/ sub-paths` section | Remove (research is no longer an artifacts/ path) |
+| `.claude/hooks/validate-task-researcher-output.ps1` | Root check function | `Test-IsUnderResearchRoot`: `return $normalized.StartsWith('artifacts/research/', ...)` | Rewrite to accept two new roots |
+| `.claude/hooks/validate-task-researcher-output.ps1` | Error messages | Three messages hard-code `artifacts/research/` as the target | Update all three messages |
+| `.claude/hooks/validate-task-researcher-output.ps1` | Missing research-path guidance | `"must report \`research-path: <path>\` pointing to artifacts/research/"` | Update message |
+| `.claude/hooks/validate-task-researcher-output.ps1` | Filename convention message | `"artifacts/research/<timestamp>-<short-name>-research.md"` in error message | Update message |
+| `.claude/hooks/enforce-evidence-locations.ps1` | Docstring + allowed-path list | Docstring explicitly lists `artifacts/research/` as a permitted allowed path | Update docstring; no logic change needed (the hook uses an exclusion-only approach, so `artifacts/research/` is currently allowed by absence from forbidden list — this remains valid as long as the path is not added to the forbidden list; however the docstring must be updated) |
+| `.claude/settings.json` | SubagentStop inline hook regex | `'(plan-path\|research-path\|review-artifact\|PREFLIGHT\|evidence/)'` — `research-path` token is accepted regardless of the path value; no path root check here | No functional change needed; the `research-path` token remains the contract |
+| `.claude/settings.json` | Write permission allowlist | `"Write(/artifacts/**)"` — covers any artifacts/ sub-path | No change needed for the orchestrator; the task-researcher agent-level allowlist is the relevant gate |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md` | All same as root copy | Identical content — same changes required | Mirror all changes from root copy |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/agents/orchestrator.md` | Delegation prose | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/skills/research-issue/SKILL.md` | Output path prose | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/skills/orchestrate/SKILL.md` | Delegation prose + permitted sub-path | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md` | Permitted sub-path list | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1` | Root check + error messages | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1` | Docstring | Identical to root | Mirror docstring update |
+| `extensions/drm-copilot/resources/claude-customizations/.claude/settings.json` | SubagentStop regex + allowlist | Identical to root | No functional change; mirror docstring/description updates if any |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml` | Write allowlist in embedded frontmatter | `"Write(/artifacts/research/**)"` | Replace with two new roots |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml` | Body prose | Same as Claude copy embedded as `developer_instructions` | Mirror all prose changes |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml` | Stop hook | `"Block termination unless research artifact path has been confirmed on disk under artifacts/research/."` | Update to two new roots |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml` | Delegation prose | `"task-researcher: research artifacts under \`artifacts/research/\`"` in `developer_instructions` | Update |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1` | Docstring | Lists `artifacts/research/` as permitted | Mirror docstring update |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md` | Output path prose | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md` | Delegation prose + permitted sub-path | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md` | Permitted sub-path list | Identical to root | Mirror |
+| `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/translate-claude-to-codex/SKILL.md` | Authoritative research path reference | `"artifacts/research/codex-native-ecosystem.2026-06-16T13-32.md"` — this is a concrete file path reference in the Authoritative Inputs section and the research basis reference in the plan template | This is a path to a specific historical research artifact, not a path-routing rule. No change is required for that historical reference. The plan template line `Research basis: artifacts/research/...` is also historical. However, after this feature ships, new translate-claude-to-codex research artifacts would go to a docs path. The SKILL.md does not need a change for the contract; future invocations will naturally use the new location. |
+| `.github/agents/task-researcher.agent.md` | Role definition prose | `"Your sole responsibility is to write transient research notes in the untracked scratch area \`artifacts/research/\`"` | Update — research is now tracked |
+| `.github/agents/task-researcher.agent.md` | Operational constraint | `"You MUST create and edit files ONLY in \`artifacts/research/\`"` | Update |
+| `.github/agents/task-researcher.agent.md` | Collaborative process | `"Search for existing research files in \`artifacts/research/\`"` | Update |
+| `.github/prompts/research-issue.prompt.md` | Output path prose | `Path: \`artifacts/research/<timestamp>-<short-name>-research.md\`` and filename convention example | Update |
+| `.github/prompts/research-issue.prompt.md` | Operating rules reference | `"write to \`artifacts/research/\`, evidence-based"` | Update |
+| `.github/prompts/fillout-prd-feature.prompt.md` | Research path reference | `"If research exists under \`artifacts/research\`, the caller must include the specific research file paths"` | Update to reference both new roots |
+| `extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md` | Same as root | Identical | Mirror all changes |
+| `extensions/drm-copilot/resources/customizations/.github/prompts/research-issue.prompt.md` | Same as root | Identical | Mirror all changes |
+| `extensions/drm-copilot/resources/customizations/.github/prompts/fillout-prd-feature.prompt.md` | Same as root | Identical | Mirror all changes |
+| `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1` | Test assertions | Multiple `It` blocks assert `artifacts/research/` root, error messages containing `artifacts/research/`, and valid path examples like `artifacts/research/2026-05-04T00-00-hook-contract-research.md` | Rewrite affected tests; add new tests for both new roots |
+| `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1` | Test assertion | One `It` block: `'allows writes to artifacts/research/ (permitted research path)'` with path `artifacts/research/notes.md` | This test must be updated: writing to `artifacts/research/` must now be rejected, and tests for both new canonical roots must be added |
+| `tests/scripts/dev_tools/test_validate_evidence_locations.py` | Allowed path in `test_clean_tree_exits_zero` | `Path("/fake/repo/artifacts/research/notes.md")` listed as an allowed path in the clean-tree test | This path must be replaced with a new canonical path; `artifacts/research/` is no longer allowed |
+| `scripts/dev_tools/validate_evidence_locations.py` | `_FORBIDDEN_PREFIX_TO_CANONICAL` dict | `artifacts/research/` is not in the forbidden list (allowed by omission) | `artifacts/research/` must be added to the forbidden prefix map with a canonical suggestion pointing to the two new roots |
+
+---
+
+## Proposed Contract for the Two New Tracked Locations
+
+### Filename Convention (preserved)
+
+The timestamp-and-name convention is unchanged:
+
+```
+<timestamp>-<short-name>-research.md
+```
+
+where `<timestamp>` uses the existing `yyyy-MM-ddTHH-mm` format (e.g., `2026-06-24T13-02`).
+
+### Two Canonical Research Roots
+
+**Feature-associated research (orchestration context):**
+```
+docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md
+```
+
+Example: `docs/features/active/2026-06-24-relocate-research-canonical-location-227/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md`
+
+**One-off research (no associated feature):**
+```
+docs/research/<timestamp>-<short-name>-research.md
+```
+
+Example: `docs/research/2026-06-24T14-00-codex-native-ecosystem-research.md`
+
+### Hook Regex / Path Validator Logic
+
+The `Test-IsUnderResearchRoot` function in `validate-task-researcher-output.ps1`
+must be rewritten to accept either root:
+
+```
+Accepted pattern A: docs/features/**/research/<timestamp>-<short-name>-research.md
+Accepted pattern B: docs/research/<timestamp>-<short-name>-research.md
+Rejected: artifacts/research/...
+Rejected: any other path
+```
+
+The implementation approach: normalize to forward-slash, then check
+`StartsWith('docs/features/')` with a `/research/` segment present after the
+feature folder, OR `StartsWith('docs/research/')`. Both checks are
+case-insensitive.
+
+The filename pattern check `Test-IsValidResearchFileName` operates on
+`[System.IO.Path]::GetFileName($normalized)` and uses:
+```
+^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-[A-Za-z0-9][A-Za-z0-9-]*-research\.md$
+```
+This regex does not include a path prefix and therefore does not require change.
+
+The `enforce-evidence-locations.ps1` hook does not need a logic change. It uses
+an exclusion-only model: paths not in `$forbiddenPrefixes` pass through. As long
+as `artifacts/research/` is added to the forbidden list and `docs/features/` and
+`docs/research/` are not in the forbidden list, the hook will correctly:
+- Block: `artifacts/research/...`
+- Allow: `docs/features/**/research/...`
+- Allow: `docs/research/...`
+
+However, the `scripts/dev_tools/validate_evidence_locations.py` script uses the
+`_FORBIDDEN_PREFIX_TO_CANONICAL` dict, and `artifacts/research/` is currently
+absent (allowed by omission). After this change, it must be added as a forbidden
+prefix with a canonical suggestion.
+
+### Task-Researcher Agent Write-Path Allowlist
+
+**Current form (Claude .md frontmatter):**
+```yaml
+tools:
+  - "Write(/artifacts/research/**)"
+```
+
+**Required new form:**
+```yaml
+tools:
+  - "Write(/docs/features/**/research/**)"
+  - "Write(/docs/research/**)"
+```
+
+**Current form (Codex .toml `developer_instructions` embedded frontmatter):**
+```
+"Write(/artifacts/research/**)"
+```
+
+**Required new form:**
+```
+"Write(/docs/features/**/research/**)"
+"Write(/docs/research/**)"
+```
+
+Note: Claude's `Write(...)` tool allowlist uses glob syntax with `/` prefix
+anchored at repo root. The double-star `**` matches any intermediate segments,
+including the `<feature>` folder segment.
+
+### Orchestrator Routing Decision Rule
+
+The orchestrator must determine which root to use before delegating to
+`task-researcher`. The rule is:
+
+- If there is an active feature folder in scope (i.e., `feature-folder` is set
+  in `orchestrator-state.json`), write research to
+  `<feature-folder>/research/<timestamp>-<short-name>-research.md`.
+- If no active feature folder is in scope (standalone research request, ad-hoc
+  investigation), write research to
+  `docs/research/<timestamp>-<short-name>-research.md`.
+
+The delegation prompt from the orchestrator to `task-researcher` must include
+the resolved output path. The `task-researcher` agent does not infer the feature
+folder independently.
+
+The `research-issue` skill must similarly be updated to document both paths and
+the routing rule, replacing the single `artifacts/research/` instruction.
+
+---
+
+## Recommended Approach
+
+**Direct substitution with dual-root acceptance.** Update every occurrence of
+`artifacts/research/` in the enforcement/instruction layer to express the new
+two-root contract. This is the only viable approach because:
+
+1. The change is purely a relocation of a path contract, not a new behavioral
+   system. No architectural re-design is needed.
+2. All enforcement points (hook functions, agent frontmatter, skill prose) are
+   individually addressable — each file has a well-defined and isolated change.
+3. The `validate_evidence_locations.py` script must add `artifacts/research/`
+   as a forbidden prefix to prevent agents from writing there; this is a
+   two-line addition to the existing dict.
+4. The `enforce-evidence-locations.ps1` hook logic requires no code change —
+   only a docstring update — because it already uses an exclusion-only approach.
+
+**Rejected alternative — create a redirect shim at `artifacts/research/`:** A
+shim that detects writes and re-routes them would add complexity, is not
+supported by the Claude Code permissions model (Write allowlist is a strict
+gate, not a redirect), and cannot be tested reliably. Rejected.
+
+---
+
+## Cross-Ecosystem Consistency Map
+
+### Root copies and their bundled mirrors
+
+The root copy is the source of truth. The bundled copy must remain identical.
+
+| Root file | Bundled mirror | Sync mechanism |
+|---|---|---|
+| `.claude/agents/task-researcher.md` | `extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md` | Manual copy; content verified identical in this investigation |
+| `.claude/agents/orchestrator.md` | `extensions/drm-copilot/resources/claude-customizations/.claude/agents/orchestrator.md` | Manual copy; content verified identical |
+| `.claude/skills/research-issue/SKILL.md` | `extensions/drm-copilot/resources/claude-customizations/.claude/skills/research-issue/SKILL.md` | Manual copy; content verified identical |
+| `.claude/skills/orchestrate/SKILL.md` | `extensions/drm-copilot/resources/claude-customizations/.claude/skills/orchestrate/SKILL.md` | Manual copy; content verified identical |
+| `.claude/skills/evidence-and-timestamp-conventions/SKILL.md` | `extensions/drm-copilot/resources/claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md` | Manual copy; content verified identical |
+| `.claude/hooks/validate-task-researcher-output.ps1` | `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1` | Manual copy; content verified identical |
+| `.claude/hooks/enforce-evidence-locations.ps1` | `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1` | Manual copy; content verified identical |
+| `.claude/settings.json` | `extensions/drm-copilot/resources/claude-customizations/.claude/settings.json` | Manual copy; content verified identical |
+| `.github/agents/task-researcher.agent.md` | `extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md` | Manual copy; content verified identical |
+| `.github/prompts/research-issue.prompt.md` | `extensions/drm-copilot/resources/customizations/.github/prompts/research-issue.prompt.md` | Manual copy; content verified identical |
+| `.github/prompts/fillout-prd-feature.prompt.md` | `extensions/drm-copilot/resources/customizations/.github/prompts/fillout-prd-feature.prompt.md` | Manual copy; content verified identical |
+
+### Codex-only files (no root copy)
+
+The Codex `.toml` agents and Codex `.agents/skills/` files are separate
+translations; they do not have a root-repo counterpart. The
+`translate-claude-to-codex` skill is the documented mechanism for keeping them
+aligned with the Claude source.
+
+The Codex `task-researcher.toml` embeds the Claude agent frontmatter and body
+verbatim inside `developer_instructions`. After this change, both the embedded
+frontmatter (`"Write(/artifacts/research/**)"`) and the embedded body prose must
+be updated. The `translate-claude-to-codex` SKILL.md notes that
+`.claude/agents/<name>.md` maps to `.codex/agents/<name>.toml` — consistent
+with requiring a manual Codex-side update whenever the Claude source changes.
+
+### Role of translate-claude-to-codex skill
+
+The `translate-claude-to-codex` skill is invoked when changes to the Claude
+surface must be propagated to the Codex surface. After the root Claude files are
+updated, the Codex files must be updated to match. The skill can be invoked with
+`mode=apply` to execute this propagation. However, because the Codex
+`task-researcher.toml` also contains a migration-source header and stop-hook
+body that mention `artifacts/research/` directly, those sections must be updated
+as part of the same change, either via the skill or manually.
+
+The Codex `evidence-and-timestamp-conventions/SKILL.md`,
+`orchestrate/SKILL.md`, and `research-issue/SKILL.md` mirror their Claude
+counterparts exactly and must receive the same text changes.
+
+---
+
+## Requirements Mapping
+
+### AC: Feature-associated research is written to `<FEATURE>/research/`; one-off to `docs/research/`; `artifacts/research/` is no longer canonical
+
+Files requiring change to satisfy this criterion:
+
+- `.claude/agents/task-researcher.md` (frontmatter tools + body)
+- `.claude/skills/research-issue/SKILL.md` (output path)
+- `.github/agents/task-researcher.agent.md` (role definition, constraint, process)
+- `.github/prompts/research-issue.prompt.md` (output path + scope rule)
+- All bundled copies of the above
+
+The `research-issue` skill and prompt must also document the routing rule: the
+caller (orchestrator or user) supplies the resolved output directory, and the
+researcher writes to that directory.
+
+### AC: Claude ecosystem reflects new contract in agents, skills, and hooks
+
+Files requiring change:
+
+- `.claude/agents/task-researcher.md` — frontmatter `tools`, description, body
+- `.claude/agents/orchestrator.md` — delegation prose
+- `.claude/skills/research-issue/SKILL.md` — output path, description
+- `.claude/skills/orchestrate/SKILL.md` — delegation prose, permitted sub-path
+- `.claude/skills/evidence-and-timestamp-conventions/SKILL.md` — remove `artifacts/research/` from allowed list
+- `.claude/hooks/validate-task-researcher-output.ps1` — `Test-IsUnderResearchRoot` logic, three error messages
+- `.claude/hooks/enforce-evidence-locations.ps1` — docstring only (no logic change)
+- All bundled copies of the above
+
+### AC: Codex ecosystem reflects new contract
+
+Files requiring change:
+
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml` — embedded frontmatter and body
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml` — delegation prose
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1` — docstring only
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md`
+
+### AC: GitHub Copilot ecosystem reflects new contract
+
+Files requiring change:
+
+- `.github/agents/task-researcher.agent.md` — role definition, constraint, process
+- `.github/prompts/research-issue.prompt.md` — output path, scope rule
+- `.github/prompts/fillout-prd-feature.prompt.md` — research path reference
+- All bundled copies of the above
+
+### AC: `validate-task-researcher-output` and `enforce-evidence-locations` accept new locations and reject old
+
+Files requiring change:
+
+- `.claude/hooks/validate-task-researcher-output.ps1` — `Test-IsUnderResearchRoot` function body and error messages (3 locations)
+- `.claude/hooks/enforce-evidence-locations.ps1` — add `artifacts/research/` to `$forbiddenPrefixes` array; update docstring
+- `scripts/dev_tools/validate_evidence_locations.py` — add `artifacts/research/` to `_FORBIDDEN_PREFIX_TO_CANONICAL` dict
+- Bundled copies of the hook files
+
+### AC: Both tracked research locations resolve to git-tracked paths (not under ignored `artifacts/` tree)
+
+`docs/features/active/` and `docs/research/` are under `docs/`, which is not in
+`.gitignore`. The `artifacts` entry in `.gitignore` (line 6, bare match) covers
+the entire `artifacts/` tree. Moving research to `docs/` fully satisfies this
+criterion.
+
+No `.gitignore` modification is needed; the new paths are tracked by default.
+
+### AC: `validate-task-researcher-output` and `enforce-evidence-locations` tests updated
+
+Files requiring change:
+
+- `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1` — see Testing Implications below
+- `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1` — see Testing Implications below
+- `tests/scripts/dev_tools/test_validate_evidence_locations.py` — see Testing Implications below
+
+---
+
+## Testing Implications
+
+### `validate-task-researcher-output.Tests.ps1`
+
+**Current test inventory and required disposition:**
+
+- `'blocks when the research-path is not under artifacts/research/'` — this test
+  currently passes `docs/features/active/foo/notes.md` and expects a block. After
+  the change, `docs/features/active/foo/research/2026-06-24T13-02-foo-research.md`
+  must be ALLOWED and `docs/features/active/foo/notes.md` (no `/research/` segment)
+  must still be blocked. The test's assertion and scenario description must be updated.
+
+- `'allows termination when the research-path is valid and the file exists'` — uses
+  `artifacts/research/2026-05-04T00-00-hook-contract-research.md`. Must be updated
+  to use a valid path under one of the new roots, e.g.,
+  `docs/features/active/my-feature/research/2026-05-04T00-00-hook-contract-research.md`.
+
+- `'blocks when the advertised research file does not exist on disk'` — same path
+  update required.
+
+- `'extracts a quoted research-path value'` — path in the output string must be
+  updated.
+
+- `'returns true for valid research filenames'` — `Test-IsValidResearchFileName`
+  operates on the filename only (not the full path), so this test may not need
+  updating unless the test passes an artifacts-rooted path as the argument.
+
+- `'returns false for invalid research filenames'` — same, no change required if
+  test uses filename only.
+
+- `Test-AutomationFeasibilitySection` tests — all use `artifacts/research/` paths
+  as the `$researchPath` parameter. These must be updated to use new-root paths.
+
+- `'blocks termination when a matching artifact omits the Automation Feasibility
+  section'` — path must be updated.
+
+**New test cases to add:**
+
+- Feature-folder path is accepted: `docs/features/active/some-feature-227/research/2026-06-24T13-02-some-feature-research.md` → allowed.
+- One-off path is accepted: `docs/research/2026-06-24T13-02-some-topic-research.md` → allowed.
+- Old path is rejected: `artifacts/research/2026-06-24T13-02-some-topic-research.md` → blocked with message referencing new roots.
+- Path under `docs/features/` without `/research/` segment is rejected: `docs/features/active/some-feature/2026-06-24T13-02-some-feature-research.md` → blocked.
+- Path under `docs/features/` with correct `/research/` segment but wrong filename is rejected: `docs/features/active/some-feature/research/bad-name.md` → blocked with filename convention message.
+
+### `enforce-evidence-locations.Tests.ps1`
+
+- `'allows writes to artifacts/research/ (permitted research path)'` — this test
+  must be **changed to a rejection test**: `artifacts/research/notes.md` must now
+  produce `decision: block` with `EVIDENCE_LOCATION_BLOCKED`.
+
+- Two new allow tests must be added:
+  - `'allows writes to docs/features/ research subfolder (new canonical feature research path)'` with path `docs/features/active/my-feature/research/2026-06-24T13-02-foo-research.md` → `decision: allow`.
+  - `'allows writes to docs/research/ (new canonical one-off research path)'` with path `docs/research/2026-06-24T13-02-foo-research.md` → `decision: allow`.
+
+### `test_validate_evidence_locations.py`
+
+- `test_clean_tree_exits_zero`: the `allowed_paths` list includes
+  `Path("/fake/repo/artifacts/research/notes.md")`. After the change, this
+  path is forbidden. It must be removed and replaced with a new-root path,
+  e.g., `Path("/fake/repo/docs/features/active/my-feature/research/note.md")`.
+
+- `test_seeded_violation_exits_one`: the seeded violation uses
+  `artifacts/baselines/seeded.md`. This test does not need a path change, but
+  the implementation must also forbid `artifacts/research/`, so a new test case
+  should be added specifically seeding `artifacts/research/seeded.md` and
+  verifying it is reported as a violation with a canonical suggestion.
+
+- New test: `test_artifacts_research_is_forbidden`: seeds a file at
+  `artifacts/research/seeded.md` and verifies `find_forbidden_paths` yields
+  exactly one violation with a canonical suggestion referencing the new paths.
+
+---
+
+## Additional Findings from Grep
+
+The `docs/features/` tree contains numerous historical references to
+`artifacts/research/` in plan files, feature-audit files, and archive
+documents. These are historical records of the old contract and do not require
+update — they are not enforcement or instruction files. Only the
+operational/enforcement files listed in the per-file inventory above require
+change.
+
+The `docs/engineering/claude-code-architecture.md` references
+`artifacts/research/` in an architectural description. This is documentation and
+should be updated for accuracy but is not a blocking enforcement concern.
+
+`testResults.xml` contains test output from a prior Pester run and references
+`artifacts/research/` in test result labels. This file is generated, not
+authored, and requires no direct change.

--- a/docs/features/active/2026-06-24-relocate-research-canonical-location-227/spec.md
+++ b/docs/features/active/2026-06-24-relocate-research-canonical-location-227/spec.md
@@ -1,0 +1,285 @@
+# relocate-research-canonical-location - Refactor Spec
+
+- **Issue:** #227
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-24T13-09
+- **Status:** Draft
+- **Version:** 0.2
+
+## Intent & Outcomes
+
+### Problem Statement
+
+The research step of orchestration writes research files to `artifacts/research/`. The repository `.gitignore` ignores `artifacts` (line 6, a bare entry that matches the `artifacts/` tree at any depth), so research output is never tracked in version control. Research artifacts contain substantive findings (current-state analysis, candidate approaches, requirements mapping, file inventories) that are valuable to retain alongside the feature they support. Because the path is under the ignored `artifacts/` tree, these findings are lost on every clean checkout.
+
+### Motivation
+
+Research output that supports a feature should be durable and versioned alongside that feature. The fix is to relocate the canonical research output to two git-tracked roots under `docs/` and to update every enforcement point, instruction surface, agent write-path allowlist, and test that currently assumes `artifacts/research/`, consistently across the Claude, Codex, and GitHub Copilot ecosystems and their bundled extension copies.
+
+### Outcomes
+
+1. Feature-associated research is written to `<FEATURE>/research/<timestamp>-<short-name>-research.md` (for example `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`).
+2. One-off research not associated with a feature is written to `docs/research/<timestamp>-<short-name>-research.md`.
+3. `artifacts/research/` is no longer the canonical target and is rejected by the enforcement hooks and the Python evidence-location validator.
+4. Both tracked research roots resolve to git-tracked paths (not under the ignored `artifacts/` tree).
+
+## Invariants (must not change)
+
+- **Filename convention:** The timestamp-and-name filename convention is preserved. Files continue to use `<timestamp>-<short-name>-research.md`, where `<timestamp>` uses the existing `yyyy-MM-ddTHH-mm` format (for example `2026-06-24T13-02`). The validating regex `^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-[A-Za-z0-9][A-Za-z0-9-]*-research\.md$` operates on the filename only and does not change.
+- **`research-path` reporting token:** The `SubagentStop` inline hook regex in `.claude/settings.json` accepts the `research-path` token regardless of the path value. This token remains the contract; no functional change to the regex is required.
+- **`enforce-evidence-locations` exclusion-only model:** The hook continues to use an exclusion-only model (forbidden-prefix list; paths not on the list pass through). The model itself does not change; only the forbidden-prefix membership and docstring change.
+- **Evidence-location enforcement for non-research paths:** Enforcement behavior for all non-research evidence paths (baselines, QA gates, coverage, regression results) remains unchanged.
+- **Performance characteristics:** No performance-sensitive behavior is involved. Hook and validator execution remain string/regex operations with no measurable latency change expected.
+- **Compatibility guarantees:** No CLI flags, config schemas, or versioned external interfaces are altered. The change is a relocation of a path contract within the customization/enforcement layer.
+
+## Scope (structural changes)
+
+Change the canonical research output location across all three customization ecosystems (Claude, Codex, GitHub Copilot), including bundled extension copies, so research is persisted in tracked locations:
+
+- Feature-associated research: `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`.
+- One-off research: `docs/research/<timestamp>-<short-name>-research.md`.
+
+The validation hooks, agent write-path allowlists, skills, prompts, and tests that currently assume `artifacts/research/` must be updated to the new contract consistently across ecosystems and their bundled copies.
+
+### In-Scope File Inventory (by ecosystem)
+
+**Claude ecosystem (root):**
+- `.claude/agents/task-researcher.md` — frontmatter `tools` write allowlist, description metadata, and body output-location prose.
+- `.claude/agents/orchestrator.md` — delegation prose referencing the research output path.
+- `.claude/skills/research-issue/SKILL.md` — output-path prose and description metadata.
+- `.claude/skills/orchestrate/SKILL.md` — delegation prose and the `artifacts/research/` entry in the Evidence Location Authority permitted-sub-path list.
+- `.claude/skills/evidence-and-timestamp-conventions/SKILL.md` — `artifacts/research/` entry in the allowed `artifacts/` sub-paths list (to be removed; research is no longer an `artifacts/` path).
+- `.claude/hooks/validate-task-researcher-output.ps1` — `Test-IsUnderResearchRoot` root-check logic and three hard-coded `artifacts/research/` error messages.
+- `.claude/hooks/enforce-evidence-locations.ps1` — docstring/allowed-path documentation update, plus addition of `artifacts/research/` to the forbidden-prefix set.
+- `.claude/settings.json` — no functional change required (`research-path` token and `Write(/artifacts/**)` orchestrator allowlist are unaffected); update any descriptive text if present.
+
+**Claude ecosystem (bundled copy — content verified byte-for-byte identical to root):**
+- `extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/agents/orchestrator.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/skills/research-issue/SKILL.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/skills/orchestrate/SKILL.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1`
+- `extensions/drm-copilot/resources/claude-customizations/.claude/settings.json`
+
+**Codex ecosystem (bundled):**
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml` — embedded write allowlist (`"Write(/artifacts/research/**)"`), embedded body prose (mirrors the Claude agent), and the stop-hook text that confirms the artifact path under `artifacts/research/`.
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml` — delegation prose in `developer_instructions`.
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1` — docstring update (mirrors the Claude hook).
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md`
+- `extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md`
+
+**GitHub Copilot ecosystem (root):**
+- `.github/agents/task-researcher.agent.md` — role-definition prose, operational constraint, and collaborative-process references that describe `artifacts/research/` as the (untracked) scratch area.
+- `.github/prompts/research-issue.prompt.md` — output-path prose, filename-convention example, and operating-rules reference.
+- `.github/prompts/fillout-prd-feature.prompt.md` — research-path reference that instructs callers to include research file paths under `artifacts/research`.
+
+**GitHub Copilot ecosystem (bundled copy — content verified identical to root):**
+- `extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md`
+- `extensions/drm-copilot/resources/customizations/.github/prompts/research-issue.prompt.md`
+- `extensions/drm-copilot/resources/customizations/.github/prompts/fillout-prd-feature.prompt.md`
+
+**Hooks (called out for testing emphasis):**
+- `.claude/hooks/validate-task-researcher-output.ps1` and its bundled mirror.
+- `.claude/hooks/enforce-evidence-locations.ps1`, its Claude bundled mirror, and the Codex bundled copy.
+
+**Validators (Python):**
+- `scripts/dev_tools/validate_evidence_locations.py` — `_FORBIDDEN_PREFIX_TO_CANONICAL` dict; add `artifacts/research/` with a canonical suggestion pointing to the two new roots.
+
+**Tests:**
+- `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1`
+- `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`
+- `tests/scripts/dev_tools/test_validate_evidence_locations.py`
+
+## Non-Goals
+
+- **Migrating existing historical `artifacts/research/` files.** Existing archived research under `artifacts/research/` is historical and is not migrated, moved, or rewritten by this change.
+- **Changing `.gitignore`.** No `.gitignore` modification is required. `docs/` is already tracked, so `docs/features/active/` and `docs/research/` are tracked by default. The `artifacts` entry remains unchanged.
+- **Updating historical feature documents.** Plan files, feature-audit files, and archive documents that reference `artifacts/research/` as context are historical records, not enforcement or instruction files, and are out of scope.
+- **Updating generated files.** `testResults.xml` and similar generated outputs are not authored and are out of scope.
+- **Re-architecting the research workflow.** This is a relocation of a path contract, not a new behavioral system. No redirect shim, new routing service, or architectural redesign is introduced.
+
+## Dependencies / Touchpoints
+
+- **Cross-ecosystem mirrors:** Each root Claude and GitHub Copilot file has a bundled mirror under `extensions/drm-copilot/resources/`. The root copy is the source of truth; the bundled copy must remain identical after the change.
+- **Codex translation:** The Codex `.toml` agents and `.agents/skills/` files are separate translations with no root-repo counterpart. The `translate-claude-to-codex` skill is the documented propagation mechanism. The Codex `task-researcher.toml` embeds the Claude agent frontmatter and body verbatim inside `developer_instructions` and also contains a stop-hook body that references `artifacts/research/` directly; both the embedded sections and the stop-hook body must be updated as part of this change.
+- **Orchestrator routing input:** The orchestrator determines which research root to use before delegating to `task-researcher`, based on whether an active feature folder is in scope (`feature-folder` in `artifacts/orchestration/orchestrator-state.json`). The resolved output path is passed in the delegation prompt; the `task-researcher` agent does not infer the feature folder independently.
+- **Documentation:** `docs/engineering/claude-code-architecture.md` references `artifacts/research/` in an architectural description. It should be updated for accuracy but is not a blocking enforcement concern.
+- **Required coordination:** None outside this repository. No CI/CD configuration or release tooling depends on the research output path.
+
+## Risks & Mitigations
+
+- **Risk: cross-ecosystem divergence.** The change is contract-wide and must remain consistent across the three ecosystems and their bundled copies; divergence is a regression. **Mitigation:** apply identical edits to each root file and its bundled mirror, and verify content equality after editing; propagate Claude-side changes to the Codex translations.
+- **Risk: weakened enforcement.** Hook regexes and agent write-path allowlists must accept two distinct roots without weakening evidence-location enforcement. **Mitigation:** the dual-root acceptance check in `Test-IsUnderResearchRoot` is explicit (feature-folder path with a `/research/` segment, or `docs/research/`), and `artifacts/research/` is added to the forbidden-prefix set in both the PowerShell hook and the Python validator. Negative tests confirm rejection of the old path and of malformed paths.
+- **Risk: backward compatibility with archived research.** Existing archived research under `artifacts/research/` is historical and is not migrated. **Mitigation:** this is an explicit non-goal; historical references in feature documents are left unchanged.
+- **Risk: filename-convention regression.** The filename convention must remain valid under the new roots. **Mitigation:** the filename regex is unchanged and operates on the filename only; tests assert filename-convention enforcement under both new roots.
+
+## Technical Specifications
+
+### Two-root research contract
+
+**Feature-associated research (orchestration context):**
+```
+docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md
+```
+Example: `docs/features/active/2026-06-24-relocate-research-canonical-location-227/research/2026-06-24T13-02-relocate-research-canonical-location-227-research.md`
+
+**One-off research (no associated feature):**
+```
+docs/research/<timestamp>-<short-name>-research.md
+```
+Example: `docs/research/2026-06-24T14-00-codex-native-ecosystem-research.md`
+
+No `docs/research/` directory currently exists; it is created by the first research file written there (or a `.gitkeep`).
+
+### Filename convention (preserved)
+
+```
+<timestamp>-<short-name>-research.md
+```
+`<timestamp>` uses `yyyy-MM-ddTHH-mm`. The validating regex `^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-[A-Za-z0-9][A-Za-z0-9-]*-research\.md$` is unchanged.
+
+### Hook acceptance/rejection logic
+
+`Test-IsUnderResearchRoot` in `validate-task-researcher-output.ps1` is rewritten to accept either root. Implementation approach: normalize the path to forward slashes, then accept when the path `StartsWith('docs/features/')` and contains a `/research/` segment after the feature folder, OR when the path `StartsWith('docs/research/')`. Both checks are case-insensitive. Acceptance/rejection matrix:
+
+```
+Accepted: docs/features/**/research/<timestamp>-<short-name>-research.md
+Accepted: docs/research/<timestamp>-<short-name>-research.md
+Rejected: artifacts/research/...
+Rejected: docs/features/**/<file>  (no /research/ segment)
+Rejected: any other path
+```
+
+The three error messages in the hook that currently hard-code `artifacts/research/` (the root-mismatch message, the missing `research-path` guidance, and the filename-convention message) are updated to reference the two new roots.
+
+`enforce-evidence-locations.ps1` requires no logic change to its exclusion-only model. `artifacts/research/` is added to the forbidden-prefix set so that:
+- Block: `artifacts/research/...`
+- Allow: `docs/features/**/research/...`
+- Allow: `docs/research/...`
+
+The docstring/allowed-path documentation in the hook is updated to remove `artifacts/research/` from the permitted set.
+
+`scripts/dev_tools/validate_evidence_locations.py` adds `artifacts/research/` to the `_FORBIDDEN_PREFIX_TO_CANONICAL` dict with a canonical suggestion pointing to the two new roots. Previously `artifacts/research/` was allowed by omission.
+
+### Agent write-path allowlist forms
+
+**Claude `.md` frontmatter — current:**
+```yaml
+tools:
+  - "Write(/artifacts/research/**)"
+```
+**Claude `.md` frontmatter — required new form:**
+```yaml
+tools:
+  - "Write(/docs/features/**/research/**)"
+  - "Write(/docs/research/**)"
+```
+
+**Codex `.toml` embedded frontmatter — current:**
+```
+"Write(/artifacts/research/**)"
+```
+**Codex `.toml` embedded frontmatter — required new form:**
+```
+"Write(/docs/features/**/research/**)"
+"Write(/docs/research/**)"
+```
+
+The Claude `Write(...)` allowlist uses glob syntax with a `/` prefix anchored at repo root; the double-star `**` matches intermediate segments including the `<feature>` folder segment.
+
+### Orchestrator routing decision rule
+
+- If an active feature folder is in scope (`feature-folder` set in `orchestrator-state.json`), write research to `<feature-folder>/research/<timestamp>-<short-name>-research.md`.
+- If no active feature folder is in scope (standalone or ad-hoc investigation), write research to `docs/research/<timestamp>-<short-name>-research.md`.
+
+The orchestrator includes the resolved output path in the delegation prompt to `task-researcher`. The `research-issue` skill and the GitHub Copilot `research-issue` prompt are updated to document both paths and the routing rule, replacing the single `artifacts/research/` instruction.
+
+### Cross-ecosystem consistency requirement
+
+The root copy is the source of truth for each Claude and GitHub Copilot file; its bundled mirror under `extensions/drm-copilot/resources/` must remain identical after the change. The Codex `.toml` agents and `.agents/skills/` files are translations with no root counterpart and must receive the equivalent text changes (the Codex `evidence-and-timestamp-conventions/SKILL.md`, `orchestrate/SKILL.md`, and `research-issue/SKILL.md` mirror their Claude counterparts exactly). Root-versus-bundled divergence, or Claude-versus-Codex divergence, is a regression.
+
+### Data flow or validation adjustments
+
+- `task-researcher` writes only to one of the two new roots; its write-path allowlist enforces this.
+- `validate-task-researcher-output.ps1` validates the reported `research-path` against the dual-root contract and the filename convention.
+- `enforce-evidence-locations.ps1` and `validate_evidence_locations.py` block writes under `artifacts/research/`.
+
+### Logging/telemetry updates
+
+None.
+
+### Migration or backfill needs
+
+None. Historical `artifacts/research/` content is not migrated (see Non-Goals).
+
+## Test Strategy
+
+### `validate-task-researcher-output.Tests.ps1`
+
+- Update existing tests that assert the `artifacts/research/` root and error-message text, and that use `artifacts/research/...` example paths (root-check test, valid-path termination test, missing-file block test, quoted-path extraction test, and the Automation Feasibility section tests) to use valid paths under the new roots.
+- The `Test-IsValidResearchFileName` tests operate on the filename only and require no change unless they pass an `artifacts`-rooted path argument.
+- Add: feature-folder path accepted (`docs/features/active/some-feature-227/research/2026-06-24T13-02-some-feature-research.md`).
+- Add: one-off path accepted (`docs/research/2026-06-24T13-02-some-topic-research.md`).
+- Add: old path rejected (`artifacts/research/2026-06-24T13-02-some-topic-research.md`) with a message referencing the new roots.
+- Add: feature path without a `/research/` segment rejected (`docs/features/active/some-feature/2026-06-24T13-02-some-feature-research.md`).
+- Add: feature path with a correct `/research/` segment but a non-conforming filename rejected (`docs/features/active/some-feature/research/bad-name.md`) with the filename-convention message.
+
+### `enforce-evidence-locations.Tests.ps1`
+
+- Change the existing `'allows writes to artifacts/research/ (permitted research path)'` test into a rejection test: `artifacts/research/notes.md` must produce `decision: block` with `EVIDENCE_LOCATION_BLOCKED`.
+- Add: `docs/features/active/my-feature/research/2026-06-24T13-02-foo-research.md` produces `decision: allow`.
+- Add: `docs/research/2026-06-24T13-02-foo-research.md` produces `decision: allow`.
+
+### `test_validate_evidence_locations.py`
+
+- In `test_clean_tree_exits_zero`, replace the allowed path `Path("/fake/repo/artifacts/research/notes.md")` with a new-root path such as `Path("/fake/repo/docs/features/active/my-feature/research/note.md")`.
+- Add `test_artifacts_research_is_forbidden`: seed a file at `artifacts/research/seeded.md` and verify `find_forbidden_paths` yields exactly one violation with a canonical suggestion referencing the new paths.
+
+### Invariant validation tests
+
+- Filename-convention enforcement asserted under both new roots.
+- Evidence-location enforcement for non-research paths (baselines, QA gates, coverage) confirmed unchanged.
+
+### Coverage impact and targets for changed lines/modules
+
+Coverage thresholds are uniform: line coverage >= 85%, branch coverage >= 75%. Changed lines in the PowerShell hooks and the Python validator must retain coverage at or above these thresholds, with no regression on changed lines.
+
+### Toolchain commands to run (format → lint → type-check → test)
+
+Run the full seven-stage toolchain loop in order until all stages pass in a single pass. For PowerShell: Invoke-Formatter, PSScriptAnalyzer, then Pester for the two hook test files. For Python: Black, Ruff, Pyright, then Pytest for `test_validate_evidence_locations.py`. Architecture-boundary, contract/schema, and integration stages apply where relevant.
+
+### Manual validation steps
+
+- Verify each root file and its bundled mirror are content-identical after edits.
+- Verify the Codex translations contain the equivalent text changes.
+
+## Definition of Done
+
+- [x] Structure matches this spec; legacy `artifacts/research/` path retired and rejected by enforcement
+- [x] Invariants validated with tests (filename convention preserved; non-research evidence enforcement unchanged)
+- [x] Agent write-path allowlists, hooks, validator, skills, and prompts updated across all three ecosystems and bundled copies
+- [x] Edge cases and negative scenarios verified (old path rejected; missing `/research/` segment rejected; non-conforming filename rejected)
+- [x] Tests, linting, and type checks clean
+- [x] Docs updated where accuracy requires (`docs/engineering/claude-code-architecture.md`)
+- [x] Toolchain pass completed (format → lint → type-check → test)
+
+## Acceptance Criteria
+
+Mapped to the issue acceptance criteria; each item is concrete and verifiable.
+
+- [x] Feature-associated research is written to `<FEATURE>/research/<timestamp>-<short-name>-research.md` and one-off research to `docs/research/<timestamp>-<short-name>-research.md`; `artifacts/research/` is no longer the canonical target.
+- [x] The Claude ecosystem (root `.claude/` and bundled `claude-customizations`) reflects the new contract in `task-researcher.md` (frontmatter `tools`, description, body), `orchestrator.md`, `research-issue/SKILL.md`, `orchestrate/SKILL.md`, `evidence-and-timestamp-conventions/SKILL.md`, and both hooks.
+- [x] The Codex ecosystem (bundled `codex-and-agents-customizations`) reflects the new contract in `task-researcher.toml` (embedded frontmatter, body, stop hook), `orchestrator.toml`, the three mirrored skills, and the `enforce-evidence-locations.ps1` docstring.
+- [x] The GitHub Copilot ecosystem (root `.github/` and bundled `customizations`) reflects the new contract in `task-researcher.agent.md`, `research-issue.prompt.md`, and `fillout-prd-feature.prompt.md`.
+- [x] `validate-task-researcher-output.ps1` accepts both new tracked roots and rejects `artifacts/research/`, with three error messages updated; `enforce-evidence-locations.ps1` and `validate_evidence_locations.py` reject `artifacts/research/`; tests updated accordingly in all three test files.
+- [x] Both tracked research locations resolve to git-tracked paths (under `docs/`, not under the ignored `artifacts/` tree); no `.gitignore` change is made.
+- [x] Root copies and their bundled mirrors are content-identical after the change; Codex translations contain the equivalent text changes.
+
+## Seeded Test Conditions (from potential)
+- [x] Hook unit tests for accepted (feature and one-off) and rejected research paths.
+- [x] Filename-convention validation preserved under the new roots.
+- [x] Evidence-location enforcement unaffected for non-research paths.

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/agents/orchestrator.md
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/agents/orchestrator.md
@@ -69,7 +69,7 @@ Delegate exclusively through configured subagents:
 - `atomic-planner` — generates phased implementation plans (planning only)
 - `atomic-executor` — executes approved plans task-by-task (execution only)
 - `feature-review` — produces policy, code, and feature audit artifacts
-- `task-researcher` — performs deep research and writes findings to `artifacts/research/`
+- `task-researcher` — performs deep research and writes findings to the research path the orchestrator resolves before delegating: `docs/features/<feature>/research/` when an active `feature-folder` is in scope in `orchestrator-state.json`, otherwise `docs/research/` for one-off research. The orchestrator passes the resolved path in the delegation prompt.
 
 For required delegated steps, delegation is mandatory. If a handoff cannot be started, resumed, or completed, stop execution and record blocked state. Do not perform the step locally.
 

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/agents/task-researcher.md
@@ -1,13 +1,14 @@
 ---
 name: task-researcher
-description: Research specialist that performs deep investigation and writes structured findings exclusively to artifacts/research/.
+description: Research specialist that performs deep investigation and writes structured findings to the orchestrator-supplied research path under docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).
 model: sonnet
 tools:
   - Read
   - Grep
   - Glob
   - WebFetch
-  - "Write(/artifacts/research/**)"
+  - "Write(/docs/features/**/research/**)"
+  - "Write(/docs/research/**)"
   - evidence-and-timestamp-conventions
 memory: project
 hooks:
@@ -20,13 +21,16 @@ hooks:
 
 # Task Researcher Agent
 
-You are a research-only specialist. You perform deep analysis for task planning and write structured research notes. You do not make changes to source code, configurations, or project files outside `artifacts/research/`.
+You are a research-only specialist. You perform deep analysis for task planning and write structured research notes. You do not make changes to source code, configurations, or project files outside the research root the orchestrator supplies.
 
 ## Output Location
 
-Write all research artifacts to `artifacts/research/` using the filename convention:
+Write each research artifact to the research path the orchestrator supplies in the delegation prompt. There are two tracked research roots:
 
-- `artifacts/research/<timestamp>-<short-name>-research.md`
+- Feature-associated research: `docs/features/<feature>/research/<timestamp>-<short-name>-research.md` (for example `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`).
+- One-off research not tied to a feature: `docs/research/<timestamp>-<short-name>-research.md`.
+
+The orchestrator resolves which root to use from whether an active feature folder is in scope and passes the exact path in the delegation prompt; do not infer the feature folder independently. The filename convention `<timestamp>-<short-name>-research.md` is unchanged.
 
 ## Core Principles
 
@@ -67,7 +71,7 @@ Write all research artifacts to `artifacts/research/` using the filename convent
 
 ## Constraints
 
-- Write only to `artifacts/research/`. Do not modify source code or configurations.
+- Write only to the orchestrator-supplied research path under `docs/features/<feature>/research/` (feature-associated) or `docs/research/` (one-off). Do not modify source code or configurations.
 - Ground all findings in verified evidence.
 - Keep discussion of non-selected approaches brief.
 - Do not claim nested worker delegation.

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1
@@ -137,18 +137,40 @@ function Invoke-EvidenceLocationDecision {
     return [ordered]@{ decision = 'allow' }
 }
 
+function Invoke-EvidenceLocationEntryPoint {
+    <#
+    .SYNOPSIS
+        Runs the evidence-location decision and returns the process exit code.
+    .DESCRIPTION
+        Wraps the dispatch logic that the hook entry point performs so it can be
+        exercised by unit tests. On success it writes the compact JSON decision to
+        the output stream and returns 0. On a hard failure (malformed JSON) it
+        writes the error record and returns 1. This function does not call exit;
+        the thin entry-point wiring converts the returned code into a process exit.
+    .PARAMETER ToolInputRaw
+        The raw JSON string from $env:CLAUDE_TOOL_INPUT.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [string] $ToolInputRaw = $env:CLAUDE_TOOL_INPUT
+    )
+
+    try {
+        $decision = Invoke-EvidenceLocationDecision -ToolInputRaw $ToolInputRaw
+    } catch {
+        Write-Error $_
+        return 1
+    }
+
+    $decision | ConvertTo-Json -Compress | Write-Output
+
+    return 0
+}
+
 # Guard allows dot-sourcing in tests without executing the entrypoint.
 if ($MyInvocation.InvocationName -eq '.') {
     return
 }
 
-try {
-    $decision = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
-} catch {
-    Write-Error $_
-    exit 1
-}
-
-$decision | ConvertTo-Json -Compress | Write-Output
-
-exit 0
+exit (Invoke-EvidenceLocationEntryPoint)

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/hooks/enforce-evidence-locations.ps1
@@ -17,12 +17,15 @@
       - artifacts/evidence/
       - artifacts/regression-testing/
       - artifacts/post-change/
+      - artifacts/research/
 
     All other paths pass through, including canonical evidence paths of the form
     <FEATURE>/evidence/<kind>/ and permitted artifacts/ sub-paths such as
-    artifacts/orchestration/, artifacts/research/, artifacts/pr_context,
-    artifacts/reviews/, artifacts/status/, artifacts/python/, artifacts/pester/,
-    and artifacts/csharp/.
+    artifacts/orchestration/, artifacts/pr_context, artifacts/reviews/,
+    artifacts/status/, artifacts/python/, artifacts/pester/, and
+    artifacts/csharp/. Research output is no longer an artifacts/ sub-path; it
+    is written to the tracked roots docs/features/<feature>/research/
+    (feature-associated) or docs/research/ (one-off).
 
     If the file_path resolves to a forbidden prefix, the script writes a JSON response
     to stdout with 'decision': 'block' and exits with code 0 so Claude Code surfaces
@@ -61,7 +64,8 @@ function Test-EvidenceLocationForbidden {
         'artifacts/coverage/',
         'artifacts/evidence/',
         'artifacts/regression-testing/',
-        'artifacts/post-change/'
+        'artifacts/post-change/',
+        'artifacts/research/'
     )
 
     # Match the prefix either at the start of the string or after any directory separator,

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/hooks/validate-task-researcher-output.ps1
@@ -5,8 +5,10 @@
 .DESCRIPTION
     Blocks termination of the task-researcher subagent unless the agent's
     final output advertises a `research-path` token, the path is rooted
-    under artifacts/research/, matches the documented filename convention,
-    and the file exists on disk.
+    under one of the two tracked research roots
+    (docs/features/<feature>/research/ for feature-associated research, or
+    docs/research/ for one-off research), matches the documented filename
+    convention, and the file exists on disk.
 
 .NOTES
     Reads the hook payload from CLAUDE_HOOK_INPUT as JSON. Exits 0 to allow
@@ -64,7 +66,20 @@ function Test-IsUnderResearchRoot {
     )
 
     $normalized = $Path -replace '\\', '/'
-    return $normalized.StartsWith('artifacts/research/', [System.StringComparison]::OrdinalIgnoreCase)
+
+    # Accept either of the two tracked research roots:
+    #   - feature-associated research: docs/features/<...>/research/<file>
+    #     (a feature-folder path that contains a /research/ segment), or
+    #   - one-off research: docs/research/<file>.
+    # The /research/ segment requirement distinguishes feature research from
+    # other files under docs/features/ (for example spec.md or plan files).
+    $isFeatureResearch =
+    $normalized.StartsWith('docs/features/', [System.StringComparison]::OrdinalIgnoreCase) -and
+    $normalized.IndexOf('/research/', [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    $isOneOffResearch =
+    $normalized.StartsWith('docs/research/', [System.StringComparison]::OrdinalIgnoreCase)
+
+    return ($isFeatureResearch -or $isOneOffResearch)
 }
 
 function Test-IsValidResearchFileName {
@@ -174,15 +189,15 @@ function Invoke-TaskResearcherOutputValidation {
 
     $researchPath = Get-ResearchPathFromOutput -AgentOutput $agentOutput
     if ($null -eq $researchPath) {
-        return @{ Ok = $false; Message = 'task-researcher hook: agent output does not advertise a research-path. Researcher must report `research-path: <path>` pointing to artifacts/research/.' }
+        return @{ Ok = $false; Message = 'task-researcher hook: agent output does not advertise a research-path. Researcher must report `research-path: <path>` pointing to docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).' }
     }
 
     if (-not (Test-IsUnderResearchRoot -Path $researchPath)) {
-        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' is not under artifacts/research/. All research artifacts must be written to artifacts/research/." }
+        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' is not under a tracked research root. All research artifacts must be written to docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off)." }
     }
 
     if (-not (Test-IsValidResearchFileName -Path $researchPath)) {
-        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' does not match the required filename convention `artifacts/research/<timestamp>-<short-name>-research.md`." }
+        return @{ Ok = $false; Message = "task-researcher hook: research-path '$researchPath' does not match the required filename convention `<timestamp>-<short-name>-research.md` under docs/features/<feature>/research/ or docs/research/." }
     }
 
     if (-not (Test-ResearchFile -Path $researchPath)) {
@@ -208,3 +223,4 @@ if (-not $result.Ok) {
 }
 
 exit 0
+

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/skills/evidence-and-timestamp-conventions/SKILL.md
@@ -31,7 +31,6 @@ The following sub-paths under `artifacts/` are FORBIDDEN for evidence output:
 
 Allowed `artifacts/` sub-paths (non-evidence orchestration use only):
 - `artifacts/orchestration/`
-- `artifacts/research/`
 
 No delegation prompt, plan task, or upstream agent instruction may override this scheme. If a caller supplies a non-canonical path, the receiving agent MUST reject it, substitute the canonical path, and record `EVIDENCE_LOCATION_OVERRIDE_REJECTED: <supplied path> replaced with <canonical path>`.
 

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/skills/orchestrate/SKILL.md
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/skills/orchestrate/SKILL.md
@@ -61,7 +61,7 @@ After reading `artifacts/orchestration/orchestrator-state.json`, the main sessio
 - `atomic-planner` — generates phased implementation plans
 - `atomic-executor` — executes approved plans task-by-task
 - `feature-review` — produces policy, code, and feature audit artifacts
-- `task-researcher` — performs deep research and writes findings to `artifacts/research/`
+- `task-researcher` — performs deep research and writes findings to the research path the orchestrator resolves before delegating: `docs/features/<feature>/research/` when an active `feature-folder` is in scope in `orchestrator-state.json`, otherwise `docs/research/` for one-off research. The orchestrator passes the resolved path in the delegation prompt.
 
 The orchestrator does not perform deep implementation itself. It coordinates, tracks state, and enforces completion.
 
@@ -71,7 +71,6 @@ All evidence artifacts produced during orchestration MUST comply with the canoni
 
 Permitted `artifacts/`-rooted sub-paths (non-evidence orchestration use only):
 - `artifacts/orchestration/` — orchestrator state and checkpoints
-- `artifacts/research/` — research outputs from task-researcher
 - `artifacts/pr_context` — PR context artifacts
 - `artifacts/reviews/` — review staging artifacts
 - `artifacts/status/` — status update artifacts

--- a/extensions/drm-copilot/resources/claude-customizations/.claude/skills/research-issue/SKILL.md
+++ b/extensions/drm-copilot/resources/claude-customizations/.claude/skills/research-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-issue
-description: Investigate the best implementation approach for a feature or bug by analyzing the codebase and external references, then writing structured findings to artifacts/research/.
+description: Investigate the best implementation approach for a feature or bug by analyzing the codebase and external references, then writing structured findings to the resolved research path under docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).
 allowed-tools:
   - Read
   - Grep
@@ -22,9 +22,11 @@ Accept one or more feature documents as context:
 
 ## Output
 
-Create or update a single research file:
+Create or update a single research file at one of the two tracked research roots:
 
-- Path: `artifacts/research/<timestamp>-<short-name>-research.md`
+- Feature-associated research: `docs/features/<feature>/research/<timestamp>-<short-name>-research.md` (for example `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`).
+- One-off research not tied to a feature: `docs/research/<timestamp>-<short-name>-research.md`.
+- Routing rule: write to the feature research root when an active feature folder is in scope (the orchestrator supplies the resolved path from `feature-folder` in `orchestrator-state.json`); otherwise write to `docs/research/`. The filename convention `<timestamp>-<short-name>-research.md` is unchanged.
 - Use the Task Researcher template from the repository exactly.
 - Place rejected-alternatives summaries inside `## Recommended Approach`, not as a separate top-level header.
 

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/evidence-and-timestamp-conventions/SKILL.md
@@ -31,7 +31,6 @@ The following sub-paths under `artifacts/` are FORBIDDEN for evidence output:
 
 Allowed `artifacts/` sub-paths (non-evidence orchestration use only):
 - `artifacts/orchestration/`
-- `artifacts/research/`
 
 No delegation prompt, plan task, or upstream agent instruction may override this scheme. If a caller supplies a non-canonical path, the receiving agent MUST reject it, substitute the canonical path, and record `EVIDENCE_LOCATION_OVERRIDE_REJECTED: <supplied path> replaced with <canonical path>`.
 

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/orchestrate/SKILL.md
@@ -89,7 +89,7 @@ After reading `artifacts/orchestration/orchestrator-state.json`, the main sessio
 - `atomic-planner` — generates phased implementation plans
 - `atomic-executor` — executes approved plans task-by-task
 - `feature-review` — produces policy, code, and feature audit artifacts
-- `task-researcher` — performs deep research and writes findings to `artifacts/research/`
+- `task-researcher` — performs deep research and writes findings to the research path the orchestrator resolves before delegating: `docs/features/<feature>/research/` when an active `feature-folder` is in scope in `orchestrator-state.json`, otherwise `docs/research/` for one-off research. The orchestrator passes the resolved path in the delegation prompt.
 - `prd-feature` — produces issue, specification, and user-story artifacts when required by the selected workflow
 - `staged-review` — reviews staged changes when a pre-commit review is required
 - `epic-review` — reviews epic-level artifacts when the work item is an epic
@@ -125,7 +125,6 @@ All evidence artifacts produced during orchestration MUST comply with the canoni
 
 Permitted `artifacts/`-rooted sub-paths (non-evidence orchestration use only):
 - `artifacts/orchestration/` — orchestrator state and checkpoints
-- `artifacts/research/` — research outputs from task-researcher
 - `artifacts/pr_context` — PR context artifacts
 - `artifacts/reviews/` — review staging artifacts
 - `artifacts/status/` — status update artifacts

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.agents/skills/research-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-issue
-description: Investigate the best implementation approach for a feature or bug by analyzing the codebase and external references, then writing structured findings to artifacts/research/.
+description: Investigate the best implementation approach for a feature or bug by analyzing the codebase and external references, then writing structured findings to the resolved research path under docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).
 ---
 
 # Research Issue Skill
@@ -17,9 +17,11 @@ Accept one or more feature documents as context:
 
 ## Output
 
-Create or update a single research file:
+Create or update a single research file at one of the two tracked research roots:
 
-- Path: `artifacts/research/<timestamp>-<short-name>-research.md`
+- Feature-associated research: `docs/features/<feature>/research/<timestamp>-<short-name>-research.md` (for example `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`).
+- One-off research not tied to a feature: `docs/research/<timestamp>-<short-name>-research.md`.
+- Routing rule: write to the feature research root when an active feature folder is in scope (the orchestrator supplies the resolved path from `feature-folder` in `orchestrator-state.json`); otherwise write to `docs/research/`. The filename convention `<timestamp>-<short-name>-research.md` is unchanged.
 - Use the Task Researcher template from the repository exactly.
 - Place rejected-alternatives summaries inside `## Recommended Approach`, not as a separate top-level header.
 

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/orchestrator.toml
@@ -45,7 +45,7 @@ Delegate exclusively through configured subagents for required specialist steps:
 - `atomic-planner`: planning only.
 - `atomic-executor`: preflight validation and execution only.
 - `feature-review`: policy, code, and feature audit artifacts.
-- `task-researcher`: research artifacts under `artifacts/research/`.
+- `task-researcher`: research artifacts under the research path the orchestrator resolves before delegating — `docs/features/<feature>/research/` when an active `feature-folder` is in scope in `orchestrator-state.json`, otherwise `docs/research/` for one-off research; the orchestrator passes the resolved path in the delegation prompt.
 - `prd-feature`: issue, specification, and user-story authoring when full feature or bug workflow requires it.
 - `staged-review`: staged-diff review when the workflow requires pre-commit inspection.
 - `epic-review`: epic-level review when the promoted work item is an epic.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/agents/task-researcher.toml
@@ -23,31 +23,35 @@ Migration contract:
 
 ---
 name: task-researcher
-description: Research specialist that performs deep investigation and writes structured findings exclusively to artifacts/research/.
+description: Research specialist that performs deep investigation and writes structured findings to the orchestrator-supplied research path under docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off).
 model: sonnet
 tools:
   - Read
   - Grep
   - Glob
   - WebFetch
-  - "Write(/artifacts/research/**)"
+  - "Write(/docs/features/**/research/**)"
+  - "Write(/docs/research/**)"
   - evidence-and-timestamp-conventions
 memory: project
 hooks:
   Stop:
     - matcher: ""
-      body: "Block termination unless research artifact path has been confirmed on disk under artifacts/research/."
+      body: "Block termination unless research artifact path has been confirmed on disk under docs/features/<feature>/research/ (feature-associated) or docs/research/ (one-off)."
 ---
 
 # Task Researcher Agent
 
-You are a research-only specialist. You perform deep analysis for task planning and write structured research notes. You do not make changes to source code, configurations, or project files outside `artifacts/research/`.
+You are a research-only specialist. You perform deep analysis for task planning and write structured research notes. You do not make changes to source code, configurations, or project files outside the research root the orchestrator supplies.
 
 ## Output Location
 
-Write all research artifacts to `artifacts/research/` using the filename convention:
+Write each research artifact to the research path the orchestrator supplies in the delegation prompt. There are two tracked research roots:
 
-- `artifacts/research/<timestamp>-<short-name>-research.md`
+- Feature-associated research: `docs/features/<feature>/research/<timestamp>-<short-name>-research.md` (for example `docs/features/active/<feature>/research/<timestamp>-<short-name>-research.md`).
+- One-off research not tied to a feature: `docs/research/<timestamp>-<short-name>-research.md`.
+
+The orchestrator resolves which root to use from whether an active feature folder is in scope and passes the exact path in the delegation prompt; do not infer the feature folder independently. The filename convention `<timestamp>-<short-name>-research.md` is unchanged.
 
 ## Core Principles
 
@@ -88,7 +92,7 @@ Write all research artifacts to `artifacts/research/` using the filename convent
 
 ## Constraints
 
-- Write only to `artifacts/research/`. Do not modify source code or configurations.
+- Write only to the orchestrator-supplied research path under `docs/features/<feature>/research/` (feature-associated) or `docs/research/` (one-off). Do not modify source code or configurations.
 - Ground all findings in verified evidence.
 - Keep discussion of non-selected approaches brief.
 - Do not claim nested worker delegation.

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1
@@ -20,12 +20,15 @@
       - artifacts/evidence/
       - artifacts/regression-testing/
       - artifacts/post-change/
+      - artifacts/research/
 
     All other paths pass through, including canonical evidence paths of the form
     <FEATURE>/evidence/<kind>/ and permitted artifacts/ sub-paths such as
-    artifacts/orchestration/, artifacts/research/, artifacts/pr_context,
-    artifacts/reviews/, artifacts/status/, artifacts/python/, artifacts/pester/,
-    and artifacts/csharp/.
+    artifacts/orchestration/, artifacts/pr_context, artifacts/reviews/,
+    artifacts/status/, artifacts/python/, artifacts/pester/, and
+    artifacts/csharp/. Research output is no longer an artifacts/ sub-path; it
+    is written to the tracked roots docs/features/<feature>/research/
+    (feature-associated) or docs/research/ (one-off).
 
     If the file_path resolves to a forbidden prefix, the script writes a JSON response
     to stdout with 'decision': 'block' and exits with code 0 so Claude Code surfaces
@@ -64,7 +67,8 @@ function Test-EvidenceLocationForbidden {
         'artifacts/coverage/',
         'artifacts/evidence/',
         'artifacts/regression-testing/',
-        'artifacts/post-change/'
+        'artifacts/post-change/',
+        'artifacts/research/'
     )
 
     # Match the prefix either at the start of the string or after any directory separator,

--- a/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1
+++ b/extensions/drm-copilot/resources/codex-and-agents-customizations/.codex/hooks/enforce-evidence-locations.ps1
@@ -140,18 +140,40 @@ function Invoke-EvidenceLocationDecision {
     return [ordered]@{ decision = 'allow' }
 }
 
+function Invoke-EvidenceLocationEntryPoint {
+    <#
+    .SYNOPSIS
+        Runs the evidence-location decision and returns the process exit code.
+    .DESCRIPTION
+        Wraps the dispatch logic that the hook entry point performs so it can be
+        exercised by unit tests. On success it writes the compact JSON decision to
+        the output stream and returns 0. On a hard failure (malformed JSON) it
+        writes the error record and returns 1. This function does not call exit;
+        the thin entry-point wiring converts the returned code into a process exit.
+    .PARAMETER ToolInputRaw
+        The raw JSON string from $env:CLAUDE_TOOL_INPUT.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [string] $ToolInputRaw = $env:CLAUDE_TOOL_INPUT
+    )
+
+    try {
+        $decision = Invoke-EvidenceLocationDecision -ToolInputRaw $ToolInputRaw
+    } catch {
+        Write-Error $_
+        return 1
+    }
+
+    $decision | ConvertTo-Json -Compress | Write-Output
+
+    return 0
+}
+
 # Guard allows dot-sourcing in tests without executing the entrypoint.
 if ($MyInvocation.InvocationName -eq '.') {
     return
 }
 
-try {
-    $decision = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
-} catch {
-    Write-Error $_
-    exit 1
-}
-
-$decision | ConvertTo-Json -Compress | Write-Output
-
-exit 0
+exit (Invoke-EvidenceLocationEntryPoint)

--- a/extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md
+++ b/extensions/drm-copilot/resources/customizations/.github/agents/task-researcher.agent.md
@@ -8,13 +8,13 @@ tools: [vscode/getProjectSetupInfo, vscode/installExtension, vscode/newWorkspace
 
 ## Role Definition
 
-You are a research-only specialist who performs deep, comprehensive analysis for task planning. Your sole responsibility is to write transient research notes in the untracked scratch area `artifacts/research/`. You MUST NOT make changes to any other files, code, or configurations.
+You are a research-only specialist who performs deep, comprehensive analysis for task planning. Your sole responsibility is to write research notes to one of the two tracked research roots: `docs/features/<feature>/research/` for feature-associated research, or `docs/research/` for one-off research not tied to a feature. The orchestrator resolves which root to use and supplies the path; do not infer the feature folder independently. You MUST NOT make changes to any other files, code, or configurations.
 
 ## Core Research Principles
 
 You MUST operate under these constraints:
 
-- You WILL ONLY do deep research using ALL available tools and create/edit files in `artifacts/research/` (intentionally untracked scratch space) without modifying source code or configurations
+- You WILL ONLY do deep research using ALL available tools and create/edit files in the orchestrator-supplied research root (`docs/features/<feature>/research/` for feature-associated research, or `docs/research/` for one-off research) without modifying source code or configurations
 - You WILL document ONLY verified findings from actual tool usage, never assumptions, ensuring all research is backed by concrete evidence
 - You MUST cross-reference findings across multiple authoritative sources to validate accuracy
 - You WILL understand underlying principles and implementation rationale beyond surface-level patterns
@@ -71,7 +71,7 @@ In the final research document, "remove alternatives" means:
 
 ## Operational Constraints
 
-You WILL use read tools throughout the entire workspace and external sources. You MUST create and edit files ONLY in `artifacts/research/`. You MUST NOT modify any source code, configurations, or other project files.
+You WILL use read tools throughout the entire workspace and external sources. You MUST create and edit files ONLY in the orchestrator-supplied research root: `docs/features/<feature>/research/` (feature-associated) or `docs/research/` (one-off). You MUST NOT modify any source code, configurations, or other project files.
 
 You WILL provide brief, focused updates without overwhelming details. You WILL present discoveries and guide user toward single solution selection. You WILL keep all conversation focused on research activities and findings. You WILL NEVER repeat information already documented in research files.
 
@@ -205,7 +205,7 @@ For each research activity, you MUST:
 
 You MUST maintain research files as living documents:
 
-1. Search for existing research files in `artifacts/research/`
+1. Search for existing research files in the orchestrator-supplied research root (`docs/features/<feature>/research/` for feature-associated research, or `docs/research/` for one-off research)
 2. Create new research file if none exists for the topic
 3. Initialize with comprehensive research template structure
 

--- a/extensions/drm-copilot/resources/customizations/.github/prompts/fillout-prd-feature.prompt.md
+++ b/extensions/drm-copilot/resources/customizations/.github/prompts/fillout-prd-feature.prompt.md
@@ -18,7 +18,7 @@ Use this prompt when invoking the prd_feature agent via `/fillout-prd-feature <p
 
 1. Load each supplied path in order; note missing or unreadable files explicitly.
 2. Extract available details (issue number, owner, status, story statements, constraints, inputs/outputs, CLI flags, personas, risks, acceptance criteria, non-goals).
-3. If research exists under `artifacts/research`, the caller must include the specific research file paths in the `/fillout-prd-feature` command; the agent must read each provided research file before writing.
+3. If research exists under `docs/features/<feature>/research/` (feature-associated) or `docs/research/` (one-off), the caller must include the specific research file paths in the `/fillout-prd-feature` command; the agent must read each provided research file before writing.
 4. Identify gaps; if the research document is insufficient to populate required sections, delegate additional research to the Task Researcher Agent and pause drafting until that research is complete.
 5. Before writing, run a technical completeness check: confirm Proposed Fix, Assumptions, Data/Config Impact, Test Strategy, and Acceptance Criteria can be filled with domain-specific, testable details (no placeholders).
 6. Apply the prd_feature agent’s section guidance when filling content:

--- a/extensions/drm-copilot/resources/customizations/.github/prompts/research-issue.prompt.md
+++ b/extensions/drm-copilot/resources/customizations/.github/prompts/research-issue.prompt.md
@@ -16,7 +16,7 @@ Your output must be actionable for an engineer/agent to implement, and must be g
 
 ## Scope and operating rules
 
-Follow the operating rules in your agent definition (research-only, write to `artifacts/research/`, evidence-based). Do not restate those rules in the research notes; apply them.
+Follow the operating rules in your agent definition (research-only; write to the orchestrator-supplied research root under `docs/features/<feature>/research/` for feature-associated research or `docs/research/` for one-off research; evidence-based). Do not restate those rules in the research notes; apply them.
 
 ## Inputs / Context (authoritative)
 
@@ -31,11 +31,12 @@ Also identify (from the feature docs) the **implementation target files** in the
 
 ## Research Outputs (required)
 
-Create (or update) a single research file under `artifacts/research/` using the Task Researcher template exactly.
+Create (or update) a single research file under the orchestrator-supplied research root using the Task Researcher template exactly. The two tracked research roots are `docs/features/<feature>/research/` (feature-associated; for example `docs/features/active/<feature>/research/`) and `docs/research/` (one-off, not tied to a feature). Routing rule: use the feature research root when an active feature folder is in scope (the orchestrator supplies the resolved path from `feature-folder` in `orchestrator-state.json`); otherwise use `docs/research/`.
 
 Filename convention:
 
-- `artifacts/research/YYYYMMDD-<short-feature-name>-implementation-research.md`
+- `docs/features/<feature>/research/YYYYMMDD-<short-feature-name>-implementation-research.md` (feature-associated), or
+- `docs/research/YYYYMMDD-<short-feature-name>-implementation-research.md` (one-off)
 
 In the research file, keep any discussion of non-selected approaches *brief and non-exhaustive*. After selecting a recommendation, remove detailed notes for other approaches and keep only a short “Rejected alternatives” summary (what was rejected and why).
 

--- a/scripts/dev_tools/validate_evidence_locations.py
+++ b/scripts/dev_tools/validate_evidence_locations.py
@@ -35,6 +35,7 @@ _FORBIDDEN_PREFIX_TO_CANONICAL: dict[str, str] = {
     "artifacts/evidence/": "<FEATURE>/evidence/<kind>/",
     "artifacts/regression-testing/": "<FEATURE>/evidence/qa-gates/",
     "artifacts/post-change/": "<FEATURE>/evidence/qa-gates/",
+    "artifacts/research/": "docs/features/active/<feature>/research/ or docs/research/",
 }
 
 

--- a/tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1
+++ b/tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1
@@ -122,4 +122,50 @@ Describe 'enforce-evidence-locations.ps1' {
                 Should -Throw '*malformed JSON*'
         }
     }
+
+    Context 'entry-point dispatch' {
+        It 'returns exit code 0 and emits allow JSON for an allowed path' {
+            # Arrange — a representative allowed file_path
+            $allowedJson = '{"file_path":"src/hello-typescript.ts"}'
+
+            # Act — the function emits the JSON on the output stream and returns the
+            # int exit code as the final pipeline element; collect both.
+            $emitted = @(Invoke-EvidenceLocationEntryPoint -ToolInputRaw $allowedJson)
+            $code = $emitted[-1]
+            $stdout = ($emitted[0..($emitted.Count - 2)] -join '')
+
+            # Assert — exit code is 0 and emitted JSON is the compact allow decision
+            $code | Should -Be 0
+            $stdout | Should -Match '"decision":"allow"'
+        }
+
+        It 'returns exit code 1 and writes a malformed-JSON error for unparseable input' {
+            # Arrange — unparseable payload triggers the hard-failure path
+            $errorRecords = $null
+
+            # Act — capture the error stream while collecting the function output
+            $emitted = @(Invoke-EvidenceLocationEntryPoint -ToolInputRaw '{ not valid json' -ErrorAction SilentlyContinue -ErrorVariable errorRecords)
+            $code = $emitted[-1]
+
+            # Assert — exit code is 1 and an error record matching the malformed-JSON message was written
+            $code | Should -Be 1
+            $errorRecords | Should -Not -BeNullOrEmpty
+            ($errorRecords | Out-String) | Should -Match 'malformed JSON'
+        }
+
+        It 'returns exit code 0 and emits block JSON for a forbidden path' {
+            # Arrange — a retired/forbidden artifacts/research path
+            $forbiddenJson = '{"file_path":"artifacts/research/notes.md"}'
+
+            # Act — collect the function output and the returned exit code
+            $emitted = @(Invoke-EvidenceLocationEntryPoint -ToolInputRaw $forbiddenJson)
+            $code = $emitted[-1]
+            $stdout = ($emitted[0..($emitted.Count - 2)] -join '')
+
+            # Assert — exit code is 0 and emitted JSON is the compact block decision
+            $code | Should -Be 0
+            $stdout | Should -Match '"decision":"block"'
+            $stdout | Should -Match 'EVIDENCE_LOCATION_BLOCKED'
+        }
+    }
 }

--- a/tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1
+++ b/tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1
@@ -37,15 +37,17 @@ Describe 'enforce-evidence-locations.ps1' {
             $result.decision | Should -Be 'allow'
         }
 
-        It 'allows writes to artifacts/research/ (permitted research path)' {
-            # Arrange
+        It 'blocks writes to artifacts/research/ (retired research path)' {
+            # Arrange — research is no longer a permitted artifacts/ sub-path;
+            # it must now resolve to a tracked docs/ root and is blocked here.
             $env:CLAUDE_TOOL_INPUT = '{"file_path":"artifacts/research/notes.md"}'
 
             # Act
             $result = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
 
             # Assert
-            $result.decision | Should -Be 'allow'
+            $result.decision | Should -Be 'block'
+            $result.reason | Should -Match 'EVIDENCE_LOCATION_BLOCKED'
         }
     }
 
@@ -53,6 +55,28 @@ Describe 'enforce-evidence-locations.ps1' {
         It 'allows writes to <FEATURE>/evidence/baseline/ (canonical evidence path)' {
             # Arrange: a full canonical evidence path inside a feature folder
             $env:CLAUDE_TOOL_INPUT = '{"file_path":"docs/features/active/my-feature/evidence/baseline/baseline.md"}'
+
+            # Act
+            $result = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
+
+            # Assert
+            $result.decision | Should -Be 'allow'
+        }
+
+        It 'allows writes to docs/features/ research subfolder (new canonical feature research path)' {
+            # Arrange: feature-associated research now resolves to a tracked docs/ root
+            $env:CLAUDE_TOOL_INPUT = '{"file_path":"docs/features/active/my-feature/research/2026-06-24T13-02-foo-research.md"}'
+
+            # Act
+            $result = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
+
+            # Assert
+            $result.decision | Should -Be 'allow'
+        }
+
+        It 'allows writes to docs/research/ (new canonical one-off research path)' {
+            # Arrange: one-off research now resolves to the tracked docs/research/ root
+            $env:CLAUDE_TOOL_INPUT = '{"file_path":"docs/research/2026-06-24T13-02-foo-research.md"}'
 
             # Act
             $result = Invoke-EvidenceLocationDecision -ToolInputRaw $env:CLAUDE_TOOL_INPUT
@@ -72,6 +96,30 @@ Describe 'enforce-evidence-locations.ps1' {
 
             # Assert
             $result.decision | Should -Be 'allow'
+        }
+    }
+
+    Context 'input edge cases' {
+        It 'allows when the tool input is empty (no file_path to evaluate)' {
+            # Arrange — empty raw input represents a non-file tool call
+            $result = Invoke-EvidenceLocationDecision -ToolInputRaw ''
+
+            # Assert
+            $result.decision | Should -Be 'allow'
+        }
+
+        It 'allows when the JSON has no file_path field' {
+            # Arrange — valid JSON object that carries no file_path
+            $result = Invoke-EvidenceLocationDecision -ToolInputRaw '{"other":"value"}'
+
+            # Assert
+            $result.decision | Should -Be 'allow'
+        }
+
+        It 'throws on malformed JSON input' {
+            # Arrange — unparseable payload triggers the hard-failure path
+            { Invoke-EvidenceLocationDecision -ToolInputRaw '{ not valid json' } |
+                Should -Throw '*malformed JSON*'
         }
     }
 }

--- a/tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1
+++ b/tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1
@@ -53,18 +53,18 @@ Describe 'validate-task-researcher-output.ps1' {
     }
 
     Context 'research root and filename enforcement' {
-        It 'blocks when the research-path is not under artifacts/research/' {
+        It 'blocks when the research-path is not under a tracked research root' {
             $raw = @{ output = 'research-path: docs/features/active/foo/notes.md' } | ConvertTo-Json -Compress
 
             $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
 
             $result.Ok | Should -BeFalse
-            $result.Message | Should -Match 'is not under artifacts/research/'
+            $result.Message | Should -Match 'is not under a tracked research root'
         }
 
         It 'blocks when the research-path filename does not match the documented convention' {
             Mock -CommandName Test-ResearchFile -MockWith { $true }
-            $raw = @{ output = 'research-path: artifacts/research/foo.md' } | ConvertTo-Json -Compress
+            $raw = @{ output = 'research-path: docs/features/active/foo/research/foo.md' } | ConvertTo-Json -Compress
 
             $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
 
@@ -74,7 +74,7 @@ Describe 'validate-task-researcher-output.ps1' {
 
         It 'allows termination when the research-path is valid and the file exists' {
             Mock -CommandName Test-ResearchFile -MockWith { $true }
-            $raw = @{ output = 'research-path: artifacts/research/2026-05-04T00-00-hook-contract-research.md' } | ConvertTo-Json -Compress
+            $raw = @{ output = 'research-path: docs/features/active/foo/research/2026-05-04T00-00-hook-contract-research.md' } | ConvertTo-Json -Compress
 
             $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
 
@@ -85,7 +85,7 @@ Describe 'validate-task-researcher-output.ps1' {
         It 'blocks when the advertised research file does not exist on disk' {
             # Arrange - valid path and filename, but the file is absent
             Mock -CommandName Test-ResearchFile -MockWith { $false }
-            $raw = @{ output = 'research-path: artifacts/research/2026-05-04T00-00-hook-contract-research.md' } | ConvertTo-Json -Compress
+            $raw = @{ output = 'research-path: docs/features/active/foo/research/2026-05-04T00-00-hook-contract-research.md' } | ConvertTo-Json -Compress
 
             # Act
             $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
@@ -96,19 +96,88 @@ Describe 'validate-task-researcher-output.ps1' {
         }
     }
 
+    Context 'dual-root research contract' {
+        It 'accepts a feature-folder research path' {
+            # Arrange - feature-associated research under docs/features/.../research/
+            Mock -CommandName Test-ResearchFile -MockWith { $true }
+            $raw = @{ output = 'research-path: docs/features/active/some-feature-227/research/2026-06-24T13-02-some-feature-research.md' } | ConvertTo-Json -Compress
+
+            # Act
+            $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
+
+            # Assert
+            $result.Ok | Should -BeTrue
+            $result.Message | Should -BeNullOrEmpty
+        }
+
+        It 'accepts a one-off research path under docs/research/' {
+            # Arrange - one-off research under docs/research/
+            Mock -CommandName Test-ResearchFile -MockWith { $true }
+            $raw = @{ output = 'research-path: docs/research/2026-06-24T13-02-some-topic-research.md' } | ConvertTo-Json -Compress
+
+            # Act
+            $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
+
+            # Assert
+            $result.Ok | Should -BeTrue
+            $result.Message | Should -BeNullOrEmpty
+        }
+
+        It 'rejects the retired artifacts/research/ path with a message naming the new roots' {
+            # Arrange - the old artifacts/research/ root is no longer accepted
+            Mock -CommandName Test-ResearchFile -MockWith { $true }
+            $raw = @{ output = 'research-path: artifacts/research/2026-06-24T13-02-some-topic-research.md' } | ConvertTo-Json -Compress
+
+            # Act
+            $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
+
+            # Assert
+            $result.Ok | Should -BeFalse
+            $result.Message | Should -Match 'is not under a tracked research root'
+            $result.Message | Should -Match 'docs/features/<feature>/research/'
+            $result.Message | Should -Match 'docs/research/'
+        }
+
+        It 'rejects a feature path that lacks a /research/ segment' {
+            # Arrange - under docs/features/ but with no /research/ segment
+            Mock -CommandName Test-ResearchFile -MockWith { $true }
+            $raw = @{ output = 'research-path: docs/features/active/some-feature/2026-06-24T13-02-some-feature-research.md' } | ConvertTo-Json -Compress
+
+            # Act
+            $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
+
+            # Assert
+            $result.Ok | Should -BeFalse
+            $result.Message | Should -Match 'is not under a tracked research root'
+        }
+
+        It 'rejects a feature research path whose filename does not conform' {
+            # Arrange - correct /research/ segment but non-conforming filename
+            Mock -CommandName Test-ResearchFile -MockWith { $true }
+            $raw = @{ output = 'research-path: docs/features/active/some-feature/research/bad-name.md' } | ConvertTo-Json -Compress
+
+            # Act
+            $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
+
+            # Assert
+            $result.Ok | Should -BeFalse
+            $result.Message | Should -Match 'filename convention'
+        }
+    }
+
     Context 'helper functions' {
         It 'extracts a quoted research-path value' {
-            Get-ResearchPathFromOutput -AgentOutput 'research-path: "artifacts/research/2026-05-04T00-00-foo-research.md"' |
-                Should -Be 'artifacts/research/2026-05-04T00-00-foo-research.md'
+            Get-ResearchPathFromOutput -AgentOutput 'research-path: "docs/research/2026-05-04T00-00-foo-research.md"' |
+                Should -Be 'docs/research/2026-05-04T00-00-foo-research.md'
         }
 
         It 'returns true for valid research filenames' {
-            Test-IsValidResearchFileName -Path 'artifacts/research/2026-05-04T00-00-foo-research.md' |
+            Test-IsValidResearchFileName -Path 'docs/research/2026-05-04T00-00-foo-research.md' |
                 Should -BeTrue
         }
 
         It 'returns false for invalid research filenames' {
-            Test-IsValidResearchFileName -Path 'artifacts/research/foo.md' |
+            Test-IsValidResearchFileName -Path 'docs/research/foo.md' |
                 Should -BeFalse
         }
     }
@@ -117,8 +186,8 @@ Describe 'validate-task-researcher-output.ps1' {
         It 'passes a non-matching research artifact unaffected' {
             # Arrange - neither the filename nor the output mentions the
             # autonomous-execution detection tokens, so the section is not required
-            $researchPath = 'artifacts/research/2026-06-16T11-00-generic-topic-research.md'
-            $agentOutput = 'research-path: artifacts/research/2026-06-16T11-00-generic-topic-research.md'
+            $researchPath = 'docs/features/active/foo/research/2026-06-16T11-00-generic-topic-research.md'
+            $agentOutput = 'research-path: docs/features/active/foo/research/2026-06-16T11-00-generic-topic-research.md'
             $readStub = { param($Path) '# Generic research, no automation section' }
 
             # Act
@@ -132,8 +201,8 @@ Describe 'validate-task-researcher-output.ps1' {
         It 'blocks a matching artifact (by filename) missing the Automation Feasibility section' {
             # Arrange - the filename matches the detection pattern but the body
             # has no '## Automation Feasibility' heading
-            $researchPath = 'artifacts/research/2026-06-16T11-00-autonomous-execution-research.md'
-            $agentOutput = 'research-path: artifacts/research/2026-06-16T11-00-autonomous-execution-research.md'
+            $researchPath = 'docs/features/active/foo/research/2026-06-16T11-00-autonomous-execution-research.md'
+            $agentOutput = 'research-path: docs/features/active/foo/research/2026-06-16T11-00-autonomous-execution-research.md'
             $readStub = { param($Path) "# Research`n## Findings`nNo feasibility section here." }
 
             # Act
@@ -147,8 +216,8 @@ Describe 'validate-task-researcher-output.ps1' {
         It 'passes a matching artifact (by content) that includes the Automation Feasibility section' {
             # Arrange - the agent output mentions human-interaction (matching the
             # detection pattern) and the body contains the required heading
-            $researchPath = 'artifacts/research/2026-06-16T11-00-topic-research.md'
-            $agentOutput = 'research-path: artifacts/research/2026-06-16T11-00-topic-research.md (covers human-interaction)'
+            $researchPath = 'docs/research/2026-06-16T11-00-topic-research.md'
+            $agentOutput = 'research-path: docs/research/2026-06-16T11-00-topic-research.md (covers human-interaction)'
             $readStub = { param($Path) "# Research`n## Automation Feasibility`nFully automatable." }
 
             # Act
@@ -161,8 +230,8 @@ Describe 'validate-task-researcher-output.ps1' {
 
         It 'blocks a matching artifact whose body is empty' {
             # Arrange - filename matches the detection pattern but the file body is blank
-            $researchPath = 'artifacts/research/2026-06-16T11-00-autonomous-execution-research.md'
-            $agentOutput = 'research-path: artifacts/research/2026-06-16T11-00-autonomous-execution-research.md'
+            $researchPath = 'docs/features/active/foo/research/2026-06-16T11-00-autonomous-execution-research.md'
+            $agentOutput = 'research-path: docs/features/active/foo/research/2026-06-16T11-00-autonomous-execution-research.md'
             $readStub = { param($Path) '   ' }
 
             # Act
@@ -185,7 +254,7 @@ Describe 'validate-task-researcher-output.ps1' {
             Mock -CommandName Test-AutomationFeasibilitySection -MockWith {
                 @{ Ok = $false; Message = 'task-researcher hook: missing the required automation feasibility section.' }
             }
-            $raw = @{ output = 'research-path: artifacts/research/2026-05-04T00-00-autonomous-execution-research.md' } | ConvertTo-Json -Compress
+            $raw = @{ output = 'research-path: docs/features/active/foo/research/2026-05-04T00-00-autonomous-execution-research.md' } | ConvertTo-Json -Compress
 
             # Act
             $result = Invoke-TaskResearcherOutputValidation -RawPayload $raw
@@ -200,13 +269,13 @@ Describe 'validate-task-researcher-output.ps1' {
         It 'extracts a research-path from a markdown link form' {
             # Arrange - the [research-path](...) markdown form exercises the
             # second regex capture group
-            $output = 'See [research-path](artifacts/research/2026-05-04T00-00-foo-research.md) for details.'
+            $output = 'See [research-path](docs/research/2026-05-04T00-00-foo-research.md) for details.'
 
             # Act
             $value = Get-ResearchPathFromOutput -AgentOutput $output
 
             # Assert
-            $value | Should -Be 'artifacts/research/2026-05-04T00-00-foo-research.md'
+            $value | Should -Be 'docs/research/2026-05-04T00-00-foo-research.md'
         }
     }
 }

--- a/tests/scripts/dev_tools/test_validate_evidence_locations.py
+++ b/tests/scripts/dev_tools/test_validate_evidence_locations.py
@@ -3,6 +3,8 @@
 Covers:
     - find_forbidden_paths yields no results on a tree with no forbidden paths.
     - find_forbidden_paths yields a violation when a forbidden path is present.
+    - artifacts/research/ is treated as a forbidden prefix with a canonical
+      suggestion naming both new tracked research roots.
     - Non-file entries (directories) are skipped.
     - Entries where relative_to raises ValueError are skipped.
     - main() exits 0 with no output for a clean tree.
@@ -36,7 +38,7 @@ def test_clean_tree_exits_zero(monkeypatch: MagicMock) -> None:
         Path("/fake/repo/src/hello.ts"),
         Path("/fake/repo/docs/features/active/feat/evidence/baseline/result.md"),
         Path("/fake/repo/artifacts/orchestration/orchestrator-state.json"),
-        Path("/fake/repo/artifacts/research/notes.md"),
+        Path("/fake/repo/docs/features/active/my-feature/research/note.md"),
     ]
 
     # Each mock path must respond to is_file() → True and relative_to(root)
@@ -90,6 +92,44 @@ def test_seeded_violation_exits_one(monkeypatch: MagicMock) -> None:
     ), "Expected the forbidden mock path to be returned"
     assert "evidence/baseline/" in canonical_suggestion, (
         f"Expected canonical_suggestion to contain 'evidence/baseline/', "
+        f"got: {canonical_suggestion!r}"
+    )
+
+
+def test_artifacts_research_is_forbidden(monkeypatch: MagicMock) -> None:
+    """find_forbidden_paths flags a file under artifacts/research/ as a violation.
+
+    Scenario: rglob returns one file seeded under artifacts/research/ (the retired
+    research root, now forbidden).
+    Expected: exactly one (path, canonical_suggestion) tuple is yielded, and the
+    canonical suggestion references both new tracked research roots.
+    """
+    root = Path("/fake/repo")
+    forbidden_abs = Path("/fake/repo/artifacts/research/seeded.md")
+
+    # Build a mock representing the seeded forbidden research file.
+    forbidden_mock = MagicMock(spec=Path)
+    forbidden_mock.is_file.return_value = True
+    forbidden_mock.relative_to.return_value = forbidden_abs.relative_to(root)
+
+    # Patch rglob to return only the one forbidden file.
+    root_mock = MagicMock(spec=Path)
+    root_mock.rglob.return_value = iter([forbidden_mock])
+
+    results = list(find_forbidden_paths(root_mock))
+
+    # Assert: exactly one violation, with a suggestion naming both new roots.
+    assert len(results) == 1, f"Expected 1 violation but got {len(results)}: {results}"
+    reported_path, canonical_suggestion = results[0]
+    assert (
+        reported_path is forbidden_mock
+    ), "Expected the seeded research mock path to be returned"
+    assert "docs/features/active/<feature>/research/" in canonical_suggestion, (
+        f"Expected canonical_suggestion to name the feature research root, "
+        f"got: {canonical_suggestion!r}"
+    )
+    assert "docs/research/" in canonical_suggestion, (
+        f"Expected canonical_suggestion to name the one-off research root, "
         f"got: {canonical_suggestion!r}"
     )
 


### PR DESCRIPTION
# refactor(research): relocate canonical research output to tracked docs paths

## Summary

- Moves the canonical research output location off the `.gitignore`-excluded `artifacts/` tree so research is retained in version control.
- Feature-associated research is now written to `<FEATURE>/research/<timestamp>-<short-name>-research.md`; one-off research to `docs/research/<timestamp>-<short-name>-research.md`.
- `artifacts/research/` is no longer canonical and is rejected by the enforcement hooks and the Python evidence-location validator.
- Applied consistently across all three customization ecosystems (Claude, Codex, GitHub Copilot) and their bundled extension copies.
- Raises `enforce-evidence-locations.ps1` line coverage by extracting the entry-point dispatch into a testable function.

## Why

The repository `.gitignore` ignores the entire `artifacts/` tree, so research artifacts produced by the orchestration research step were never tracked and were lost on clean checkout, discarding substantive findings. The change relocates research into tracked `docs/` paths so the learnings persist alongside the feature they support. No `.gitignore` change is made; existing historical research under `artifacts/research/` is not migrated.

## What Changed

**Core logic (9 files):**
- `.claude/hooks/validate-task-researcher-output.ps1` — `Test-IsUnderResearchRoot` accepts `docs/features/**/research/` and `docs/research/`, rejects `artifacts/research/`; three error messages and the description updated.
- `.claude/hooks/enforce-evidence-locations.ps1` — adds `artifacts/research/` to the forbidden-prefix set; entry-point dispatch extracted into a testable function.
- `scripts/dev_tools/validate_evidence_locations.py` — adds `artifacts/research/` to the forbidden mapping.
- Bundled mirrors of both hooks under `extensions/drm-copilot/resources/claude-customizations/` and the Codex translation under `codex-and-agents-customizations/`.

**Tests:**
- `tests/scripts/claude-hooks/validate-task-researcher-output.Tests.ps1`, `tests/scripts/claude-hooks/enforce-evidence-locations.Tests.ps1`, and `tests/scripts/dev_tools/test_validate_evidence_locations.py` — accept/reject cases for both new roots; old-path rejection.

**Docs / agents / prompts (instruction surfaces):**
- Claude agents and skills (`task-researcher`, `orchestrator`, `research-issue`, `orchestrate`, `evidence-and-timestamp-conventions`), Codex `.toml` agents and `.agents` skills, and GitHub Copilot `task-researcher.agent.md` / `research-issue.prompt.md` / `fillout-prd-feature.prompt.md`, plus their bundled mirrors. task-researcher write-path allowlists replace `artifacts/research` with the two tracked roots.

## Architecture / How It Fits Together

The research-output contract is expressed in three coordinated layers: agent write-path allowlists (where research files may be written), instruction surfaces (skills/prompts that direct the researcher), and enforcement hooks/validators (`validate-task-researcher-output.ps1` at SubagentStop, `enforce-evidence-locations.ps1` at PreToolUse, and `validate_evidence_locations.py`). Root files and their bundled extension copies are kept content-identical; Codex `.toml` files carry the equivalent translated text.

## Verification

Completed (from context bundle):
- PowerShell format and analyze: EXIT 0, 0 findings across the changed hooks and tests.
- Python: `pytest` for `test_validate_evidence_locations.py` with branch coverage — EXIT 0; `validate_evidence_locations.py` reported 100% line and branch coverage.
- Cross-ecosystem equality and Codex equivalence checks: pass.
- Residual `artifacts/research` reference scan: remaining matches classified as intentional (forbidden-prefix entries, rejection-test assertions) only.
- `validate_evidence_locations.py` against a scratch tree containing `artifacts/research/`: EXIT 1 (correctly reports the now-forbidden path).

Recommended:
- `gh pr checks` against the PR head to confirm the required CI checks are green.

## Backward Compatibility / Migration Notes

- No `.gitignore` change.
- Existing historical research under `artifacts/research/` is not migrated; it remains in place and untracked.
- `artifacts/research/` is now a rejected write target for new research and evidence.

## Risks and Mitigations

- Risk: divergence between root files and bundled extension copies. Mitigation: content-equality and Codex-equivalence checks recorded in the feature evidence.
- Risk: weakening evidence-location enforcement for non-research paths. Mitigation: enforcement for non-research paths confirmed unchanged by the hook tests.

## Review Guide

1. Start with the three logic-bearing files: `validate-task-researcher-output.ps1`, `enforce-evidence-locations.ps1`, `validate_evidence_locations.py`.
2. Confirm the corresponding test updates exercise both new roots and the old-path rejection.
3. Skim the bundled mirrors and Codex translation for parity (largely mechanical).
4. Review the instruction-surface prose edits last.

## Follow-ups

- None required for this change.

## GitHub Auto-close

- Closes #227
