### PR TITLE
release: bump extension 0.0.6 and mcp-server 0.0.6

### DIFF
--- a/extensions/drm-copilot/package-lock.json
+++ b/extensions/drm-copilot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drm-copilot",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drm-copilot",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/extensions/drm-copilot/package.json
+++ b/extensions/drm-copilot/package.json
@@ -2,7 +2,7 @@
   "name": "drm-copilot",
   "displayName": "drm-copilot",
   "description": "Extension-side bundled workflow execution utilities and MCP bridge.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "DanMoisan",
   "license": "MIT",
   "repository": {

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danmoisan/drm-copilot-mcp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danmoisan/drm-copilot-mcp",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danmoisan/drm-copilot-mcp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Stdio MCP server exposing drm-copilot repo-automation tools.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
Automated full release version-bump PR. Extension -> 0.0.6, mcp-server -> 0.0.6. Merge to main, then run the post-merge tag-push task to publish.