### PR TITLE
feat(extension): port shared subprocess and utility layer to TypeScript (#240)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ downloads/
 eggs/
 .eggs/
 lib/
+# TypeScript source/test directories named "lib" are not Python build artifacts.
+!extensions/drm-copilot/src/lib/
+!extensions/drm-copilot/src/lib/**
+!extensions/drm-copilot/test/lib/
+!extensions/drm-copilot/test/lib/**
 lib64/
 parts/
 sdist/

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/code-review.2026-06-25T22-50.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/code-review.2026-06-25T22-50.md
@@ -1,0 +1,113 @@
+# Code Review: F1 — TypeScript Shared Subprocess and Utility Layer (Issue #240)
+
+**Review Date:** 2026-06-25
+**Reviewer:** feature-review agent
+**Feature Folder:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+**Feature Folder Selection Rule:** Folder suffix `-240` matches the issue number in the branch name `feat/ts-port-shared-utilities-240` and contains the F1 scoping/plan/evidence docs.
+**Base Branch:** `main` @ `38a9c11ee34895e92b6e38ea5400e7dd07cddc9d`
+**Head Branch:** `feat/ts-port-shared-utilities-240` @ `b7ca64197c13884e8ed9833ee6937b3a9d827c80`
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+F1 delivers the foundational shared layer for the epic's Python-to-TypeScript port: an injectable `FileSystem` abstraction (`RealFileSystem` + interface), a `SubprocessRunner` modeled on `pr_context/git.py`, and ports of `prompt_mode_contract.py`, `json_config.py`, and the pure-logic plus injected-I/O functions of `markdown_label_formatter.py`. The implementation is a faithful, well-documented port: function signatures, return shapes, error-message strings, and reason strings match the Python sources. I/O is isolated behind injected interfaces, keeping all domain logic testable without touching the network, real filesystem, or real subprocesses.
+
+The change comprises 10 TypeScript files (5 src, 5 test; 1,947 lines total, every file under 500), plus a `.gitignore` negation and 17 feature-folder docs. The full TypeScript toolchain was re-run during this review and is clean: Prettier check, ESLint (0 findings), `tsc --noEmit` (0 errors), and Jest with coverage (76 F1 tests pass; src/lib at 97.3% line / 88.13% branch). Implementation quality is high.
+
+**What changed:**
+Five new `src/lib/*.ts` modules and five mirroring `test/lib/*.test.ts` suites were added under `extensions/drm-copilot/`. No existing runtime files (`command-runtime.ts`, `repo-automation-service.ts`, MCP handlers) were modified; F1 is purely additive. `.gitignore` gained negation entries so the new `lib/` paths are tracked (the root `lib/` Python-artifact ignore had otherwise excluded them).
+
+**Top 3 risks:**
+1. Test-framework policy divergence: the package uses Jest while `typescript.md` mandates Vitest. Pre-existing and package-wide, but unreconciled in policy.
+2. Subprocess `rstrip("\n")` parity is correctly implemented, but the `CommandResult` JSDoc misdescribes it as stripping "a single trailing newline," which could mislead future maintainers.
+3. `splitLines` covers only `\n`/`\r`/`\r\n`, whereas Python `str.splitlines()` splits on additional Unicode boundaries; an exotic line separator in input would diverge from the Python source. Low likelihood for chat-transcript inputs.
+
+**PR readiness recommendation:** **Conditional Go** — code is correct, typed, and well-covered; merge is gated only on reconciling the Jest-vs-Vitest policy item and the missing `full-feature` AC source files, both tracked as remediation inputs.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Major | `.claude/rules/typescript.md` vs `extensions/drm-copilot/package.json` | `package.json` scripts/devDeps; rule "Testing — Vitest" | Package uses Jest (`ts-jest`, `@jest/globals`, `run-jest.cjs`) but the TypeScript rule mandates Vitest and Vitest-only facilities. | Reconcile policy: document the extension package's Jest toolchain in `typescript.md`, or plan a Vitest migration. Do not silently diverge. | Policy/implementation mismatch creates ambiguity for future contributors and CI expectations. Pre-existing and package-wide; not a defect in F1 code. | `package.json:188-200` (jest deps, no vitest); `typescript.md` Toolchain step 4; F1 plan "Toolchain Facts" lines 21-29. |
+| Major | `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/` | feature folder root | `full-feature` work mode requires `spec.md` and `user-story.md` as AC sources; neither exists. | Author the epic `spec.md`/`user-story.md`, or formally designate the F1 plan checklist as the AC source for this folder. | The acceptance-criteria contract for `full-feature` cannot resolve its mandated sources; AC tracking falls back to the plan checklist and epic issue. | `ls` of feature folder: no `spec.md`/`user-story.md`; `issue.md:11` `- Work Mode: full-feature`. |
+| Minor | `extensions/drm-copilot/src/lib/subprocess-runner.ts` | line 8 (`CommandResult` JSDoc) | JSDoc says stdout/stderr have "a single trailing newline stripped (matching Python rstrip)". The helper `stripTrailingNewlines` (lines 53-60) removes ALL trailing newlines, which is the correct `rstrip("\n")` behavior. The doc on line 8 contradicts the (correct) implementation. | Reword the `CommandResult` JSDoc to "all trailing newline characters stripped" for accuracy. | Inaccurate contract documentation can mislead callers about multi-newline behavior. Behavior itself is correct and matches `git.py`. | `subprocess-runner.ts:8` vs `:42-60`; Python `git.py:73-74` `(...).rstrip("\n")`. |
+| Minor | `extensions/drm-copilot/src/lib/markdown-label-formatter.ts` | `splitLines` lines 43-79 | Covers `\n`, `\r`, `\r\n` only; Python `str.splitlines()` also splits on `\v`, `\f`, `\x1c`-`\x1e`, `\x85`, ` `, ` `. | Document the intentional narrowing in JSDoc, or extend the boundary set if exotic separators are in-scope for transcripts. | Behavior parity gap for exotic separators; low likelihood for the governed chat-transcript inputs. | `markdown-label-formatter.ts:43-79`; Python `markdown_label_formatter.py:58` `content.splitlines()`. |
+| Info | `artifacts/pr_context.summary.txt` | "Changed files overview" | Summary reports "Core logic changes: 0 files" and lists only docs, but the branch diff contains 10 TypeScript files (3,354 insertions). The summary is stale/inaccurate. | Regenerate PR context before relying on the summary; this review used the authoritative `git diff 38a9c11..b7ca641`. | A stale summary could cause a reviewer to under-scope. Audit was performed against the real diff, not the summary. | `pr_context.summary.txt:88-104` vs `git diff --stat 38a9c11..HEAD`. |
+| Info | `extensions/drm-copilot/coverage/lcov.info` | n/a | Coverage lcov artifact is produced under the package directory, not the SKILL's repo-root default `coverage/lcov.info`. | None required; note the package-local location for downstream consumers. | The package is self-contained and runs its toolchain locally; the artifact exists and was inspected. | `ls extensions/drm-copilot/coverage/` → `lcov.info` present. |
+
+No Blocker findings.
+
+---
+
+## Implementation Audit
+
+### TypeScript implementation audit
+
+#### What changed well
+
+- Faithful ports with parity preserved: error-message strings (`"work_mode must be one of: ..."`, `"full-bug may only be used with bug work"`, the `SubprocessRunner` throw format) and reason strings match the Python sources verbatim, which the tests assert against literals.
+- Clean separation of concerns: `processMarkdown`, `iterGovernedFiles`, and the work-mode functions are pure; all disk/stream/process access is injected (`FileSystem`, stdin/stdout callbacks) or isolated in `RealFileSystem`/`SubprocessRunner`. This is the host-neutral design the general code-change policy and the No-COM architecture both call for.
+- The `RealFileSystem.glob` walker and the test fakes share the same glob-translation semantics, so the consumer tests validate `iterGovernedFiles` logic rather than the glob engine.
+- Defensive parity choices are explicit and commented: `null` spawn status mapped to a non-zero failure; `Path.glob`-style "absent path yields nothing"; U+FFFD replacement for undecodable bytes mirroring Python `errors="replace"`.
+
+#### Type safety and maintainability
+
+- Exported types are precise: `CommandResult`, `CommandRunner`, `CommandRunOptions`, `FileSystem`, `ParsedWorkMode`, `LabelHeading`, plus `as const` literal tuples for work modes and globs. No `any`; `unknown`-plus-narrowing where needed. `tsc` clean under `strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`.
+- No suppressions of any kind (`eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`) appear in the diff.
+- One documentation inaccuracy (the `CommandResult` JSDoc, Minor) is the only maintainability nit.
+
+#### Error handling and logging
+
+- Fail-fast with explicit, contract-matching errors (`SubprocessRunner.run`, `normalizeRequestedWorkMode`). The `try/catch` blocks in `RealFileSystem` are intentional `Path.glob`-parity semantics, documented inline, not silent error swallowing. No ad-hoc logging is introduced, which is appropriate for a pure utility layer.
+
+---
+
+## Test Quality Audit
+
+The five Jest suites mirror the Python test scenarios and add cases to reach branch coverage (e.g., `resolveSelectedWorkMode(null)`, malformed-marker detection). Tests are hermetic: `node:child_process` and `node:fs` are mocked; `FileSystem` is replaced by in-memory fakes (`VirtualFileSystem`, `InMemoryFileSystem`). All follow Arrange-Act-Assert with explicit comments and reset mocks in `afterEach`.
+
+### Reviewed test and QA artifacts
+
+- `extensions/drm-copilot/test/lib/subprocess-runner.test.ts` — success/allowError/throw-format/stderr/UTF-8-replacement/null-status/cwd paths; mocks `spawnSync`. No real process spawned.
+- `extensions/drm-copilot/test/lib/file-system.test.ts` — `isFile`/`readTextFile`/`writeTextFile`/`glob` via mocked `node:fs`. No real filesystem access.
+- `extensions/drm-copilot/test/lib/json-config.test.ts` — include/exclude/parent-exclusion/non-file-skip scenarios via in-memory fake with production-equivalent glob semantics.
+- `extensions/drm-copilot/test/lib/markdown-label-formatter.test.ts` — pure-logic formatting plus injected-I/O read/write paths.
+- `extensions/drm-copilot/test/lib/prompt-mode-contract.test.ts` — parse/normalize/resolve/fallback paths including all error branches.
+- `evidence/qa-gates/final-test-coverage.md` and `evidence/qa-gates/coverage-delta.md` — executor coverage evidence; figures reproduced exactly by this review.
+
+### Quality assessment prompts
+
+- **Determinism:** No wall-clock, RNG, real I/O, or banned timing APIs. Fully deterministic.
+- **Isolation:** Each test targets one behavior; per-function grouping.
+- **Speed:** F1 lib subset ran in ~1.08s.
+- **Diagnostics:** Literal expected values (including full error strings) yield clear failure messages.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | No credentials/tokens in diff (inspection). |
+| No unsafe subprocess or command construction | ✅ PASS | `spawnSync(executable, args.slice(1), { shell: false })`; no shell interpolation; args passed verbatim. Mirrors Python `shell=False`. |
+| Input validation at boundaries | ✅ PASS | `SubprocessRunner.run` rejects empty args; work-mode functions validate inputs with explicit errors; glob/exclude paths normalized to POSIX. |
+| Error handling remains explicit | ✅ PASS | Fail-fast throws with context; `Path.glob`-parity catches are documented, not silent swallows. |
+| Configuration / path handling is safe | ✅ PASS | `toPosixPath`/`joinPosix` normalize separators; exclusion-by-parent mirrors Python `path.parents` membership. |
+
+---
+
+## Research Log
+
+No external research required. Verification relied on diff inspection, the Python source files (`scripts/dev_tools/pr_context/git.py`, `markdown_label_formatter.py`), repository policy rules, feature-folder evidence, and independent toolchain re-runs.
+
+---
+
+## Verdict
+
+F1 is a high-quality, correctness-preserving port with strong typing, clean separation of concerns, and comprehensive hermetic tests at 97.3% line / 88.13% branch coverage. No Blocker or code-defect findings were identified; the `.gitignore` collision previously escalated by the executor is resolved on the branch (the negation entries are present and `git check-ignore` confirms the files are tracked).
+
+Two Major items are policy/documentation reconciliations rather than code defects: the Jest-vs-Vitest framework divergence and the absent `full-feature` AC source files. Two Minor documentation/parity nits (the `CommandResult` JSDoc wording and the `splitLines` boundary set) are non-blocking. The change is ready for normal PR flow after the two Major reconciliation items are addressed; these are captured in `remediation-inputs.2026-06-25T22-50.md`. Recommendation: **Conditional Go**.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-format.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-format.md
@@ -1,0 +1,6 @@
+# Baseline — TypeScript Format
+
+Timestamp: 2026-06-25T22-33
+Command: npm run format
+EXIT_CODE: 0
+Output Summary: prettier --write completed. All `src/**/*.ts`, `test/**/*.ts`, `*.json`, `*.cjs` reported "unchanged"; no files reformatted. (npm dependencies installed via `npm ci` prior to this run; node_modules was empty.)

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-lint.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-lint.md
@@ -1,0 +1,6 @@
+# Baseline — TypeScript Lint
+
+Timestamp: 2026-06-25T22-33
+Command: npm run lint
+EXIT_CODE: 0
+Output Summary: eslint completed with 0 errors and 0 warnings over `src` and `test`.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-test-coverage.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-test-coverage.md
@@ -1,0 +1,12 @@
+# Baseline — TypeScript Test and Coverage
+
+Timestamp: 2026-06-25T22-33
+Command: node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"
+EXIT_CODE: 0
+Output Summary:
+- Test Suites: 36 passed, 36 total
+- Tests: 416 passed, 416 total
+- Coverage for `src/lib/**` (pre-implementation denominator is empty): All files
+  0% Stmts, 0% Branch, 0% Funcs, 0% Lines (no `src/lib` files exist yet).
+- Baseline line coverage (src/lib): 0% (0/0 — no files)
+- Baseline branch coverage (src/lib): 0% (0/0 — no files)

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-typecheck.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-typecheck.md
@@ -1,0 +1,6 @@
+# Baseline — TypeScript Type-Check
+
+Timestamp: 2026-06-25T22-33
+Command: npm run typecheck
+EXIT_CODE: 0
+Output Summary: tsc -p ./ --noEmit completed with 0 type errors.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,30 @@
+# Phase 0 — Policy Instructions Read (F1)
+
+Timestamp: 2026-06-25T22-33
+
+Policy Order:
+1. CLAUDE.md
+2. .claude/rules/general-code-change.md
+3. .claude/rules/general-unit-test.md
+4. .claude/rules/typescript.md
+5. .claude/rules/typescript-suppressions.md
+6. .claude/rules/quality-tiers.md
+7. .claude/rules/self-explanatory-code-commenting.md
+
+Files Read:
+- CLAUDE.md (loaded via standing instructions)
+- .claude/rules/general-code-change.md (loaded via standing instructions)
+- .claude/rules/general-unit-test.md (loaded via standing instructions)
+- .claude/rules/typescript.md (read)
+- .claude/rules/typescript-suppressions.md (read)
+- .claude/rules/quality-tiers.md (loaded via standing instructions)
+- .claude/rules/self-explanatory-code-commenting.md (read)
+
+Notes:
+- The repository TypeScript policy text references Vitest; the authoritative
+  toolchain for `extensions/drm-copilot/` is Jest (`jest.config.cjs`,
+  `ts-jest`, `run-jest.cjs`) per the plan toolchain facts. Tests use Jest
+  conventions (`@jest/globals`, `jest.fn()`, `jest.mock`, `jest.spyOn`).
+- Coverage thresholds applied: line >= 85%, branch >= 75% (uniform across
+  tiers per quality-tiers.md).
+- No `any`; prefer `unknown` plus narrowing. Kebab-case filenames. ES modules.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/phase0-python-sources.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/phase0-python-sources.md
@@ -1,0 +1,65 @@
+# Phase 0 — Python Source Signatures (F1 Port Targets)
+
+Timestamp: 2026-06-25T22-33
+
+Files Read:
+- scripts/dev_tools/prompt_mode_contract.py
+- scripts/dev_tools/json_config.py
+- scripts/dev_tools/markdown_label_formatter.py
+- scripts/dev_tools/pr_context/git.py
+- scripts/dev_tools/pr_context/models.py
+
+## Signatures
+
+### prompt_mode_contract.py
+- Constants:
+  - `CANONICAL_WORK_MODES = ("minor-audit", "full-feature", "full-bug")`
+  - `LEGACY_FULL_MODE = "full"`
+  - `ACCEPTED_WORK_MODES = (*CANONICAL_WORK_MODES, LEGACY_FULL_MODE)`
+- `normalize_requested_work_mode(requested_mode: str, promotion_type: str) -> str`
+  - raises ValueError "work_mode must be one of: minor-audit, full-feature, full-bug, full"
+  - minor-audit returned unchanged
+  - legacy "full" -> "full-bug" if promotion_type=="bug" else "full-feature"
+  - raises "full-bug may only be used with bug work" when full-bug and not bug
+  - raises "full-feature may not be used with bug work" when full-feature and bug
+- `parse_issue_work_mode(issue_content: str) -> tuple[str | None, bool]`
+  - valid regex: `(?im)^-\s*Work Mode:\s*(minor-audit|full-feature|full-bug|full)\s*$`
+  - malformed regex: `(?im)^-\s*Work Mode:\s*(.+)\s*$`
+  - returns (mode, False) on valid; (None, malformed_detected) otherwise
+- `resolve_selected_work_mode(issue_content: str | None) -> str`
+  - None -> "full-feature"; valid legacy "full" -> "full-feature"; valid -> that mode; else "full-feature"
+- `build_fallback_reason(issue_content: str | None) -> str`
+  - None -> "issue.md missing; fail closed to full-feature"
+  - valid legacy full -> "issue.md Work Mode marker uses legacy full; normalized to full-feature"
+  - valid canonical -> "none"
+  - malformed -> "issue.md Work Mode marker malformed; fail closed to full-feature"
+  - missing -> "issue.md Work Mode marker missing; fail closed to full-feature"
+
+### json_config.py
+- `GOVERNED_GLOBS = ("scripts/**/*.json", "docs/**/*.json", "examples/**/*.json")`
+- `EXCLUDE_GLOBS = ("data/**", "artifacts/**", "htmlcov/**", "coverage*/**", "**/node_modules/**", ".venv", ".venv/**", "**/.venv", "**/.venv/**")`
+- `iter_governed_files(root: Path | str) -> Iterable[Path]`
+  - glob includes from GOVERNED_GLOBS; build excluded set from EXCLUDE_GLOBS
+  - skip path if any parent in excluded, or path in excluded; yield only if path.is_file()
+
+### markdown_label_formatter.py (pure-logic + I/O; CLI glue deferred)
+- `LABEL_PREFIXES = ("User:", "GitHub Copilot:")`
+- `SEPARATOR_LINE = "---"`
+- `is_label_line(line: str) -> bool` — startswith any LABEL_PREFIXES
+- `is_separator_line(line: str) -> bool` — stripped == "" or "---"
+- `format_label_heading(line: str) -> tuple[str, str]` — partition(":"); heading=`# {label.strip()}:`; trailing=remainder.lstrip()
+- `ensure_separator_block(output_lines: list[str]) -> None` — pop trailing blanks; extend ["", "---", ""]
+- `prefix_content_line(line: str) -> str` — `> {line}` if line else `>`
+- `process_markdown(content: str) -> str` — splitlines; preserve trailing newline
+- `read_content(source: Path | None) -> str` — stdin when None else read_text utf-8
+- `write_output(content: str, target: Path | None) -> None` — stdout when None else write_text utf-8
+- DEFERRED (not ported): parse_args, main, __main__ CLI glue
+
+### pr_context/git.py + models.py (subprocess runner)
+- `CommandResult` dataclass: `stdout: str`, `stderr: str`, `code: int`
+- `CommandRunner` Protocol: `run(args: Sequence[str], *, cwd: Path | None = None, allow_error: bool = False) -> CommandResult`
+- `SubprocessRunner.run(...)`:
+  - subprocess.run(args, cwd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, shell=False)
+  - stdout = (completed.stdout or "").rstrip("\n"); stderr = (completed.stderr or "").rstrip("\n")
+  - code = int(completed.returncode)
+  - if not allow_error and code != 0: joined = (stdout + "\n" + stderr).strip(); raise RuntimeError(f"{' '.join(args)} failed ({code}): {joined}")

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/coverage-delta.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/coverage-delta.md
@@ -1,0 +1,26 @@
+# Coverage Delta Verification (F1 src/lib)
+
+Timestamp: 2026-06-25T22-44
+
+## Baseline (P0-T6)
+- `src/lib/**` did not exist pre-implementation; coverage denominator was empty.
+- Baseline line coverage (src/lib): 0% (0/0 files)
+- Baseline branch coverage (src/lib): 0% (0/0 files)
+- Baseline suite: 36 suites, 416 tests passing.
+
+## Post-change (P6-T4)
+- All files (src/lib): 97.3% line, 88.13% branch
+- Suite: 41 suites, 492 tests passing (5 new test files added under test/lib).
+
+## New / changed-code coverage (F1 src/lib files)
+All files added in F1 are net-new; their coverage equals the new-code coverage:
+- file-system.ts: 96.47% line, 86.2% branch
+- json-config.ts: 96.19% line, 83.33% branch
+- markdown-label-formatter.ts: 95.85% line, 87.87% branch
+- prompt-mode-contract.ts: 100% line, 96.29% branch
+- subprocess-runner.ts: 98.59% line, 82.35% branch
+
+## Threshold verdict
+- New-code line coverage 97.3% (aggregate) and every file >= 95.85% — all >= 85% PASS.
+- New-code branch coverage 88.13% (aggregate) and every file >= 82.35% — all >= 75% PASS.
+- No coverage regression: pre-existing suites remain green (416 -> 492 tests, all passing).

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-format.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-format.md
@@ -1,0 +1,6 @@
+# Final QA — TypeScript Format
+
+Timestamp: 2026-06-25T22-44
+Command: npm run format
+EXIT_CODE: 0
+Output Summary: prettier --write completed. All `src/lib/*.ts` and `test/lib/*.ts` files reported "unchanged"; no files reformatted on the final pass.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-lint.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-lint.md
@@ -1,0 +1,6 @@
+# Final QA — TypeScript Lint
+
+Timestamp: 2026-06-25T22-44
+Command: npm run lint
+EXIT_CODE: 0
+Output Summary: eslint completed with 0 errors and 0 warnings over `src` and `test`.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-test-coverage.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-test-coverage.md
@@ -1,0 +1,17 @@
+# Final QA — TypeScript Test and Coverage
+
+Timestamp: 2026-06-25T22-44
+Command: node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"
+EXIT_CODE: 0
+Output Summary:
+- Test Suites: 41 passed, 41 total
+- Tests: 492 passed, 492 total
+- Coverage for `src/lib/**` (collectCoverageFrom restricted to src/lib):
+  - All files: 97.3% Stmts, 88.13% Branch, 100% Funcs, 97.3% Lines
+  - file-system.ts: 96.47% Lines, 86.2% Branch
+  - json-config.ts: 96.19% Lines, 83.33% Branch
+  - markdown-label-formatter.ts: 95.85% Lines, 87.87% Branch
+  - prompt-mode-contract.ts: 100% Lines, 96.29% Branch
+  - subprocess-runner.ts: 98.59% Lines, 82.35% Branch
+- Threshold check: line coverage 97.3% >= 85% PASS; branch coverage 88.13% >= 75% PASS.
+  Every individual src/lib file is at or above both thresholds.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-typecheck.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-typecheck.md
@@ -1,0 +1,6 @@
+# Final QA — TypeScript Type-Check
+
+Timestamp: 2026-06-25T22-44
+Command: npm run typecheck
+EXIT_CODE: 0
+Output Summary: tsc -p ./ --noEmit completed with 0 type errors.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/scope-verification.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/scope-verification.md
@@ -1,0 +1,78 @@
+# Scope Verification (F1)
+
+Timestamp: 2026-06-25T22-44
+Command: git status --porcelain
+EXIT_CODE: 0
+
+## Output Summary
+
+`git status --porcelain` (untracked, excluding node_modules) reports changes only
+under the feature folder:
+
+```
+?? docs/features/active/2026-06-25-port-python-commands-to-typescript-240/...
+```
+
+No modifications appear to `repo-automation-service.ts`, `command-runtime.ts`, MCP
+handlers, or any `.claude/` / `.github/` policy files. Those files were not edited.
+
+## Files created on disk (verified present)
+
+Production (src/lib):
+- extensions/drm-copilot/src/lib/subprocess-runner.ts
+- extensions/drm-copilot/src/lib/file-system.ts
+- extensions/drm-copilot/src/lib/prompt-mode-contract.ts
+- extensions/drm-copilot/src/lib/markdown-label-formatter.ts
+- extensions/drm-copilot/src/lib/json-config.ts
+
+Tests (test/lib):
+- extensions/drm-copilot/test/lib/subprocess-runner.test.ts
+- extensions/drm-copilot/test/lib/file-system.test.ts
+- extensions/drm-copilot/test/lib/prompt-mode-contract.test.ts
+- extensions/drm-copilot/test/lib/markdown-label-formatter.test.ts
+- extensions/drm-copilot/test/lib/json-config.test.ts
+
+## BLOCKER — gitignore collision (escalation)
+
+`git check-ignore -v` shows all ten new F1 files are matched by the root
+`.gitignore` line 20 (`lib/`), which is part of the Python build-artifact
+section but also matches `extensions/drm-copilot/src/lib/` and
+`extensions/drm-copilot/test/lib/`:
+
+```
+.gitignore:20:lib/  extensions/drm-copilot/src/lib/subprocess-runner.ts
+.gitignore:20:lib/  extensions/drm-copilot/src/lib/file-system.ts
+.gitignore:20:lib/  extensions/drm-copilot/src/lib/prompt-mode-contract.ts
+.gitignore:20:lib/  extensions/drm-copilot/src/lib/markdown-label-formatter.ts
+.gitignore:20:lib/  extensions/drm-copilot/src/lib/json-config.ts
+.gitignore:20:lib/  extensions/drm-copilot/test/lib/json-config.test.ts
+(and the remaining test/lib files)
+```
+
+Consequence: the F1 source and test files exist on disk and pass the full
+toolchain (format, lint, type-check, test, coverage) but are currently
+untracked-and-ignored, so they would not be committed.
+
+This is a new independent outcome not described by any plan task. Per the
+atomic-executor anti-replanning rules, the executor does not modify `.gitignore`
+unilaterally (that change falls outside the allowed plan paths `src/lib/**` and
+`test/lib/**`). This item is escalated for planner/orchestrator remediation.
+
+Recommended remediation (for the planner to authorize as a task): add a
+negation entry to `.gitignore` un-ignoring the extension lib paths, for example:
+
+```
+!extensions/drm-copilot/src/lib/
+!extensions/drm-copilot/src/lib/**
+!extensions/drm-copilot/test/lib/
+!extensions/drm-copilot/test/lib/**
+```
+
+Note: a bare negation may be insufficient if a parent path is ignored; the
+exact form must be validated with `git check-ignore` after the edit.
+
+## Verdict
+
+- No out-of-scope files were modified. PASS for the scope-containment acceptance.
+- gitignore collision recorded as a BLOCKER requiring planner remediation before
+  the F1 artifacts can be version-controlled.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/feature-audit.2026-06-25T22-50.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/feature-audit.2026-06-25T22-50.md
@@ -1,0 +1,128 @@
+# Feature Audit: F1 — TypeScript Shared Subprocess and Utility Layer (Issue #240)
+
+**Audit Date:** 2026-06-25
+**Feature Folder:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+**Base Branch:** `main` @ `38a9c11ee34895e92b6e38ea5400e7dd07cddc9d`
+**Head Branch:** `feat/ts-port-shared-utilities-240` @ `b7ca64197c13884e8ed9833ee6937b3a9d827c80`
+**Work Mode:** `full-feature`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `38a9c11ee34895e92b6e38ea5400e7dd07cddc9d`)
+- **Head branch/commit:** `feat/ts-port-shared-utilities-240` (commit `b7ca64197c13884e8ed9833ee6937b3a9d827c80`)
+- **Merge base:** `38a9c11ee34895e92b6e38ea5400e7dd07cddc9d`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt` (noted stale; see code-review Info finding)
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt` and authoritative `git diff 38a9c11..b7ca641`
+  - Feature evidence: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/**`
+  - Additional evidence: independent toolchain re-run (Prettier, ESLint, tsc, Jest+coverage)
+- **Feature folder used:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+- **Requirements source:** F1 plan "Acceptance Criteria Checklist (F1)" in `plans/F1-shared-utilities.plan.md` (task-authorized AC source) and the epic AC in `issue.md`.
+- **Work mode resolution note:** `issue.md:11` declares `- Work Mode: full-feature`, which per the acceptance-criteria contract resolves AC sources to `spec.md` and `user-story.md`. Neither file exists in this feature folder. Per the caller's explicit authorization and the absence of those files, the F1 plan checklist is used as the operative AC source for this feature audit, supplemented by the epic `issue.md` AC for epic-level context. The missing `spec.md`/`user-story.md` is recorded as a Major gap in the policy audit and code review.
+- **Scope note:** Audit scope is the full branch diff (`38a9c11..b7ca641`), not a plan subset. Only TypeScript files changed; Python/PowerShell/C# have zero changed files.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `plans/F1-shared-utilities.plan.md` — operative AC source (F1 feature scope), checkbox-backed.
+- `issue.md` — epic-level AC, checkbox-backed (most items are epic-wide, beyond F1 scope).
+
+### Acceptance criteria — F1 plan "Acceptance Criteria Checklist (F1)"
+
+1. `subprocess-runner.ts` exists, exports `CommandResult`, `CommandRunner`, and `SubprocessRunner`; uses `node:child_process` with `Buffer` capture decoded via `buffer.toString("utf8")`; returns typed `{ stdout, stderr, code }`; throws on non-zero exit when `allowError` is false with the message format matching `git.py`.
+2. `file-system.ts` exists, exports a `FileSystem` interface and `RealFileSystem` implementation enabling injectable, hermetic file I/O.
+3. `prompt-mode-contract.ts` replicates `prompt_mode_contract.py` behavior exactly (functions, constants, error and reason strings).
+4. `markdown-label-formatter.ts` replicates `markdown_label_formatter.py` pure-logic and I/O behavior (I/O via injected `FileSystem`); CLI glue intentionally deferred.
+5. `json-config.ts` replicates `json_config.py` constants and `iterGovernedFiles` semantics via injected `FileSystem`.
+6. All four Jest test files exist under `test/lib/` mirroring the Python test scenarios, plus `subprocess-runner.test.ts` and `file-system.test.ts`.
+7. All tests use Jest conventions, AAA structure, and are hermetic (no real subprocess, no temp files).
+8. No file exceeds 500 lines.
+9. `npm run format`, `npm run lint`, `npm run typecheck` all pass with 0 errors from `extensions/drm-copilot/`.
+10. Tests pass with line coverage >= 85% and branch coverage >= 75% for `src/lib/**`.
+11. `repo-automation-service.ts`, `command-runtime.ts`, MCP handlers, and policy files are unmodified.
+12. All evidence artifacts written under `<FEATURE>/evidence/<kind>/` with required schema fields.
+
+### Acceptance criteria — epic `issue.md` (epic-wide, for context)
+
+E1. Every Python command script invoked by the extension or MCP server has a TypeScript equivalent with parity of behavior.
+E2. Test coverage for the TypeScript ports is equal to or better than the Python tests (line >= 85%, branch >= 75%).
+E3. The extension and MCP server invoke the TypeScript implementations, not Python.
+E4. No remaining runtime dependency on a `python` interpreter for command execution.
+E5. All CI gates pass.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | subprocess-runner exports + throw format | PASS | `subprocess-runner.ts:12-16,38-40,87-141` export `CommandResult`/`CommandRunner`/`SubprocessRunner`; throw format matches `git.py:79-81`; tests assert exact message. | `npx tsc -p ./ --noEmit`; `node run-jest.cjs test/lib/subprocess-runner.test.ts` | Buffer decode + null-status handling verified. |
+| 2 | file-system FileSystem + RealFileSystem | PASS | `file-system.ts:25-43` interface, `:153-227` `RealFileSystem`; both exported. | `npx tsc -p ./ --noEmit`; `node run-jest.cjs test/lib/file-system.test.ts` | Injectable; tests use in-memory fakes. |
+| 3 | prompt-mode-contract parity | PASS | `prompt-mode-contract.ts` mirrors Python functions, constants, error and reason strings; tests assert literals. | `node run-jest.cjs test/lib/prompt-mode-contract.test.ts` | 100% line / 96.29% branch. |
+| 4 | markdown-label-formatter parity + injected I/O; CLI deferred | PASS | `markdown-label-formatter.ts` matches `markdown_label_formatter.py:17-100` function-for-function; `readContent`/`writeOutput` take injected `FileSystem`+callbacks; CLI glue deferred per JSDoc. | `node run-jest.cjs test/lib/markdown-label-formatter.test.ts` | Minor parity nit: `splitLines` covers `\n`/`\r`/`\r\n` only (non-blocking; see code review). |
+| 5 | json-config constants + iterGovernedFiles | PASS | `json-config.ts:14-31` constants match Python; `:69-105` `iterGovernedFiles` with injected `FileSystem`; parent-exclusion mirrors `path.parents`. | `node run-jest.cjs test/lib/json-config.test.ts` | 96.19% line / 83.33% branch. |
+| 6 | All five test files exist | PASS | `test/lib/{subprocess-runner,file-system,prompt-mode-contract,markdown-label-formatter,json-config}.test.ts` present. | `ls extensions/drm-copilot/test/lib/` | 5 suites, 76 tests. |
+| 7 | Jest conventions, AAA, hermetic | PASS | `@jest/globals` imports; `jest.mock`/`jest.fn`; `afterEach` resets; AAA comments; in-memory fakes; no temp files. | inspection; `node run-jest.cjs test/lib` | No real subprocess/filesystem. |
+| 8 | No file exceeds 500 lines | PASS | Max 288 (test) / 241 (src). | `wc -l src/lib/*.ts test/lib/*.ts` | All under 500. |
+| 9 | format/lint/typecheck pass, 0 errors | PASS | Prettier clean; ESLint 0 findings; tsc 0 errors (re-run by review). | `npx prettier --check ...`; `npx eslint ... src/lib test`; `npx tsc -p ./ --noEmit` | Reproduces executor evidence. |
+| 10 | src/lib coverage >= 85% line, >= 75% branch | PASS | All files 97.3% line / 88.13% branch; each file at/above thresholds. | `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts" test/lib` | Independently reproduced. |
+| 11 | Runtime/handler/policy files unmodified | PASS | `git diff --name-only 38a9c11..HEAD` shows no changes to `command-runtime.ts`, `repo-automation-service.ts`, MCP handlers, `.claude/rules/**`, `.github/instructions/**`. | `git diff --name-only 38a9c11..HEAD` | Only src/lib, test/lib, .gitignore, docs changed. |
+| 12 | Evidence artifacts under canonical path with schema fields | PASS | Evidence under `<FEATURE>/evidence/{baseline,qa-gates}/`; validator clean. | `python scripts/dev_tools/validate_evidence_locations.py --root .` (exit 0) | No non-canonical evidence paths. |
+| E1 | All Python command scripts ported | PARTIAL | F1 ports 4 utilities + FS abstraction only; the epic targets the full `scripts/dev_tools/**` surface (~28,100 LoC). | n/a | Epic-wide AC; out of F1 scope by design. |
+| E2 | TS coverage >= Python tests (line >=85%, branch >=75%) | PASS (for F1 modules) | F1 modules at 97.3% line / 88.13% branch. | `node run-jest.cjs --coverage ...` | Epic-wide completion is pending remaining features. |
+| E3 | Extension/MCP invoke TS, not Python | FAIL (epic, out of F1 scope) | F1 explicitly does NOT modify `command-runtime.ts`/handlers; no wiring change made. | `git diff --name-only` | Deferred to a later feature per F1 plan constraint. |
+| E4 | No runtime Python dependency | FAIL (epic, out of F1 scope) | Python interpreter probing in `command-runtime.ts` unchanged. | `git diff --name-only` | Deferred to a later feature. |
+| E5 | All CI gates pass | UNVERIFIED | PR-context CI status "(not available)"; no green workflow run recorded for the branch head. | `artifacts/pr_context.summary.txt` "CI status (HEAD): (not available)" | No `.github/workflows/**` changes on branch; local toolchain passes. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** NEEDS REVISION
+
+The F1 feature-scope acceptance criteria (items 1-12) are all PASS: the five modules are implemented with behavioral parity, fully typed, hermetically tested at 97.3% line / 88.13% branch, with all files under 500 lines, a clean toolchain, no out-of-scope modifications, and canonical evidence. The epic-wide criteria (E1, E3, E4) are intentionally out of F1 scope and remain unmet at the epic level; E5 is UNVERIFIED because no CI status is available for the branch head.
+
+The "NEEDS REVISION" verdict reflects two Major policy-reconciliation gaps surfaced in the policy audit and code review, not any F1 code defect: (1) the package's Jest toolchain diverges from the Vitest mandate in `typescript.md`, and (2) the `full-feature` work mode's required AC source files (`spec.md`/`user-story.md`) are absent. F1 itself is functionally complete and mergeable once these are reconciled.
+
+**Criteria summary:**
+- **PASS:** 13 criteria (F1 items 1-12; epic E2 for F1 modules)
+- **PARTIAL:** 1 criterion (E1)
+- **UNVERIFIED:** 1 criterion (E5)
+- **FAIL:** 2 criteria (E3, E4 — both epic-wide, out of F1 scope by design)
+
+**Top gaps preventing PASS:**
+1. Missing `full-feature` AC source files (`spec.md`/`user-story.md`) — policy/scaffolding gap.
+2. Jest-vs-Vitest framework policy divergence — reconcile policy or migrate.
+3. CI green-run for the branch head not available (E5 UNVERIFIED).
+
+**Recommended follow-up verification steps:**
+1. Author the epic `spec.md`/`user-story.md`, or formally designate the F1 plan checklist as the AC source for this folder.
+2. Reconcile `typescript.md` to acknowledge the extension package's Jest toolchain (or schedule a Vitest migration).
+3. Trigger a CI run against the branch head to resolve E5; confirm green before merge.
+
+---
+
+## Acceptance Criteria Check-Off
+
+Per the acceptance-criteria tracking rules:
+- F1 plan items 1-12 are already marked `[x]` in `plans/F1-shared-utilities.plan.md` by the executor; this audit independently verifies them as PASS, so no checkbox change is required.
+- Epic `issue.md` items E1-E5 remain unchecked. E1 (PARTIAL), E3/E4 (FAIL, out of F1 scope), and E5 (UNVERIFIED) must remain unchecked. E2 is satisfied only for the F1 modules, not epic-wide, so its `issue.md` checkbox correctly remains unchecked until the epic completes.
+- No checkbox edits were made to source files in this audit: all PASS items in the F1 plan were already checked, and no epic `issue.md` item is fully satisfied at the epic level.
+
+### AC Status Summary
+
+- Source: `plans/F1-shared-utilities.plan.md` (operative) and `issue.md` (epic)
+- Total AC items: 12 (F1 plan) + 5 (epic) = 17
+- Checked off (delivered): 12 (F1 plan items, pre-checked by executor and verified PASS here)
+- Remaining (unchecked): 5 (epic E1-E5)
+- Items remaining: E1 (PARTIAL), E2 (epic-wide pending), E3 (FAIL/out-of-scope), E4 (FAIL/out-of-scope), E5 (UNVERIFIED)
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `plans/F1-shared-utilities.plan.md` | 12 | 12 | 0 | Checkbox-backed; verified PASS; no change needed (already checked). |
+| `issue.md` | 5 | 0 | 5 | Checkbox-backed epic AC; epic-wide, mostly beyond F1 scope; correctly remain unchecked. |

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/initiative.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/initiative.md
@@ -1,0 +1,81 @@
+# port-python-commands-to-typescript - Initiative Overview
+
+- Issue: #240
+- Owner: drmoisan
+- Last Updated: 2026-06-25T22-19
+
+## Goal & Outcomes
+
+Port every Python command script invoked by the VS Code extension and the standalone
+MCP server to TypeScript, with behavior parity and equally robust automated tests, so
+that neither the extension nor the published MCP npm package requires a Python
+interpreter at runtime.
+
+Measurable outcomes:
+
+- The 12 runtime-invoked MCP commands execute via in-process TypeScript, not by spawning
+  Python.
+- The `"python"` runtime branch in `command-runtime.ts` and the bundled Python resources
+  are removed.
+- TypeScript test coverage meets repository policy (line >= 85%, branch >= 75%).
+
+Authoritative scope and inventory: `research/python-to-typescript-inventory.md`.
+
+## Decomposition (Child Features/Workstreams)
+
+Ordered, independently shippable features (each one branch + PR + green CI + merge):
+
+- F1 `ts-shared-subprocess-and-utility-layer` (Issue #240) — shared subprocess runner,
+  prompt-mode contract, json-config, markdown-label-formatter. Prereq for all.
+- F2 `ts-validate-orchestration-artifacts` (Issue #240) — validate_* cluster. Prereq: F1.
+- F4 `ts-collect-commit-context` (Issue #240) — self-contained git context. Prereq: F1.
+- F5 `ts-resolve-prompts` (Issue #240) — hard-lock and file prompt resolvers. Prereq: F1.
+- F6 `ts-new-potential-bug-entry` (Issue #240) — bug entry creator. Prereq: F1.
+- F3 `ts-push-down-customizations` (Issue #240) — copilot/codex/claude push-down. Prereq: F1.
+- F7 `ts-potential-to-issue` (Issue #240) — potential→issue promotion (gh). Prereq: F1.
+- F8 `ts-new-active-feature-folder` (Issue #240) — active folder creation (gh). Prereq: F1.
+- F9 `ts-pr-context` (Issue #240) — full PR context cluster (git + gh). Prereq: F1.
+- F10 `ts-codex-native-converter` (Issue #240) — converter pipeline. Prereq: F1.
+- F11 `ts-command-runtime-cleanup` (Issue #240) — remove Python bridge + bundled resources.
+  Prereq: F2–F10 complete.
+
+Dependencies: F1 → {F2, F3, F4, F5, F6, F7, F8, F9, F10} → F11.
+
+## Cross-Cutting Constraints & Assumptions
+
+- TypeScript ports live under `extensions/drm-copilot/src/lib/**`; tests mirror under
+  `extensions/drm-copilot/test/lib/**`.
+- 500-line file size limit applies; files over the limit in Python are split in TS
+  (noted per feature in the research doc).
+- Subprocess (`git`/`gh`) access goes through an injectable `SubprocessRunner`; filesystem
+  access goes through an injectable `FileSystem` interface to keep unit tests hermetic
+  (no temp files, no real subprocess).
+- The `RepoAutomationService` interface is unchanged; only `DefaultRepoAutomationService`
+  method bodies switch from `executeScript()` to in-process TS calls.
+- Behavior parity must be preserved: CLI output, exit codes, file artifacts, JSON shapes.
+
+## Milestones & Status
+
+- M1 F1 shared utilities — In progress
+- M2 F2–F10 cluster ports — Not started
+- M3 F11 Python bridge removal — Not started
+- M4 No Python runtime dependency for extension/MCP commands — Not started
+
+## Initiative-Level Validation
+
+- End-to-end: each ported MCP command produces output identical to its Python predecessor.
+- Integration: extension and MCP server tests pass without a Python interpreter.
+- Determinism/Regression: ported pure functions covered by unit (and where applicable
+  property-based) tests; no coverage regression.
+- Error handling/Resilience: error messages, exit codes, and failure modes match the
+  Python originals.
+
+## Notes / Follow-Ups
+
+- Out of scope (dev-internal Python tooling, not bundled/invoked by extension or MCP):
+  `fix_all*`, `shell_qc`, `copy_research_to_issue`, `clean_devcontainer`,
+  `plan_progress_report`, `atomic_executor/**`, `resolve_execute_plan_prompt.py` (tkinter),
+  `tk_dialog_helpers.py`. Rationale recorded in `research/python-to-typescript-inventory.md`
+  Section 3.2.
+- `agentic_sync.ROOT_FOLDERS` constant is inlined into the push-down TS port; the rest of
+  `agentic_sync.py` is not ported.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/issue.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/issue.md
@@ -1,0 +1,67 @@
+# port-python-commands-to-typescript (Issue #240)
+
+- Date captured: 2026-06-25
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/port-python-commands-to-typescript/ (Issue #240)
+- Classification: Epic (multi-feature)
+
+- Issue: #240
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/240
+- Last Updated: 2026-06-26
+- Work Mode: full-feature
+
+## Problem / Why
+
+Many extension command scripts and MCP server scripts are implemented in Python
+(`scripts/dev_tools/**`, bundled at `extensions/drm-copilot/resources/scripts/dev_tools/**`
+and `extensions/drm-copilot/resources/templates/**`). The VS Code extension and the
+standalone MCP server (`packages/mcp-server`) shell out to these scripts through
+`command-runtime.ts`, which probes for a `python` runtime on PATH. This makes a Python
+interpreter a hard runtime dependency for end users of the extension and the published
+MCP npm package.
+
+Porting these scripts to TypeScript removes the Python runtime dependency, unifies the
+toolchain on Node/TypeScript, and lets the extension and MCP server invoke logic
+in-process rather than spawning an external interpreter.
+
+Scope measured: ~28,100 LoC of production Python under `scripts/dev_tools/**`, ~1,155 LoC
+of bundled templates, and ~39,750 LoC of Python tests.
+
+## Proposed Behavior
+
+Port every Python command script used by the extension and the MCP server to TypeScript,
+preserving behavior exactly, with equally robust automated tests. After the port, neither
+the extension nor the MCP server requires a Python interpreter to execute its commands.
+
+## Acceptance Criteria (early draft)
+
+- [ ] Every Python command script invoked by the extension or MCP server has a TypeScript
+      equivalent with parity of behavior.
+- [ ] Test coverage for the TypeScript ports is equal to or better than the Python tests
+      (line >= 85%, branch >= 75% per repository policy).
+- [ ] The extension and MCP server invoke the TypeScript implementations, not Python.
+- [ ] No remaining runtime dependency on a `python` interpreter for command execution.
+- [ ] All CI gates pass.
+
+## Constraints & Risks
+
+- Large surface area; must be decomposed into independently shippable features.
+- Behavior parity must be preserved exactly, including CLI output, exit codes, and file
+  artifacts.
+- The bundled resources under `extensions/drm-copilot/resources/**` and the
+  `packages/mcp-server/resources/**` copy must remain consistent.
+- Cross-cutting MCP tool handlers and `command-runtime.ts` runtime selection must be
+  updated without breaking existing TypeScript tests.
+
+## Test Conditions to Consider
+
+- [ ] Unit coverage for each ported module
+- [ ] Behavior-parity tests against the original Python outputs
+- [ ] MCP handler integration scenarios
+- [ ] CLI/API examples for each command
+
+## Next Step
+
+- [ ] Promote to GitHub issue (epic)
+- [ ] Create epic feature folder from the template
+- [ ] Decompose into per-cluster features and execute one by one

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/plans/F1-shared-utilities.plan.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/plans/F1-shared-utilities.plan.md
@@ -1,0 +1,127 @@
+# F1 — ts-shared-subprocess-and-utility-layer — Atomic Implementation Plan
+
+**Issue:** #240
+**Feature:** F1 (foundational shared subprocess runner and utility layer)
+**Work Mode:** full-feature
+**Plan path:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/plans/F1-shared-utilities.plan.md`
+**Feature folder (`<FEATURE>`):** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+
+## Scope Summary
+
+Port the following Python modules to TypeScript under `extensions/drm-copilot/src/lib/`, replicating behavior exactly (signatures, return shapes, error messages, edge cases):
+
+1. `scripts/dev_tools/prompt_mode_contract.py` → `extensions/drm-copilot/src/lib/prompt-mode-contract.ts`
+2. `scripts/dev_tools/json_config.py` → `extensions/drm-copilot/src/lib/json-config.ts`
+3. `scripts/dev_tools/markdown_label_formatter.py` → `extensions/drm-copilot/src/lib/markdown-label-formatter.ts`
+4. Shared subprocess runner (modeled on `scripts/dev_tools/pr_context/git.py` `SubprocessRunner`/`CommandResult`) → `extensions/drm-copilot/src/lib/subprocess-runner.ts`
+5. Shared filesystem abstraction (modeled on Python `FileSystem` Protocol; required by `json-config.ts` directory traversal) → `extensions/drm-copilot/src/lib/file-system.ts`
+
+Tests (Jest, mirroring Python test scenarios) under `extensions/drm-copilot/test/lib/`.
+
+## Toolchain Facts (authoritative for this plan)
+
+- The package `extensions/drm-copilot/` uses **Jest** (`jest.config.cjs`, `ts-jest`, `run-jest.cjs`), NOT Vitest. All tests MUST use Jest conventions: `import { describe, expect, it, jest } from "@jest/globals";`, `jest.fn()`, `jest.spyOn()`, `jest.mock()`.
+- All toolchain commands run from inside `extensions/drm-copilot/`.
+  - Format: `npm run format`
+  - Lint: `npm run lint`
+  - Type-check: `npm run typecheck`
+  - Test: `npm test`
+  - Coverage: `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"` (the `run-jest.cjs` wrapper forwards all extra args to Jest; there is no `test:coverage` npm script and no configured `coverageThreshold`, so coverage thresholds must be verified manually against policy: line >= 85%, branch >= 75%).
+- `tsconfig.json` uses `module: "Node16"`, `rootDir: "src"`, `strict: true`, `noUncheckedIndexedAccess: true`, `exactOptionalPropertyTypes: true`. New `src/lib/*.ts` files are included automatically. No `any`; prefer `unknown` plus narrowing.
+
+## Constraints (must hold for every task)
+
+- No production or test file may exceed 500 lines.
+- ES modules only; no `require`/`module.exports` in `src/`.
+- Strong typing; no `any`. Kebab-case filenames.
+- Tests hermetic: no real subprocess, no temp files, no real filesystem writes. Mock `node:child_process`; inject the `FileSystem` interface.
+- AAA (Arrange–Act–Assert) test structure; reset mocks in `afterEach`.
+- Do NOT modify `repo-automation-service.ts`, `command-runtime.ts`, MCP handlers, or any service wiring in F1. F1 adds only the `src/lib/` layer plus its tests.
+- Do NOT modify policy files under `.claude/rules/` or `.github/instructions/`.
+
+## Evidence Location Invariant
+
+All evidence artifacts MUST be written under `<FEATURE>/evidence/<kind>/`:
+- Baseline: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/`
+- QA gates: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/`
+- Regression: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/regression-testing/`
+
+Writing evidence to `artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, or any non-canonical path is a policy violation. Each command-step evidence artifact MUST include `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`. Coverage artifacts MUST record numeric line and branch coverage values.
+
+---
+
+### Phase 0 — Baseline Capture and Policy Reading
+
+- [x] [P0-T1] Read repository policy files in required order and record evidence. Read, in order: `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/typescript.md`, `.claude/rules/typescript-suppressions.md`, `.claude/rules/quality-tiers.md`, `.claude/rules/self-explanatory-code-commenting.md`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/phase0-instructions-read.md` containing `Timestamp:`, `Policy Order:` (the ordered list above), and an explicit `Files Read:` list. Acceptance: the evidence file exists and lists every file above.
+- [x] [P0-T2] Read all F1 Python source files to be ported and record their observed signatures/return shapes. Read `scripts/dev_tools/prompt_mode_contract.py`, `scripts/dev_tools/json_config.py`, `scripts/dev_tools/markdown_label_formatter.py`, `scripts/dev_tools/pr_context/git.py`, `scripts/dev_tools/pr_context/models.py` (for `CommandResult`). Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/phase0-python-sources.md` with `Timestamp:`, the list of files read, and a `Signatures:` section enumerating each function/class to be ported. Acceptance: the evidence file exists and enumerates every public function from the four port targets.
+- [x] [P0-T3] Capture baseline TypeScript format state. From `extensions/drm-copilot/`, run `npm run format`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-format.md` with `Timestamp:`, `Command: npm run format`, `EXIT_CODE:`, and `Output Summary:`. Acceptance: artifact exists with all four fields populated.
+- [x] [P0-T4] Capture baseline TypeScript lint state. From `extensions/drm-copilot/`, run `npm run lint`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-lint.md` with `Timestamp:`, `Command: npm run lint`, `EXIT_CODE:`, and `Output Summary:`. Acceptance: artifact exists with all four fields populated.
+- [x] [P0-T5] Capture baseline TypeScript type-check state. From `extensions/drm-copilot/`, run `npm run typecheck`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-typecheck.md` with `Timestamp:`, `Command: npm run typecheck`, `EXIT_CODE:`, and `Output Summary:`. Acceptance: artifact exists with all four fields populated.
+- [x] [P0-T6] Capture baseline test and coverage state. From `extensions/drm-copilot/`, run `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-test-coverage.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` including the baseline numeric line coverage and branch coverage headline values (the `src/lib/**` denominator is empty pre-implementation; record the observed values, e.g. existing suite pass count and the reported coverage totals). Acceptance: artifact exists with all four fields and numeric coverage values recorded.
+
+---
+
+### Phase 1 — Subprocess Runner and Filesystem Abstractions
+
+- [x] [P1-T1] Create `extensions/drm-copilot/src/lib/subprocess-runner.ts` defining the `CommandResult` interface and the runner contract. Define `interface CommandResult { stdout: string; stderr: string; code: number; }` (mirror `pr_context/models.py` `CommandResult`; field `code` is the exit code). Define `interface CommandRunner { run(args: readonly string[], options?: { cwd?: string; allowError?: boolean }): CommandResult; }` mirroring the Python `CommandRunner` Protocol. Export both. Acceptance: file exists, exports `CommandResult` and `CommandRunner`, contains no implementation logic beyond type declarations and the runner class added in P1-T2, and is under 500 lines.
+- [x] [P1-T2] Implement `SubprocessRunner` in `extensions/drm-copilot/src/lib/subprocess-runner.ts` using `node:child_process`. Use `spawnSync(args[0], args.slice(1), { cwd, shell: false })` capturing stdout/stderr as `Buffer`, then decode with `buffer.toString("utf8")` to match Python `encoding="utf-8", errors="replace"`. Replicate Python behavior exactly: strip a single trailing `\n` from stdout and stderr via `rstrip("\n")` equivalent (remove trailing newline characters), build `CommandResult` with integer `code` from `status` (treat `null` status as a non-zero failure), and when `allowError` is false and `code !== 0` throw an `Error` with message `` `${args.join(" ")} failed (${code}): ${joined}` `` where `joined` is `(stdout + "\n" + stderr).trim()`. Add a class docstring/JSDoc and decision/intent comments per the commenting policy. Acceptance: `npm run typecheck` passes for this file; the throw message format and trailing-newline stripping match `git.py` `SubprocessRunner.run`.
+- [x] [P1-T3] Create `extensions/drm-copilot/src/lib/file-system.ts` defining a `FileSystem` interface for hermetic file I/O. Model on the Python `FileSystem` Protocol pattern. Define an interface with the operations required by `json-config.ts` and `markdown-label-formatter.ts`: at minimum `glob(root: string, pattern: string): string[]`, `isFile(path: string): boolean`, `readTextFile(path: string): string`, and `writeTextFile(path: string, content: string): void`. Export the interface and a `RealFileSystem` class implementing it via `node:fs` (`fs.readFileSync`/`fs.writeFileSync` with `"utf8"`, `fs.statSync().isFile()`, and a glob implementation consistent with Python `Path.glob` semantics for the governed/exclude patterns). Add JSDoc. Acceptance: `npm run typecheck` passes; interface and `RealFileSystem` both exported; file under 500 lines.
+
+---
+
+### Phase 2 — Port `prompt-mode-contract.ts`
+
+- [x] [P2-T1] Create `extensions/drm-copilot/src/lib/prompt-mode-contract.ts` porting `scripts/dev_tools/prompt_mode_contract.py`. Export constants `CANONICAL_WORK_MODES = ["minor-audit", "full-feature", "full-bug"] as const`, `LEGACY_FULL_MODE = "full"`, and `ACCEPTED_WORK_MODES`. Export `normalizeRequestedWorkMode(requestedMode: string, promotionType: string): string` replicating all branches and the exact error message strings: `"work_mode must be one of: minor-audit, full-feature, full-bug, full"`, `"full-bug may only be used with bug work"`, `"full-feature may not be used with bug work"`. Export `parseIssueWorkMode(issueContent: string): { mode: string | null; malformed: boolean }` using regex equivalent to the Python `(?im)^-\s*Work Mode:\s*(minor-audit|full-feature|full-bug|full)\s*$` for the valid case and `(?im)^-\s*Work Mode:\s*(.+)\s*$` for the malformed-detection case. Export `resolveSelectedWorkMode(issueContent: string | null): string` and `buildFallbackReason(issueContent: string | null): string` replicating the exact returned reason strings from the Python source. Throw `Error` (not a custom type) for the validation failures. Add JSDoc and decision-logic comments. Acceptance: `npm run typecheck` passes; the file contains no `any`; all four functions and three constants are exported; error and reason strings match the Python source verbatim.
+- [x] [P2-T2] Create `extensions/drm-copilot/test/lib/prompt-mode-contract.test.ts` mirroring `tests/scripts/dev_tools/test_prompt_mode_contract.py`. Use `import { describe, expect, it } from "@jest/globals";`. Port every scenario from the Python test: valid `minor-audit` marker parse; valid `full-feature` marker parse; legacy `full` normalization to `full-feature` via `resolveSelectedWorkMode`; fail-closed when marker missing; fail-closed when marker malformed; `buildFallbackReason` for missing marker; `normalizeRequestedWorkMode` minor-audit unchanged; full-feature accepted for feature; legacy full → full-bug for bug; reject full-bug for feature work (expect thrown `Error` with matching message); reject full-feature for bug work (expect thrown `Error` with matching message); `buildFallbackReason` returns `"none"` for valid marker; legacy-full normalization reason; malformed-marker reason. Add an extra case for `resolveSelectedWorkMode(null)` returning `"full-feature"` and `buildFallbackReason(null)` returning the missing-file reason, plus a malformed-marker `parseIssueWorkMode` case asserting `malformed === true`, to reach branch coverage. Use AAA structure. Acceptance: `npm test` runs this file and all assertions pass.
+
+---
+
+### Phase 3 — Port `markdown-label-formatter.ts`
+
+- [x] [P3-T1] Create `extensions/drm-copilot/src/lib/markdown-label-formatter.ts` porting the pure-logic functions of `scripts/dev_tools/markdown_label_formatter.py`. Export `LABEL_PREFIXES = ["User:", "GitHub Copilot:"] as const`, `SEPARATOR_LINE = "---"`. Export `isLabelLine(line: string): boolean`, `isSeparatorLine(line: string): boolean`, `formatLabelHeading(line: string): { heading: string; trailing: string }` (use `partition(":")` equivalent: split on first `:`, heading is `` `# ${label.trim()}:` ``, trailing is the remainder left-stripped), `ensureSeparatorBlock(outputLines: string[]): void` (mutates the array exactly as Python: pop trailing blank lines, then push `"", "---", ""`), `prefixContentLine(line: string): string`, and `processMarkdown(content: string): string` replicating `content.splitlines()` semantics and trailing-newline preservation. Acceptance: `npm run typecheck` passes; no `any`; `processMarkdown` output matches the Python expected strings in the test scenarios exactly.
+- [x] [P3-T2] Add file I/O functions to `extensions/drm-copilot/src/lib/markdown-label-formatter.ts` using the injected `FileSystem` interface (not direct `fs`/stdin). Port `readContent` and `writeOutput` as functions that accept a `FileSystem` and an optional path: `readContent(fs: FileSystem, source: string | null, stdin: () => string): string` and `writeOutput(fs: FileSystem, content: string, target: string | null, stdout: (s: string) => void): void`. This keeps logic testable without touching real files or process streams (the Python CLI `argparse`/`main` glue is out of scope for F1 since service wiring is deferred; do not port `parse_args`/`main`). Document in JSDoc that the CLI entry-point glue is intentionally deferred to a consuming feature. Acceptance: `npm run typecheck` passes; `readContent`/`writeOutput` take injected `FileSystem` and stream callbacks; no direct `node:fs` or `process.stdin`/`process.stdout` use in this module.
+- [x] [P3-T3] Create `extensions/drm-copilot/test/lib/markdown-label-formatter.test.ts` mirroring `tests/scripts/dev_tools/test_markdown_label_formatter.py`. Use `@jest/globals`. Port the `processMarkdown` scenarios verbatim: first label with content; separator before non-initial label; multiple labels quoting other lines; label without inline text skips extra spacing; trailing newline preserved; whitespace-only separator handling. Port helper-function tests: `isLabelLine` recognizes `User:` and `GitHub Copilot:` and rejects non-labels; `isSeparatorLine` for blank, `---`, and content; `formatLabelHeading` with and without trailing text; `prefixContentLine` with and without text; `ensureSeparatorBlock` adds separator and removes trailing blanks. Port the I/O tests using a fake `FileSystem` object (in-memory map) and stub stream callbacks rather than mocking `node:fs`: `readContent` from file; `readContent` from "stdin" callback when path is null; `writeOutput` to file; `writeOutput` to "stdout" callback when path is null. Use AAA. Acceptance: `npm test` runs this file and all assertions pass; no real filesystem or temp files used.
+
+---
+
+### Phase 4 — Port `json-config.ts`
+
+- [x] [P4-T1] Create `extensions/drm-copilot/src/lib/json-config.ts` porting `scripts/dev_tools/json_config.py`. Export `GOVERNED_GLOBS = ["scripts/**/*.json", "docs/**/*.json", "examples/**/*.json"] as const` and `EXCLUDE_GLOBS` mirroring the Python tuple exactly (`"data/**"`, `"artifacts/**"`, `"htmlcov/**"`, `"coverage*/**"`, `"**/node_modules/**"`, `".venv"`, `".venv/**"`, `"**/.venv"`, `"**/.venv/**"`). Export `iterGovernedFiles(fs: FileSystem, root: string): string[]` that accepts the injected `FileSystem` (per P1-T3), replicating the Python algorithm: resolve include matches via `fs.glob`, build the exclusion set via `fs.glob`, then yield each included path that is a file (`fs.isFile`) and whose parents are not excluded and which is not itself excluded. The exclusion-by-parent check must mirror the Python `any(parent in excluded for parent in path.parents)` semantics. Return an array (TypeScript has no generator requirement; an array of paths matches `list(iter_governed_files(...))` usage in the Python tests). Add JSDoc and an intent comment on the iteration. Acceptance: `npm run typecheck` passes; no `any`; constants match the Python source; `iterGovernedFiles` takes an injected `FileSystem`.
+- [x] [P4-T2] Create `extensions/drm-copilot/test/lib/json-config.test.ts` mirroring `tests/scripts/dev_tools/test_json_config.py`. Use `@jest/globals` and a fake in-memory `FileSystem` implementation (no real filesystem). Port every scenario: `GOVERNED_GLOBS` is a non-empty array containing `"scripts/**/*.json"`; `EXCLUDE_GLOBS` is a non-empty array containing `"data/**"`; empty filesystem yields `[]`; excludes `.vscode/*.json`; excludes nested `.vscode/**/*.json`; excludes `data/**`; excludes `artifacts/**`; excludes when a parent dir is excluded (`htmlcov/subdir/report.json`); excludes `.devcontainer/*.json`; finds `scripts/**/*.json`; finds `docs/**/*.json`; finds `examples/**/*.json`; accepts a string root; mixed included/excluded yields only included; skips non-file glob matches (a directory named `weird.json`). The fake `FileSystem.glob` must implement glob/exclude matching consistent with the production `RealFileSystem.glob` so the tests validate `iterGovernedFiles` logic, not the glob engine. Use AAA. Acceptance: `npm test` runs this file and all assertions pass.
+
+---
+
+### Phase 5 — Subprocess Runner Tests
+
+- [x] [P5-T1] Create `extensions/drm-copilot/test/lib/subprocess-runner.test.ts` covering `SubprocessRunner` with `node:child_process` mocked. Use `import { afterEach, describe, expect, it, jest } from "@jest/globals";` and `jest.mock("node:child_process", () => ({ spawnSync: jest.fn() }));`. Reset mocks in `afterEach(() => { jest.resetAllMocks(); })`. Cover these scenarios: (1) success — `spawnSync` returns `{ status: 0, stdout: Buffer.from("out\n"), stderr: Buffer.from("") }`; assert `result.code === 0`, `result.stdout === "out"` (trailing newline stripped), `result.stderr === ""`; (2) non-zero exit with `allowError: true` returns the result with `code !== 0` instead of throwing; (3) non-zero exit with `allowError` false (default) throws `Error` whose message matches the `` `${args.join(" ")} failed (${code}): ${joined}` `` format; (4) stderr capture — assert stderr buffer content is decoded and trailing newline stripped; (5) UTF-8 replacement — provide a `Buffer` containing an invalid UTF-8 byte sequence (e.g. `Buffer.from([0xff, 0xfe])`) and assert `result.stdout` contains the U+FFFD replacement character rather than throwing; (6) `null` status treated as failure. Use AAA. Acceptance: `npm test` runs this file and all assertions pass; no real subprocess is spawned.
+- [x] [P5-T2] Add `extensions/drm-copilot/test/lib/file-system.test.ts` covering `RealFileSystem` glob and predicate logic with `node:fs` mocked. Use `@jest/globals` and `jest.mock("node:fs", ...)`. Cover `isFile` true/false via mocked `statSync`, `readTextFile` returning decoded UTF-8 content via mocked `readFileSync`, `writeTextFile` delegating to mocked `writeFileSync` with `"utf8"`, and `glob` returning matches consistent with the governed/exclude pattern semantics used by `json-config`. Reset mocks in `afterEach`. Acceptance: `npm test` runs this file and all assertions pass; no real filesystem access.
+
+---
+
+### Phase 6 — Final QA Loop and Coverage Verification
+
+Run the full toolchain in order. If any step fails or changes files, fix and restart from P6-T1.
+
+- [x] [P6-T1] Run formatting. From `extensions/drm-copilot/`, run `npm run format`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-format.md` with `Timestamp:`, `Command: npm run format`, `EXIT_CODE:`, `Output Summary:`. Acceptance: EXIT_CODE 0; if files changed, restart the loop at P6-T1.
+- [x] [P6-T2] Run linting. From `extensions/drm-copilot/`, run `npm run lint`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-lint.md` with `Timestamp:`, `Command: npm run lint`, `EXIT_CODE:`, `Output Summary:` (must report 0 errors). Acceptance: EXIT_CODE 0 and 0 lint errors; otherwise fix and restart at P6-T1.
+- [x] [P6-T3] Run type checking. From `extensions/drm-copilot/`, run `npm run typecheck`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-typecheck.md` with `Timestamp:`, `Command: npm run typecheck`, `EXIT_CODE:`, `Output Summary:` (must report 0 type errors). Acceptance: EXIT_CODE 0; otherwise fix and restart at P6-T1.
+- [x] [P6-T4] Run tests with coverage and verify thresholds. From `extensions/drm-copilot/`, run `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-test-coverage.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` recording numeric line coverage and branch coverage for `src/lib/**`. Acceptance: EXIT_CODE 0, all tests pass, line coverage >= 85% and branch coverage >= 75% for the `src/lib/**` files added in F1; if any test fails or thresholds are unmet, add/adjust tests and restart at P6-T1.
+- [x] [P6-T5] Record coverage delta verification. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/coverage-delta.md` with `Timestamp:`, baseline coverage (from P0-T6), post-change coverage (from P6-T4), and new/changed-code coverage for the F1 `src/lib/**` files. Acceptance: artifact reports baseline, post-change, and new-code coverage; new-code line coverage >= 85% and branch coverage >= 75%.
+- [x] [P6-T6] Verify no out-of-scope files were modified. Confirm via `git status` (from repo root) that the only changes are under `extensions/drm-copilot/src/lib/`, `extensions/drm-copilot/test/lib/`, and `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/`. Confirm `repo-automation-service.ts`, `command-runtime.ts`, MCP handlers, and policy files are unchanged. Write `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/scope-verification.md` with `Timestamp:`, `Command: git status --porcelain`, `EXIT_CODE:`, and `Output Summary:` listing changed paths. Acceptance: no changes outside the allowed paths.
+
+---
+
+## Acceptance Criteria Checklist (F1)
+
+- [x] `extensions/drm-copilot/src/lib/subprocess-runner.ts` exists, exports `CommandResult`, `CommandRunner`, and `SubprocessRunner`; uses `node:child_process` with `Buffer` capture decoded via `buffer.toString("utf8")`; returns typed `{ stdout, stderr, code }`; throws on non-zero exit when `allowError` is false with the message format matching `git.py`.
+- [x] `extensions/drm-copilot/src/lib/file-system.ts` exists, exports a `FileSystem` interface and `RealFileSystem` implementation enabling injectable, hermetic file I/O.
+- [x] `extensions/drm-copilot/src/lib/prompt-mode-contract.ts` replicates `prompt_mode_contract.py` behavior exactly (functions, constants, error and reason strings).
+- [x] `extensions/drm-copilot/src/lib/markdown-label-formatter.ts` replicates `markdown_label_formatter.py` pure-logic and I/O behavior (I/O via injected `FileSystem`); CLI glue intentionally deferred.
+- [x] `extensions/drm-copilot/src/lib/json-config.ts` replicates `json_config.py` constants and `iterGovernedFiles` semantics via injected `FileSystem`.
+- [x] All four Jest test files exist under `extensions/drm-copilot/test/lib/` mirroring the Python test scenarios, plus `subprocess-runner.test.ts` and `file-system.test.ts`.
+- [x] All tests use Jest conventions (`@jest/globals`, `jest.fn()`, `jest.mock()`, `jest.spyOn()`), AAA structure, and are hermetic (no real subprocess, no temp files).
+- [x] No file exceeds 500 lines.
+- [x] `npm run format`, `npm run lint`, `npm run typecheck` all pass with 0 errors from `extensions/drm-copilot/`.
+- [x] Tests pass with line coverage >= 85% and branch coverage >= 75% for `src/lib/**`.
+- [x] `repo-automation-service.ts`, `command-runtime.ts`, MCP handlers, and policy files are unmodified.
+- [x] All evidence artifacts written under `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/<kind>/` with required schema fields.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/policy-audit.2026-06-25T22-50.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/policy-audit.2026-06-25T22-50.md
@@ -1,0 +1,421 @@
+# Policy Compliance Audit: F1 — TypeScript Shared Subprocess and Utility Layer (Issue #240)
+
+**Audit Date:** 2026-06-25
+**Code Under Test:** Feature branch `feat/ts-port-shared-utilities-240` @ `b7ca64197c13884e8ed9833ee6937b3a9d827c80` versus base `main` @ `38a9c11ee34895e92b6e38ea5400e7dd07cddc9d` (merge base identical).
+
+TypeScript production files (new):
+- `extensions/drm-copilot/src/lib/file-system.ts`
+- `extensions/drm-copilot/src/lib/json-config.ts`
+- `extensions/drm-copilot/src/lib/markdown-label-formatter.ts`
+- `extensions/drm-copilot/src/lib/prompt-mode-contract.ts`
+- `extensions/drm-copilot/src/lib/subprocess-runner.ts`
+
+TypeScript test files (new):
+- `extensions/drm-copilot/test/lib/file-system.test.ts`
+- `extensions/drm-copilot/test/lib/json-config.test.ts`
+- `extensions/drm-copilot/test/lib/markdown-label-formatter.test.ts`
+- `extensions/drm-copilot/test/lib/prompt-mode-contract.test.ts`
+- `extensions/drm-copilot/test/lib/subprocess-runner.test.ts`
+
+Other changes: `.gitignore` (negation entries un-ignoring the extension `lib/` paths) and 17 documentation/evidence files under the feature folder.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| TypeScript | 10 files (5 src, 5 test) | 76 (F1 lib subset); 492 (full suite) | PASS 76 pass, 0 fail | 0% (src/lib did not exist) | 97.3% lines, 88.13% branch | 97.3% lines, 88.13% branch |
+| Python | 0 files | N/A | N/A | N/A | N/A | N/A |
+| PowerShell | 0 files | N/A | N/A | N/A | N/A | N/A |
+| C# | 0 files | N/A | N/A | N/A | N/A | N/A |
+
+**Note:** Only TypeScript has changed files in the branch diff. Python, PowerShell, and C# have zero changed files; their N/A verdicts are legitimate per the Coverage Verification scope invariant.
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/baseline-test-coverage.md` (src/lib denominator empty pre-implementation)
+- TypeScript post-change coverage artifact: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/final-test-coverage.md`; lcov artifact present at `extensions/drm-copilot/coverage/lcov.info`
+- TypeScript coverage-delta artifact: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/coverage-delta.md`
+- Python / PowerShell / C# coverage artifacts: `N/A - no changed files in branch diff`
+- Per-language comparison summary: Section 1.2.1 below
+
+**Coverage-artifact-path note:** The SKILL's default TypeScript coverage artifact path is repo-root `coverage/lcov.info`. This package runs its toolchain from `extensions/drm-copilot/`, so the lcov artifact is produced at `extensions/drm-copilot/coverage/lcov.info`. The artifact exists and was inspected; the path differs from the repo-root default because the package is self-contained. This is a path-location observation, not a coverage gap.
+
+**Non-negotiable verdict rule:** Numeric baseline (0%, empty denominator) and post-change (97.3% line / 88.13% branch) coverage are recorded for the only in-scope language (TypeScript). Verdict basis satisfied.
+
+---
+
+## Rejected Scope Narrowing
+
+The caller prompt scoped the review to "Feature F1" of epic #240 and stated new code is under `extensions/drm-copilot/src/lib/**`. This is a description of the branch contents, not an instruction to narrow the audit, and it matches the actual full branch diff. No language coverage was marked "plan scope only," "out of scope," "informational only," or "not applicable" for a language with changed files. No scope-narrowing instruction was detected. The audit was performed against the full branch diff (`38a9c11..b7ca641`).
+
+One discrepancy was noted in a legitimate scope source: `artifacts/pr_context.summary.txt` reports "Core logic changes: 0 files" and lists only documentation files under "Changed files overview." This summary is stale/inaccurate relative to the actual `git diff --stat` of the branch, which contains 10 TypeScript source/test files (3,354 insertions). The audit proceeded against the authoritative `git diff 38a9c11..b7ca641`, not the understated summary. This staleness is recorded in the code review as an Info finding and does not narrow scope.
+
+---
+
+## Evidence Location Compliance
+
+The branch diff was scanned for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`. None were found. All evidence artifacts are written under the canonical `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/<kind>/` path (baseline and qa-gates subdirectories).
+
+Validator: `python scripts/dev_tools/validate_evidence_locations.py --root .` → EXIT_CODE 0 (no violations).
+
+No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` entries were required.
+
+**Verdict: PASS.**
+
+---
+
+## Executive Summary
+
+F1 ports four Python shared utilities to TypeScript and adds an injectable FileSystem abstraction: `prompt-mode-contract.ts`, `json-config.ts`, `markdown-label-formatter.ts`, a `SubprocessRunner` modeled on `pr_context/git.py`, and `file-system.ts`. Each module is host-neutral with I/O isolated behind injected interfaces or `node:child_process`/`node:fs`. Five Jest test suites (76 tests) cover the new code with positive, negative, edge-case, and error paths.
+
+The full TypeScript toolchain was re-run by this review and passes independently: Prettier check (clean), ESLint (0 findings), `tsc --noEmit` (0 errors), and Jest with coverage (76 F1 tests pass; src/lib at 97.3% line / 88.13% branch, every file at or above 85% line and 75% branch). These results reproduce the executor evidence exactly.
+
+**Policy documents evaluated:**
+- PASS `general-code-change.md`
+- PASS `general-unit-test.md`
+
+**Language-specific policies evaluated:**
+- N/A `python-code-change` / `python-unit-test` (0 Python files changed)
+- N/A `powershell-*` (0 PowerShell files changed)
+- N/A `csharp-*` (0 C# files changed)
+- PASS (with one Major framework deviation, see below) `typescript.md` + `typescript-suppressions.md`
+
+**Temporary artifacts cleanup:**
+- PASS No temporary or throwaway scripts were introduced by F1.
+- N/A No ongoing tooling scripts were added.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | PASS | Each suite resets mocks in `afterEach(() => { jest.resetAllMocks(); })` (e.g., `subprocess-runner.test.ts:31`, `file-system.test.ts:36`). Pure-logic suites (`prompt-mode-contract`, `markdown-label-formatter`, `json-config`) hold no shared mutable state across tests. |
+| **Isolation** - Each test targets single behavior | PASS | Tests are grouped per function with one assertion target each (e.g., `formatLabelHeading` with and without trailing text are separate tests). |
+| **Fast Execution** - Tests complete quickly | PASS | F1 lib subset (76 tests) ran in ~1.08s (`node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts" test/lib`). |
+| **Determinism** - Consistent results | PASS | No wall-clock, RNG, real subprocess, or real filesystem use. `node:child_process` and `node:fs` are mocked; `FileSystem` is injected via in-memory fakes. No banned timing APIs. |
+| **Readability & Maintainability** - Clear structure | PASS | Descriptive `describe`/`it` names; explicit Arrange/Act/Assert comments throughout. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | PASS | Baseline: src/lib did not exist; denominator empty (0/0). Command `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`. Recorded in `evidence/baseline/baseline-test-coverage.md`. |
+| **No Coverage Regression** | PASS | Pre-existing suites remain green (416 → 492 tests, all passing). No changed-line regression: all F1 files are net-new. |
+| **New Code Coverage** (uniform tier rule: line >= 85%, branch >= 75%) | PASS | New-code line coverage 97.3% aggregate; every file >= 95.85% line and >= 82.35% branch. Independently reproduced by this review. |
+| **Comprehensive Coverage** | PASS | All exported functions covered (100% function coverage reported). Uncovered residual lines are defensive catch/guard branches (e.g., `subprocess-runner.ts:102-103` undefined-executable guard; `file-system.ts` readdir catch). |
+| **Positive Flows** | PASS | e.g., `parseIssueWorkMode` valid markers; `processMarkdown` label-with-content; `SubprocessRunner` success path. |
+| **Negative Flows** | PASS | e.g., `normalizeRequestedWorkMode` rejects unrecognized mode and incompatible type/mode combinations with exact error strings. |
+| **Edge Cases** | PASS | e.g., whitespace-only separator line; trailing-newline preservation; directory named `*.json`; empty filesystem. |
+| **Error Handling** | PASS | e.g., `SubprocessRunner` non-zero-exit throw with `git.py` message format; null status treated as failure; `statSync`/`readdirSync` throw paths. |
+| **Concurrency** | N/A | No concurrent behavior in the ported modules. |
+| **State Transitions** | N/A | No stateful components; modules are pure functions plus thin I/O wrappers. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- TypeScript: Baseline 0% line (empty src/lib denominator) -> Post-change 97.3% line / 88.13% branch. Change: net-new. New/changed-code coverage: 97.3% line / 88.13% branch. Disposition: PASS. Evidence: `evidence/qa-gates/final-test-coverage.md`, `evidence/qa-gates/coverage-delta.md`, `extensions/drm-copilot/coverage/lcov.info`, and this review's independent re-run.
+- Python: N/A - no changed files in branch diff.
+- PowerShell: N/A - no changed files in branch diff.
+- C#: N/A - no changed files in branch diff.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | PASS | Assertions use exact `toBe`/`toEqual`/`toThrow` with literal expected values, including full error-message strings. |
+| **Arrange-Act-Assert Pattern** | PASS | Explicit `// Arrange` / `// Act` / `// Assert` comments in every test. |
+| **Document Intent** | PASS | Descriptive `it` names; helper functions carry docstrings (e.g., `spawnResult`, `dirent`, `VirtualFileSystem`). |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | PASS | No network, DB, real processes, or real filesystem. `node:child_process` and `node:fs` mocked; `FileSystem` injected. |
+| **Use Mocks/Stubs** | PASS | `jest.mock("node:child_process", ...)`, `jest.mock("node:fs", ...)`, plus in-memory `FileSystem` fakes (`VirtualFileSystem`, `InMemoryFileSystem`). |
+| **Environment Stability** | PASS | No temporary files created (verified by inspection; tests use in-memory maps). No mutable global state. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | PASS | This audit plus `code-review.2026-06-25T22-50.md` and `feature-audit.2026-06-25T22-50.md` constitute the required review. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | PASS | Objective documented in `issue.md` (#240) and `plans/F1-shared-utilities.plan.md`. |
+| **Read existing change plans** | PASS | `evidence/baseline/phase0-instructions-read.md` records the policy reading order; `phase0-python-sources.md` records source signatures. |
+| **Document the plan** | PASS | Atomic plan `plans/F1-shared-utilities.plan.md` with phased tasks. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | PASS | Each module is a direct, readable port; control flow is linear with documented branches. |
+| **Reusability** | PASS | `FileSystem` interface is shared by `json-config.ts` and `markdown-label-formatter.ts`; `toPosixPath` reused. |
+| **Extensibility** | PASS | I/O behind interfaces (`FileSystem`, `CommandRunner`); options objects use optional keyword-style fields with defaults. |
+| **Separation of concerns** | PASS | Pure logic separated from I/O: `processMarkdown` is pure; file/stream access is injected. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | PASS | One concern per file (subprocess, filesystem, json-config discovery, markdown formatting, work-mode contract). |
+| **Under 500 lines** | PASS | Max production file 241 lines (`markdown-label-formatter.ts`); max test 288 lines. All under 500. |
+| **Public vs internal** | PASS | Public surface is the exported functions/classes; helpers (`joinPosix`, `escapeRegExp`, `compileGlob`, `stripTrailingNewlines`, `splitLines`, `parentPaths`) are module-private. |
+| **No circular dependencies** | PASS | Consumers import the `FileSystem` type from `file-system.ts`; no back-edges. `tsc` and ESLint `import` plugin clean. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | PASS | `iterGovernedFiles`, `resolveSelectedWorkMode`, `ensureSeparatorBlock`, etc. Kebab-case filenames. |
+| **Docs/docstrings** | PASS | Module-level and per-export JSDoc present across all five files. |
+| **Comment why, not what** | PASS | Intent comments above loops/branches (e.g., glob translation, exclusion-by-parent). One docstring inaccuracy noted (see code review, `CommandResult` JSDoc on `subprocess-runner.ts:8`). |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | PASS | Command: `npx prettier --check "src/lib/**/*.ts" "test/lib/**/*.ts"` → "All matched files use Prettier code style!" (re-run by review). |
+| **2. Linting** | PASS | Command: `npx eslint --no-error-on-unmatched-pattern src/lib test/lib` → 0 findings (re-run by review). |
+| **3. Type checking** | PASS | Command: `npx tsc -p ./ --noEmit` → 0 errors (re-run by review). |
+| **4. Testing** | PASS | Command: `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts" test/lib` → 76 pass, 0 fail (re-run by review). |
+| **Full toolchain loop** | PASS | Executor evidence (`evidence/qa-gates/final-*.md`) and this review both report a clean single pass. |
+| **Explicit reporting** | PASS | Commands and results recorded here and in Appendix B. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | PASS | Summarized in this audit and the code review. |
+| **Design choices explained** | PASS | JSDoc explains deferral of CLI glue and injection rationale. |
+| **Update supporting documents** | PARTIAL | The epic AC source files `spec.md`/`user-story.md` (required by `full-feature` work mode) do not exist in the feature folder. The F1 plan checklist serves as the de-facto AC source for this feature. See Gaps. |
+| **Provide next steps** | PASS | Next features of the epic are listed in `initiative.md` / research inventory. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3T: TypeScript Code Change Policy Compliance
+
+#### 3T.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with Prettier** | PASS | `npx prettier --check` clean. |
+| **Linting with ESLint** | PASS | `npx eslint src/lib test/lib` → 0 findings. |
+| **Type checking with tsc** | PASS | `tsc -p ./ --noEmit` → 0 errors. `tsconfig` uses `strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`. |
+| **Testing** | MAJOR DEVIATION | `typescript.md` mandates **Vitest**. This package uses **Jest** (`jest.config.cjs`, `ts-jest`, `run-jest.cjs`, `@jest/globals`). See finding TS-1. |
+
+#### 3T.2 TypeScript Design & Typing
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Strong typing; no `any`** | PASS | No `any` in src/lib. `unknown` plus narrowing used. Exported APIs fully typed (`CommandResult`, `CommandRunner`, `FileSystem`, `ParsedWorkMode`, `LabelHeading`). |
+| **ES modules only** | PASS | `import`/`export` only in `src/`; no `require`/`module.exports`. |
+| **Domain types encode invariants** | PASS | `as const` literal tuples for work modes / globs; discriminated `ParsedWorkMode`. |
+| **No `I` prefix; kebab-case files** | PASS | Interfaces named `FileSystem`, `CommandRunner` (no `I` prefix); filenames kebab-case. |
+| **Separation from host-bound APIs** | PASS | Pure logic separated from `node:fs`/`node:child_process`/streams via injection. |
+
+#### 3T.3 Suppressions
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **No unauthorized suppressions** | PASS | No `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck` present in src/lib or test/lib (verified by inspection; ESLint clean). |
+
+#### 3T.4 Error Handling
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Fail fast with clear errors** | PASS | `SubprocessRunner` throws with explicit message on non-zero exit; `normalizeRequestedWorkMode` throws explicit validation errors. |
+| **No silent catch-all** | PASS | `try/catch` in `RealFileSystem.glob`/`isFile` is a deliberate, documented "absent path yields nothing" semantic mirroring Python `Path.glob`, not a swallowed error. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4T: TypeScript Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Test framework** | MAJOR DEVIATION | Jest used; `typescript.md` mandates Vitest. See TS-1. Tests are otherwise well-formed and hermetic. |
+| **Test file location mirrors source** | PASS | `test/lib/<name>.test.ts` mirrors `src/lib/<name>.ts`. Not colocated in `src/`. |
+| **`*.test.ts` naming** | PASS | All five files use the `*.test.ts` suffix. |
+| **AAA structure** | PASS | Explicit Arrange/Act/Assert throughout. |
+| **One behavior per test** | PASS | Verified by inspection. |
+| **No external deps / temp files** | PASS | Mocked `node:fs`/`node:child_process`; in-memory `FileSystem` fakes. |
+| **Coverage thresholds (>=85% line, >=75% branch)** | PASS | 97.3% line / 88.13% branch; every file at or above thresholds. |
+
+---
+
+## 5. Test Coverage Detail
+
+| Module | Tests | Line % | Branch % | Uncovered (residual) |
+|--------|-------|--------|----------|----------------------|
+| `prompt-mode-contract.ts` | 25 | 100 | 96.29 | line 111 (malformed-regex no-match branch tail) |
+| `markdown-label-formatter.ts` | ~24 | 95.85 | 87.87 | lines 59-68 (`\r`/`\r\n` boundary branch in `splitLines`) |
+| `json-config.ts` | 16 | 96.19 | 83.33 | lines 94-95, 97-98 (excluded-parent / excluded-self continue branches) |
+| `file-system.ts` | 6 | 96.47 | 86.2 | lines 66-67, 69-70 (`joinPosix` empty-segment guards), 130-133 (`?` token branch) |
+| `subprocess-runner.ts` | 7 | 98.59 | 82.35 | lines 102-103 (undefined-executable guard) |
+
+All residual uncovered lines are defensive guards or rarely-exercised parity branches. All files exceed the uniform thresholds.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (F1 lib subset) | 76 | PASS |
+| Tests Passed | 76 (100%) | PASS |
+| Tests Failed | 0 | PASS |
+| Full-suite total | 492 pass / 41 suites | PASS |
+| Execution Time (F1 subset) | ~1.08s | Fast |
+| Functions/Classes Tested | 100% functions | PASS |
+| Max File Size | 288 lines (test), 241 lines (src) | PASS |
+| Code Coverage | 97.3% line, 88.13% branch (src/lib) | PASS |
+
+---
+
+## 7. Code Quality Checks
+
+**For TypeScript:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Prettier | `npx prettier --check "src/lib/**/*.ts" "test/lib/**/*.ts"` | clean | PASS |
+| ESLint | `npx eslint --no-error-on-unmatched-pattern src/lib test/lib` | 0 findings | PASS |
+| tsc | `npx tsc -p ./ --noEmit` | 0 errors | PASS |
+| Jest (coverage) | `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts" test/lib` | 76 pass | PASS |
+
+**Notes:** No pre-existing failures observed in the F1 lib subset. The full suite reports 492 passing.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+- **Test framework deviation (TS-1, Major):** The package uses Jest, but `typescript.md` mandates Vitest and Vitest-specific facilities (`vi.useFakeTimers`, `vi.spyOn`). This is a pre-existing, repo-wide condition for `extensions/drm-copilot/` (41 suites use Jest), not introduced by F1; the F1 plan documents Jest as authoritative for this package. Treated as Major (policy-vs-implementation divergence) but not Blocking, because the divergence predates this feature and the policy text does not carve out the extension package. Recommended resolution: either reconcile `typescript.md` to acknowledge the extension package's Jest toolchain, or migrate the package to Vitest as a separate initiative.
+- **Missing full-feature AC sources (Major):** Work mode is `full-feature`, which requires `spec.md` and `user-story.md` as AC sources. Neither exists in the feature folder. The epic `issue.md` AC and the F1 plan's "Acceptance Criteria Checklist (F1)" are the only available AC sources. This is an epic-scaffolding gap.
+
+### Approved Exceptions
+
+- **None.** No suppressions or policy exceptions were used in the code.
+
+### Removed/Skipped Tests
+
+- **None.** No tests were removed or skipped.
+
+---
+
+## 9. Summary of Changes
+
+### Branch
+
+`feat/ts-port-shared-utilities-240` @ `b7ca64197c13884e8ed9833ee6937b3a9d827c80`, base `main` @ `38a9c11ee34895e92b6e38ea5400e7dd07cddc9d`.
+
+### Files (delta vs base)
+
+- 5 new TypeScript production modules under `extensions/drm-copilot/src/lib/` (NEW).
+- 5 new Jest test suites under `extensions/drm-copilot/test/lib/` (NEW).
+- `.gitignore` (MODIFIED): added negation entries un-ignoring `extensions/drm-copilot/src/lib/` and `test/lib/`; resolves the previously-escalated gitignore collision so the 10 files are tracked.
+- 17 documentation/evidence files under the feature folder (NEW).
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ⚠️ PARTIALLY COMPLIANT
+
+The implementation and tests satisfy the general code-change and unit-test policies and the TypeScript design/typing/suppression rules. Format, lint, type-check, and coverage gates all pass and were independently reproduced. Two Major policy-level gaps remain: the Jest-vs-Vitest framework divergence (pre-existing, package-wide) and the absence of the `full-feature` AC source files (`spec.md`/`user-story.md`). Neither is a code defect in F1; both are documentation/policy-reconciliation items. No Blocking code findings were identified.
+
+**Fail-closed reminder:** All required baseline, QA, and coverage artifacts are present; the verdict is PARTIALLY COMPLIANT (not PASS) solely due to the two Major policy-reconciliation gaps above.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- PASS Before Making Changes
+- PASS Design Principles
+- PASS Module & File Structure
+- PASS Naming, Docs, Comments (one Minor docstring inaccuracy, non-blocking)
+- PASS Toolchain Execution
+- PARTIAL Summarize & Document (missing AC source files)
+
+#### Language-Specific Code Change Policy (Section 3)
+**For TypeScript:**
+- PARTIAL Tooling & Baseline (Jest vs mandated Vitest)
+- PASS Design & Typing
+- PASS Suppressions
+- PASS Error Handling
+
+#### General Unit Test Policy (Section 1)
+- PASS Core Principles
+- PASS Coverage & Scenarios
+- PASS Test Structure
+- PASS External Dependencies
+- PASS Policy Audit
+
+#### Language-Specific Unit Test Policy (Section 4)
+**For TypeScript:**
+- PARTIAL Framework (Jest vs Vitest)
+- PASS Test Style & Structure
+- PASS Naming & Readability
+- PASS Coverage
+
+---
+
+### Metrics Summary
+
+- PASS 76/76 F1 lib tests passing (100%); 492/492 full suite
+- PASS 100% of exported functions tested
+- PASS 97.3% line coverage, 88.13% branch coverage (src/lib)
+- PASS Proper test-file organization (test/lib mirrors src/lib)
+- PASS All code quality checks passing
+- PASS Fast execution (~1.08s for F1 subset)
+
+---
+
+### Recommendation
+
+**Conditional Go.** The F1 code is mergeable from a correctness, typing, and coverage standpoint. Before or alongside merge, resolve the two Major policy-reconciliation items: (1) reconcile the Jest-vs-Vitest policy divergence for the extension package, and (2) author the epic's `spec.md`/`user-story.md` (or formally designate the F1 plan checklist as the AC source for `full-feature` work in this folder). These are tracked in `remediation-inputs.2026-06-25T22-50.md`.
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For TypeScript (run from `extensions/drm-copilot/`):**
+```bash
+# Formatting (check-only, as run by this review)
+npx prettier --check "src/lib/**/*.ts" "test/lib/**/*.ts"
+
+# Linting
+npx eslint --no-error-on-unmatched-pattern src/lib test/lib
+
+# Type checking
+npx tsc -p ./ --noEmit
+
+# Testing with coverage (F1 lib subset)
+node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts" test/lib
+```
+
+**Evidence-location validator (run from repo root):**
+```bash
+python scripts/dev_tools/validate_evidence_locations.py --root .
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-06-25
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/remediation-inputs.2026-06-25T22-50.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/remediation-inputs.2026-06-25T22-50.md
@@ -1,0 +1,58 @@
+# Remediation Inputs — F1 TypeScript Shared Utility Layer (Issue #240)
+
+**Entry timestamp:** 2026-06-25T22-50
+**Feature folder:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+**Branch:** `feat/ts-port-shared-utilities-240` @ `b7ca64197c13884e8ed9833ee6937b3a9d827c80`
+**Base:** `main` @ `38a9c11ee34895e92b6e38ea5400e7dd07cddc9d`
+
+## Source audit artifacts
+
+- `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/policy-audit.2026-06-25T22-50.md`
+- `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/code-review.2026-06-25T22-50.md`
+- `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/feature-audit.2026-06-25T22-50.md`
+
+## Finding classification
+
+- **Blocking findings: 0.** No Blocker-severity code defects were identified. The F1 code passes format, lint, type-check, and coverage gates and was independently reproduced.
+- **Material PARTIAL / Major (remediation-required): 2.**
+- **Minor / Info (non-blocking, optional): 3.**
+
+The two Major items are policy/scaffolding reconciliations, not code defects. They are recorded here because the feature-audit verdict is NEEDS REVISION and the policy-audit verdict is PARTIALLY COMPLIANT.
+
+## Remediation-required findings
+
+### R1 (Major) — Missing `full-feature` acceptance-criteria source files
+- **Finding:** `issue.md` declares `- Work Mode: full-feature`, which requires `spec.md` and `user-story.md` as authoritative AC sources. Neither exists in the feature folder. AC tracking currently falls back to the F1 plan checklist.
+- **Files:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/spec.md` (to create), `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/user-story.md` (to create).
+- **Expected behavior:** Either (a) author `spec.md` and `user-story.md` for the epic with checkbox-backed acceptance criteria, or (b) if F1 is to be tracked independently, change the work-mode marker to the mode whose AC source matches the existing checkbox-backed F1 plan, with rationale recorded.
+- **Verification:** AC source files exist and contain checkbox-format acceptance criteria; `feature-audit` can resolve AC sources without fallback. `ls docs/features/active/2026-06-25-port-python-commands-to-typescript-240/spec.md docs/features/active/.../user-story.md`.
+
+### R2 (Major) — Test-framework policy divergence (Jest vs mandated Vitest)
+- **Finding:** `extensions/drm-copilot/` uses Jest (`ts-jest`, `@jest/globals`, `run-jest.cjs`), but `.claude/rules/typescript.md` mandates Vitest and Vitest-only facilities (`vi.useFakeTimers`, `vi.spyOn`). The divergence is pre-existing and package-wide (41 suites), not introduced by F1.
+- **Files:** `.claude/rules/typescript.md` (policy; do not edit without authorization), `extensions/drm-copilot/package.json`, `extensions/drm-copilot/jest.config.cjs`.
+- **Expected behavior:** Reconcile the divergence. Preferred: document the extension package's Jest toolchain as an authorized exception in `typescript.md` (requires policy-owner approval, since policy files must not be edited unilaterally). Alternative: schedule a Vitest migration for the package as a separate initiative.
+- **Verification:** Policy text and package toolchain agree; no unreconciled MAJOR divergence remains in a future policy audit.
+- **Note:** This item requires a decision by the policy owner. The feature-review and atomic-executor agents must not modify `.claude/rules/typescript.md` without explicit approval.
+
+## Optional (non-blocking) improvements
+
+- **O1 (Minor):** `extensions/drm-copilot/src/lib/subprocess-runner.ts:8` — `CommandResult` JSDoc says "a single trailing newline stripped" but the implementation (and Python `rstrip("\n")`) strips all trailing newlines. Reword to "all trailing newline characters stripped." Verification: `npx tsc -p ./ --noEmit` still clean after edit.
+- **O2 (Minor):** `extensions/drm-copilot/src/lib/markdown-label-formatter.ts:43-79` — `splitLines` covers `\n`/`\r`/`\r\n` only; Python `str.splitlines()` splits on additional Unicode boundaries. Document the intentional narrowing in JSDoc, or extend the boundary set if exotic separators are in-scope. Verification: a test asserting the documented behavior.
+- **O3 (Info):** `artifacts/pr_context.summary.txt` is stale (reports 0 core logic changes). Regenerate PR context before relying on the summary. Verification: regenerated summary lists the 10 TypeScript files.
+
+## CI verification (E5)
+
+- E5 ("All CI gates pass") is UNVERIFIED: PR-context CI status is "(not available)" for the branch head. No `.github/workflows/**`, `scripts/benchmarks/**`, or `.github/actions/**` files changed on the branch, so the `modified-workflow-needs-green-run` rule does NOT fire and no green-run evidence is required by that rule. Recommend triggering a CI run against the branch head to resolve E5 before merge.
+
+## Do-not-do list
+
+- Do not modify `command-runtime.ts`, `repo-automation-service.ts`, or MCP handlers under F1; service wiring is a later epic feature (E3/E4).
+- Do not modify `.claude/rules/**` or `.github/instructions/**` without explicit policy-owner approval (R2).
+- Do not weaken or remove any existing test or assertion.
+- Do not lower coverage thresholds or add coverage `exclude` entries for production paths.
+- Do not expand scope beyond R1/R2 and the optional items above.
+- Do not introduce new runtime dependencies.
+
+## Handoff
+
+Remediation plan authored at `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/remediation-plan.2026-06-25T22-50.md` per `remediation-handoff-atomic-planner` and `atomic-plan-contract`.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/remediation-plan.2026-06-25T22-50.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/remediation-plan.2026-06-25T22-50.md
@@ -1,0 +1,82 @@
+# Remediation Plan — F1 TypeScript Shared Utility Layer (Issue #240)
+
+**Issue:** #240
+**Feature:** F1 (ts-shared-subprocess-and-utility-layer)
+**Work Mode:** full-feature
+**Entry timestamp:** 2026-06-25T22-50
+**Plan path:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/remediation-plan.2026-06-25T22-50.md`
+**Feature folder (`<FEATURE>`):** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+**Remediation inputs:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/remediation-inputs.2026-06-25T22-50.md`
+
+## Scope Summary
+
+Address the two Major policy-reconciliation findings (R1, R2) and three optional non-blocking improvements (O1-O3) from the 2026-06-25T22-50 audit cycle. No Blocking code defects were found; the F1 implementation passes the full toolchain. This plan does not change F1 runtime behavior except for the documentation-accuracy edits in O1/O2.
+
+## Constraints (must hold for every task)
+
+- No production or test file may exceed 500 lines.
+- ES modules only; no `require`/`module.exports` in `src/`.
+- Strong typing; no `any`.
+- Do NOT modify `command-runtime.ts`, `repo-automation-service.ts`, or MCP handlers (epic-scope, deferred).
+- Do NOT modify `.claude/rules/**` or `.github/instructions/**` without explicit policy-owner approval (applies to R2).
+- Do not weaken tests, lower coverage thresholds, or add production-path coverage excludes.
+- Tests remain hermetic: no real subprocess, temp files, or real filesystem writes.
+
+## Evidence Location Invariant
+
+All evidence artifacts MUST be written under `<FEATURE>/evidence/<kind>/`:
+- Baseline: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/`
+- QA gates: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/`
+- Regression: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/regression-testing/`
+
+Each command-step evidence artifact MUST include `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`. Coverage artifacts MUST record numeric line and branch coverage values. Writing evidence to `artifacts/baselines/`, `artifacts/qa/`, or `artifacts/coverage/` is a policy violation.
+
+---
+
+### Phase 0 — Policy Reads and Baseline Capture
+
+- [ ] [P0-T1] Read repository policy files in required order per `policy-compliance-order`: `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/typescript.md`, `.claude/rules/typescript-suppressions.md`, `.claude/rules/quality-tiers.md`, `.claude/rules/self-explanatory-code-commenting.md`. Write `evidence/baseline/remediation-phase0-instructions-read.2026-06-25T22-50.md` with `Timestamp:`, `Policy Order:`, and `Files Read:`. Acceptance: evidence file exists and lists every file.
+- [ ] [P0-T2] Capture baseline toolchain state from `extensions/drm-copilot/`: run `npm run format`, `npm run lint`, `npm run typecheck`, and `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`. Write `evidence/baseline/remediation-baseline-toolchain.2026-06-25T22-50.md` with `Timestamp:`, `Command:` (each), `EXIT_CODE:` (each), and `Output Summary:` including numeric line and branch coverage for `src/lib/**`. Acceptance: artifact records all four commands with exit codes and numeric coverage.
+
+---
+
+### Phase 1 — R1: Acceptance-Criteria Source Reconciliation
+
+- [ ] [P1-T1] Resolve the AC-source gap for `full-feature` work mode. Decide with the issue owner between: (a) author `spec.md` and `user-story.md` for the epic with checkbox-backed acceptance criteria, or (b) record a documented determination that the F1 plan checklist is the operative AC source for this folder. If (a): create `<FEATURE>/spec.md` and `<FEATURE>/user-story.md` with checkbox AC that cover the F1 deliverables and reference the epic AC. If (b): record the determination in `<FEATURE>/issue.md` (or a decision note) without weakening the work-mode contract. Acceptance: `feature-review` can resolve AC sources without fallback; the chosen artifacts exist and contain checkbox-format AC.
+
+---
+
+### Phase 2 — R2: Test-Framework Policy Reconciliation (decision-gated)
+
+- [ ] [P2-T1] Prepare a policy-reconciliation proposal for the Jest-vs-Vitest divergence. Document the two options: (a) author an authorized exception in `.claude/rules/typescript.md` acknowledging the extension package's Jest toolchain (requires policy-owner approval — DO NOT edit the policy file without it), or (b) scope a Vitest migration for `extensions/drm-copilot/` as a separate initiative. Write the proposal and the chosen path to `evidence/regression-testing/r2-framework-reconciliation-decision.2026-06-25T22-50.md`. Acceptance: the decision artifact records both options and the owner-approved path. No policy file is edited without recorded approval.
+
+---
+
+### Phase 3 — Optional Documentation/Parity Fixes (O1, O2)
+
+- [ ] [P3-T1] (O1) Correct the `CommandResult` JSDoc in `extensions/drm-copilot/src/lib/subprocess-runner.ts` (line 8) to state that all trailing newline characters are stripped (matching the `stripTrailingNewlines` helper and Python `rstrip("\n")`). Acceptance: `npx tsc -p ./ --noEmit` clean; JSDoc accurately describes the helper behavior.
+- [ ] [P3-T2] (O2) In `extensions/drm-copilot/src/lib/markdown-label-formatter.ts`, document in the `splitLines` JSDoc that only `\n`/`\r`/`\r\n` boundaries are handled (intentional narrowing relative to Python `str.splitlines()` Unicode boundaries), or extend the boundary set if exotic separators are in-scope. If behavior changes, add a covering test in `test/lib/markdown-label-formatter.test.ts`. Acceptance: JSDoc or test reflects the decided behavior; toolchain remains clean.
+
+---
+
+### Phase 4 — Final QA Loop and Coverage Verification
+
+Run the full toolchain in order from `extensions/drm-copilot/`. If any step fails or changes files, fix and restart from P4-T1.
+
+- [ ] [P4-T1] Run `npm run format`. Write `evidence/qa-gates/remediation-final-format.2026-06-25T22-50.md` with the four required fields. Acceptance: EXIT_CODE 0; if files changed, restart.
+- [ ] [P4-T2] Run `npm run lint`. Write `evidence/qa-gates/remediation-final-lint.2026-06-25T22-50.md`. Acceptance: EXIT_CODE 0 and 0 lint errors.
+- [ ] [P4-T3] Run `npm run typecheck`. Write `evidence/qa-gates/remediation-final-typecheck.2026-06-25T22-50.md`. Acceptance: EXIT_CODE 0 and 0 type errors.
+- [ ] [P4-T4] Run `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`. Write `evidence/qa-gates/remediation-final-test-coverage.2026-06-25T22-50.md` recording numeric line and branch coverage. Acceptance: EXIT_CODE 0, all tests pass, line coverage >= 85% and branch coverage >= 75% for `src/lib/**`.
+- [ ] [P4-T5] Verify scope containment via `git status --porcelain` and `git diff --name-only`. Confirm no changes outside `extensions/drm-copilot/src/lib/`, `extensions/drm-copilot/test/lib/`, the feature folder, and (only with recorded approval) the policy decision artifacts. Write `evidence/qa-gates/remediation-scope-verification.2026-06-25T22-50.md`. Acceptance: no out-of-scope modifications.
+
+---
+
+## Acceptance Criteria Checklist (Remediation)
+
+- [ ] R1: `full-feature` AC sources resolved (files created or determination recorded); `feature-review` resolves AC without fallback.
+- [ ] R2: Jest-vs-Vitest divergence reconciled via owner-approved path; no unauthorized policy-file edit.
+- [ ] O1: `CommandResult` JSDoc corrected.
+- [ ] O2: `splitLines` parity documented or extended (with test if behavior changed).
+- [ ] Full toolchain passes (format, lint, typecheck, tests) with `src/lib/**` line >= 85% and branch >= 75%.
+- [ ] No out-of-scope files modified; no policy file edited without recorded approval.
+- [ ] All evidence artifacts written under `<FEATURE>/evidence/<kind>/` with required schema fields.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/research/python-to-typescript-inventory.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/research/python-to-typescript-inventory.md
@@ -1,0 +1,863 @@
+# Python-to-TypeScript Port — Authoritative Inventory and Feature Decomposition
+**Issue #240 | Research Date: 2026-06-25**
+
+---
+
+## 1. Current State Analysis
+
+### 1.1 Runtime Bridge Architecture
+
+The VS Code extension bridges Python through `extensions/drm-copilot/src/command-runtime.ts`. The key pattern is:
+
+1. `detectRuntime("python")` probes `python` then `py` on PATH.
+2. `executeBundledScriptFromExtensionRoot()` resolves the script from the bundled extension resources directory, spawns the interpreter as a child process, and streams stdout/stderr.
+3. MCP handlers in `src/mcp-handlers/*.ts` call methods on `RepoAutomationService` (defined in `src/repo-automation-service.ts`), which calls the private `executeScript()` method, which in turn calls `executeBundledScriptFromExtensionRoot()`.
+4. Template wrapper scripts under `extensions/drm-copilot/resources/templates/*.py` add the bundled `resources/scripts/` directory to `sys.path` and delegate in-process to the matching `dev_tools.*` module.
+
+After the port, the `"python"` branch of `detectRuntime()` and all `runtimeKind: "python"` invocations are eliminated. Each `RepoAutomationService` method switches to calling an in-process TypeScript function instead of spawning a child process.
+
+### 1.2 Python File Count by Location
+
+| Location | File count | Approx. LoC |
+|---|---|---|
+| `scripts/dev_tools/**` | 90 files | ~28,100 |
+| `extensions/drm-copilot/resources/templates/*.py` | 13 files | ~1,155 |
+| Python tests (`tests/**`) | ~131 files | ~39,750 |
+
+---
+
+## 2. Complete Python Module Inventory
+
+### 2.1 Template Wrapper Files (entry points invoked at runtime)
+
+These thirteen files live in `extensions/drm-copilot/resources/templates/` and are the direct targets spawned by the extension. Each is a thin bootstrap wrapper that adds `resources/scripts/` to `sys.path` and delegates to a `dev_tools` module.
+
+| File | LoC | Purpose | Invoked by (service method) |
+|---|---|---|---|
+| `collect_commit_context.py` | 212 | Collects git staged/unstaged context for commit message generation; self-contained, no delegation | `collectCommitContext` |
+| `collect_pr_context.py` | 75 | Wrapper; delegates to `dev_tools.pr_context.collector.main` | `collectPrContext` |
+| `codex_native_converter.py` | 36 | Wrapper; delegates to `dev_tools.codex_native_converter.cli.main` | `runCodexNativeConverter` |
+| `new_active_feature_folder.py` | 67 | Wrapper; delegates to `dev_tools.new_active_feature_folder.main`, injects `--template-root` | `newActiveFeatureFolder` |
+| `new_potential_bug_entry.py` | 55 | Wrapper; delegates to `dev_tools.new_potential_bug_entry.main` | `newPotentialBugEntry` |
+| `potential_to_issue.py` | 56 | Wrapper; delegates to `dev_tools.potential_to_issue.main` | `potentialToIssue` |
+| `push_down_claude_customizations.py` | 234 | Full implementation; delegates to `push_down_claude_customizations` engine, parses `--packs/--csharp-variant/--memory-mode` | `pushDownClaudeCustomizations` |
+| `push_down_codex_and_agents_customizations.py` | 96 | Wrapper; delegates to `dev_tools.push_down_codex_and_agents_customizations` | `pushDownCodexAndAgentsCustomizations` |
+| `push_down_copilot_customizations.py` | 125 | Wrapper; delegates to `dev_tools.push_down_copilot_customizations.push_down_customizations` | `pushDownCopilotCustomizations` |
+| `resolve_atomic_plan_prompt.py` | 76 | Wrapper; delegates to `dev_tools.resolve_file_prompt.main`, injects atomic-plan template path | `resolveAtomicPlanPrompt` |
+| `resolve_hard_lock_prompt.py` | 66 | Wrapper; delegates to `dev_tools.resolve_hard_lock_prompt.main`, injects template root | `resolveExecuteHardLockPrompt` |
+| `validate_orchestration_artifacts.py` | 56 | Wrapper; delegates to `dev_tools.validate_orchestration_artifacts.main` | `validateOrchestrationArtifacts` |
+| `hello_python.py` | ~5 | Smoke-test placeholder; no production use | None |
+
+### 2.2 Production `dev_tools` Modules — Cluster A: `pr_context`
+
+The PR context cluster is the implementation behind `collect_pr_context.py` and `collect_commit_context.py`.
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `pr_context/collector.py` | 619 | Top-level orchestrator: builds git/gh clients, gathers diffs, feature docs, issue/PR details, verification evidence, writes summary+appendix files | `test_collect_pr_context.py`, `test_collect_pr_context_part2-4.py`, `test_pr_context_integration.py` |
+| `pr_context/git.py` | 153 | `GitClient` + `SubprocessRunner`; typed git subprocess wrapper | `test_git.py` |
+| `pr_context/github.py` | 549 | `GhClient`: `gh` CLI wrapper; entity classification, issue/PR/CI fetches, repo file fetch | `test_github.py`, `test_github_part2-3.py` |
+| `pr_context/models.py` | 198 | Dataclass models: `CommandResult`, `IssueDetails`, `PullRequestDetails`, `PRContextResult`, helpers | (covered by collector tests) |
+| `pr_context/render.py` | 342 | Build PR context text from git/gh data; select base, format diffs | `test_collect_pr_context.py` |
+| `pr_context/render_feature_excerpts.py` | 256 | Render feature doc excerpts for PR context | `test_feature_docs.py` |
+| `pr_context/render_pr_helpers.py` | 291 | Build autoclose section, issue-to-autoclose logic | (covered by collector tests) |
+| `pr_context/summary_helpers.py` | 386 | Digest builders, bucket text, timestamp append, numstat parsing | (covered by collector tests) |
+| `pr_context/feature_docs.py` | 349 | Discover feature docs, extract issue refs, read excerpts | `test_feature_docs.py` |
+| `pr_context/verification_evidence.py` | 171 | Parse verification evidence YAML files | (covered by collector tests) |
+| `pr_context/__init__.py` | 5 | Re-exports | — |
+| `collect_commit_context.py` | 212 | Self-contained git context collector for commit messages | `test_collect_commit_context.py` |
+
+**External dependencies**: `git` binary, `gh` CLI binary, filesystem, subprocess.
+
+### 2.3 Production `dev_tools` Modules — Cluster B: `codex_native_converter`
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `codex_native_converter/cli.py` | 308 | Typer CLI: `review` and `apply` commands, dispatches to engine | `test_cli_review.py`, `test_cli_apply.py`, `test_cli_entrypoints.py` |
+| `codex_native_converter/engine.py` | 499 | Orchestrates full pipeline: inventory → classify → map → rewrite → validate → report → (apply) | `test_end_to_end.py`, `test_reporting_topology_end_to_end.py` |
+| `codex_native_converter/models.py` | 460 | Domain enums and dataclasses: `SourceKind`, `TargetRole`, `RunOptions`, `ValidationFinding` | (covered by other tests) |
+| `codex_native_converter/models_intermediate.py` | 226 | Intermediate pipeline models: `PlannedEmission`, `SectionIntent`, `SemanticCue` | `test_intermediate_state.py` |
+| `codex_native_converter/classifier.py` | 484 | Classify source artifacts into `SourceKind` | `test_classifier.py`, `test_section_classifier.py` |
+| `codex_native_converter/inventory.py` | 217 | Discover source artifacts from source root | `test_inventory.py` |
+| `codex_native_converter/mapping.py` | 234 | Plan target paths from classified sources | `test_mapping.py` |
+| `codex_native_converter/parser.py` | 292 | Parse Markdown/YAML source into sections | `test_parser.py` |
+| `codex_native_converter/rewrites.py` | 485 | Apply text rewrites to convert content | `test_rewrites.py` |
+| `codex_native_converter/reporting.py` | 433 | Generate conversion reports | `test_reporting.py` |
+| `codex_native_converter/validation.py` | 418 | Validate converted artifacts | `test_validation.py` |
+| `codex_native_converter/section_intent.py` | 249 | Classify section intent/kind | `test_section_intent.py` |
+| `codex_native_converter/pipeline.py` | 462 | Pipeline data structures and step orchestration | `test_prompt_decomposition_end_to_end.py` |
+| `codex_native_converter/intermediate_state.py` | 271 | Serialize/deserialize intermediate pipeline state | `test_intermediate_state.py` |
+| `codex_native_converter/_pipeline_traces.py` | 139 | Trace collection for pipeline debugging | (covered by end-to-end tests) |
+| `codex_native_converter/_reporting_topology.py` | 175 | Reporting topology builder | `test_reporting_topology_end_to_end.py` |
+| `codex_native_converter/__init__.py` | 24 | Re-exports | — |
+| `codex_native_converter/__main__.py` | 23 | Module entry point (`python -m`) | — |
+
+**External dependencies**: `typer` library, filesystem, subprocess (none beyond Python itself).
+
+### 2.4 Production `dev_tools` Modules — Cluster C: `new_active_feature_folder`
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `new_active_feature_folder.py` | 79 | Public re-export facade | `test_new_active_feature_folder.py` |
+| `new_active_feature_folder_flow.py` | 366 | CLI entrypoint and orchestration: `create_active_folder`, `main`, `parse_args` | `test_new_active_feature_folder_part2-4.py` |
+| `new_active_feature_folder_docs.py` | 268 | Feature doc update logic, minor-audit mode detection | (covered by flow tests) |
+| `new_active_feature_folder_io.py` | 305 | Filesystem I/O: template copy, slug building, issue fetching via `gh` | `test_new_active_feature_folder.py` |
+| `new_active_feature_folder_markdown.py` | 252 | Markdown section manipulation helpers | `test_new_active_feature_folder_markdown_escape.py` |
+| `new_active_feature_folder_models.py` | 136 | Models: `ActiveFolderResult`, `IssueMeta`, `FileSystem` protocol, `RealFileSystem` | `test_new_active_feature_folder_models_coverage.py` |
+
+**External dependencies**: `gh` CLI (issue title fetch), filesystem, `code`/`code-insiders` (optional VS Code launch), subprocess.
+
+### 2.5 Production `dev_tools` Modules — Cluster D: `new_potential_bug_entry`
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `new_potential_bug_entry.py` | 465 | Create bug entry from template, validate short name, open VS Code | `test_new_potential_bug_entry.py`, `tests/extensions/drm_copilot/resources/templates/test_new_potential_bug_entry.py` |
+
+**External dependencies**: filesystem, `git config` (author lookup), `code`/`code-insiders` (optional), subprocess.
+
+### 2.6 Production `dev_tools` Modules — Cluster E: `potential_to_issue`
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `potential_to_issue.py` | 634 | Promote potential file to GitHub issue using `gh issue create`; creates labels, updates metadata | `test_potential_to_issue.py`, `test_potential_to_issue_missing_label_regression.py`, template tests |
+| `potential_to_issue_content.py` | 212 | Parse/build issue body from potential file sections | `test_potential_to_issue_content.py` |
+
+**External dependencies**: `gh` CLI (issue create, label create/list), filesystem, subprocess.
+
+### 2.7 Production `dev_tools` Modules — Cluster F: `push_down_*` customizations
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `push_down_copilot_customizations.py` | 504 | Copy `.github` tree to destination workspace, rewrite references, emit summary JSON | `test_push_down_copilot_customizations.py` (via integration) |
+| `push_down_copilot_customizations_filesystem.py` | 217 | `PushDownFileSystem` protocol + `RealPushDownFileSystem` adapter | (covered by push-down tests) |
+| `push_down_copilot_customizations_rewrites.py` | 293 | Rewrite repo-specific command references in copied files | (covered by push-down tests) |
+| `push_down_codex_and_agents_customizations.py` | 118 | Copy `.codex` and `.agents` trees; delegates engine from copilot module | (covered by parity tests) |
+| `push_down_claude_customizations.py` | 403 | Copy `.claude` tree with pack selection, C# variant routing, memory scope filter | `test_push_down_claude_customizations.py`, `test_push_down_claude_pack_end_to_end.py`, `test_push_down_claude_memory_scope.py` |
+| `push_down_claude_filesystem.py` | 472 | Filtering filesystem adapter for `.claude` push-down: memory scope detection, pack/variant routing | (covered by claude push-down tests) |
+| `push_down_claude_pack_selection.py` | 401 | Pure pack-manifest loading, path computation, C# variant assertion | `test_push_down_claude_pack_end_to_end.py` |
+
+**External dependencies**: filesystem only (no git/gh).
+
+### 2.8 Production `dev_tools` Modules — Cluster G: `resolve_*` prompts
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `resolve_hard_lock_prompt.py` | 479 | Read template, substitute `${plan-path}`, write output file, optionally copy to clipboard | `test_resolve_hard_lock_prompt*.py`, template tests |
+| `resolve_file_prompt.py` | 619 | Generic template resolver: substitute `${file}`, `${folderpath}`, `${name}`, `${spec}`, etc. | (covered by resolve_atomic_plan_prompt tests) |
+| `resolve_execute_plan_prompt.py` | 586 | Interactive plan prompt resolver (GUI file picker via tkinter) | — |
+| `prompt_mode_contract.py` | 157 | Work-mode normalization: `minor-audit`, `full-feature`, `full-bug` | `test_prompt_mode_contract.py` |
+
+**External dependencies**: filesystem, clipboard (`pyperclip` optional, falls back to `clip`/`pbcopy`/`xclip`), tkinter (optional, only `resolve_execute_plan_prompt.py`).
+
+### 2.9 Production `dev_tools` Modules — Cluster H: `validate_*` artifacts
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `validate_orchestration_artifacts.py` | 246 | CLI dispatcher for plan/review/checkpoint/policy-audit validation | `test_validate_orchestration_artifacts.py`, template tests |
+| `validate_orchestrator_state.py` | 505 | Checkpoint JSON validation: required keys, status values, receipt formats, remediation cycles | (covered by orchestration contract tests) |
+| `validate_orchestration_review_artifacts.py` | 107 | Code-review and feature-audit heading validators | (covered by orchestration artifact tests) |
+| `validate_policy_audit_artifact.py` | 472 | Policy-audit coverage table and checklist validators | (covered by orchestration artifact tests) |
+| `validate_evidence_locations.py` | 109 | Scan repo tree for files at forbidden `artifacts/` evidence paths | `test_orchestration_guardrail_contracts.py` |
+| `validate_json.py` | 278 | Generic JSON schema validation utility | `test_format_json.py` |
+| `_orchestrator_state_human_interaction.py` | 127 | Human-interaction block validation sub-module | (covered by orchestrator state tests) |
+| `_orchestrator_state_routing.py` | 216 | Routing contract validation sub-module | `test_orchestration_routing_config_parity.py` |
+
+**External dependencies**: filesystem, JSON parsing (stdlib), regex (stdlib).
+
+### 2.10 Production `dev_tools` Modules — Cluster I: Utility/shared
+
+| File | LoC | Purpose | Python tests |
+|---|---|---|---|
+| `json_config.py` | 51 | JSON config load/save with round-trip formatting | `test_json_config.py` |
+| `format_json.py` | 159 | Reformat JSON files in place | `test_format_json.py` |
+| `markdown_label_formatter.py` | 140 | GitHub label markdown formatter | `test_markdown_label_formatter.py` |
+| `agentic_sync.py` | 819 | Sync `.github` docs between two repos by mtime/content | `test_agentic_sync.py` |
+| `tk_dialog_helpers.py` | 260 | Tkinter file-dialog utilities with HiDPI scaling | (via copy_research_to_issue tests) |
+
+### 2.11 Production `dev_tools` Modules — Dev/internal tooling (NOT shipped to extension)
+
+These modules are invoked only as repo-internal dev tooling. They are not bundled with the extension and are not invoked by any MCP handler or `RepoAutomationService` method.
+
+| File | LoC | Purpose |
+|---|---|---|
+| `fix_all.py` | 628 | Parallel multi-branch fix-all workflow runner |
+| `fix_all_branches.py` | 375 | Branch iteration and orchestration for fix_all |
+| `fix_all_branches_extra.py` | 359 | Additional branch fix-all scenarios |
+| `fix_all_runtime.py` | 183 | Process management for fix_all |
+| `shell_qc.py` | 495 | Shell script formatting/linting/testing via shfmt/shellcheck/bats |
+| `agentic_sync.py` | 819 | Two-repo `.github` document sync (also imported by push_down_copilot) |
+| `copy_research_to_issue.py` | 318 | GUI file picker to copy research doc into active issue folder |
+| `clean_devcontainer.py` | 183 | Docker container/volume cleanup for devcontainer reset |
+| `plan_progress_report.py` | 396 | Markdown report of unchecked plan tasks across `docs/features/active/` |
+| `atomic_executor/` (22 files) | ~5,400 | Copilot atomic task executor (spawns Copilot Chat sessions, QC runner, throttling) |
+
+### 2.12 `atomic_executor` Sub-cluster Detail
+
+| File | LoC | Purpose |
+|---|---|---|
+| `atomic_executor/cli.py` | 459 | Main CLI entry point |
+| `atomic_executor/cli_copilot_runtime.py` | 439 | Copilot session runtime |
+| `atomic_executor/cli_execute_one_task.py` | 308 | Execute a single atomic task |
+| `atomic_executor/cli_preflight.py` | 413 | Preflight checks |
+| `atomic_executor/cli_task_runtime.py` | 407 | Task runtime management |
+| `atomic_executor/cli_workspace.py` | 312 | Workspace management |
+| `atomic_executor/copilot_runner.py` | 38 | Thin Copilot process runner |
+| `atomic_executor/copilot_throttling.py` | 340 | Rate/throttle control |
+| `atomic_executor/feature_resolver.py` | 207 | Feature path resolution |
+| `atomic_executor/plan_discovery.py` | 124 | Plan file discovery |
+| `atomic_executor/plan_parser.py` | 669 | Plan Markdown parser |
+| `atomic_executor/prompt_builder.py` | 434 | Build Copilot prompts |
+| `atomic_executor/pytest_expectations.py` | 384 | Pytest result interpretation |
+| `atomic_executor/qc_runner.py` | 571 | QC run orchestrator |
+| `atomic_executor/qc_runner_expectations.py` | 184 | QC result expectations |
+| `atomic_executor/qc_runner_loop.py` | 287 | QC retry loop |
+| `atomic_executor/qc_runner_process.py` | 97 | QC subprocess management |
+| `atomic_executor/qc_toolchain.py` | 78 | QC toolchain description |
+| `atomic_executor/__init__.py` | 27 | Re-exports |
+
+---
+
+## 3. Extension/MCP Invocation Map
+
+### 3.1 Scripts Invoked at Runtime by the Extension or MCP Server
+
+The following `bundledRelativePath` values are set in `RepoAutomationService` methods and the methods they call. These are the scripts that **must** be ported to eliminate the Python dependency.
+
+| MCP tool name | Service method | Template wrapper | Core module(s) |
+|---|---|---|---|
+| `collect_commit_context` | `collectCommitContext` | `resources/templates/collect_commit_context.py` | (self-contained) |
+| `collect_pr_context` | `collectPrContext` | `resources/templates/collect_pr_context.py` | `pr_context/collector.py` + cluster A |
+| `run_codex_native_converter` | `runCodexNativeConverter` | `resources/templates/codex_native_converter.py` | `codex_native_converter/` cluster B |
+| `push_down_copilot_customizations` | `pushDownCopilotCustomizations` | `resources/templates/push_down_copilot_customizations.py` | `push_down_copilot_customizations.py` + cluster F |
+| `push_down_codex_and_agents_customizations` | `pushDownCodexAndAgentsCustomizations` | `resources/templates/push_down_codex_and_agents_customizations.py` | `push_down_codex_and_agents_customizations.py` + cluster F |
+| `push_down_claude_customizations` | `pushDownClaudeCustomizations` | `resources/templates/push_down_claude_customizations.py` | `push_down_claude_customizations.py` + cluster F |
+| `new_potential_bug_entry` | `newPotentialBugEntry` | `resources/templates/new_potential_bug_entry.py` | `new_potential_bug_entry.py` (cluster D) |
+| `potential_to_issue` | `potentialToIssue` | `resources/templates/potential_to_issue.py` | `potential_to_issue.py` + `potential_to_issue_content.py` (cluster E) |
+| `new_active_feature_folder` | `newActiveFeatureFolder` | `resources/templates/new_active_feature_folder.py` | `new_active_feature_folder*.py` cluster C |
+| `resolve_execute_hard_lock_prompt` | `resolveExecuteHardLockPrompt` | `resources/templates/resolve_hard_lock_prompt.py` | `resolve_hard_lock_prompt.py` + `resolve_file_prompt.py` (cluster G) |
+| `resolve_atomic_plan_prompt` | `resolveAtomicPlanPrompt` | `resources/templates/resolve_atomic_plan_prompt.py` | `resolve_file_prompt.py` (cluster G) |
+| `validate_orchestration_artifacts` | `validateOrchestrationArtifacts` | `resources/templates/validate_orchestration_artifacts.py` | `validate_orchestration_artifacts.py` + cluster H |
+
+**Not Python**: `newPotentialEntry`, `linkParentChild`, and all `runPoshQC*` methods use `runtimeKind: "powershell"` and are out of scope for this epic.
+
+**Not script-invoked**: `resolvePolicyAuditTemplateAsset` uses file copy only (`policy-audit-template-assets.ts`); no Python subprocess.
+
+### 3.2 Scripts NOT Invoked by Extension or MCP (dev-internal only)
+
+The following Python modules are repo-internal dev tooling and are **not** bundled or invoked by the extension or MCP server:
+
+- `fix_all.py`, `fix_all_branches.py`, `fix_all_branches_extra.py`, `fix_all_runtime.py`
+- `shell_qc.py`
+- `agentic_sync.py` (partially — imported by `push_down_copilot_customizations.py` for `ROOT_FOLDERS` constant only; the sync logic itself is not invoked)
+- `copy_research_to_issue.py`
+- `clean_devcontainer.py`
+- `plan_progress_report.py`
+- `atomic_executor/` (entire cluster)
+- `format_json.py`, `validate_json.py` (repo dev tools, not MCP-exposed)
+- `validate_evidence_locations.py` (repo dev tool; CI hook only)
+- `tk_dialog_helpers.py` (GUI support for dev tools only)
+- `resolve_execute_plan_prompt.py` (uses tkinter; not exposed via MCP)
+- `markdown_label_formatter.py`, `json_config.py`
+
+**Scoping recommendation**: The epic title states "port ALL Python command scripts used by the VS Code extension and the standalone MCP server." Accordingly:
+
+- **In scope for the port**: The 12 runtime-invoked commands listed in Section 3.1, and all `dev_tools` modules those commands depend on (clusters A, B, C, D, E, F, G, H, and the shared utilities those clusters import).
+- **Out of scope**: `fix_all*`, `shell_qc`, `copy_research_to_issue`, `clean_devcontainer`, `plan_progress_report`, `atomic_executor/**` — these are developer workflow tools that run on developer machines only. They do not need a port to remove the Python runtime dependency from the published extension and MCP server.
+- `agentic_sync.ROOT_FOLDERS` constant (imported by `push_down_copilot_customizations.py`): only this constant needs to be replicated in the TS port of that module; the full sync logic is out of scope.
+
+---
+
+## 4. Existing TypeScript Bridge (Current MCP Architecture)
+
+### 4.1 Handler → Service → subprocess chain
+
+```
+MCP tool call
+  → mcp-handlers/<name>-handlers.ts     (input validation)
+  → repo-automation-service.ts           (DefaultRepoAutomationService)
+  → executeBundledScriptFromExtensionRoot()  (command-runtime.ts)
+  → cp.spawn(python, [scriptPath, ...args])
+  → template wrapper .py
+  → dev_tools module
+```
+
+### 4.2 Post-port target chain
+
+```
+MCP tool call
+  → mcp-handlers/<name>-handlers.ts     (unchanged input validation)
+  → repo-automation-service.ts           (DefaultRepoAutomationService)
+  → in-process TS function call          (no subprocess)
+  → TS module implementing dev_tools logic
+```
+
+The `RepoAutomationService` interface (`repo-automation-service.ts`) remains unchanged. Only the `DefaultRepoAutomationService` implementation of each method changes: the `executeScript()` call is replaced by a direct function call to the TS equivalent. The MCP handlers, tool definitions, and input schemas are unaffected.
+
+### 4.3 Removal targets in command-runtime.ts
+
+After all Python commands are ported:
+- The `"python"` branch of `detectRuntime()` can be removed.
+- `executeBundledScriptFromExtensionRoot()` can remain for PowerShell commands; the Python probing logic inside it is no longer needed.
+- Template wrapper `.py` files in `resources/templates/` are removed (no longer bundled).
+- The bundled `resources/scripts/dev_tools/` copy is removed from the extension package.
+
+---
+
+## 5. Module Cluster Summary with Dependencies
+
+### Cluster A — `pr_context` (collect_pr_context + collect_commit_context)
+- **Files**: 11 files in `pr_context/` + `collect_commit_context.py`
+- **Total LoC**: ~3,273
+- **Inter-cluster deps**: None
+- **External deps**: `git` binary, `gh` CLI binary, filesystem, subprocess, `base64` (stdlib), `json` (stdlib)
+- **Complexity**: Highest; `collector.py` (619 LoC) orchestrates git + gh + feature doc discovery + verification evidence + CI status; `github.py` (549 LoC) wraps many `gh api` calls
+
+### Cluster B — `codex_native_converter`
+- **Files**: 18 files
+- **Total LoC**: ~4,678
+- **Inter-cluster deps**: None
+- **External deps**: `typer` library (for CLI), filesystem; the conversion pipeline is pure logic
+- **Complexity**: High; the engine is a multi-stage pipeline with many model types; `typer` must be replaced with a plain TS argument parser
+
+### Cluster C — `new_active_feature_folder`
+- **Files**: 6 files
+- **Total LoC**: ~1,406
+- **Inter-cluster deps**: `prompt_mode_contract.py` (cluster G shared utility), `gh` CLI (issue fetch)
+- **External deps**: `gh` CLI, filesystem, `code`/`code-insiders` (optional VS Code launch), subprocess
+
+### Cluster D — `new_potential_bug_entry`
+- **Files**: 1 file
+- **Total LoC**: 465
+- **Inter-cluster deps**: None
+- **External deps**: `git config`, filesystem, `code`/`code-insiders` (optional), subprocess
+
+### Cluster E — `potential_to_issue`
+- **Files**: 2 files
+- **Total LoC**: 846
+- **Inter-cluster deps**: `prompt_mode_contract.py` (cluster G shared utility)
+- **External deps**: `gh` CLI (issue create, label operations), filesystem, subprocess
+
+### Cluster F — `push_down_*`
+- **Files**: 7 files
+- **Total LoC**: ~2,408
+- **Inter-cluster deps**: `agentic_sync.ROOT_FOLDERS` constant (can be inlined in TS)
+- **External deps**: Filesystem only; JSON parsing (stdlib); YAML frontmatter parsing (regex-based, no yaml library)
+
+### Cluster G — `resolve_*` prompts
+- **Files**: 4 files
+- **Total LoC**: ~1,841
+- **Inter-cluster deps**: None
+- **External deps**: Filesystem, clipboard (optional; `clip` on Windows, `pbcopy` macOS, `xclip`/`wl-copy` Linux)
+
+### Cluster H — `validate_*` artifacts
+- **Files**: 8 files
+- **Total LoC**: ~2,060
+- **Inter-cluster deps**: None
+- **External deps**: Filesystem, JSON parsing (stdlib), regex (stdlib)
+
+### Cluster I — Shared utility (in-scope portion)
+- **Files**: `prompt_mode_contract.py` (157 LoC), `json_config.py` (51), `markdown_label_formatter.py` (140)
+- **Total LoC**: 348
+- **External deps**: Filesystem, regex
+
+---
+
+## 6. Hard-to-Port Behaviors and Recommended Approaches
+
+### 6.1 `tkinter` GUI dialogs (`tk_dialog_helpers.py`, `resolve_execute_plan_prompt.py`)
+
+**Situation**: `resolve_execute_plan_prompt.py` opens a native OS file picker via `tkinter.filedialog.askopenfilename`. This module is NOT exposed via any MCP handler or `RepoAutomationService` method. It is a developer-interactive script only.
+
+**Recommendation**: Exclude from the port. `resolve_execute_plan_prompt.py` and `tk_dialog_helpers.py` serve the developer experience on developer machines where Python is present. The MCP/extension-facing equivalent is `resolve_hard_lock_prompt.py` (which takes `--target` as a CLI argument and is in scope). No tkinter dependency exists in the in-scope MCP commands.
+
+### 6.2 Subprocess orchestration (`gh` CLI, `git`)
+
+**Situation**: Multiple clusters spawn `git` and `gh` subprocesses. The TS extension already uses `cp.spawn` for PowerShell commands. Node.js `child_process` provides identical capabilities.
+
+**Recommendation**: Port `SubprocessRunner`/`CommandRunner` as a TypeScript interface + class. Use `node:child_process` `spawnSync` or `execFile` with `encoding: 'utf8'` and `errors: 'replace'` to match Python's `encoding="utf-8", errors="replace"` behavior. Each cluster's git/gh calls map directly to Node.js subprocess calls with the same arguments.
+
+### 6.3 Encoding and Unicode handling
+
+**Situation**: Python uses `encoding="utf-8", errors="replace"` for subprocess stdout, which replaces invalid bytes with U+FFFD. Node.js `child_process` with `encoding: 'utf8'` does not apply replacement characters; it may throw on invalid sequences if using `'utf8'` string mode.
+
+**Recommendation**: Capture subprocess output as `Buffer` (binary) and decode with `buffer.toString('utf8')`. For Windows code page compatibility, use `buffer.toString('utf8')` which replaces lone surrogates rather than throwing. This matches the Python behavior. Document this explicitly in the TS implementation.
+
+### 6.4 `typer` library (`codex_native_converter/cli.py`)
+
+**Situation**: The converter CLI uses Typer for argument parsing and command dispatch. Typer is a Python-only library.
+
+**Recommendation**: Replace with a plain TypeScript argument parser. The converter CLI has two commands (`review`, `apply`) with well-defined option sets. Use a small hand-written parser consistent with the existing TS extension pattern (no external CLI framework dependency). Alternatively, the CLI layer is thin; the port can expose the engine as a TypeScript function and have the `RepoAutomationService` call it directly, bypassing the CLI layer entirely.
+
+### 6.5 `pyperclip` clipboard integration (`resolve_hard_lock_prompt.py`, `resolve_file_prompt.py`)
+
+**Situation**: The `resolve_hard_lock_prompt` and `resolve_file_prompt` commands attempt to copy the resolved prompt to clipboard using `pyperclip` with fallback to OS clipboard commands (`clip`, `pbcopy`, `xclip`, `wl-copy`). The MCP invocation path sets `--quiet` and writes to `artifacts/hard_lock_prompt.txt`, bypassing the clipboard entirely.
+
+**Recommendation**: In the TS port, the `resolveExecuteHardLockPrompt` and `resolveAtomicPlanPrompt` service methods pass `quiet: true`, so no clipboard interaction is needed. Implement clipboard support as an optional feature that falls back gracefully when no clipboard mechanism is available, using Node.js subprocess calls to `clip`/`pbcopy`/`xclip` as the Python code does.
+
+### 6.6 `push_down` YAML frontmatter memory-scope reading (`push_down_claude_filesystem.py`)
+
+**Situation**: The Claude push-down reads YAML frontmatter from agent-memory files to determine `metadata.scope`. It does this with a regex-based parser, not a full YAML library, so no YAML dependency is introduced.
+
+**Recommendation**: Port the regex-based frontmatter parser directly to TypeScript. The same approach works with Node.js regex APIs. No `js-yaml` or similar dependency is required.
+
+### 6.7 `agentic_sync.ROOT_FOLDERS` constant
+
+**Situation**: `push_down_copilot_customizations.py` imports `ROOT_FOLDERS` from `agentic_sync.py`, which is the tuple `(Path(".github/agents"), Path(".github/instructions"), Path(".github/prompts"), Path(".github/skills"))`.
+
+**Recommendation**: Inline this constant in the TS port of `push-down-copilot-customizations.ts` as a typed tuple. No need to port the rest of `agentic_sync.py`.
+
+---
+
+## 7. Feature Decomposition (Ordered, Independently Shippable)
+
+### 7.1 Dependency Graph
+
+```
+F1 (shared utilities)
+  └─► F2 (validate_* cluster)
+  └─► F3 (push_down cluster)
+  └─► F4 (collect_commit_context)
+  └─► F5 (resolve_* prompts)
+  └─► F6 (new_potential_bug_entry)
+  └─► F7 (potential_to_issue) [depends on F1]
+  └─► F8 (new_active_feature_folder) [depends on F1, F7 shared]
+F2, F3, F4, F5, F6, F7, F8 are independent of each other
+F9 (pr_context) [depends on F1 git/gh utilities]
+F10 (codex_native_converter) [depends on F1 for subprocess wrapper]
+F11 (command-runtime.ts cleanup) [depends on F2–F10 all done]
+```
+
+### 7.2 Feature List
+
+---
+
+#### F1 — `ts-shared-subprocess-and-utility-layer`
+
+**Purpose**: Establish the shared TypeScript infrastructure all other features depend on.
+
+**Python files ported**:
+- `prompt_mode_contract.py` (157 LoC)
+- `json_config.py` (51 LoC)
+- `markdown_label_formatter.py` (140 LoC)
+- Subprocess runner abstraction (extracted from `pr_context/git.py` pattern)
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/prompt-mode-contract.ts`
+- `extensions/drm-copilot/src/lib/json-config.ts`
+- `extensions/drm-copilot/src/lib/markdown-label-formatter.ts`
+- `extensions/drm-copilot/src/lib/subprocess-runner.ts`
+
+**Tests to port**:
+- `tests/scripts/dev_tools/test_prompt_mode_contract.py` → `extensions/drm-copilot/test/lib/prompt-mode-contract.test.ts`
+- `tests/scripts/dev_tools/test_json_config.py` → `extensions/drm-copilot/test/lib/json-config.test.ts`
+- `tests/scripts/dev_tools/test_markdown_label_formatter.py` → `extensions/drm-copilot/test/lib/markdown-label-formatter.test.ts`
+
+**Prerequisites**: None. First feature.
+
+**LoC estimate**: ~500 LoC new TS production + ~400 LoC tests. Fits within 500-line file limit per file.
+
+---
+
+#### F2 — `ts-validate-orchestration-artifacts`
+
+**Purpose**: Port the full `validate_orchestration_artifacts` command cluster to TypeScript.
+
+**Python files ported**:
+- `validate_orchestration_artifacts.py` (246 LoC)
+- `validate_orchestrator_state.py` (505 LoC)
+- `validate_orchestration_review_artifacts.py` (107 LoC)
+- `validate_policy_audit_artifact.py` (472 LoC)
+- `_orchestrator_state_human_interaction.py` (127 LoC)
+- `_orchestrator_state_routing.py` (216 LoC)
+- `validate_evidence_locations.py` (109 LoC)
+- `validate_json.py` (278 LoC)
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/validate/orchestration-artifacts.ts` (entry point / dispatcher)
+- `extensions/drm-copilot/src/lib/validate/orchestrator-state.ts`
+- `extensions/drm-copilot/src/lib/validate/orchestrator-state-human-interaction.ts`
+- `extensions/drm-copilot/src/lib/validate/orchestrator-state-routing.ts`
+- `extensions/drm-copilot/src/lib/validate/policy-audit-artifact.ts`
+- `extensions/drm-copilot/src/lib/validate/review-artifacts.ts`
+- `extensions/drm-copilot/src/lib/validate/evidence-locations.ts`
+- `extensions/drm-copilot/src/lib/validate/json-validator.ts`
+
+**Update**:
+- `repo-automation-service.ts` `validateOrchestrationArtifacts()`: replace `executeScript()` call with direct TS call
+
+**Tests to port**:
+- `tests/extensions/drm_copilot/resources/templates/test_validate_orchestration_artifacts.py`
+- `tests/scripts/dev_tools/test_orchestration_guardrail_contracts.py`
+- `tests/scripts/dev_tools/test_orchestration_routing_config_parity.py`
+→ `extensions/drm-copilot/test/lib/validate/*.test.ts`
+
+**Prerequisites**: F1.
+
+**Note**: `validate_orchestrator_state.py` (505 LoC) exceeds the 500-line file limit; split into `orchestrator-state-core.ts` + `orchestrator-state-remediation.ts` in the TS port.
+
+---
+
+#### F3 — `ts-push-down-customizations`
+
+**Purpose**: Port all three push-down command variants to TypeScript.
+
+**Python files ported**:
+- `push_down_copilot_customizations.py` (504 LoC)
+- `push_down_copilot_customizations_filesystem.py` (217 LoC)
+- `push_down_copilot_customizations_rewrites.py` (293 LoC)
+- `push_down_codex_and_agents_customizations.py` (118 LoC)
+- `push_down_claude_customizations.py` (403 LoC)
+- `push_down_claude_filesystem.py` (472 LoC)
+- `push_down_claude_pack_selection.py` (401 LoC)
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/push-down/copilot-customizations.ts`
+- `extensions/drm-copilot/src/lib/push-down/filesystem-adapter.ts`
+- `extensions/drm-copilot/src/lib/push-down/reference-rewrites.ts`
+- `extensions/drm-copilot/src/lib/push-down/codex-agents-customizations.ts`
+- `extensions/drm-copilot/src/lib/push-down/claude-customizations.ts`
+- `extensions/drm-copilot/src/lib/push-down/claude-filesystem-adapter.ts`
+- `extensions/drm-copilot/src/lib/push-down/claude-pack-selection.ts`
+
+**Update**:
+- `repo-automation-service.ts` `pushDownCopilotCustomizations()`, `pushDownCodexAndAgentsCustomizations()`, `pushDownClaudeCustomizations()`: replace `executeScript()` with direct TS calls
+- `repo-automation-service-push-down.ts`: remove Python arg-building code
+
+**Tests to port**:
+- `tests/scripts/dev_tools/test_push_down_claude_customizations.py`
+- `tests/scripts/dev_tools/test_push_down_claude_pack_end_to_end.py`
+- `tests/scripts/dev_tools/test_push_down_claude_memory_scope.py`
+- `tests/scripts/dev_tools/test_push_down_claude_bundled_parity.py`
+- `tests/scripts/dev_tools/test_poshqc_bundled_parity.py` (cross-reference)
+→ `extensions/drm-copilot/test/lib/push-down/*.test.ts`
+
+**Prerequisites**: F1. `push_down_copilot_customizations.py` (504 LoC) exceeds the 500-line limit; split into `copilot-customizations-engine.ts` + `copilot-customizations-cli.ts`.
+
+---
+
+#### F4 — `ts-collect-commit-context`
+
+**Purpose**: Port `collect_commit_context.py` to TypeScript; it is self-contained.
+
+**Python files ported**:
+- `extensions/drm-copilot/resources/templates/collect_commit_context.py` (212 LoC) — self-contained, all logic inline
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/collect-commit-context.ts`
+
+**Update**:
+- `repo-automation-service.ts` `collectCommitContext()`: replace `executeScript()` with direct TS call
+
+**Tests to port**:
+- `tests/scripts/dev_tools/test_collect_commit_context.py`
+→ `extensions/drm-copilot/test/lib/collect-commit-context.test.ts`
+
+**Prerequisites**: F1 (subprocess runner).
+
+---
+
+#### F5 — `ts-resolve-prompts`
+
+**Purpose**: Port the hard-lock and file-prompt resolvers to TypeScript.
+
+**Python files ported**:
+- `resolve_hard_lock_prompt.py` (479 LoC)
+- `resolve_file_prompt.py` (619 LoC) — note: exceeds 500 LoC, requires split
+- `prompt_mode_contract.py` — already in F1
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/resolve/hard-lock-prompt.ts`
+- `extensions/drm-copilot/src/lib/resolve/file-prompt-core.ts`
+- `extensions/drm-copilot/src/lib/resolve/file-prompt-variables.ts`
+
+**Update**:
+- `repo-automation-service.ts` `resolveExecuteHardLockPrompt()`, `resolveAtomicPlanPrompt()`: replace `executeScript()` with direct TS calls
+- `repo-automation-service-workflows.ts`: remove Python arg builders for these commands
+
+**Tests to port**:
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_hard_lock_prompt*.py`
+- `tests/extensions/drm_copilot/resources/templates/test_resolve_atomic_plan_prompt*.py`
+→ `extensions/drm-copilot/test/lib/resolve/*.test.ts`
+
+**Prerequisites**: F1.
+
+**Note**: `resolve_file_prompt.py` is 619 LoC; must be split into at least two TS files (core resolver + variable substitution logic).
+
+---
+
+#### F6 — `ts-new-potential-bug-entry`
+
+**Purpose**: Port `new_potential_bug_entry.py` to TypeScript.
+
+**Python files ported**:
+- `new_potential_bug_entry.py` (465 LoC)
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/new-potential-bug-entry.ts`
+
+**Update**:
+- `repo-automation-service.ts` `newPotentialBugEntry()`: replace `executeScript()` with direct TS call
+
+**Tests to port**:
+- `tests/scripts/dev_tools/test_new_potential_bug_entry.py`
+- `tests/extensions/drm_copilot/resources/templates/test_new_potential_bug_entry.py`
+→ `extensions/drm-copilot/test/lib/new-potential-bug-entry.test.ts`
+
+**Prerequisites**: F1.
+
+---
+
+#### F7 — `ts-potential-to-issue`
+
+**Purpose**: Port the potential-to-issue promotion command to TypeScript.
+
+**Python files ported**:
+- `potential_to_issue.py` (634 LoC) — exceeds 500 LoC; split required
+- `potential_to_issue_content.py` (212 LoC)
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/potential-to-issue/content.ts`
+- `extensions/drm-copilot/src/lib/potential-to-issue/promotion.ts` (core workflow)
+- `extensions/drm-copilot/src/lib/potential-to-issue/gh-client.ts` (gh label/issue ops)
+
+**Update**:
+- `repo-automation-service.ts` `potentialToIssue()`: replace `executeScript()` with direct TS call
+
+**Tests to port**:
+- `tests/scripts/dev_tools/test_potential_to_issue.py`
+- `tests/scripts/dev_tools/test_potential_to_issue_content.py`
+- `tests/scripts/dev_tools/test_potential_to_issue_missing_label_regression.py`
+- `tests/extensions/drm_copilot/resources/templates/test_potential_to_issue*.py`
+→ `extensions/drm-copilot/test/lib/potential-to-issue/*.test.ts`
+
+**Prerequisites**: F1. `potential_to_issue.py` is 634 LoC; split into at least two files.
+
+---
+
+#### F8 — `ts-new-active-feature-folder`
+
+**Purpose**: Port the active feature folder creation command to TypeScript.
+
+**Python files ported**:
+- `new_active_feature_folder_models.py` (136 LoC)
+- `new_active_feature_folder_markdown.py` (252 LoC)
+- `new_active_feature_folder_io.py` (305 LoC)
+- `new_active_feature_folder_docs.py` (268 LoC)
+- `new_active_feature_folder_flow.py` (366 LoC)
+- `new_active_feature_folder.py` (79 LoC — facade)
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/new-active-feature-folder/models.ts`
+- `extensions/drm-copilot/src/lib/new-active-feature-folder/markdown.ts`
+- `extensions/drm-copilot/src/lib/new-active-feature-folder/io.ts`
+- `extensions/drm-copilot/src/lib/new-active-feature-folder/docs.ts`
+- `extensions/drm-copilot/src/lib/new-active-feature-folder/flow.ts`
+- `extensions/drm-copilot/src/lib/new-active-feature-folder/index.ts`
+
+**Update**:
+- `repo-automation-service.ts` `newActiveFeatureFolder()`: replace `executeScript()` with direct TS call
+
+**Tests to port**:
+- `tests/scripts/dev_tools/test_new_active_feature_folder*.py` (7 files)
+- `tests/extensions/drm_copilot/resources/templates/test_new_active_feature_folder.py`
+→ `extensions/drm-copilot/test/lib/new-active-feature-folder/*.test.ts`
+
+**Prerequisites**: F1.
+
+---
+
+#### F9 — `ts-pr-context`
+
+**Purpose**: Port the full PR context collection cluster to TypeScript. This is the largest and most complex single feature.
+
+**Python files ported**:
+- `pr_context/models.py` (198 LoC)
+- `pr_context/git.py` (153 LoC)
+- `pr_context/github.py` (549 LoC) — exceeds 500 LoC; split required
+- `pr_context/feature_docs.py` (349 LoC)
+- `pr_context/render.py` (342 LoC)
+- `pr_context/render_feature_excerpts.py` (256 LoC)
+- `pr_context/render_pr_helpers.py` (291 LoC)
+- `pr_context/summary_helpers.py` (386 LoC)
+- `pr_context/verification_evidence.py` (171 LoC)
+- `pr_context/collector.py` (619 LoC) — exceeds 500 LoC; split required
+
+**TS target paths**:
+- `extensions/drm-copilot/src/lib/pr-context/models.ts`
+- `extensions/drm-copilot/src/lib/pr-context/git-client.ts`
+- `extensions/drm-copilot/src/lib/pr-context/gh-client-core.ts`
+- `extensions/drm-copilot/src/lib/pr-context/gh-client-details.ts`
+- `extensions/drm-copilot/src/lib/pr-context/feature-docs.ts`
+- `extensions/drm-copilot/src/lib/pr-context/render.ts`
+- `extensions/drm-copilot/src/lib/pr-context/render-feature-excerpts.ts`
+- `extensions/drm-copilot/src/lib/pr-context/render-pr-helpers.ts`
+- `extensions/drm-copilot/src/lib/pr-context/summary-helpers.ts`
+- `extensions/drm-copilot/src/lib/pr-context/verification-evidence.ts`
+- `extensions/drm-copilot/src/lib/pr-context/collector-core.ts`
+- `extensions/drm-copilot/src/lib/pr-context/collector-output.ts`
+
+**Update**:
+- `repo-automation-service.ts` `collectPrContext()`: replace `executeScript()` with direct TS call
+
+**Tests to port**:
+- `tests/scripts/dev_tools/test_collect_pr_context*.py` (4 files)
+- `tests/scripts/dev_tools/test_feature_docs.py`
+- `tests/scripts/dev_tools/test_git.py`
+- `tests/scripts/dev_tools/test_github*.py` (3 files)
+- `tests/scripts/dev_tools/test_pr_context_integration.py`
+→ `extensions/drm-copilot/test/lib/pr-context/*.test.ts`
+
+**Prerequisites**: F1.
+
+**Note**: `github.py` (549 LoC) and `collector.py` (619 LoC) must each be split into at least two TS files.
+
+---
+
+#### F10 — `ts-codex-native-converter`
+
+**Purpose**: Port the codex-native converter pipeline to TypeScript.
+
+**Python files ported**:
+- `codex_native_converter/models.py` (460 LoC)
+- `codex_native_converter/models_intermediate.py` (226 LoC)
+- `codex_native_converter/inventory.py` (217 LoC)
+- `codex_native_converter/classifier.py` (484 LoC)
+- `codex_native_converter/section_intent.py` (249 LoC)
+- `codex_native_converter/parser.py` (292 LoC)
+- `codex_native_converter/mapping.py` (234 LoC)
+- `codex_native_converter/rewrites.py` (485 LoC)
+- `codex_native_converter/validation.py` (418 LoC)
+- `codex_native_converter/pipeline.py` (462 LoC)
+- `codex_native_converter/intermediate_state.py` (271 LoC)
+- `codex_native_converter/reporting.py` (433 LoC)
+- `codex_native_converter/_pipeline_traces.py` (139 LoC)
+- `codex_native_converter/_reporting_topology.py` (175 LoC)
+- `codex_native_converter/engine.py` (499 LoC)
+- `codex_native_converter/cli.py` (308 LoC) — CLI layer replaced by direct function call from service
+
+**TS target paths** (mirroring the 500-line limit):
+- `extensions/drm-copilot/src/lib/codex-native-converter/models.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/models-intermediate.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/inventory.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/classifier.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/section-intent.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/parser.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/mapping.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/rewrites.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/validation.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/pipeline.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/intermediate-state.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/reporting.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/pipeline-traces.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/reporting-topology.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/engine.ts`
+- `extensions/drm-copilot/src/lib/codex-native-converter/index.ts`
+
+**Update**:
+- `repo-automation-service.ts` `runCodexNativeConverter()`: replace `executeScript()` with direct TS call
+- `repo-automation-service-workflows.ts`: update `buildRunCodexNativeConverterOptions` to build TS function call args
+
+**Tests to port**:
+- All 16 files in `tests/scripts/dev_tools/codex_native_converter/`
+→ `extensions/drm-copilot/test/lib/codex-native-converter/*.test.ts`
+
+**Prerequisites**: F1.
+
+---
+
+#### F11 — `ts-command-runtime-cleanup`
+
+**Purpose**: Remove the Python bridge from `command-runtime.ts` and clean up bundled resources.
+
+**Changes**:
+- Remove `"python"` branch from `detectRuntime()` in `command-runtime.ts`
+- Remove `resources/templates/*.py` from the extension bundle
+- Remove `resources/scripts/dev_tools/` from the extension bundle (`package.json`, `.vscodeignore`)
+- Remove `runtimeKind: "python"` from all `ScriptExecutionOptions` usages (they all become direct TS calls after F2–F10)
+- Update `packages/mcp-server/` `prepack` script accordingly
+- Update integration tests that verify Python is no longer needed
+
+**Prerequisites**: F2, F3, F4, F5, F6, F7, F8, F9, F10 all complete.
+
+---
+
+## 8. Recommended Execution Order
+
+The recommended order balances: delivering value early, establishing shared infrastructure first, and isolating complex features.
+
+```
+F1  → shared utilities (prerequisite for all)
+F2  → validate_orchestration_artifacts (pure logic, no git/gh, quickest win)
+F4  → collect_commit_context (self-contained, 212 LoC, quick win)
+F5  → resolve_* prompts (file I/O only, no git/gh)
+F6  → new_potential_bug_entry (single file, manageable)
+F3  → push_down_* customizations (pure filesystem, complex but no subprocess)
+F7  → potential_to_issue (gh CLI, moderate complexity)
+F8  → new_active_feature_folder (gh CLI + filesystem, moderate complexity)
+F9  → pr_context (most complex; git + gh + feature doc discovery)
+F10 → codex_native_converter (pure pipeline logic, complex but isolated)
+F11 → command-runtime cleanup (cleanup; all prior features complete)
+```
+
+**Rationale**:
+- F1 unblocks all other features. It is small and has zero risk.
+- F2 and F4 are pure-logic ports (no external processes) and serve as confidence builders.
+- F5 is small and validates the template-resolver pattern early.
+- F3 (push-down) is filesystem-only and its TS structure is well-scoped.
+- F7 and F8 share `gh` CLI patterns; doing F7 before F8 lets F8 reuse the `gh` helper patterns established in F7.
+- F9 is the largest feature and is saved until the team has established patterns from smaller features.
+- F10 is a pure-logic pipeline that can proceed in parallel with F9 once F1 is done; it is placed after F9 only for sequencing simplicity.
+- F11 is a cleanup feature that confirms the port is complete.
+
+---
+
+## 9. Testing Implications
+
+### 9.1 Test Location Policy
+
+Per repository policy (`.claude/rules/general-unit-test.md`), all TS test files go under `extensions/drm-copilot/test/` mirroring the production source structure:
+- Production: `extensions/drm-copilot/src/lib/pr-context/git-client.ts`
+- Test: `extensions/drm-copilot/test/lib/pr-context/git-client.test.ts`
+
+### 9.2 Mocking Strategy
+
+- `git` and `gh` subprocess calls: mock at the `subprocess-runner.ts` boundary using `vi.spyOn`. All git/gh clients accept an injected runner (matching the Python `CommandRunner` protocol pattern).
+- Filesystem reads/writes: use in-memory maps passed via a `FileSystem` interface (matching the Python `FileSystem` Protocol pattern).
+- No real subprocesses, no real filesystem temp files in unit tests (per policy).
+
+### 9.3 Coverage Requirements
+
+Line coverage >= 85%, branch coverage >= 75% (uniform across all tiers, per `.claude/rules/quality-tiers.md`). The Python tests across the 12 in-scope commands total ~39,750 LoC and cover substantial edge cases. All distinct behavioral scenarios from the Python tests must be ported.
+
+### 9.4 Property-Based Tests
+
+The `pr_context`, `codex_native_converter`, and `validate_*` clusters contain pure functions that qualify for property-based testing. Per quality tier policy (T1/T2 modules require >= 1 property test per pure function), at minimum one `fast-check` property test should be added per pure function in clusters B and H.
+
+---
+
+## 10. Automation Feasibility
+
+The entire conversion is fully automatable with no human interaction required. All operations involved are:
+
+- Reading Python source files from the local repository.
+- Writing TypeScript source files to the same repository.
+- Running the TypeScript toolchain (`npm run format`, `npm run lint`, `npm run typecheck`, `npm run test`).
+- Running the Python toolchain to verify behavior parity (`poetry run pytest`).
+- Git operations (`git add`, `git commit`).
+- GitHub operations via `gh pr create` for PR submission.
+
+No third-party UI interaction, no external service authentication beyond what already exists in the dev environment, and no manual approval gates are required within any individual feature PR.
+
+The only human decision point is the epic-level scoping review at the start (the decision in Section 3.2 above, which is resolved by this document).
+
+**AUTOMATION_FEASIBILITY: FULLY_AUTOMATABLE. No third-party UI interaction required.**
+
+---
+
+## 11. Rejected Alternatives
+
+**Alternative: keep Python as a bundled runtime (ship a minimal Python distribution with the extension)**: Rejected because it increases the extension bundle size by approximately 50–200 MB, complicates cross-platform packaging, and does not eliminate the runtime dependency — it only embeds it. The objective is to eliminate Python as a dependency entirely.
+
+**Alternative: port only the template wrappers and keep `dev_tools` in Python**: Rejected because the template wrappers are thin adapters that immediately delegate to `dev_tools` modules; porting the wrappers without porting `dev_tools` would still require bundling the full Python `dev_tools` package and a Python interpreter.
+
+**Alternative: use WASM-compiled Python (e.g., Pyodide)**: Rejected because Pyodide is not supported in VS Code extension hosts or Node.js MCP server contexts without significant shim infrastructure. The existing Python code does not use the scientific Python stack; there is no benefit to WASM Python over native TypeScript.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/spec.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/spec.md
@@ -1,0 +1,59 @@
+# Spec — Port Python Commands to TypeScript (Epic #240)
+
+- Issue: #240
+- Work mode: full
+- Authoritative inventory: `research/python-to-typescript-inventory.md`
+- Decomposition: `initiative.md`
+
+## User Story
+
+As a user of the drm-copilot extension and the published MCP server, I want every command
+to run without a Python interpreter on PATH, so that the tools work on machines that do not
+have Python installed.
+
+## Epic Acceptance Criteria
+
+- [ ] AC-E1: Every Python command script invoked by the extension or MCP server has a
+      TypeScript equivalent with behavior parity (CLI output, exit codes, file artifacts,
+      JSON shapes).
+- [ ] AC-E2: TypeScript test coverage for ported modules meets policy (line >= 85%,
+      branch >= 75%).
+- [ ] AC-E3: `RepoAutomationService` methods invoke in-process TypeScript instead of
+      spawning Python; the `"python"` runtime branch and bundled Python resources are
+      removed (delivered by F11).
+- [ ] AC-E4: No remaining runtime dependency on a `python` interpreter for extension or
+      MCP command execution.
+- [ ] AC-E5: All CI gates pass on each feature PR.
+
+Per-feature acceptance criteria are tracked in each feature's plan checklist under
+`plans/F#-*.plan.md`. The epic ACs above are satisfied incrementally as features merge and
+are fully realized at F11.
+
+## Feature F1 — ts-shared-subprocess-and-utility-layer
+
+### Acceptance Criteria (F1)
+
+- [x] AC-F1-1: `prompt-mode-contract.ts` ports `prompt_mode_contract.py` with identical
+      normalization, regexes, and error/reason strings.
+- [x] AC-F1-2: `json-config.ts` ports `json_config.py` including governed-file iteration
+      and parent-exclusion semantics.
+- [x] AC-F1-3: `markdown-label-formatter.ts` ports `markdown_label_formatter.py` pure logic
+      with `splitlines()`-equivalent behavior.
+- [x] AC-F1-4: `subprocess-runner.ts` replicates the `pr_context/git.py` runner: injectable
+      interface, UTF-8 decode with U+FFFD replacement, trailing-newline strip, non-zero exit
+      throws with the parity message format.
+- [x] AC-F1-5: `file-system.ts` provides an injectable `FileSystem` interface and
+      `RealFileSystem` so consumers can unit-test hermetically.
+- [x] AC-F1-6: New `src/lib/**` files covered by Jest tests; line >= 85%, branch >= 75%.
+- [x] AC-F1-7: Format, lint, type-check, and test all pass from `extensions/drm-copilot/`.
+- [x] AC-F1-8: No changes to `RepoAutomationService` or `command-runtime.ts` in F1.
+- [x] AC-F1-9: No file exceeds 500 lines; tests are hermetic (no real subprocess/temp files).
+
+## Decisions / Accepted Divergences
+
+- D1 (R2 from F1 review): The `extensions/drm-copilot` package uses Jest (`ts-jest`,
+  `run-jest.cjs`), while `.claude/rules/typescript.md` text mentions Vitest. This is a
+  pre-existing, package-wide condition not introduced by this epic. The actual runnable and
+  CI-exercised toolchain is Jest. Ported tests follow the real Jest toolchain to keep CI
+  green. Changing the policy rule is out of scope for this epic and would require a separate
+  policy decision; `.claude/rules/**` is not modified here.

--- a/extensions/drm-copilot/src/lib/file-system.ts
+++ b/extensions/drm-copilot/src/lib/file-system.ts
@@ -1,0 +1,227 @@
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
+
+/**
+ * Filesystem abstraction enabling hermetic, injectable file I/O.
+ *
+ * Purpose:
+ *     Model the Python `FileSystem` Protocol pattern so consuming modules
+ *     (`json-config.ts`, `markdown-label-formatter.ts`) depend on an interface
+ *     rather than `node:fs` directly. Tests inject an in-memory fake; production
+ *     wiring injects {@link RealFileSystem}.
+ *
+ * Responsibilities:
+ *     - `glob`: enumerate paths under a root matching a glob pattern, mirroring
+ *       Python `Path.glob` semantics for the governed/exclude patterns used by
+ *       `json-config`.
+ *     - `isFile`: predicate for whether a path is a regular file.
+ *     - `readTextFile` / `writeTextFile`: UTF-8 text I/O.
+ *
+ * Path convention:
+ *     Paths are returned and accepted using forward-slash separators to keep a
+ *     single, OS-neutral matching semantics consistent with Python `Path.glob`
+ *     pattern strings.
+ */
+export interface FileSystem {
+  /**
+   * Enumerate paths under `root` matching `pattern`.
+   *
+   * @param root Root directory to search under.
+   * @param pattern Glob pattern relative to `root` (e.g. `scripts/**\/*.json`).
+   * @returns Matching paths joined to `root`, using forward-slash separators.
+   */
+  glob(root: string, pattern: string): string[];
+
+  /** Return true when `path` refers to an existing regular file. */
+  isFile(path: string): boolean;
+
+  /** Read the file at `path` as UTF-8 text. */
+  readTextFile(path: string): string;
+
+  /** Write `content` to `path` as UTF-8 text. */
+  writeTextFile(path: string, content: string): void;
+}
+
+/**
+ * Normalize a path to forward-slash separators.
+ *
+ * @param value A path that may contain OS-specific separators.
+ * @returns The path with all backslashes converted to forward slashes.
+ */
+export function toPosixPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+/**
+ * Join a root and a relative path using forward-slash separators.
+ *
+ * @param root Base path.
+ * @param relative Path relative to the base.
+ * @returns The combined POSIX-style path.
+ */
+function joinPosix(root: string, relative: string): string {
+  const normalizedRoot = toPosixPath(root).replace(/\/+$/, "");
+  const normalizedRelative = toPosixPath(relative).replace(/^\/+/, "");
+  if (normalizedRoot === "") {
+    return normalizedRelative;
+  }
+  if (normalizedRelative === "") {
+    return normalizedRoot;
+  }
+  return `${normalizedRoot}/${normalizedRelative}`;
+}
+
+/**
+ * Escape regular-expression metacharacters in a literal pattern segment.
+ *
+ * @param value Literal text that may contain regex metacharacters.
+ * @returns The text with metacharacters escaped for safe use in a RegExp.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Compile a glob pattern into an anchored RegExp matching a relative path.
+ *
+ * Supported tokens (sufficient for the governed/exclude patterns and Python
+ * `Path.glob` semantics used by `json-config`):
+ * - `**` matches any number of path segments (including zero).
+ * - `*` matches any run of characters within a single path segment.
+ * - `?` matches a single non-separator character.
+ * - All other characters match literally.
+ *
+ * The pattern is matched against a relative POSIX path (no leading slash).
+ *
+ * @param pattern Glob pattern using forward-slash separators.
+ * @returns A RegExp anchored to the full relative path.
+ */
+function compileGlob(pattern: string): RegExp {
+  const normalized = toPosixPath(pattern);
+  let regex = "";
+  let index = 0;
+
+  // Walk the pattern character by character, translating glob tokens. A
+  // single pass keeps `**`, `*`, and `?` handling unambiguous and ordered.
+  while (index < normalized.length) {
+    const char = normalized[index];
+
+    if (char === "*") {
+      const isDoubleStar = normalized[index + 1] === "*";
+      if (isDoubleStar) {
+        // `**/` (or trailing `**`) spans zero or more full path segments.
+        const followedBySlash = normalized[index + 2] === "/";
+        if (followedBySlash) {
+          regex += "(?:.*/)?";
+          index += 3;
+        } else {
+          regex += ".*";
+          index += 2;
+        }
+        continue;
+      }
+      // Single `*` matches within one segment (no separators).
+      regex += "[^/]*";
+      index += 1;
+      continue;
+    }
+
+    if (char === "?") {
+      regex += "[^/]";
+      index += 1;
+      continue;
+    }
+
+    regex += escapeRegExp(char ?? "");
+    index += 1;
+  }
+
+  return new RegExp(`^${regex}$`);
+}
+
+/**
+ * Production {@link FileSystem} backed by `node:fs`.
+ *
+ * Purpose:
+ *     Provide real disk I/O and a glob walker whose matching semantics align
+ *     with the compiled glob RegExp, so hermetic fakes that reuse the same
+ *     pattern semantics validate consumer logic rather than the glob engine.
+ *
+ * Side effects:
+ *     Reads from and writes to the local filesystem.
+ */
+export class RealFileSystem implements FileSystem {
+  /**
+   * Enumerate files and directories under `root` matching `pattern`.
+   *
+   * Walks the directory tree once and tests each discovered relative path
+   * against the compiled glob. Both files and directories are returned, so the
+   * caller (e.g. `iterGovernedFiles`) can apply its own file/exclude checks.
+   *
+   * @param root Root directory to search under.
+   * @param pattern Glob pattern relative to `root`.
+   * @returns Matching absolute-style POSIX paths joined to `root`.
+   */
+  glob(root: string, pattern: string): string[] {
+    const matcher = compileGlob(pattern);
+    const matches: string[] = [];
+    const normalizedRoot = toPosixPath(root);
+
+    // Recursively descend the tree, recording every relative path that matches.
+    const walk = (currentDir: string, relativePrefix: string): void => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(currentDir, { withFileTypes: true });
+      } catch {
+        // A missing or unreadable directory yields no matches rather than
+        // raising; this mirrors Path.glob returning nothing for absent roots.
+        return;
+      }
+
+      // Inspect each entry: test it against the matcher and recurse into dirs.
+      for (const entry of entries) {
+        const relativePath =
+          relativePrefix === ""
+            ? entry.name
+            : `${relativePrefix}/${entry.name}`;
+        if (matcher.test(relativePath)) {
+          matches.push(joinPosix(normalizedRoot, relativePath));
+        }
+        if (entry.isDirectory()) {
+          walk(nodePath.join(currentDir, entry.name), relativePath);
+        }
+      }
+    };
+
+    walk(normalizedRoot, "");
+    return matches;
+  }
+
+  /**
+   * @param path Path to test.
+   * @returns True when `path` exists and is a regular file.
+   */
+  isFile(path: string): boolean {
+    try {
+      return fs.statSync(path).isFile();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * @param path File to read.
+   * @returns The file content decoded as UTF-8.
+   */
+  readTextFile(path: string): string {
+    return fs.readFileSync(path, "utf8");
+  }
+
+  /**
+   * @param path File to write.
+   * @param content Text content to write as UTF-8.
+   */
+  writeTextFile(path: string, content: string): void {
+    fs.writeFileSync(path, content, "utf8");
+  }
+}

--- a/extensions/drm-copilot/src/lib/json-config.ts
+++ b/extensions/drm-copilot/src/lib/json-config.ts
@@ -1,0 +1,105 @@
+import type { FileSystem } from "./file-system";
+import { toPosixPath } from "./file-system";
+
+/**
+ * Governed JSON config discovery, ported from
+ * `scripts/dev_tools/json_config.py`.
+ *
+ * Note: `.vscode` and `.devcontainer` files are JSONC (JSON with comments) and
+ * cannot be formatted by jq. They are excluded from formatting because the
+ * governed globs do not include them, not via an explicit exclude entry.
+ */
+
+/** Governed JSON config globs (relative to repo root). */
+export const GOVERNED_GLOBS = [
+  "scripts/**/*.json",
+  "docs/**/*.json",
+  "examples/**/*.json",
+] as const;
+
+/** Globs for large/generated data and artifacts excluded from governance. */
+export const EXCLUDE_GLOBS = [
+  "data/**",
+  "artifacts/**",
+  "htmlcov/**",
+  "coverage*/**",
+  "**/node_modules/**",
+  ".venv",
+  ".venv/**",
+  "**/.venv",
+  "**/.venv/**",
+] as const;
+
+/**
+ * Enumerate the ancestor directories of a POSIX path.
+ *
+ * Replicates Python `Path.parents`: yields each parent directory from the
+ * immediate parent up to (but not including) the path itself. The root-most
+ * parent is the first path segment.
+ *
+ * @param path A POSIX-style path.
+ * @returns The ancestor paths, immediate parent first.
+ */
+function parentPaths(path: string): string[] {
+  const segments = path.split("/").filter((segment) => segment !== "");
+  const parents: string[] = [];
+  // Build each ancestor prefix by dropping trailing segments one at a time.
+  for (let count = segments.length - 1; count >= 1; count -= 1) {
+    parents.push(segments.slice(0, count).join("/"));
+  }
+  return parents;
+}
+
+/**
+ * Yield governed JSON files under the repo root respecting excludes.
+ *
+ * Port of Python `iter_governed_files`. The algorithm:
+ * 1) Resolve include matches from {@link GOVERNED_GLOBS}.
+ * 2) Build an exclusion set from {@link EXCLUDE_GLOBS}.
+ * 3) Keep an included path only when none of its parents are excluded, the path
+ *    itself is not excluded, and the path is a regular file.
+ *
+ * The exclusion-by-parent check mirrors Python
+ * `any(parent in excluded for parent in path.parents)`.
+ *
+ * @param fs Injected filesystem providing `glob` and `isFile`.
+ * @param root Repository root to search under.
+ * @returns The governed JSON file paths (POSIX style), in include order.
+ */
+export function iterGovernedFiles(fs: FileSystem, root: string): string[] {
+  const normalizedRoot = toPosixPath(root);
+
+  // Resolve include matches first, preserving glob order across patterns.
+  const includes: string[] = [];
+  for (const pattern of GOVERNED_GLOBS) {
+    includes.push(...fs.glob(normalizedRoot, pattern));
+  }
+
+  // Build the exclusion set from every exclude glob match.
+  const excluded = new Set<string>();
+  for (const pattern of EXCLUDE_GLOBS) {
+    for (const match of fs.glob(normalizedRoot, pattern)) {
+      excluded.add(match);
+    }
+  }
+
+  // Filter includes: skip any path whose ancestor is excluded, that is itself
+  // excluded, or that is not a regular file (e.g. a directory named *.json).
+  const result: string[] = [];
+  for (const path of includes) {
+    const hasExcludedParent = parentPaths(path).some((parent) =>
+      excluded.has(parent),
+    );
+    if (hasExcludedParent) {
+      continue;
+    }
+    if (excluded.has(path)) {
+      continue;
+    }
+    if (fs.isFile(path)) {
+      result.push(path);
+    }
+  }
+
+  return result;
+}

--- a/extensions/drm-copilot/src/lib/markdown-label-formatter.ts
+++ b/extensions/drm-copilot/src/lib/markdown-label-formatter.ts
@@ -1,0 +1,241 @@
+import type { FileSystem } from "./file-system";
+
+/**
+ * Format markdown chat transcripts with labeled sections.
+ *
+ * This module is a port of the pure-logic and I/O functions of
+ * `scripts/dev_tools/markdown_label_formatter.py`. The CLI entry-point glue
+ * (`parse_args`/`main`) is intentionally NOT ported here: service wiring is
+ * deferred to a consuming feature, so this module exposes only host-neutral,
+ * testable functions. File and stream access flow through an injected
+ * {@link FileSystem} and explicit stream callbacks rather than `node:fs` or
+ * `process.stdin`/`process.stdout`.
+ */
+
+/** Recognized speaker-label prefixes that become H1 headings. */
+export const LABEL_PREFIXES = ["User:", "GitHub Copilot:"] as const;
+
+/** Separator token inserted between labeled sections. */
+export const SEPARATOR_LINE = "---";
+
+/**
+ * Heading and trailing text produced from a label line.
+ *
+ * - `heading`: the formatted H1 heading (e.g. `# User:`).
+ * - `trailing`: any text following the label, left-stripped.
+ */
+export interface LabelHeading {
+  heading: string;
+  trailing: string;
+}
+
+/**
+ * Split content into lines mirroring Python `str.splitlines()`.
+ *
+ * Python `splitlines()` splits on line boundaries (`\n`, `\r`, `\r\n`) and does
+ * not emit a trailing empty element when the content ends in a newline. This
+ * helper replicates that behavior so trailing-newline handling matches the
+ * Python source exactly.
+ *
+ * @param content Raw text content.
+ * @returns The list of lines without their terminating newline characters.
+ */
+function splitLines(content: string): string[] {
+  const lines: string[] = [];
+  let current = "";
+  let index = 0;
+
+  // Walk the content character by character, breaking on line boundaries.
+  // \r\n is consumed as a single boundary to avoid emitting an empty line.
+  while (index < content.length) {
+    const char = content[index];
+    if (char === "\n") {
+      lines.push(current);
+      current = "";
+      index += 1;
+      continue;
+    }
+    if (char === "\r") {
+      lines.push(current);
+      current = "";
+      // Consume a following \n as part of the same \r\n boundary.
+      if (content[index + 1] === "\n") {
+        index += 2;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+    current += char;
+    index += 1;
+  }
+
+  // A non-empty trailing segment (no terminating newline) is its own line.
+  if (current !== "") {
+    lines.push(current);
+  }
+
+  return lines;
+}
+
+/**
+ * Return true when the line starts with a known speaker label.
+ *
+ * @param line A single line of input.
+ * @returns True when the line begins with one of {@link LABEL_PREFIXES}.
+ */
+export function isLabelLine(line: string): boolean {
+  // Match Python str.startswith(tuple): true if any prefix matches.
+  return LABEL_PREFIXES.some((prefix) => line.startsWith(prefix));
+}
+
+/**
+ * Return true when the line is blank or exactly the separator token.
+ *
+ * @param line A single line of input.
+ * @returns True when the stripped line is empty or equals `---`.
+ */
+export function isSeparatorLine(line: string): boolean {
+  const stripped = line.trim();
+  return stripped === "" || stripped === SEPARATOR_LINE;
+}
+
+/**
+ * Convert a label line to an H1 heading and return remaining text.
+ *
+ * Mirrors Python `line.partition(":")`: split on the first colon, format the
+ * heading from the stripped label, and left-strip the trailing remainder.
+ *
+ * @param line A line starting with one of the supported labels.
+ * @returns The formatted heading and any trailing text following the label.
+ */
+export function formatLabelHeading(line: string): LabelHeading {
+  const colonIndex = line.indexOf(":");
+  // partition(":"): when no colon exists, label is the whole line and trailing
+  // is empty. The supported labels always contain a colon, but replicate the
+  // full partition semantics for parity.
+  const label = colonIndex === -1 ? line : line.slice(0, colonIndex);
+  const trailing = colonIndex === -1 ? "" : line.slice(colonIndex + 1);
+  const heading = `# ${label.trim()}:`;
+  return { heading, trailing: trailing.replace(/^\s+/, "") };
+}
+
+/**
+ * Ensure a blank/---/blank separator exists before the next label.
+ *
+ * Mutates `outputLines` in place: pop trailing blank lines, then append the
+ * separator block. Replicates the Python `ensure_separator_block` behavior.
+ *
+ * @param outputLines The accumulated output lines, mutated in place.
+ */
+export function ensureSeparatorBlock(outputLines: string[]): void {
+  // Remove any trailing blank lines so the separator block is well-formed.
+  while (
+    outputLines.length > 0 &&
+    outputLines[outputLines.length - 1]?.trim() === ""
+  ) {
+    outputLines.pop();
+  }
+  outputLines.push("", SEPARATOR_LINE, "");
+}
+
+/**
+ * Prefix a non-label, non-separator line with a markdown quote marker.
+ *
+ * @param line A content line.
+ * @returns `> <line>` for non-empty input, otherwise `>`.
+ */
+export function prefixContentLine(line: string): string {
+  return line ? `> ${line}` : ">";
+}
+
+/**
+ * Process markdown text according to the requested formatting rules.
+ *
+ * Labels become H1 headings preceded (when not first) by a separator block;
+ * separators are normalized; all other lines are quoted. A trailing newline in
+ * the input is preserved in the output.
+ *
+ * @param content Raw markdown content.
+ * @returns The formatted markdown content.
+ */
+export function processMarkdown(content: string): string {
+  const lines = splitLines(content);
+  const trailingNewline = content.endsWith("\n");
+
+  const outputLines: string[] = [];
+
+  // Walk each input line and route it by kind: label, separator, or content.
+  for (const line of lines) {
+    if (isLabelLine(line)) {
+      // A label that is not the first output gets a separator block above it.
+      if (outputLines.length > 0) {
+        ensureSeparatorBlock(outputLines);
+      }
+
+      const { heading, trailing } = formatLabelHeading(line);
+      outputLines.push(heading);
+
+      // Inline text after the label is spaced out and quoted on its own line.
+      if (trailing) {
+        outputLines.push("", "");
+        outputLines.push(prefixContentLine(trailing));
+      }
+      continue;
+    }
+
+    if (isSeparatorLine(line)) {
+      // A literal `---` is preserved; whitespace-only lines collapse to blank.
+      outputLines.push(line.trim() ? SEPARATOR_LINE : "");
+      continue;
+    }
+
+    outputLines.push(prefixContentLine(line));
+  }
+
+  let result = outputLines.join("\n");
+  if (trailingNewline) {
+    result += "\n";
+  }
+  return result;
+}
+
+/**
+ * Read content from a file path, or from a stdin callback when path is null.
+ *
+ * @param fs Injected filesystem used for file reads.
+ * @param source File path to read, or null to read from `stdin`.
+ * @param stdin Callback returning the standard-input content.
+ * @returns The content read from the file or from `stdin`.
+ */
+export function readContent(
+  fs: FileSystem,
+  source: string | null,
+  stdin: () => string,
+): string {
+  if (source === null) {
+    return stdin();
+  }
+  return fs.readTextFile(source);
+}
+
+/**
+ * Write content to a file path, or to a stdout callback when path is null.
+ *
+ * @param fs Injected filesystem used for file writes.
+ * @param content The content to write.
+ * @param target File path to write, or null to write to `stdout`.
+ * @param stdout Callback receiving the content when no target path is given.
+ */
+export function writeOutput(
+  fs: FileSystem,
+  content: string,
+  target: string | null,
+  stdout: (s: string) => void,
+): void {
+  if (target === null) {
+    stdout(content);
+    return;
+  }
+  fs.writeTextFile(target, content);
+}

--- a/extensions/drm-copilot/src/lib/prompt-mode-contract.ts
+++ b/extensions/drm-copilot/src/lib/prompt-mode-contract.ts
@@ -1,0 +1,176 @@
+/**
+ * Shared issue.md work-mode contract helpers for prompt resolvers.
+ *
+ * Purpose:
+ *     Centralize parsing and fail-closed work-mode resolution so all prompt
+ *     resolvers use one deterministic contract:
+ *     1) Parse a persisted issue marker when valid.
+ *     2) Normalize legacy `full` markers to a canonical full-mode variant.
+ *     3) Fall back to `full-feature` when the marker is missing or malformed.
+ *     4) Surface an auditable fallback or normalization reason string.
+ *
+ * This module is a direct port of
+ * `scripts/dev_tools/prompt_mode_contract.py`; function signatures, return
+ * shapes, error messages, and reason strings match the Python source verbatim.
+ */
+
+/** Canonical work modes accepted as persisted marker values. */
+export const CANONICAL_WORK_MODES = [
+  "minor-audit",
+  "full-feature",
+  "full-bug",
+] as const;
+
+/** Legacy plain `full` marker retained for backward compatibility. */
+export const LEGACY_FULL_MODE = "full";
+
+/** All accepted work modes, including the legacy `full` value. */
+export const ACCEPTED_WORK_MODES = [
+  ...CANONICAL_WORK_MODES,
+  LEGACY_FULL_MODE,
+] as const;
+
+/**
+ * Outcome of parsing the work-mode marker from issue content.
+ *
+ * - `mode`: the parsed marker value when a valid marker is present, else null.
+ * - `malformed`: true when a `- Work Mode:` line exists but its value is not a
+ *   recognized work mode.
+ */
+export interface ParsedWorkMode {
+  mode: string | null;
+  malformed: boolean;
+}
+
+/**
+ * Normalize a requested work mode into a canonical persisted value.
+ *
+ * Convert user-facing or legacy CLI values into canonical persisted markers.
+ * Plain `full` remains accepted for backward compatibility but is normalized to
+ * the deterministic variant that matches the promotion target.
+ *
+ * @param requestedMode Requested work mode from CLI or caller.
+ * @param promotionType Promotion or feature type (`feature`, `bug`, etc.).
+ * @returns Canonical work mode (`minor-audit`, `full-feature`, or `full-bug`).
+ * @throws Error When the request is invalid or incompatible with the type.
+ */
+export function normalizeRequestedWorkMode(
+  requestedMode: string,
+  promotionType: string,
+): string {
+  // Reject any value outside the accepted set before branching on intent.
+  if (!(ACCEPTED_WORK_MODES as readonly string[]).includes(requestedMode)) {
+    throw new Error(
+      "work_mode must be one of: minor-audit, full-feature, full-bug, full",
+    );
+  }
+
+  // minor-audit is already canonical and applies to any promotion type.
+  if (requestedMode === "minor-audit") {
+    return requestedMode;
+  }
+
+  const isBug = promotionType === "bug";
+
+  // Legacy `full` is resolved to the variant matching the promotion target.
+  if (requestedMode === LEGACY_FULL_MODE) {
+    return isBug ? "full-bug" : "full-feature";
+  }
+
+  // Canonical full-bug is only valid for bug work; reject otherwise.
+  if (requestedMode === "full-bug" && !isBug) {
+    throw new Error("full-bug may only be used with bug work");
+  }
+
+  // Canonical full-feature is invalid for bug work; reject that combination.
+  if (requestedMode === "full-feature" && isBug) {
+    throw new Error("full-feature may not be used with bug work");
+  }
+
+  return requestedMode;
+}
+
+/**
+ * Parse the work-mode marker from issue.md content.
+ *
+ * Extract a valid `- Work Mode:` marker value from issue content while
+ * distinguishing malformed marker lines from truly missing markers.
+ *
+ * @param issueContent Raw `issue.md` file content.
+ * @returns A {@link ParsedWorkMode}: `mode` is the parsed value when valid
+ *   (`minor-audit`, `full-feature`, `full-bug`, or legacy `full`), otherwise
+ *   null; `malformed` indicates whether a malformed marker line was detected.
+ */
+export function parseIssueWorkMode(issueContent: string): ParsedWorkMode {
+  // Mirror Python (?im) flags: case-insensitive, multiline (per-line anchors).
+  const validMatch =
+    /^-\s*Work Mode:\s*(minor-audit|full-feature|full-bug|full)\s*$/im.exec(
+      issueContent,
+    );
+  if (validMatch !== null) {
+    return { mode: validMatch[1] ?? null, malformed: false };
+  }
+
+  // A marker line with an unrecognized value is malformed, not merely missing.
+  const malformedMatch = /^-\s*Work Mode:\s*(.+)\s*$/im.exec(issueContent);
+  return { mode: null, malformed: malformedMatch !== null };
+}
+
+/**
+ * Resolve the selected work mode with fail-closed behavior.
+ *
+ * Honor a valid marker when present, normalize legacy `full` to `full-feature`,
+ * and fail closed to `full-feature` for all other states.
+ *
+ * @param issueContent Raw issue content, or null when the file is unavailable.
+ * @returns `minor-audit`, `full-feature`, or `full-bug`.
+ */
+export function resolveSelectedWorkMode(issueContent: string | null): string {
+  // Decision logic:
+  // - If the issue file is unavailable, fail closed immediately.
+  // - If a valid marker exists, trust it as the selected mode.
+  // - Otherwise, fail closed to full-feature.
+  if (issueContent === null) {
+    return "full-feature";
+  }
+
+  const { mode } = parseIssueWorkMode(issueContent);
+  if (mode !== null) {
+    if (mode === LEGACY_FULL_MODE) {
+      return "full-feature";
+    }
+    return mode;
+  }
+
+  return "full-feature";
+}
+
+/**
+ * Build a deterministic fallback reason for mode resolution.
+ *
+ * Produce a stable reason string suitable for prompt substitution and audit
+ * evidence, aligned with fail-closed mode semantics.
+ *
+ * @param issueContent Raw issue content, or null when missing or unreadable.
+ * @returns `none` when no fallback was needed, otherwise an explicit reason.
+ */
+export function buildFallbackReason(issueContent: string | null): string {
+  if (issueContent === null) {
+    return "issue.md missing; fail closed to full-feature";
+  }
+
+  const { mode, malformed } = parseIssueWorkMode(issueContent);
+  if (mode !== null) {
+    if (mode === LEGACY_FULL_MODE) {
+      return "issue.md Work Mode marker uses legacy full; normalized to full-feature";
+    }
+    return "none";
+  }
+
+  // Branch by marker quality so diagnostics are explicit and actionable.
+  if (malformed) {
+    return "issue.md Work Mode marker malformed; fail closed to full-feature";
+  }
+
+  return "issue.md Work Mode marker missing; fail closed to full-feature";
+}

--- a/extensions/drm-copilot/src/lib/subprocess-runner.ts
+++ b/extensions/drm-copilot/src/lib/subprocess-runner.ts
@@ -1,0 +1,142 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * Structured outcome of a shell command.
+ *
+ * Mirrors the Python `CommandResult` dataclass in
+ * `scripts/dev_tools/pr_context/models.py`:
+ * - `stdout` and `stderr` are decoded UTF-8 text with a single trailing
+ *   newline stripped (matching Python `rstrip("\n")`).
+ * - `code` is the integer process exit code.
+ */
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/**
+ * Optional invocation parameters for {@link CommandRunner.run}.
+ *
+ * - `cwd`: working directory for the spawned process.
+ * - `allowError`: when `false` (default), a non-zero exit code raises an Error;
+ *   when `true`, the captured result is returned regardless of exit status.
+ */
+export interface CommandRunOptions {
+  cwd?: string;
+  allowError?: boolean;
+}
+
+/**
+ * Contract for running shell commands and returning structured results.
+ *
+ * Mirrors the Python `CommandRunner` Protocol in
+ * `scripts/dev_tools/pr_context/git.py`. Implementations capture stdout,
+ * stderr, and the exit code; whether a non-zero exit raises is governed by
+ * {@link CommandRunOptions.allowError}.
+ */
+export interface CommandRunner {
+  run(args: readonly string[], options?: CommandRunOptions): CommandResult;
+}
+
+/**
+ * Removes a single trailing newline character from a decoded stream.
+ *
+ * Replicates Python `rstrip("\n")` as used by the source `SubprocessRunner`:
+ * Python's `rstrip("\n")` removes all trailing `\n` characters, so this helper
+ * strips every trailing newline rather than just one. This keeps parity with
+ * the Python behavior where multiple trailing newlines collapse to none.
+ *
+ * @param value Decoded stream content.
+ * @returns The content with all trailing `\n` characters removed.
+ */
+function stripTrailingNewlines(value: string): string {
+  let end = value.length;
+  // Walk backward over trailing newline characters to mirror rstrip("\n").
+  while (end > 0 && value[end - 1] === "\n") {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+/**
+ * Command runner that shells out using `node:child_process.spawnSync`.
+ *
+ * Purpose:
+ *     Execute a command and capture stdout, stderr, and the exit code,
+ *     replicating the behavior of the Python `SubprocessRunner` in
+ *     `scripts/dev_tools/pr_context/git.py`.
+ *
+ * Responsibilities:
+ *     - Spawn the process without a shell (`shell: false`), passing the
+ *       argument list verbatim (no shell interpolation).
+ *     - Decode stdout/stderr buffers as UTF-8 with replacement of undecodable
+ *       bytes (Node's default `Buffer.toString("utf8")` emits U+FFFD for
+ *       invalid sequences, matching Python `errors="replace"`).
+ *     - Strip trailing newlines from both streams.
+ *     - Raise on non-zero exit unless `allowError` is set.
+ *
+ * Side effects:
+ *     Spawns a child process.
+ *
+ * Invariants:
+ *     - A `null` status (process terminated by signal or failed to spawn) is
+ *       treated as a non-zero failure, matching the contract that a missing
+ *       exit code is not success.
+ */
+export class SubprocessRunner implements CommandRunner {
+  /**
+   * Execute a command and capture its output.
+   *
+   * @param args Command and arguments; `args[0]` is the executable.
+   * @param options Optional `cwd` and `allowError` flag.
+   * @returns Captured stdout, stderr, and integer exit code.
+   * @throws Error When the process exits non-zero and `allowError` is false.
+   *   The message format matches the Python source:
+   *   `` `${args.join(" ")} failed (${code}): ${joined}` `` where `joined` is
+   *   `(stdout + "\n" + stderr).trim()`.
+   */
+  run(args: readonly string[], options?: CommandRunOptions): CommandResult {
+    const executable = args[0];
+    if (executable === undefined) {
+      throw new Error("SubprocessRunner.run requires at least one argument");
+    }
+
+    const allowError = options?.allowError ?? false;
+
+    const spawnOptions: { cwd?: string; shell: false } =
+      options?.cwd === undefined
+        ? { shell: false }
+        : { cwd: options.cwd, shell: false };
+
+    const completed = spawnSync(executable, args.slice(1), spawnOptions);
+
+    // Decode captured buffers as UTF-8. Node replaces undecodable byte
+    // sequences with U+FFFD, matching Python encoding="utf-8", errors="replace".
+    const rawStdout =
+      completed.stdout instanceof Buffer
+        ? completed.stdout.toString("utf8")
+        : "";
+    const rawStderr =
+      completed.stderr instanceof Buffer
+        ? completed.stderr.toString("utf8")
+        : "";
+
+    const stdout = stripTrailingNewlines(rawStdout);
+    const stderr = stripTrailingNewlines(rawStderr);
+
+    // A null status indicates the process did not exit normally (signal or
+    // spawn failure). Treat it as a non-zero failure rather than success.
+    const code = completed.status === null ? 1 : completed.status;
+
+    const result: CommandResult = { stdout, stderr, code };
+
+    // Fail-fast on non-zero exit unless the caller opted into tolerating errors.
+    if (!allowError && result.code !== 0) {
+      const joined = (stdout + "\n" + stderr).trim();
+      throw new Error(`${args.join(" ")} failed (${result.code}): ${joined}`);
+    }
+
+    return result;
+  }
+}

--- a/extensions/drm-copilot/test/lib/file-system.test.ts
+++ b/extensions/drm-copilot/test/lib/file-system.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import * as fs from "node:fs";
+
+import { RealFileSystem } from "../../src/lib/file-system";
+
+jest.mock("node:fs", () => ({
+  readdirSync: jest.fn(),
+  statSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}));
+
+const readdirSyncMock = fs.readdirSync as jest.MockedFunction<
+  typeof fs.readdirSync
+>;
+const statSyncMock = fs.statSync as jest.MockedFunction<typeof fs.statSync>;
+const readFileSyncMock = fs.readFileSync as jest.MockedFunction<
+  typeof fs.readFileSync
+>;
+const writeFileSyncMock = fs.writeFileSync as jest.MockedFunction<
+  typeof fs.writeFileSync
+>;
+
+/**
+ * Build a minimal Dirent-like entry for mocking readdirSync results.
+ */
+function dirent(name: string, isDir: boolean): fs.Dirent {
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+  } as unknown as fs.Dirent;
+}
+
+describe("RealFileSystem", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("isFile", () => {
+    it("returns true for a regular file", () => {
+      // Arrange
+      statSyncMock.mockReturnValue({
+        isFile: () => true,
+      } as unknown as fs.Stats);
+      const sut = new RealFileSystem();
+
+      // Act / Assert
+      expect(sut.isFile("/some/file.json")).toBe(true);
+    });
+
+    it("returns false for a directory", () => {
+      // Arrange
+      statSyncMock.mockReturnValue({
+        isFile: () => false,
+      } as unknown as fs.Stats);
+      const sut = new RealFileSystem();
+
+      // Act / Assert
+      expect(sut.isFile("/some/dir")).toBe(false);
+    });
+
+    it("returns false when statSync throws (missing path)", () => {
+      // Arrange
+      statSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const sut = new RealFileSystem();
+
+      // Act / Assert
+      expect(sut.isFile("/missing")).toBe(false);
+    });
+  });
+
+  describe("readTextFile", () => {
+    it("returns decoded UTF-8 content", () => {
+      // Arrange
+      readFileSyncMock.mockReturnValue("file body");
+      const sut = new RealFileSystem();
+
+      // Act
+      const result = sut.readTextFile("/some/file.txt");
+
+      // Assert
+      expect(result).toBe("file body");
+      expect(readFileSyncMock).toHaveBeenCalledWith("/some/file.txt", "utf8");
+    });
+  });
+
+  describe("writeTextFile", () => {
+    it("delegates to writeFileSync with utf8 encoding", () => {
+      // Arrange
+      const sut = new RealFileSystem();
+
+      // Act
+      sut.writeTextFile("/out/file.txt", "content");
+
+      // Assert
+      expect(writeFileSyncMock).toHaveBeenCalledWith(
+        "/out/file.txt",
+        "content",
+        "utf8",
+      );
+    });
+  });
+
+  describe("glob", () => {
+    it("returns matches consistent with governed glob semantics", () => {
+      // Arrange: model a tree where readdirSync returns entries per directory.
+      readdirSyncMock.mockImplementation((dir: fs.PathLike) => {
+        const path = String(dir);
+        if (path.endsWith("/repo") || path === "/repo") {
+          return [dirent("scripts", true)] as unknown as ReturnType<
+            typeof fs.readdirSync
+          >;
+        }
+        if (path.endsWith("scripts")) {
+          return [
+            dirent("config.json", false),
+            dirent("notes.txt", false),
+          ] as unknown as ReturnType<typeof fs.readdirSync>;
+        }
+        return [] as unknown as ReturnType<typeof fs.readdirSync>;
+      });
+      const sut = new RealFileSystem();
+
+      // Act
+      const matches = sut.glob("/repo", "scripts/**/*.json");
+
+      // Assert: only the .json file under scripts matches.
+      expect(matches).toContain("/repo/scripts/config.json");
+      expect(matches).not.toContain("/repo/scripts/notes.txt");
+    });
+
+    it("returns an empty list when the root cannot be read", () => {
+      // Arrange
+      readdirSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const sut = new RealFileSystem();
+
+      // Act
+      const matches = sut.glob("/missing", "scripts/**/*.json");
+
+      // Assert
+      expect(matches).toEqual([]);
+    });
+
+    it("matches a directory entry against a directory-style exclude glob", () => {
+      // Arrange
+      readdirSyncMock.mockImplementation((dir: fs.PathLike) => {
+        const path = String(dir);
+        if (path === "/repo") {
+          return [dirent("data", true)] as unknown as ReturnType<
+            typeof fs.readdirSync
+          >;
+        }
+        if (path.endsWith("data")) {
+          return [dirent("corpus.json", false)] as unknown as ReturnType<
+            typeof fs.readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof fs.readdirSync>;
+      });
+      const sut = new RealFileSystem();
+
+      // Act
+      const matches = sut.glob("/repo", "data/**");
+
+      // Assert: data/** matches the nested file under data.
+      expect(matches).toContain("/repo/data/corpus.json");
+    });
+  });
+});

--- a/extensions/drm-copilot/test/lib/json-config.test.ts
+++ b/extensions/drm-copilot/test/lib/json-config.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { FileSystem } from "../../src/lib/file-system";
+import {
+  EXCLUDE_GLOBS,
+  GOVERNED_GLOBS,
+  iterGovernedFiles,
+} from "../../src/lib/json-config";
+
+/**
+ * Compile a glob into an anchored RegExp using the same token semantics as the
+ * production RealFileSystem.glob (`**`, `*`, `?`). Defined locally so the fake
+ * filesystem validates iterGovernedFiles logic with matching glob semantics.
+ */
+function compileGlob(pattern: string): RegExp {
+  let regex = "";
+  let index = 0;
+  while (index < pattern.length) {
+    const char = pattern[index];
+    if (char === "*") {
+      if (pattern[index + 1] === "*") {
+        if (pattern[index + 2] === "/") {
+          regex += "(?:.*/)?";
+          index += 3;
+        } else {
+          regex += ".*";
+          index += 2;
+        }
+        continue;
+      }
+      regex += "[^/]*";
+      index += 1;
+      continue;
+    }
+    if (char === "?") {
+      regex += "[^/]";
+      index += 1;
+      continue;
+    }
+    regex += (char ?? "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    index += 1;
+  }
+  return new RegExp(`^${regex}$`);
+}
+
+/**
+ * In-memory FileSystem fake modeling a virtual tree from a set of file paths.
+ * Directories are derived from the file paths. glob matches both files and
+ * directories (as the production walker does); isFile is true only for files.
+ */
+class VirtualFileSystem implements FileSystem {
+  private readonly files: Set<string>;
+  private readonly dirs: Set<string>;
+  private readonly root: string;
+
+  constructor(filePaths: readonly string[], root: string) {
+    this.root = root;
+    this.files = new Set(filePaths);
+    this.dirs = new Set<string>();
+    // Derive every ancestor directory of each file path.
+    for (const file of filePaths) {
+      const segments = file.split("/");
+      for (let count = 1; count < segments.length; count += 1) {
+        this.dirs.add(segments.slice(0, count).join("/"));
+      }
+    }
+  }
+
+  glob(root: string, pattern: string): string[] {
+    const matcher = compileGlob(pattern);
+    const matches: string[] = [];
+    // Test every known directory and file (relative to root) against the glob.
+    for (const candidate of [...this.dirs, ...this.files]) {
+      if (matcher.test(candidate)) {
+        matches.push(`${root}/${candidate}`);
+      }
+    }
+    return matches;
+  }
+
+  isFile(path: string): boolean {
+    const prefix = `${this.root}/`;
+    const relative = path.startsWith(prefix) ? path.slice(prefix.length) : path;
+    return this.files.has(relative);
+  }
+
+  readTextFile(): string {
+    throw new Error("not used");
+  }
+
+  writeTextFile(): void {
+    throw new Error("not used");
+  }
+}
+
+const ROOT = "/repo";
+
+describe("json-config constants", () => {
+  it("GOVERNED_GLOBS is a non-empty array containing scripts glob", () => {
+    // Arrange / Act / Assert
+    expect(Array.isArray(GOVERNED_GLOBS)).toBe(true);
+    expect(GOVERNED_GLOBS.length).toBeGreaterThan(0);
+    expect(GOVERNED_GLOBS).toContain("scripts/**/*.json");
+  });
+
+  it("EXCLUDE_GLOBS is a non-empty array containing data exclude", () => {
+    // Arrange / Act / Assert
+    expect(Array.isArray(EXCLUDE_GLOBS)).toBe(true);
+    expect(EXCLUDE_GLOBS.length).toBeGreaterThan(0);
+    expect(EXCLUDE_GLOBS).toContain("data/**");
+  });
+});
+
+describe("iterGovernedFiles", () => {
+  it("yields nothing for an empty filesystem", () => {
+    // Arrange
+    const fs = new VirtualFileSystem([], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("excludes .vscode/*.json (JSONC, not governed)", () => {
+    // Arrange
+    const fs = new VirtualFileSystem([".vscode/tasks.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).not.toContain(`${ROOT}/.vscode/tasks.json`);
+  });
+
+  it("excludes nested .vscode/**/*.json", () => {
+    // Arrange
+    const fs = new VirtualFileSystem([".vscode/subdir/config.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).not.toContain(`${ROOT}/.vscode/subdir/config.json`);
+  });
+
+  it("excludes files under data/**", () => {
+    // Arrange
+    const fs = new VirtualFileSystem(["data/metadata.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).not.toContain(`${ROOT}/data/metadata.json`);
+  });
+
+  it("excludes files under artifacts/**", () => {
+    // Arrange
+    const fs = new VirtualFileSystem(["artifacts/output.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).not.toContain(`${ROOT}/artifacts/output.json`);
+  });
+
+  it("excludes when a parent directory is excluded", () => {
+    // Arrange: htmlcov is excluded; a nested report is not governed/included.
+    const fs = new VirtualFileSystem(["htmlcov/subdir/report.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).not.toContain(`${ROOT}/htmlcov/subdir/report.json`);
+  });
+
+  it("excludes .devcontainer/*.json (JSONC, not governed)", () => {
+    // Arrange
+    const fs = new VirtualFileSystem([".devcontainer/devcontainer.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).not.toContain(`${ROOT}/.devcontainer/devcontainer.json`);
+  });
+
+  it("finds files under scripts/**/*.json", () => {
+    // Arrange
+    const fs = new VirtualFileSystem(["scripts/subdir/config.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).toContain(`${ROOT}/scripts/subdir/config.json`);
+  });
+
+  it("finds files under docs/**/*.json", () => {
+    // Arrange
+    const fs = new VirtualFileSystem(["docs/features/manifest.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).toContain(`${ROOT}/docs/features/manifest.json`);
+  });
+
+  it("finds files under examples/**/*.json", () => {
+    // Arrange
+    const fs = new VirtualFileSystem(["examples/meta/sample.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).toContain(`${ROOT}/examples/meta/sample.json`);
+  });
+
+  it("accepts a string root", () => {
+    // Arrange
+    const fs = new VirtualFileSystem(["scripts/config.json"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).toContain(`${ROOT}/scripts/config.json`);
+  });
+
+  it("yields only included files when mixed with excluded", () => {
+    // Arrange
+    const fs = new VirtualFileSystem(
+      ["scripts/config.json", "data/corpus.json"],
+      ROOT,
+    );
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert
+    expect(result).toContain(`${ROOT}/scripts/config.json`);
+    expect(result).not.toContain(`${ROOT}/data/corpus.json`);
+  });
+
+  it("skips non-file glob matches (a directory named *.json)", () => {
+    // Arrange: a directory named weird.json matches the glob but is not a file.
+    const fs = new VirtualFileSystem(["scripts/weird.json/inner.txt"], ROOT);
+
+    // Act
+    const result = iterGovernedFiles(fs, ROOT);
+
+    // Assert: the directory scripts/weird.json must not be returned.
+    expect(result).not.toContain(`${ROOT}/scripts/weird.json`);
+  });
+});

--- a/extensions/drm-copilot/test/lib/markdown-label-formatter.test.ts
+++ b/extensions/drm-copilot/test/lib/markdown-label-formatter.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { FileSystem } from "../../src/lib/file-system";
+import {
+  ensureSeparatorBlock,
+  formatLabelHeading,
+  isLabelLine,
+  isSeparatorLine,
+  LABEL_PREFIXES,
+  prefixContentLine,
+  processMarkdown,
+  readContent,
+  SEPARATOR_LINE,
+  writeOutput,
+} from "../../src/lib/markdown-label-formatter";
+
+/**
+ * In-memory FileSystem fake for hermetic I/O tests. Backed by a Map of path to
+ * content. The glob method is unused by this suite and returns an empty list.
+ */
+class InMemoryFileSystem implements FileSystem {
+  readonly files = new Map<string, string>();
+
+  glob(): string[] {
+    return [];
+  }
+
+  isFile(path: string): boolean {
+    return this.files.has(path);
+  }
+
+  readTextFile(path: string): string {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      throw new Error(`file not found: ${path}`);
+    }
+    return content;
+  }
+
+  writeTextFile(path: string, content: string): void {
+    this.files.set(path, content);
+  }
+}
+
+describe("markdown-label-formatter constants", () => {
+  it("exposes label prefixes and separator token", () => {
+    // Arrange / Act / Assert
+    expect(LABEL_PREFIXES).toEqual(["User:", "GitHub Copilot:"]);
+    expect(SEPARATOR_LINE).toBe("---");
+  });
+});
+
+describe("processMarkdown", () => {
+  it("formats the first label with content", () => {
+    // Arrange
+    const input = "User: Hello world";
+    const expected = ["# User:", "", "", "> Hello world"].join("\n");
+
+    // Act
+    const result = processMarkdown(input);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it("inserts a separator before a non-initial label", () => {
+    // Arrange
+    const input = ["Intro line", "User: Hi there"].join("\n");
+    const expected = [
+      "> Intro line",
+      "",
+      "---",
+      "",
+      "# User:",
+      "",
+      "",
+      "> Hi there",
+    ].join("\n");
+
+    // Act
+    const result = processMarkdown(input);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it("handles multiple labels and quotes other lines", () => {
+    // Arrange
+    const input = [
+      "User: First message",
+      "Second line from user",
+      "GitHub Copilot: Reply text",
+      "Follow up line",
+    ].join("\n");
+    const expected = [
+      "# User:",
+      "",
+      "",
+      "> First message",
+      "> Second line from user",
+      "",
+      "---",
+      "",
+      "# GitHub Copilot:",
+      "",
+      "",
+      "> Reply text",
+      "> Follow up line",
+    ].join("\n");
+
+    // Act
+    const result = processMarkdown(input);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it("skips extra spacing when a label has no inline text", () => {
+    // Arrange
+    const input = ["Intro", "User:", "Next line"].join("\n");
+    const expected = ["> Intro", "", "---", "", "# User:", "> Next line"].join(
+      "\n",
+    );
+
+    // Act
+    const result = processMarkdown(input);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it("preserves a trailing newline", () => {
+    // Arrange
+    const input = "User: Hi\n";
+    const expected = ["# User:", "", "", "> Hi", ""].join("\n");
+
+    // Act
+    const result = processMarkdown(input);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it("treats a whitespace-only separator line as blank", () => {
+    // Arrange
+    const input = "User: text\n   \nmore content";
+
+    // Act
+    const result = processMarkdown(input);
+
+    // Assert: whitespace-only lines collapse to blank, producing a blank gap.
+    expect(result).toContain("\n\n");
+  });
+});
+
+describe("isLabelLine", () => {
+  it("recognizes the User label", () => {
+    expect(isLabelLine("User: some text")).toBe(true);
+  });
+
+  it("recognizes the GitHub Copilot label", () => {
+    expect(isLabelLine("GitHub Copilot: response")).toBe(true);
+  });
+
+  it("rejects a non-label line", () => {
+    expect(isLabelLine("Just some text")).toBe(false);
+  });
+});
+
+describe("isSeparatorLine", () => {
+  it("treats a blank line as a separator", () => {
+    expect(isSeparatorLine("")).toBe(true);
+  });
+
+  it("treats the separator token as a separator", () => {
+    expect(isSeparatorLine("---")).toBe(true);
+  });
+
+  it("rejects a content line", () => {
+    expect(isSeparatorLine("Some content")).toBe(false);
+  });
+});
+
+describe("formatLabelHeading", () => {
+  it("formats a label with trailing text", () => {
+    // Arrange / Act
+    const result = formatLabelHeading("User: hello world");
+
+    // Assert
+    expect(result.heading).toBe("# User:");
+    expect(result.trailing).toBe("hello world");
+  });
+
+  it("formats a label with no trailing text", () => {
+    // Arrange / Act
+    const result = formatLabelHeading("User:");
+
+    // Assert
+    expect(result.heading).toBe("# User:");
+    expect(result.trailing).toBe("");
+  });
+});
+
+describe("prefixContentLine", () => {
+  it("quotes a non-empty line", () => {
+    expect(prefixContentLine("content text")).toBe("> content text");
+  });
+
+  it("emits a bare quote marker for an empty line", () => {
+    expect(prefixContentLine("")).toBe(">");
+  });
+});
+
+describe("ensureSeparatorBlock", () => {
+  it("adds a separator block", () => {
+    // Arrange
+    const lines = ["content"];
+
+    // Act
+    ensureSeparatorBlock(lines);
+
+    // Assert
+    expect(lines).toEqual(["content", "", "---", ""]);
+  });
+
+  it("removes trailing blanks before adding the separator", () => {
+    // Arrange
+    const lines = ["content", "", ""];
+
+    // Act
+    ensureSeparatorBlock(lines);
+
+    // Assert
+    expect(lines).toEqual(["content", "", "---", ""]);
+  });
+});
+
+describe("readContent", () => {
+  it("reads from a file path", () => {
+    // Arrange
+    const fs = new InMemoryFileSystem();
+    fs.writeTextFile("input.md", "file content");
+
+    // Act
+    const result = readContent(fs, "input.md", () => "stdin content");
+
+    // Assert
+    expect(result).toBe("file content");
+  });
+
+  it("reads from the stdin callback when path is null", () => {
+    // Arrange
+    const fs = new InMemoryFileSystem();
+
+    // Act
+    const result = readContent(fs, null, () => "stdin content");
+
+    // Assert
+    expect(result).toBe("stdin content");
+  });
+});
+
+describe("writeOutput", () => {
+  it("writes to a file path", () => {
+    // Arrange
+    const fs = new InMemoryFileSystem();
+
+    // Act
+    writeOutput(fs, "output content", "out.md", () => {
+      throw new Error("stdout should not be called");
+    });
+
+    // Assert
+    expect(fs.readTextFile("out.md")).toBe("output content");
+  });
+
+  it("writes to the stdout callback when path is null", () => {
+    // Arrange
+    const fs = new InMemoryFileSystem();
+    const captured: string[] = [];
+
+    // Act
+    writeOutput(fs, "stdout content", null, (s) => captured.push(s));
+
+    // Assert
+    expect(captured).toEqual(["stdout content"]);
+  });
+});

--- a/extensions/drm-copilot/test/lib/prompt-mode-contract.test.ts
+++ b/extensions/drm-copilot/test/lib/prompt-mode-contract.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  ACCEPTED_WORK_MODES,
+  buildFallbackReason,
+  CANONICAL_WORK_MODES,
+  LEGACY_FULL_MODE,
+  normalizeRequestedWorkMode,
+  parseIssueWorkMode,
+  resolveSelectedWorkMode,
+} from "../../src/lib/prompt-mode-contract";
+
+describe("prompt-mode-contract constants", () => {
+  it("exposes canonical work modes", () => {
+    // Arrange / Act / Assert
+    expect(CANONICAL_WORK_MODES).toEqual([
+      "minor-audit",
+      "full-feature",
+      "full-bug",
+    ]);
+  });
+
+  it("exposes the legacy full mode and accepted set", () => {
+    // Arrange / Act / Assert
+    expect(LEGACY_FULL_MODE).toBe("full");
+    expect(ACCEPTED_WORK_MODES).toEqual([
+      "minor-audit",
+      "full-feature",
+      "full-bug",
+      "full",
+    ]);
+  });
+});
+
+describe("parseIssueWorkMode", () => {
+  it("parses a valid minor-audit marker", () => {
+    // Arrange
+    const content = "- Work Mode: minor-audit\n";
+
+    // Act
+    const result = parseIssueWorkMode(content);
+
+    // Assert
+    expect(result.mode).toBe("minor-audit");
+    expect(result.malformed).toBe(false);
+  });
+
+  it("parses a valid full-feature marker", () => {
+    // Arrange
+    const content = "- Work Mode: full-feature\n";
+
+    // Act
+    const result = parseIssueWorkMode(content);
+
+    // Assert
+    expect(result.mode).toBe("full-feature");
+    expect(result.malformed).toBe(false);
+  });
+
+  it("flags a malformed marker line", () => {
+    // Arrange
+    const content = "- Work Mode: maybe\n";
+
+    // Act
+    const result = parseIssueWorkMode(content);
+
+    // Assert
+    expect(result.mode).toBeNull();
+    expect(result.malformed).toBe(true);
+  });
+
+  it("reports no marker and not malformed when marker absent", () => {
+    // Arrange
+    const content = "# no marker here\n";
+
+    // Act
+    const result = parseIssueWorkMode(content);
+
+    // Assert
+    expect(result.mode).toBeNull();
+    expect(result.malformed).toBe(false);
+  });
+});
+
+describe("resolveSelectedWorkMode", () => {
+  it("normalizes the legacy full marker to full-feature", () => {
+    // Arrange / Act / Assert
+    expect(resolveSelectedWorkMode("- Work Mode: full\n")).toBe("full-feature");
+  });
+
+  it("fails closed to full-feature when marker missing", () => {
+    // Arrange / Act / Assert
+    expect(resolveSelectedWorkMode("# no marker here\n")).toBe("full-feature");
+  });
+
+  it("fails closed to full-feature when marker malformed", () => {
+    // Arrange / Act / Assert
+    expect(resolveSelectedWorkMode("- Work Mode: maybe\n")).toBe(
+      "full-feature",
+    );
+  });
+
+  it("returns full-feature when content is null", () => {
+    // Arrange / Act / Assert
+    expect(resolveSelectedWorkMode(null)).toBe("full-feature");
+  });
+
+  it("returns the canonical marker value when valid", () => {
+    // Arrange / Act / Assert
+    expect(resolveSelectedWorkMode("- Work Mode: full-bug\n")).toBe("full-bug");
+  });
+});
+
+describe("normalizeRequestedWorkMode", () => {
+  it("returns minor-audit unchanged", () => {
+    // Arrange / Act / Assert
+    expect(normalizeRequestedWorkMode("minor-audit", "feature")).toBe(
+      "minor-audit",
+    );
+  });
+
+  it("accepts full-feature for feature work", () => {
+    // Arrange / Act / Assert
+    expect(normalizeRequestedWorkMode("full-feature", "feature")).toBe(
+      "full-feature",
+    );
+  });
+
+  it("maps legacy full to full-bug for bug work", () => {
+    // Arrange / Act / Assert
+    expect(normalizeRequestedWorkMode("full", "bug")).toBe("full-bug");
+  });
+
+  it("maps legacy full to full-feature for feature work", () => {
+    // Arrange / Act / Assert
+    expect(normalizeRequestedWorkMode("full", "feature")).toBe("full-feature");
+  });
+
+  it("rejects full-bug for feature work", () => {
+    // Arrange / Act / Assert
+    expect(() => normalizeRequestedWorkMode("full-bug", "feature")).toThrow(
+      "full-bug may only be used with bug work",
+    );
+  });
+
+  it("rejects full-feature for bug work", () => {
+    // Arrange / Act / Assert
+    expect(() => normalizeRequestedWorkMode("full-feature", "bug")).toThrow(
+      "full-feature may not be used with bug work",
+    );
+  });
+
+  it("rejects an unrecognized work mode", () => {
+    // Arrange / Act / Assert
+    expect(() => normalizeRequestedWorkMode("unknown", "feature")).toThrow(
+      "work_mode must be one of: minor-audit, full-feature, full-bug, full",
+    );
+  });
+});
+
+describe("buildFallbackReason", () => {
+  it("is explicit for a missing marker", () => {
+    // Arrange / Act / Assert
+    expect(buildFallbackReason("# no marker\n")).toBe(
+      "issue.md Work Mode marker missing; fail closed to full-feature",
+    );
+  });
+
+  it("returns none for a valid marker", () => {
+    // Arrange / Act / Assert
+    expect(buildFallbackReason("- Work Mode: full-feature\n")).toBe("none");
+  });
+
+  it("describes the legacy full normalization", () => {
+    // Arrange / Act / Assert
+    expect(buildFallbackReason("- Work Mode: full\n")).toBe(
+      "issue.md Work Mode marker uses legacy full; normalized to full-feature",
+    );
+  });
+
+  it("describes a malformed marker", () => {
+    // Arrange / Act / Assert
+    expect(buildFallbackReason("- Work Mode: maybe\n")).toBe(
+      "issue.md Work Mode marker malformed; fail closed to full-feature",
+    );
+  });
+
+  it("returns the missing-file reason when content is null", () => {
+    // Arrange / Act / Assert
+    expect(buildFallbackReason(null)).toBe(
+      "issue.md missing; fail closed to full-feature",
+    );
+  });
+});

--- a/extensions/drm-copilot/test/lib/subprocess-runner.test.ts
+++ b/extensions/drm-copilot/test/lib/subprocess-runner.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { spawnSync } from "node:child_process";
+
+import { SubprocessRunner } from "../../src/lib/subprocess-runner";
+
+jest.mock("node:child_process", () => ({ spawnSync: jest.fn() }));
+
+// Typed reference to the mocked spawnSync for arranging return values.
+const spawnSyncMock = spawnSync as jest.MockedFunction<typeof spawnSync>;
+
+/**
+ * Build a minimal spawnSync return object for tests. Only the fields consumed
+ * by SubprocessRunner are populated; the cast satisfies the broad return type.
+ */
+function spawnResult(
+  status: number | null,
+  stdout: Buffer,
+  stderr: Buffer,
+): ReturnType<typeof spawnSync> {
+  return {
+    status,
+    stdout,
+    stderr,
+    pid: 1,
+    output: [null, stdout, stderr],
+    signal: null,
+  } as ReturnType<typeof spawnSync>;
+}
+
+describe("SubprocessRunner", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns a result with trailing newline stripped on success", () => {
+    // Arrange
+    spawnSyncMock.mockReturnValue(
+      spawnResult(0, Buffer.from("out\n"), Buffer.from("")),
+    );
+    const runner = new SubprocessRunner();
+
+    // Act
+    const result = runner.run(["git", "status"]);
+
+    // Assert
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("out");
+    expect(result.stderr).toBe("");
+  });
+
+  it("returns the result without throwing when allowError is true", () => {
+    // Arrange
+    spawnSyncMock.mockReturnValue(
+      spawnResult(2, Buffer.from("partial"), Buffer.from("warned")),
+    );
+    const runner = new SubprocessRunner();
+
+    // Act
+    const result = runner.run(["git", "diff"], { allowError: true });
+
+    // Assert
+    expect(result.code).toBe(2);
+    expect(result.stdout).toBe("partial");
+    expect(result.stderr).toBe("warned");
+  });
+
+  it("throws with the git.py message format on non-zero exit by default", () => {
+    // Arrange
+    spawnSyncMock.mockReturnValue(
+      spawnResult(128, Buffer.from("oops"), Buffer.from("fatal: bad")),
+    );
+    const runner = new SubprocessRunner();
+
+    // Act / Assert: message is `${args.join(" ")} failed (${code}): ${joined}`.
+    expect(() => runner.run(["git", "rev-parse", "HEAD"])).toThrow(
+      "git rev-parse HEAD failed (128): oops\nfatal: bad",
+    );
+  });
+
+  it("captures and decodes stderr with trailing newline stripped", () => {
+    // Arrange
+    spawnSyncMock.mockReturnValue(
+      spawnResult(0, Buffer.from(""), Buffer.from("warning text\n")),
+    );
+    const runner = new SubprocessRunner();
+
+    // Act
+    const result = runner.run(["git", "log"]);
+
+    // Assert
+    expect(result.stderr).toBe("warning text");
+  });
+
+  it("replaces undecodable UTF-8 bytes rather than throwing", () => {
+    // Arrange: 0xff 0xfe is an invalid UTF-8 sequence.
+    spawnSyncMock.mockReturnValue(
+      spawnResult(0, Buffer.from([0xff, 0xfe]), Buffer.from("")),
+    );
+    const runner = new SubprocessRunner();
+
+    // Act
+    const result = runner.run(["git", "show"]);
+
+    // Assert: U+FFFD replacement characters appear in the decoded output.
+    expect(result.stdout).toContain("�");
+    expect(result.code).toBe(0);
+  });
+
+  it("treats a null status as a non-zero failure", () => {
+    // Arrange
+    spawnSyncMock.mockReturnValue(
+      spawnResult(null, Buffer.from(""), Buffer.from("killed")),
+    );
+    const runner = new SubprocessRunner();
+
+    // Act / Assert: null status maps to code 1 and triggers the throw path.
+    expect(() => runner.run(["git", "fetch"])).toThrow(
+      "git fetch failed (1): killed",
+    );
+  });
+
+  it("passes cwd through to spawnSync when provided", () => {
+    // Arrange
+    spawnSyncMock.mockReturnValue(
+      spawnResult(0, Buffer.from("ok"), Buffer.from("")),
+    );
+    const runner = new SubprocessRunner();
+
+    // Act
+    runner.run(["git", "status"], { cwd: "/work" });
+
+    // Assert
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["status"],
+      expect.objectContaining({ cwd: "/work", shell: false }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the foundational TypeScript shared library (`src/lib/`) for the Python-to-TypeScript port epic (#240), implementing five modules: `prompt-mode-contract`, `json-config`, `markdown-label-formatter`, `subprocess-runner`, and `file-system`.
- All five modules achieve behavior parity with their Python counterparts; no changes are made to `RepoAutomationService`, `command-runtime.ts`, or any MCP handler.
- Jest test coverage for the new `src/lib` files: 97.3% line, 88.13% branch — above the 85%/75% policy thresholds.
- Adds epic scaffolding: research inventory, initiative decomposition, spec with per-feature AC, and the F1 plan checklist with all items verified PASS.
- Resolves a `.gitignore` collision caused by the root `lib/` exclusion pattern, which was silently ignoring `extensions/drm-copilot/src/lib/` and `extensions/drm-copilot/test/lib/`; negation entries are added to make the new files committable.
- Toolchain gates (format, lint, typecheck, tests) all pass at exit code 0, verified at `2026-06-25T22-44`.

Relates to #240

## Why

The VS Code extension and MCP server shell out to Python scripts via `command-runtime.ts`, which probes for a `python` runtime on PATH. This makes a Python interpreter a hard runtime dependency for end users. Porting these scripts to TypeScript removes that dependency, unifies the toolchain on Node/TypeScript, and enables in-process invocation.

Epic #240 covers the full ~28,100 LoC of production Python under `scripts/dev_tools/**`. This PR (Feature F1) delivers the shared utility layer that subsequent features will build upon. `RepoAutomationService` and `command-runtime.ts` are not wired to the new modules in F1; that wiring is deferred to a later feature.

## What Changed

### Core feature — `extensions/drm-copilot/src/lib/`

- **`prompt-mode-contract.ts`** — ports `prompt_mode_contract.py` with identical normalization, regexes, and error/reason strings. 100% line, 96.29% branch coverage.
- **`json-config.ts`** — ports `json_config.py` including `iterGovernedFiles` semantics and parent-exclusion logic via injected `FileSystem`. 96.19% line, 83.33% branch coverage.
- **`markdown-label-formatter.ts`** — ports `markdown_label_formatter.py` pure logic with `splitlines()`-equivalent behavior; I/O is injectable. 95.85% line, 87.87% branch coverage.
- **`subprocess-runner.ts`** — replicates the `pr_context/git.py` runner: injectable `CommandRunner` interface, UTF-8 decode with U+FFFD replacement, trailing-newline strip, non-zero exit throws with parity message format. 98.59% line, 82.35% branch coverage.
- **`file-system.ts`** — provides an injectable `FileSystem` interface and `RealFileSystem` implementation, enabling hermetic unit testing across all consumers. 96.47% line, 86.2% branch coverage.

### Tests — `extensions/drm-copilot/test/lib/`

Five new Jest test suites (76 tests across the five modules) using `@jest/globals`, `jest.mock`/`jest.fn`, `afterEach` resets, AAA structure, and in-memory fakes. No real subprocess or temp file I/O.

### Tooling/CI

- **`.gitignore`** — adds negation entries (`!extensions/drm-copilot/src/lib/`, `!extensions/drm-copilot/test/lib/`, etc.) to override the root `lib/` exclusion pattern that was silently ignoring the new files.

### Docs/templates

- Epic scaffolding: `spec.md`, `initiative.md`, `issue.md`, `plans/F1-shared-utilities.plan.md`, `research/python-to-typescript-inventory.md`.
- Audit and QA evidence: `feature-audit.2026-06-25T22-50.md`, `policy-audit.2026-06-25T22-50.md`, `code-review.2026-06-25T22-50.md`, `remediation-plan.2026-06-25T22-50.md`, `remediation-inputs.2026-06-25T22-50.md`.
- QA gate evidence: `evidence/qa-gates/` (format, lint, typecheck, test-coverage, scope-verification, coverage-delta) and `evidence/baseline/` (phase-0 snapshots).

## Architecture / How It Fits Together

```
extensions/drm-copilot/src/lib/
  file-system.ts          ← FileSystem interface + RealFileSystem
  subprocess-runner.ts    ← CommandRunner interface + SubprocessRunner
  prompt-mode-contract.ts ← pure functions + constants (no I/O)
  markdown-label-formatter.ts ← pure logic + injectable read/write
  json-config.ts          ← constants + iterGovernedFiles (injectable FS)
```

`file-system.ts` and `subprocess-runner.ts` provide the two injectable I/O abstractions. `prompt-mode-contract.ts` is fully pure. `markdown-label-formatter.ts` and `json-config.ts` accept an injected `FileSystem` so their I/O is hermetically testable. No module imports from outside `src/lib/` in this PR.

`RepoAutomationService`, `command-runtime.ts`, and MCP handlers are unmodified. Wiring these callers to the new modules is deferred to a later feature per the F1 plan constraint.

## Verification

### Completed (local toolchain, `2026-06-25T22-44`)

| Gate | Command | Result |
|------|---------|--------|
| Format | `npm run format` | EXIT 0 — all `src/lib/*.ts` and `test/lib/*.ts` unchanged by Prettier |
| Lint | `npm run lint` | EXIT 0 — 0 ESLint errors, 0 warnings |
| Type-check | `npm run typecheck` | EXIT 0 — 0 tsc errors |
| Tests + coverage | `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"` | EXIT 0 — 41 suites, 492 tests passed; 97.3% line, 88.13% branch |
| Scope | `git status --porcelain` | EXIT 0 — no out-of-scope files modified |

### Recommended before merge

- Trigger a CI run against the branch head to resolve the unverified E5 epic criterion (CI status was unavailable at PR-context capture time).
- Confirm `git check-ignore` shows the `src/lib/` and `test/lib/` files are no longer ignored after the `.gitignore` negation.

## Backward Compatibility / Migration Notes

- No public API changes. The five new modules are additive.
- No changes to `RepoAutomationService`, `command-runtime.ts`, or any MCP handler. Existing behavior is unaffected.
- The `.gitignore` negation affects only `extensions/drm-copilot/src/lib/` and `extensions/drm-copilot/test/lib/`. No previously-tracked files are affected.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Behavior parity divergence in ported modules | Each module's test suite asserts literal output strings, error message formats, and edge-case handling against the Python source semantics. Coverage is 97.3% line / 88.13% branch. |
| `.gitignore` negation side effects | Negation entries are path-specific (`extensions/drm-copilot/src/lib/` and `extensions/drm-copilot/test/lib/`); they do not affect Python `lib/` build artifacts at the repo root. Validate with `git check-ignore` after merge. |
| Jest vs. Vitest policy divergence | The `extensions/drm-copilot` package has used Jest (`ts-jest`, `run-jest.cjs`) throughout; this is a pre-existing, package-wide condition. The decision to follow the real toolchain is recorded in `spec.md` as accepted divergence D1. Resolving the policy rule is deferred and tracked separately. |
| CI status unverified | No workflow changes are included in this PR. Local toolchain passes cleanly. A green CI run should be confirmed before merge. |

## Review Guide

Suggested order:

1. **`.gitignore`** — single file, small change; confirms the negation entries that make the new files committable.
2. **`src/lib/prompt-mode-contract.ts`** and **`test/lib/prompt-mode-contract.test.ts`** — pure-logic module, easiest to review; establishes the parity pattern.
3. **`src/lib/subprocess-runner.ts`** and **`test/lib/subprocess-runner.test.ts`** — I/O boundary; review injectable interface and error-throw format against `git.py`.
4. **`src/lib/file-system.ts`** and **`test/lib/file-system.test.ts`** — FS abstraction; review interface contract and `RealFileSystem` delegation.
5. **`src/lib/json-config.ts`** / **`src/lib/markdown-label-formatter.ts`** and their test files — parity logic against `json_config.py` / `markdown_label_formatter.py`.
6. **`docs/features/active/.../spec.md`** and **`plans/F1-shared-utilities.plan.md`** — epic AC and F1 plan with all items checked.
7. Remaining `docs/features/active/…` files — audit, evidence, and scaffolding documents. These are large in aggregate but additive only; they do not affect runtime behavior.

The `docs/features/active/` tree accounts for 22 of the 33 changed files and ~3,300 of the 4,215 added lines. All are documentation and evidence; none affect the extension runtime.

## Follow-ups

- Feature F2 and beyond: port remaining Python command clusters as defined in `research/python-to-typescript-inventory.md` and `initiative.md`.
- Wire `RepoAutomationService` to call the TypeScript implementations (deferred to a later feature, per F1 plan constraint).
- Remove the `python` runtime probe from `command-runtime.ts` and bundled Python resources (epic-wide, targeted at F11 per `spec.md` AC-E3).
- Reconcile `.claude/rules/typescript.md` Vitest mention with the extension package's Jest toolchain (separate policy decision, out of epic scope).
- Trigger CI run and confirm green before merge.

## GitHub Auto-close

None
