### PR TITLE
feat(extension): port push-down customizations (copilot/codex/claude) to TypeScript (#240)

### DIFF
--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/code-review.2026-06-26T03-35.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/code-review.2026-06-26T03-35.md
@@ -1,0 +1,105 @@
+# Code Review: F3 ts-push-down-customizations (Issue #240)
+
+**Review Date:** 2026-06-26
+**Reviewer:** feature-review agent
+**Feature Folder:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+**Feature Folder Selection Rule:** Folder suffix `-240` matches issue #240; it is the active epic folder holding the F3 plan.
+**Base Branch:** `main` (merge-base `680d6f2e5d2e6d05b8e837da61a4c72afedee3b1`)
+**Head Branch:** `feat/ts-port-push-down-240` @ `3c217ac` (worktree HEAD tree content-identical)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+F3 ports the three Python push-down command variants to in-process TypeScript and rewires the three `RepoAutomationService` methods to call them through a new `push-down-service-call.ts` helper rather than spawning a Python interpreter. The implementation is a clean, well-factored port: a single `pushDownCustomizations` engine is shared by all three variants, with the codex/agents and claude variants supplying different root folders, artifact directories, and rewrite functions. The copilot module was split into engine and public-surface files to stay within the 500-line limit, and the claude frontmatter parser was extracted into `claude-memory-scope.ts` for the same reason. The reviewer independently re-ran the full toolchain: Prettier check clean, ESLint 0 errors, `tsc --noEmit` 0 errors, 825/825 Jest tests passing in 2.3 s. Per-file coverage on every new module meets line >= 85% and branch >= 75%.
+
+**What changed:**
+10 new production files under `src/lib/push-down/` (engine, public surface, filesystem adapter, reference rewrites, codex/agents variant, claude entry, claude filesystem adapter, claude memory scope, claude pack selection, service-call helper) plus modifications to `repo-automation-service.ts` (three method bodies now delegate in-process) and `repo-automation-service-push-down.ts` (claude options builder reworked). 9 new test suites + 1 shared helper, and 4 existing suites updated to assert the in-process contract instead of a Python spawn.
+
+**Top 3 risks:**
+1. Behavior-parity risk with the source Python: parity is asserted by ported unit tests and an in-memory filesystem fake, not by a live differential run against the Python implementation. The plan mandates exact parity of messages, JSON shapes, and enumeration order; tests assert exact strings, which mitigates but does not eliminate this risk.
+2. The `extensions/drm-copilot` ESLint config lacks the `no-restricted-syntax` Date/timer ban that `.claude/rules/typescript.md` prescribes, so the injected-clock discipline is enforced by convention and review rather than by lint. Pre-existing package condition.
+3. dependency-cruiser is not configured for this package, so the architecture-boundary gate is satisfied by manual import inspection rather than automated enforcement. Pre-existing package condition.
+
+**PR readiness recommendation:** **Go** — Toolchain is clean, coverage exceeds thresholds, files are within size limits, no Python or host-bound code was altered, and no blocking or major findings were identified.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Info | `src/lib/push-down/copilot-customizations-engine.ts` | line 363 | Clock seam default factory `const now = clock ?? (() => new Date())`. Compliant injected-clock pattern; production callers and tests inject the clock. | None required. Optionally add the package-level ESLint `no-restricted-syntax` allowlist entry when that rule is introduced. | typescript.md requires `Date` access through an injected seam; this is the seam default, not a direct wall-clock read. | `grep "new Date(" src/lib/push-down/` returned only this line. |
+| Info | `eslint.config.mjs` (package, not in F3 diff) | n/a | Package ESLint config does not implement the `no-restricted-syntax` Date/timer ban from typescript.md. | Track package/epic-level ESLint hardening. | Pre-existing config gap; F3 satisfies the underlying intent via the clock seam. | `grep "no-restricted-syntax" eslint.config.mjs` found no match. |
+| Info | `extensions/drm-copilot` package | n/a | dependency-cruiser not configured (no `.dependency-cruiser.cjs`, no script, binary absent). | Track epic-level architecture-tooling setup. | Boundary gate currently manual for this package. | `ls .dependency-cruiser.cjs` absent; `npx depcruise` resolves to a placeholder package. |
+
+No Blockers or Major findings.
+
+---
+
+## Implementation Audit
+
+### TypeScript implementation audit
+
+#### What changed well
+
+- **Single shared engine.** `copilot-customizations-engine.ts` holds the orchestration (validate -> enumerate -> classify created/overwritten -> rewrite -> write -> accumulate -> write summary artifact). The codex/agents and claude variants delegate to it with injected `rootFolders`, `artifactDirectory`, and a rewrite function, eliminating copy-paste of the copy loop. This matches the general-code-change reusability principle.
+- **Dedicated `PushDownFileSystem` protocol.** The plan correctly recognized that the F1 `FileSystem` interface (`glob`/`isFile`/`readTextFile`/...) does not match the Python `PushDownFileSystem` protocol (`listFiles`/`isDir`/`isFile`/`readTextFile`/`writeTextFile`/`ensureDir`), and introduced a distinct interface rather than force-fitting F1. This keeps the port faithful and the tests hermetic.
+- **Disciplined file splitting.** `copilot-customizations.ts` (102) vs `copilot-customizations-engine.ts` (448), and `claude-memory-scope.ts` (136) extracted from `claude-filesystem-adapter.ts` (303), keep every file under 500 lines while preserving cohesion.
+- **Contract preservation in the service call.** `push-down-service-call.ts` returns the exact prior `tool`, `summary`, and single-element normalized `artifacts` array (via `normalizeGeneratedPath`), so the observable result of the three methods is unchanged for callers and existing handler tests.
+
+#### Type safety and maintainability
+
+- No `any`, no type assertions to `any`, and no ESLint/TS suppressions in the push-down production files (verified by grep). Literal unions (`CSharpVariant`, `MemoryMode`) and explicit interfaces (`PushDownFileResult`, `PushDownSummary`, `PackManifest`, `PushDownServiceCallResult`) encode the domain precisely.
+- Options objects use keyword-style readonly fields with conditional spread for optional inputs (e.g. `...(input.clock === undefined ? {} : { clock: input.clock })`), which is verbose but type-exact under `exactOptionalPropertyTypes`-style strictness and avoids passing `undefined` into the engine.
+
+#### Error handling and logging
+
+- Failure paths are explicit: `validateDestination` raises distinct messages for missing destination and destination-equals-source; `ManifestError` carries the exact parity messages for each manifest fault; `assertSingleCsharpToolchain` rejects selecting both C# packs. Tests assert the exact strings.
+- Logging is routed through an optional injected `log` sink wired to `this.output.appendLine` in the service, keeping I/O out of the pure engine.
+
+---
+
+## Test Quality Audit
+
+The reviewer re-ran the full Jest suite with coverage and inspected the push-down test sources. Coverage, regression (delta), and file-size evidence are present under the feature `evidence/` tree and were regenerated by the reviewer for the coverage numbers cited.
+
+### Reviewed test and QA artifacts
+
+- `test/lib/push-down/*.test.ts` (9 suites) — port the corresponding Python tests; assert enumeration order, classification, exact error/JSON-key strings, rewrite catalog, memory-scope branches, memory modes, and the service-call contract. Quality: hermetic, AAA, exact-string assertions.
+- `test/lib/push-down/push-down.test-helpers.ts` — in-memory `PushDownFileSystem` fake mirroring the Python `RecordingFileSystem`; deterministic sorted enumeration.
+- `evidence/qa-gates/f3-final-ts-test-coverage.md` — records post-change per-file coverage; consistent with the reviewer re-run.
+- `evidence/qa-gates/f3-coverage-delta.md` — baseline vs post-change comparison; no regression.
+- `evidence/qa-gates/f3-file-size-check.md` — line counts; all <= 500.
+
+### Quality assessment prompts
+
+- **Determinism:** Artifact naming uses an injected clock; tests supply a fixed clock. No wall-clock, RNG, network, or real subprocess. 825/825 passed in a single run.
+- **Isolation:** Each suite targets one module; each `it` targets one behavior.
+- **Speed:** Full suite 2.298 s.
+- **Diagnostics:** Exact-string assertions on error messages and JSON key sets make a parity break point directly at the offending value.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | No credentials or tokens in the push-down files; pure file-copy logic. |
+| No unsafe subprocess or command construction | ✅ PASS | F3 removes the Python spawn for these three methods; the in-process port performs file I/O only through the injected adapter. No `child_process` in push-down production files. |
+| Input validation at boundaries | ✅ PASS | `validateDestination`, manifest validation, and C# mutual-exclusion assert invariants before performing work. |
+| Error handling remains explicit | ✅ PASS | Distinct exceptions with parity messages; no broad catch-and-swallow in push-down files. |
+| Configuration / path handling is safe | ✅ PASS | Paths normalized to POSIX (`toPosixPath`); enumeration is sorted and deterministic; LF-normalized writes mirror the Python `newline="\n"`. |
+
+---
+
+## Research Log
+
+No external research was required. The review relied on the F3 plan, spec.md (including divergence D1), the language rules (`typescript.md`, `general-code-change.md`, `general-unit-test.md`, `architecture-boundaries.md`), the canonical `git diff`, the regenerated PR-context artifacts, the feature `evidence/` tree, and direct inspection plus a reviewer toolchain re-run.
+
+---
+
+## Verdict
+
+F3 is a faithful, well-structured in-process port of the three push-down command variants. The shared-engine design, dedicated filesystem protocol, disciplined file splitting, clock seam, and contract-preserving service wiring are all sound. The full toolchain passes on re-run with no errors, coverage exceeds thresholds on every new file and repo-wide, and no Python or host-bound code was touched, consistent with deferring Python removal to F11. The three Info findings (clock-seam default, missing package ESLint `no-restricted-syntax` rule, absent dependency-cruiser config) are pre-existing package-config observations and do not block. The change is ready for normal PR flow.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-format.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-format.md
@@ -1,0 +1,7 @@
+# F3 Baseline — TypeScript Format
+
+Timestamp: 2026-06-26T00-08
+Command: npm run format
+EXIT_CODE: 0
+Output Summary: Prettier ran across `src` and `test`; all files reported
+"unchanged". No reformatting required at baseline.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-lint.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-lint.md
@@ -1,0 +1,7 @@
+# F3 Baseline — TypeScript Lint
+
+Timestamp: 2026-06-26T00-09
+Command: npm run lint
+EXIT_CODE: 0
+Output Summary: ESLint ran over `src` and `test` with zero errors and zero
+warnings at baseline.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-test-coverage.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-test-coverage.md
@@ -1,0 +1,11 @@
+# F3 Baseline — TypeScript Test + Coverage
+
+Timestamp: 2026-06-26T00-12
+Command: node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"
+EXIT_CODE: 0
+Output Summary:
+- Test Suites: 64 passed, 64 total
+- Tests: 725 passed, 725 total (0 failed)
+- Coverage scope `src/lib/**` (All files): line 96.33%, branch 87.87%,
+  funcs 92.85%, stmts 96.33%.
+- No `src/lib/push-down/**` files exist yet at baseline (F3 will add them).

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-typecheck.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-typecheck.md
@@ -1,0 +1,6 @@
+# F3 Baseline — TypeScript Type-Check
+
+Timestamp: 2026-06-26T00-10
+Command: npm run typecheck
+EXIT_CODE: 0
+Output Summary: `tsc -p ./ --noEmit` completed with zero type errors at baseline.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-phase0-instructions-read.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-phase0-instructions-read.md
@@ -1,0 +1,39 @@
+# Phase 0 — Instructions Read Evidence (F3 `ts-push-down-customizations`)
+
+Timestamp: 2026-06-26T00-05
+
+Policy Order:
+1. CLAUDE.md (standing instructions)
+2. .claude/rules/general-code-change.md
+3. .claude/rules/general-unit-test.md
+4. .claude/rules/typescript.md
+5. .claude/rules/typescript-suppressions.md
+6. .claude/rules/quality-tiers.md
+7. .claude/rules/architecture-boundaries.md
+8. .claude/rules/self-explanatory-code-commenting.md
+9. .claude/skills/evidence-and-timestamp-conventions/SKILL.md
+
+Files read (explicit list):
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\CLAUDE.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\rules\general-code-change.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\rules\general-unit-test.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\rules\typescript.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\rules\typescript-suppressions.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\rules\quality-tiers.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\rules\architecture-boundaries.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\rules\self-explanatory-code-commenting.md
+- C:\Users\DanMoisan\repos\drm-copilot-wt-2026-06-25-22-10\.claude\skills\evidence-and-timestamp-conventions\SKILL.md
+
+Notes:
+- The plan names baseline artifacts without an F-prefix; this folder is shared
+  across F1-F6. To preserve prior-feature audit artifacts, F3 evidence uses an
+  `f3-` filename prefix in the same canonical `evidence/baseline/` and
+  `evidence/qa-gates/` directories. This is a path-preservation micro-action; the
+  canonical evidence location is unchanged.
+- typescript.md names Vitest, but the `extensions/drm-copilot/` package uses Jest
+  (ts-jest, run-jest.cjs). The plan and task directive explicitly override the
+  framework choice for this package. Tests use `@jest/globals`, `jest.fn()`,
+  `jest.mock`, and AAA structure.
+- Coverage thresholds applied: line >= 85%, branch >= 75% (uniform across tiers).
+- F1 shared lib reused where applicable; F3 introduces a dedicated
+  `PushDownFileSystem` interface (distinct from F1 `FileSystem`).

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-coverage-delta.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-coverage-delta.md
@@ -1,0 +1,33 @@
+# F3 Coverage Delta / Threshold Verification
+
+Timestamp: 2026-06-26T01-37
+
+Baseline source: evidence/baseline/f3-baseline-ts-test-coverage.md
+Final source: evidence/qa-gates/f3-final-ts-test-coverage.md
+
+## Overall `src/lib/**` coverage
+
+| Metric | Baseline | Post-change | Delta |
+|---|---|---|---|
+| Line   | 96.33% | 96.97% | +0.64 |
+| Branch | 87.87% | 87.93% | +0.06 |
+
+No regression: both overall line% and branch% are at or above the baseline.
+
+## New-code (each `src/lib/push-down/*.ts`) coverage
+
+| File | Line% | Branch% | Meets line>=85 / branch>=75 |
+|---|---|---|---|
+| claude-customizations.ts           | 100   | 83.33 | yes / yes |
+| claude-filesystem-adapter.ts       | 94.38 | 83.33 | yes / yes |
+| claude-memory-scope.ts             | 100   | 86.36 | yes / yes |
+| claude-pack-selection.ts           | 100   | 98    | yes / yes |
+| codex-agents-customizations.ts     | 100   | 100   | yes / yes |
+| copilot-customizations-engine.ts   | 97.99 | 82    | yes / yes |
+| copilot-customizations.ts          | 100   | 100   | yes / yes |
+| filesystem-adapter.ts              | 98.03 | 86.95 | yes / yes |
+| push-down-service-call.ts          | 100   | 86.66 | yes / yes |
+| reference-rewrites.ts              | 99.17 | 93.75 | yes / yes |
+
+Outcome: PASS. No overall coverage regression versus the baseline, and every
+new push-down file meets line >= 85% and branch >= 75%.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-file-size-check.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-file-size-check.md
@@ -1,0 +1,26 @@
+# F3 File-Size Verification (<= 500 lines)
+
+Timestamp: 2026-06-26T01-39
+Command: wc -l src/lib/push-down/*.ts src/repo-automation-service.ts src/repo-automation-service-push-down.ts
+EXIT_CODE: 0
+Output Summary (line counts; all <= 500):
+- src/lib/push-down/claude-customizations.ts          244
+- src/lib/push-down/claude-filesystem-adapter.ts      303
+- src/lib/push-down/claude-memory-scope.ts            136
+- src/lib/push-down/claude-pack-selection.ts          308
+- src/lib/push-down/codex-agents-customizations.ts     80
+- src/lib/push-down/copilot-customizations.ts         102
+- src/lib/push-down/copilot-customizations-engine.ts  448
+- src/lib/push-down/filesystem-adapter.ts             204
+- src/lib/push-down/push-down-service-call.ts         180
+- src/lib/push-down/reference-rewrites.ts             243
+- src/repo-automation-service.ts                      500
+- src/repo-automation-service-push-down.ts            135
+
+All listed files are <= 500 lines. `repo-automation-service.ts` is exactly 500.
+Test files touched: test/lib/push-down/*.test.ts (all new),
+test/repo-automation-service.push-down-claude.test.ts (rewritten),
+test/extension.push-down-claude-customizations.test.ts (rewritten),
+test/extension.integration.test.ts (now 493 lines after removing the two
+push-down spawn case blocks), test/extension-test-harness.ts (added statSync/
+readdirSync mock support for the in-process push-down filesystem).

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-format.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-format.md
@@ -1,0 +1,8 @@
+# F3 Final QC — TypeScript Format
+
+Timestamp: 2026-06-26T01-30
+Command: npm run format
+EXIT_CODE: 0
+Output Summary: Prettier ran across `src` and `test`; all files reported
+"unchanged" on the final pass (stable, no reformatting). No unexpected file
+changes.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-lint.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-lint.md
@@ -1,0 +1,7 @@
+# F3 Final QC — TypeScript Lint
+
+Timestamp: 2026-06-26T01-31
+Command: npm run lint
+EXIT_CODE: 0
+Output Summary: ESLint ran over `src` and `test` with zero errors and zero
+warnings.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-test-coverage.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-test-coverage.md
@@ -1,0 +1,23 @@
+# F3 Final QC — TypeScript Test + Coverage
+
+Timestamp: 2026-06-26T01-35
+Command: node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"
+EXIT_CODE: 0
+Output Summary:
+- Test Suites: 73 passed, 73 total
+- Tests: 825 passed, 825 total (0 failed)
+- Overall `src/lib/**` (All files): line 96.97%, branch 87.93%, funcs 93.83%.
+
+Per new `src/lib/push-down/*.ts` file (line% / branch%):
+- claude-customizations.ts            100    / 83.33
+- claude-filesystem-adapter.ts        94.38  / 83.33
+- claude-memory-scope.ts              100    / 86.36
+- claude-pack-selection.ts            100    / 98
+- codex-agents-customizations.ts      100    / 100
+- copilot-customizations-engine.ts    97.99  / 82
+- copilot-customizations.ts           100    / 100
+- filesystem-adapter.ts               98.03  / 86.95
+- push-down-service-call.ts           100    / 86.66
+- reference-rewrites.ts               99.17  / 93.75
+
+Every new push-down file meets line >= 85% and branch >= 75%.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-typecheck.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-typecheck.md
@@ -1,0 +1,6 @@
+# F3 Final QC — TypeScript Type-Check
+
+Timestamp: 2026-06-26T01-32
+Command: npm run typecheck
+EXIT_CODE: 0
+Output Summary: `tsc -p ./ --noEmit` completed with zero type errors.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/feature-audit.2026-06-26T03-35.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/feature-audit.2026-06-26T03-35.md
@@ -1,0 +1,139 @@
+# Feature Audit: F3 ts-push-down-customizations (Issue #240)
+
+**Audit Date:** 2026-06-26
+**Feature Folder:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+**Base Branch:** `main`
+**Head Branch:** `feat/ts-port-push-down-240` @ `3c217ac` (worktree HEAD tree content-identical)
+**Work Mode:** `full-feature`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (merge-base commit `680d6f2e5d2e6d05b8e837da61a4c72afedee3b1`)
+- **Head branch/commit:** `feat/ts-port-push-down-240` @ `3c217ac839f69bfb1174abef5ae3b9119ee1c4ff`
+- **Merge base:** `680d6f2e5d2e6d05b8e837da61a4c72afedee3b1`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/**`
+  - Additional evidence: reviewer toolchain re-run (format/lint/typecheck/test+coverage) and `extensions/drm-copilot/coverage/lcov.info`
+- **Feature folder used:** `docs/features/active/2026-06-25-port-python-commands-to-typescript-240`
+- **Requirements source:** `spec.md` (epic ACs) and the F3 plan checklist `plans/F3-push-down-customizations.plan.md` (per-feature ACs). `user-story.md` does not exist at the feature root; the user-story content is embedded in `spec.md` under "## User Story".
+- **Work mode resolution note:** `issue.md` carries `- Work Mode: full-feature`. For `full-feature`, AC sources are `spec.md` and `user-story.md`. `user-story.md` is absent; spec.md contains the user story inline and the authoritative epic ACs. Per-feature ACs are tracked in the F3 plan checklist as spec.md directs ("Per-feature acceptance criteria are tracked in each feature's plan checklist").
+- **Scope note:** The caller-supplied authoritative merge-base `680d6f2e` (confirmed an ancestor of HEAD, matching the PR-context base ref) isolates the F3-only diff: 12 TypeScript production-file changes (10 new + 2 modified), 14 test-file changes, 12 markdown evidence/plan files. No Python, PowerShell, or C# files changed. PR context was regenerated (timestamped after the latest commit) and is fresh.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/.../spec.md` — primary (epic ACs AC-E1..AC-E5; user story inline)
+- `docs/features/active/.../plans/F3-push-down-customizations.plan.md` — per-feature ACs AC-F3-1..AC-F3-14 (spec.md delegates per-feature ACs here)
+
+### From spec.md (Epic ACs — realized incrementally; F3 contributes)
+
+1. AC-E1: Every Python command script invoked by the extension or MCP server has a TypeScript equivalent with behavior parity (CLI output, exit codes, file artifacts, JSON shapes).
+2. AC-E2: TypeScript test coverage for ported modules meets policy (line >= 85%, branch >= 75%).
+3. AC-E3: `RepoAutomationService` methods invoke in-process TypeScript instead of spawning Python; the `"python"` runtime branch and bundled Python resources are removed (delivered by F11).
+4. AC-E4: No remaining runtime dependency on a `python` interpreter for extension or MCP command execution.
+5. AC-E5: All CI gates pass on each feature PR.
+
+### From plans/F3-push-down-customizations.plan.md (per-feature ACs)
+
+1. AC-F3-1: copilot engine + public surface port `push_down_copilot_customizations.py` (two files, each <= 500) with identical enumeration order, classification, validation messages, summary JSON shape, and artifact path naming.
+2. AC-F3-2: `filesystem-adapter.ts` ports the filesystem module with sorted enumeration and LF-normalized writes.
+3. AC-F3-3: `reference-rewrites.ts` ports rewrites with identical regex, seven-entry catalog, normalization, trailing-punctuation handling, deterministic unmatched ordering and counts.
+4. AC-F3-4: `codex-agents-customizations.ts` ports the codex/agents variant reusing the shared engine.
+5. AC-F3-5: `claude-pack-selection.ts` ports pack selection with identical validation messages, always-core union, variant routing, C# mutual-exclusion.
+6. AC-F3-6: `claude-filesystem-adapter.ts` ports the frontmatter memory-scope parser (fail-safe `repo`) and the `ExcludingFileSystem` four-filter enumeration plus legacy C# read redirection.
+7. AC-F3-7: `claude-customizations.ts` ports the claude entry with pack selection, variant routing, memory modes, `settings.local.json` exclusion, claude artifact directory.
+8. AC-F3-8: the three `repo-automation-service.ts` push-down methods invoke in-process TypeScript via `push-down-service-call.ts`, preserving tool/summary/artifacts and claude inputs.
+9. AC-F3-9: `repo-automation-service.ts` remains <= 500 lines; new wiring routed through the service-call helper and the push-down support file.
+10. AC-F3-10: existing tests that asserted a Python spawn for the three commands are updated to assert the in-process contract; no surviving suite asserts a Python spawn for these three tools.
+11. AC-F3-11: new `src/lib/push-down/**` files covered by Jest with per-file line >= 85% and branch >= 75%; no `src/lib/**` regression vs baseline.
+12. AC-F3-12: format, lint, type-check, and coverage-enabled test all pass from `extensions/drm-copilot/`.
+13. AC-F3-13: no file exceeds 500 lines; tests hermetic (injected FS, no subprocess, no temp files).
+14. AC-F3-14: no changes to `command-runtime.ts`, the `"python"` branch, or any Python `scripts/dev_tools/**` / `resources/**/*.py` file.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| AC-F3-1 | Copilot port across two files | PASS | `copilot-customizations-engine.ts` (448) + `copilot-customizations.ts` (102); `copilot-customizations.test.ts` asserts the JSON key set and 2-space sorted render; engine test covers enumeration/classification/errors/artifact path. | `wc -l`, `node run-jest.cjs --coverage` | Both files <= 500. |
+| AC-F3-2 | Filesystem adapter port | PASS | `filesystem-adapter.ts` (204) exports `PushDownFileSystem` + `RealPushDownFileSystem`; `filesystem-adapter.test.ts` covers sorted enumeration, predicates, read, write-with-parent-dir. | `node run-jest.cjs` | Coverage 98.03% line / 86.95% branch. |
+| AC-F3-3 | Reference rewrites port | PASS | `reference-rewrites.ts` (243); `reference-rewrites.test.ts` covers all 7 catalog entries, normalization, trailing punctuation, unmatched ordering. | `node run-jest.cjs` | Coverage 99.17% line / 93.75% branch. |
+| AC-F3-4 | Codex/agents variant reuses engine | PASS | `codex-agents-customizations.ts` (80) delegates to the shared engine with `.codex`/`.agents` roots, passthrough rewrite, codex/agents artifact dir; test asserts passthrough zero-counts. | `node run-jest.cjs` | Coverage 100/100; no duplicated copy logic. |
+| AC-F3-5 | Claude pack selection port | PASS | `claude-pack-selection.ts` (308); test asserts each validation error string, always-core union, variant routing, both-C#-packs rejection. | `node run-jest.cjs` | Coverage 100% line / 98% branch. |
+| AC-F3-6 | Claude filesystem adapter + memory scope | PASS | `claude-filesystem-adapter.ts` (303) + extracted `claude-memory-scope.ts` (136); test covers `readMemoryScope` branches (fail-safe `repo`), `ExcludingFileSystem` filters, memory modes, legacy C# redirection. | `node run-jest.cjs` | Split declared in plan P3-T3; both <= 500. |
+| AC-F3-7 | Claude customizations entry | PASS | `claude-customizations.ts` (244); test covers no-selection publish-all, pack selection, legacy C# routing, memory modes, `parsePacksArgument`, claude artifact dir. | `node run-jest.cjs` | Coverage 100% line / 83.33% branch. |
+| AC-F3-8 | Three methods invoke in-process | PASS | `repo-automation-service.ts` lines 249–271: each method delegates to `runPushDown*` helpers; `push-down-service-call.ts` returns exact tool/summary/single-artifact; no `runtimeKind:"python"` in these three bodies. | `grep -n "pushDown.*Customizations" src/repo-automation-service.ts`; `push-down-service-call.test.ts` | Two surviving `runtimeKind:"python"` sites are `collectPrContext`/`potentialToIssue`, out of F3 scope. |
+| AC-F3-9 | Service file <= 500; wiring routed | PASS | `repo-automation-service.ts` is exactly 500 lines; `repo-automation-service-push-down.ts` 135 lines; wiring in `push-down-service-call.ts`. | `wc -l src/repo-automation-service.ts` | At the limit, compliant. |
+| AC-F3-10 | Python-spawn assertions converted | PASS | `git diff` shows `extension.integration.test.ts`, `extension.push-down-claude-customizations.test.ts`, `repo-automation-service.push-down-claude.test.ts` modified; `grep` finds no surviving Python-spawn assertion for the three tools (plan P5-T3). | `git diff --name-status 680d6f2e..HEAD`; full suite green | No coverage lost. |
+| AC-F3-11 | Per-file coverage + no regression | PASS | Every `src/lib/push-down/*.ts` >= 85% line / 75% branch (min 94.38% line, 82% branch). `src/lib/**` 96.97/87.93, no regression vs `evidence/baseline/f3-baseline-ts-test-coverage.md`. | `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"` | See policy-audit Section 5. |
+| AC-F3-12 | Format/lint/typecheck/test pass | PASS | Reviewer re-run: prettier `--check` clean; eslint 0 errors; tsc 0 errors; 825/825 tests. | see Appendix / policy-audit Appendix B | All exit 0. |
+| AC-F3-13 | No file > 500; hermetic tests | PASS | `wc -l` on all new push-down files: max 448 (engine) for production, 306 for tests. Tests use injected in-memory FS; no `child_process`/temp-file APIs in push-down tests. | `wc -l`; grep | All <= 500. |
+| AC-F3-14 | No Python/command-runtime changes | PASS | `git diff --name-status 680d6f2e..HEAD` lists no `command-runtime.ts`, no `scripts/dev_tools/**`, no `resources/**/*.py`. The `"python"` branch in `executeScript` is untouched. | `git diff --name-status 680d6f2e..HEAD` | Python removal deferred to F11. |
+| AC-E1 (epic) | Behavior parity for ported scripts | PARTIAL | F3 delivers parity for the three push-down scripts, asserted by ported unit tests with exact-string assertions. Epic-wide AC-E1 spans all scripts and is realized incrementally; not all scripts are ported at F3. | `node run-jest.cjs` | Epic-level; F3 contributes its three scripts. Not a F3 blocker. |
+| AC-E2 (epic) | Coverage policy for ported modules | PASS | F3 ported modules meet line >= 85% / branch >= 75% per-file and aggregate. | `node run-jest.cjs --coverage` | F3 contribution satisfies the threshold. |
+| AC-E3 (epic) | In-process invocation; python branch/resources removed | PARTIAL | F3 makes the three push-down methods invoke in-process TypeScript (the in-process half is delivered). Removal of the `"python"` runtime branch and bundled Python resources is explicitly deferred to F11 per spec.md. | `grep runtimeKind` | Expected PARTIAL at F3; the residual python branch and resources are F11 scope, not an F3 defect. |
+| AC-E4 (epic) | No python runtime dependency | PARTIAL | The three push-down commands no longer require Python. Other commands (`collect_pr_context`, `potential_to_issue`, etc.) still spawn Python until their features land; full removal at F11. | `grep runtimeKind` | Epic-level; not fully realized until F11. |
+| AC-E5 (epic) | CI gates pass | UNVERIFIED | Local toolchain (format/lint/typecheck/test/coverage/file-size/evidence-location) all pass. No CI workflow run against the branch head was inspected (no PR exists yet per PR-context; no `.github/workflows/**` change in the diff, so `modified-workflow-needs-green-run` does not fire). | local re-run | CI green is verified at the orchestrator S9 gate, not locally. Local proxy gates all pass. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+All 14 F3 per-feature acceptance criteria (AC-F3-1..AC-F3-14) are PASS based on independent toolchain re-run, coverage inspection, file-size checks, and diff verification. The epic-level ACs that F3 contributes to are correctly PARTIAL (AC-E1, AC-E3, AC-E4 are realized incrementally and complete at F11) or PASS (AC-E2). AC-E5 is UNVERIFIED locally because CI-green is confirmed at the orchestrator gate, not in this review; all local proxy gates pass and no workflow files changed.
+
+**Criteria summary (F3 per-feature ACs):**
+- **PASS:** 14 criteria (AC-F3-1..14)
+- **PARTIAL:** 0
+- **UNVERIFIED:** 0
+- **FAIL:** 0
+
+**Criteria summary (epic ACs, F3 contribution):**
+- **PASS:** 1 (AC-E2)
+- **PARTIAL:** 3 (AC-E1, AC-E3, AC-E4 — by design, completed at F11)
+- **UNVERIFIED:** 1 (AC-E5 — CI gate confirmed at orchestrator S9)
+- **FAIL:** 0
+
+**Top gaps preventing PASS:**
+
+1. None for the F3 per-feature scope.
+2. Epic AC-E3/E4 (full Python removal) remain open by design until F11; this is expected and not an F3 defect.
+
+**Recommended follow-up verification steps:**
+
+1. Confirm the CI workflow conclusion is success against the branch head at the orchestrator S9 gate (AC-E5).
+2. Track package-level ESLint `no-restricted-syntax` rule and dependency-cruiser config as epic-level follow-ups (see policy audit Section 8).
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules:
+- Criteria evaluated as **PASS** may be checked off in the authoritative source file(s) if represented as markdown checkboxes and not already checked.
+- Criteria evaluated as **PARTIAL**, **FAIL**, or **UNVERIFIED** remain unchecked.
+
+The F3 per-feature ACs (AC-F3-1..14) in `plans/F3-push-down-customizations.plan.md` are already checked `[x]` by the executor and are confirmed PASS by this audit; no change needed. The epic ACs (AC-E1..E5) in `spec.md` remain `[ ]` because they are realized incrementally across the epic and are not yet fully satisfied (full realization at F11); they are correctly left unchecked.
+
+### AC Status Summary
+
+- Source: `plans/F3-push-down-customizations.plan.md` (per-feature) and `spec.md` (epic)
+- Total AC items: 14 F3 per-feature + 5 epic = 19
+- Checked off (delivered): 14 (all F3 per-feature, already checked by executor and confirmed)
+- Remaining (unchecked): 5 epic ACs (correctly open until F11/CI)
+- Items remaining: AC-E1, AC-E2, AC-E3, AC-E4, AC-E5 (epic-level; tracked across the epic, not by F3 alone)
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `plans/F3-push-down-customizations.plan.md` | 14 | 14 | 0 | Checkbox-backed; all confirmed PASS, already checked by executor — no reviewer change required. |
+| `spec.md` | 5 | 0 | 5 | Checkbox-backed epic ACs; realized incrementally, fully satisfied at F11/CI. Correctly left unchecked. |
+
+No source-file checkbox change was made by this audit: the F3 per-feature ACs were already checked by the executor and are confirmed; the epic ACs are correctly unchecked pending later features.

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/plans/F3-push-down-customizations.plan.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/plans/F3-push-down-customizations.plan.md
@@ -1,0 +1,567 @@
+# Plan — F3 `ts-push-down-customizations` (Epic #240)
+
+- Issue: #240
+- Feature: F3 — port the three push-down command variants (copilot, codex+agents, claude) to in-process TypeScript and wire the three `RepoAutomationService` methods.
+- Work mode: full-feature
+- Authoritative inventory: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/research/python-to-typescript-inventory.md` (Section 7.2 F3; Section 2.7 cluster F; Section 6.6; Section 6.7).
+- Spec: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/spec.md`.
+- Toolchain: `extensions/drm-copilot/` uses **Jest** (`ts-jest`, `run-jest.cjs`), NOT Vitest (see spec decision D1). All tests use `@jest/globals`, `jest.fn()`, `jest.mock`, AAA.
+
+## Evidence Location Invariant
+
+All evidence artifacts MUST be written under
+`docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/<kind>/`
+per `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. Writing to
+`artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, or any other
+non-canonical path is a policy violation caught by the
+`enforce-evidence-locations.ps1` PreToolUse hook. This clause is non-overridable.
+
+Evidence base path (abbreviated `<EV>` below):
+`docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence`
+
+## Scope and Constraints (binding)
+
+- REUSE the F1 shared lib at `extensions/drm-copilot/src/lib/`: `file-system.ts`,
+  `subprocess-runner.ts`, `json-config.ts`. Do NOT re-port them. NOTE: the F1
+  `FileSystem` interface (`glob`/`isFile`/`readTextFile`/`writeTextFile`/`ensureDir`)
+  does NOT match the Python `PushDownFileSystem` protocol
+  (`list_files`/`is_dir`/`is_file`/`read_text`/`write_text`/`ensure_dir`). F3
+  therefore introduces a dedicated push-down filesystem protocol in
+  `filesystem-adapter.ts` (the TS port of
+  `push_down_copilot_customizations_filesystem.py`) — this is a new interface, not
+  a re-port of F1 `file-system.ts`.
+- Source of truth for behavior is the BUNDLED Python under
+  `extensions/drm-copilot/resources/scripts/dev_tools/` (the copies the service
+  invokes). The `scripts/dev_tools/` copies are references only.
+- No production, test, or reusable script file may exceed 500 lines. Split any
+  file that would exceed 500 lines.
+- Line coverage >= 85%, branch coverage >= 75% on new files (uniform tier policy).
+- Tests must be hermetic: inject the push-down filesystem; no temp files, no real
+  subprocess, in-memory fakes only.
+- ES modules, strong typing, no `any`; kebab-case filenames; AAA test structure.
+- Do NOT modify `command-runtime.ts`, the `"python"` branch, or Python
+  `scripts/dev_tools/**` / `resources/**/*.py` (removal is F11).
+- `repo-automation-service.ts` is ~498 lines; do NOT push it over 500. Route all
+  new wiring through `push-down-service-call.ts` (new helper) and the existing
+  `repo-automation-service-push-down.ts`. The three service methods change to
+  call the new helper instead of `this.executeScript(...)`.
+
+## TS target files (all under `extensions/drm-copilot/src/lib/push-down/` unless noted)
+
+- `copilot-customizations-engine.ts` — engine half of the 504-line copilot module
+  (enumerate/validate/artifact-path/render/write-summary/`pushDownCustomizations`).
+- `copilot-customizations.ts` — public entry + CLI-equivalent surface
+  (`resolveCliPath`, public `pushDownCustomizations` re-export, summary types).
+- `filesystem-adapter.ts` — `PushDownFileSystem` interface + `RealPushDownFileSystem`.
+- `reference-rewrites.ts` — rewrite catalog + `rewriteTextReferences`.
+- `codex-agents-customizations.ts` — `.codex`/`.agents` push-down + passthrough rewrite.
+- `claude-customizations.ts` — claude entry + `_resolvePublishedPaths` + pack arg parsing.
+- `claude-filesystem-adapter.ts` — frontmatter scope parser + `ExcludingFileSystem`.
+- `claude-pack-selection.ts` — manifest load/validate, path compute, variant routing,
+  C# exclusion assertion.
+- `push-down-service-call.ts` — service wiring helper for the three methods.
+- (Split any file projected over 500 lines into `-engine`/`-core` companions; the
+  copilot split is mandatory and pre-declared above.)
+
+## Test target files (all under `extensions/drm-copilot/test/lib/push-down/`)
+
+- `filesystem-adapter.test.ts`
+- `reference-rewrites.test.ts`
+- `copilot-customizations-engine.test.ts`
+- `copilot-customizations.test.ts`
+- `codex-agents-customizations.test.ts`
+- `claude-pack-selection.test.ts`
+- `claude-filesystem-adapter.test.ts` (includes memory-scope frontmatter cases)
+- `claude-customizations.test.ts` (includes pack end-to-end + bundled-parity)
+- `push-down-service-call.test.ts`
+- `push-down.test-helpers.ts` (in-memory `PushDownFileSystem` fake + builders;
+  shared by the above; not a `*.test.ts` file so Jest does not treat it as a suite)
+
+## Source-root wiring facts (preserve exactly)
+
+- Copilot template resolves `source_root`/`repo_root` to
+  `<extensionRoot>/resources/customizations`; `artifact_root` to the workspace
+  (cwd in the Python path). The service result preserves
+  `summary: "Pushed bundled Copilot customizations into the destination workspace."`
+  and the artifact path parsed from `Wrote push-down summary artifact to: <path>`.
+- Codex/agents template resolves source/repo root to
+  `<extensionRoot>/resources/codex-and-agents-customizations`; root folders
+  `(.codex, .agents)`; passthrough rewrite; artifact dir
+  `artifacts/codex-and-agents-customizations`.
+- Claude template resolves source/repo/bundle root to
+  `<extensionRoot>/resources/claude-customizations`; root folders `(.claude,)`;
+  passthrough rewrite; artifact dir `artifacts/claude-customizations`; manifests
+  under `<bundle>/pack-manifests`; legacy variant under
+  `<bundle>/.claude-variants/csharp-legacy/`.
+- `agentic_sync.ROOT_FOLDERS` (copilot) inlines to the typed tuple
+  `(".github/agents", ".github/instructions", ".github/prompts", ".github/skills")`.
+- Destination/artifact roots: the in-process port writes the summary artifact and
+  copied files through the injected filesystem; the service helper supplies the
+  destination root (= `input.workspaceRoot`) and an artifact root that preserves
+  the prior `artifact_root` semantics (workspace root). The parsed/returned
+  artifact path must match the prior `stdoutArtifactPattern` contract value.
+
+---
+
+### Phase 0 — Baseline capture and policy reading
+
+- [x] [P0-T1] Read policy files in required order and record evidence. Read, in order:
+  `CLAUDE.md`; `.claude/rules/general-code-change.md`;
+  `.claude/rules/general-unit-test.md`; `.claude/rules/typescript.md`;
+  `.claude/rules/typescript-suppressions.md`;
+  `.claude/rules/quality-tiers.md`;
+  `.claude/rules/architecture-boundaries.md`;
+  `.claude/rules/self-explanatory-code-commenting.md`;
+  `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. Write
+  `<EV>/baseline/phase0-instructions-read.md` containing `Timestamp:`,
+  `Policy Order:`, and the explicit list of files read. Acceptance: the artifact
+  exists and lists every file above.
+
+- [x] [P0-T2] Capture TypeScript format baseline. From `extensions/drm-copilot/`
+  run `npm run format`. Write `<EV>/baseline/baseline-ts-format.md` with
+  `Timestamp:`, `Command: npm run format`, `EXIT_CODE:`, `Output Summary:`.
+  Acceptance: artifact exists with all four fields populated.
+
+- [x] [P0-T3] Capture TypeScript lint baseline. From `extensions/drm-copilot/`
+  run `npm run lint`. Write `<EV>/baseline/baseline-ts-lint.md` with
+  `Timestamp:`, `Command: npm run lint`, `EXIT_CODE:`, `Output Summary:`.
+  Acceptance: artifact exists with all four fields populated.
+
+- [x] [P0-T4] Capture TypeScript type-check baseline. From
+  `extensions/drm-copilot/` run `npm run typecheck`. Write
+  `<EV>/baseline/baseline-ts-typecheck.md` with `Timestamp:`,
+  `Command: npm run typecheck`, `EXIT_CODE:`, `Output Summary:`. Acceptance:
+  artifact exists with all four fields populated.
+
+- [x] [P0-T5] Capture TypeScript test + coverage baseline. From
+  `extensions/drm-copilot/` run
+  `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`. Write
+  `<EV>/baseline/baseline-ts-test-coverage.md` with `Timestamp:`,
+  `Command: node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`,
+  `EXIT_CODE:`, and `Output Summary:` that records numeric headline values:
+  total tests passed/failed and the `src/lib/**` line% and branch% from the
+  coverage table. Acceptance: artifact exists and `Output Summary:` contains
+  numeric line% and branch% values (not placeholders).
+
+---
+
+### Phase 1 — Copilot sub-cluster (engine, filesystem, rewrites)
+
+- [x] [P1-T1] Create `extensions/drm-copilot/src/lib/push-down/filesystem-adapter.ts`
+  porting `push_down_copilot_customizations_filesystem.py`. Define the
+  `PushDownFileSystem` interface (`listFiles`, `isDir`, `isFile`, `readTextFile`,
+  `writeTextFile`, `ensureDir`; all path args as forward-slash POSIX strings) and
+  `RealPushDownFileSystem` backed by `node:fs` with recursive sorted enumeration,
+  UTF-8 read, and LF-normalized write (mirror Python `newline="\n"`). Acceptance:
+  file compiles under `npm run typecheck`, exports both symbols, stays <= 500 lines.
+
+- [x] [P1-T2] Create
+  `extensions/drm-copilot/test/lib/push-down/push-down.test-helpers.ts`
+  providing an in-memory `PushDownFileSystem` fake (deterministic sorted
+  `listFiles`, tracked directories, in-memory text store) mirroring the Python
+  `RecordingFileSystem`, plus a builder for seeding files. Acceptance: helper
+  compiles under typecheck; it is NOT named `*.test.ts`.
+
+- [x] [P1-T3] Create
+  `extensions/drm-copilot/test/lib/push-down/filesystem-adapter.test.ts`
+  (Jest, AAA) covering `RealPushDownFileSystem` behavior using the injected
+  in-memory paths where possible and `node:fs` mocks otherwise: empty enumeration
+  for a missing root, sorted file enumeration, `isDir`/`isFile` predicates, read,
+  and write with parent-dir creation. Acceptance: `node run-jest.cjs` runs this
+  suite green.
+
+- [x] [P1-T4] Create
+  `extensions/drm-copilot/src/lib/push-down/reference-rewrites.ts` porting
+  `push_down_copilot_customizations_rewrites.py`. Replicate exactly:
+  `TRAILING_PUNCTUATION`, the `SCRIPT_REFERENCE_PATTERN` regex, `RewriteTarget`
+  type, `buildRewriteCatalog` (all seven catalog entries with identical
+  `normalizedKey`/`commandId`/`title`/`scriptReference`/`isPlaceholder` values),
+  `renderCommandReference`, `normalizeReferenceForLookup`,
+  `splitTrailingPunctuation`, `rewriteMatchedReference`, and `rewriteTextReferences`
+  returning `[text, rewrittenCount, placeholderCount, unmatchedRefs]` with
+  first-seen unmatched ordering. Acceptance: file compiles, exports
+  `rewriteTextReferences`, stays <= 500 lines.
+
+- [x] [P1-T5] Create
+  `extensions/drm-copilot/test/lib/push-down/reference-rewrites.test.ts`
+  (Jest, AAA) porting `test_push_down_copilot_customizations_rewrites.py` and the
+  rewrite cases in `test_push_down_copilot_customizations_helpers.py`: each catalog
+  entry rewrite, trailing-punctuation preservation, `${workspaceFolder}` and
+  slash-variant normalization, `poetry run python -m` prefix stripping, unmatched
+  reference reporting with deterministic order and counts, and no-match passthrough.
+  Acceptance: suite green; covers every catalog key.
+
+- [x] [P1-T6] Create
+  `extensions/drm-copilot/src/lib/push-down/copilot-customizations-engine.ts`
+  porting the engine half of `push_down_copilot_customizations.py`: inline
+  `ROOT_FOLDERS` tuple (Section 6.7), `PushDownFileResult`/`PushDownSummary` types,
+  `PushDownSummaryPayload` shape, `enumerateSourceFiles` (root-order then
+  path-order), `validateDestination` (identical error messages for missing dir and
+  destination==source), `buildArtifactPath` (`push-down-%Y%m%dT%H%M%SZ.json` under
+  the artifact directory), `renderPushDownSummary` (JSON `indent=2, sort_keys=true`
+  semantics: 2-space indent with sorted keys; `files` rendered via per-result object
+  with the same field names), `writeSummaryArtifact`, and the core
+  `pushDownCustomizations` orchestration (validate → enumerate → per-file
+  created/overwritten classification → rewrite → ensureDir → write → accumulate
+  counts and first-seen unmatched → write artifact → return summary with
+  `artifactPath`). Use an injected clock seam for `startedAt`/`finishedAt`
+  (no direct `Date.now()` in production code, per typescript.md). Acceptance: file
+  compiles, stays <= 500 lines; `renderPushDownSummary` produces deterministic
+  sorted-key 2-space JSON.
+
+- [x] [P1-T7] Create
+  `extensions/drm-copilot/src/lib/push-down/copilot-customizations.ts` porting the
+  public/CLI-facing surface of `push_down_copilot_customizations.py`:
+  `resolveCliPath` (preserve the Windows-absolute-on-POSIX guard semantics in a
+  Node-equivalent form), the `ARTIFACT_DIRECTORY` constant
+  (`artifacts/copilot-customizations`), and a public `pushDownCustomizations`
+  wrapper that defaults `rewriteReferences` to `rewriteTextReferences` and
+  `rootFolders` to the inlined copilot tuple. Re-export the engine summary types.
+  Acceptance: file compiles, stays <= 500 lines, exports the public entry.
+
+- [x] [P1-T8] Create
+  `extensions/drm-copilot/test/lib/push-down/copilot-customizations-engine.test.ts`
+  (Jest, AAA, injected fake FS + fixed clock) porting
+  `test_push_down_copilot_customizations.py` core scenarios: destination-missing
+  error, destination-equals-source error, created-vs-overwritten classification,
+  deterministic root+path enumeration order, rewrite counters and unmatched
+  aggregation, summary artifact written at the deterministic path, and the
+  returned summary `artifactPath`. Acceptance: suite green.
+
+- [x] [P1-T9] Create
+  `extensions/drm-copilot/test/lib/push-down/copilot-customizations.test.ts`
+  (Jest, AAA) porting `test_push_down_copilot_customizations_helpers.py` (non-rewrite
+  helpers): `resolveCliPath` behavior, `buildArtifactPath` naming, summary JSON
+  shape parity (`renderPushDownSummary` keys, sorted, 2-space), and the public
+  wrapper defaults. Acceptance: suite green; asserts the exact JSON key set
+  `repo_root, destination_root, started_at, finished_at, created_count,
+  overwritten_count, rewritten_reference_count, placeholder_rewrite_count,
+  unmatched_references, files`.
+
+---
+
+### Phase 2 — Codex/agents sub-cluster
+
+- [x] [P2-T1] Create
+  `extensions/drm-copilot/src/lib/push-down/codex-agents-customizations.ts`
+  porting `push_down_codex_and_agents_customizations.py`: inline
+  `ROOT_FOLDERS = (".codex", ".agents")`, `ARTIFACT_DIRECTORY =
+  "artifacts/codex-and-agents-customizations"`, a passthrough rewrite
+  (`[text, 0, 0, []]`), and a `pushDownCustomizations` that delegates to the shared
+  copilot engine with those root folders, artifact directory, and the passthrough
+  rewrite. Acceptance: file compiles, stays <= 500 lines, reuses the engine
+  (no duplicated copy logic).
+
+- [x] [P2-T2] Create
+  `extensions/drm-copilot/test/lib/push-down/codex-agents-customizations.test.ts`
+  (Jest, AAA, injected fake FS + fixed clock) porting
+  `test_push_down_codex_and_agents_customizations.py`: `.codex`/`.agents` tree copy
+  with deterministic ordering, passthrough leaves content byte-identical and yields
+  zero rewrite/placeholder counts and no unmatched references, artifact written
+  under the codex/agents artifact directory, and created-vs-overwritten
+  classification. Acceptance: suite green.
+
+---
+
+### Phase 3 — Claude sub-cluster (pack selection, filtering FS, entry)
+
+- [x] [P3-T1] Create
+  `extensions/drm-copilot/src/lib/push-down/claude-pack-selection.ts` porting
+  `push_down_claude_pack_selection.py`: constants `CORE_PACK_NAME`,
+  `CSHARP_CANONICAL_PATHS` (the four exact paths), `CSHARP_PACK_NAMES`,
+  `LEGACY_VARIANT_SOURCE_PREFIX`, `CSharpVariant`/`MemoryMode` literal unions,
+  `ManifestError`, `PackManifest` type, `loadPackManifests` (always includes
+  `core`, sorted deterministic load, identical missing/invalid-JSON/non-object/
+  bad-name/bad-label/bad-paths/bad-source_prefix error messages),
+  `_parseManifest`, `computePublishedPaths` (union + always-core, `None`/undefined
+  for empty selection, error for missing loaded manifest),
+  `resolveVariantSourcePath` (legacy C# routing; modern/non-C# passthrough), and
+  `assertSingleCsharpToolchain` (reject both C# packs with the exact message).
+  Acceptance: file compiles, stays <= 500 lines, exports all listed symbols.
+
+- [x] [P3-T2] Create
+  `extensions/drm-copilot/test/lib/push-down/claude-pack-selection.test.ts`
+  (Jest, AAA) porting `test_push_down_claude_pack_selection.py`: manifest load
+  success, each manifest validation error path with its exact message, `core`
+  always loaded, `computePublishedPaths` union and always-core and empty-selection
+  -> undefined, `resolveVariantSourcePath` for modern/legacy/non-C# inputs, and
+  `assertSingleCsharpToolchain` rejecting both C# packs. Acceptance: suite green;
+  asserts the exact error message strings.
+
+- [x] [P3-T3] Create
+  `extensions/drm-copilot/src/lib/push-down/claude-filesystem-adapter.ts` porting
+  `push_down_claude_filesystem.py`: constants `AGENT_MEMORY_RELATIVE_ROOT`,
+  `GENERAL_MEMORY_SCOPE`, `REPO_MEMORY_SCOPE`; the three regexes
+  (`_FRONTMATTER_PATTERN`, `_METADATA_BLOCK_PATTERN`, `_SCOPE_LEAF_PATTERN`) with
+  identical semantics (CRLF tolerance, DOTALL frontmatter, metadata block capture,
+  scope-leaf capture, quote stripping, exact `general` comparison, fail-safe
+  `repo`); `readMemoryScope`; `isGeneralMemoryFile`; and the `ExcludingFileSystem`
+  class wrapping a `PushDownFileSystem` with the four enumeration filters
+  (hard exclusions, pack inclusion, agent-memory scope, memory mode) plus the
+  legacy C# read redirection (`_resolveReadSource`) and the source-relative POSIX
+  helper. Preserve the resolved-vs-unresolved root distinction using POSIX path
+  normalization (no `Path.resolve()` host dependence; replicate the comparison
+  semantics on normalized POSIX strings so tests stay hermetic). Acceptance: file
+  compiles, stays <= 500 lines; if projected over 500 lines, split the
+  frontmatter-parser helpers into a sibling `claude-memory-scope.ts` and import
+  them (declare the split in the task completion note).
+
+- [x] [P3-T4] Create
+  `extensions/drm-copilot/test/lib/push-down/claude-filesystem-adapter.test.ts`
+  (Jest, AAA) porting `test_push_down_claude_memory_scope.py` and the
+  `ExcludingFileSystem` cases in `test_push_down_claude_customizations.py` and
+  `test_push_down_claude_pack_memory_modes.py`: `readMemoryScope` for present
+  frontmatter (general, quoted general, with inline comment), absent/unterminated
+  frontmatter, no metadata block, no scope leaf, non-general value, and top-level
+  scope outside metadata (all fail-safe to `repo`); `isGeneralMemoryFile` for
+  in-subtree vs out-of-subtree paths; and `ExcludingFileSystem` filtering for
+  hard-excluded `settings.local.json`, pack inclusion/exclusion, scope filtering,
+  memory modes `overwrite`/`skip`/`merge` (merge excludes only memories already
+  present at destination), and legacy C# read redirection. Acceptance: suite green;
+  covers every `readMemoryScope` branch.
+
+- [x] [P3-T5] Create
+  `extensions/drm-copilot/src/lib/push-down/claude-customizations.ts` porting
+  `push_down_claude_customizations.py`: constants `ARTIFACT_DIRECTORY`
+  (`artifacts/claude-customizations`), `ROOT_FOLDERS = (".claude",)`,
+  `EXCLUDED_RELATIVE_PATHS = (".claude/settings.local.json",)`,
+  `BUNDLE_ROOT_RELATIVE_DIR`, `PACK_MANIFEST_SUBDIR`, `CSHARP_VARIANT_CHOICES`,
+  `MEMORY_MODE_CHOICES`; the passthrough rewrite; `_resolvePublishedPaths`
+  (no manifest read for empty selection, otherwise load + compute + assert);
+  `parsePacksArgument` (comma-split, trim, drop empties, undefined for empty);
+  and `pushDownCustomizations` composing `ExcludingFileSystem` over the injected
+  adapter and delegating to the shared copilot engine with the claude root folders,
+  artifact dir, and passthrough rewrite. Preserve `bundleRoot` default
+  (`source / BUNDLE_ROOT_RELATIVE_DIR`) AND allow an explicit `bundleRoot`
+  (the bundled template passes the customizations dir directly). Acceptance: file
+  compiles, stays <= 500 lines; if projected over 500 lines, extract
+  `_resolvePublishedPaths` + `parsePacksArgument` into a sibling
+  `claude-customizations-core.ts` (declare the split in the completion note).
+
+- [x] [P3-T6] Create
+  `extensions/drm-copilot/test/lib/push-down/claude-customizations.test.ts`
+  (Jest, AAA, injected fake FS + fixed clock) porting
+  `test_push_down_claude_customizations.py`,
+  `test_push_down_claude_pack_end_to_end.py`, and
+  `test_push_down_claude_bundled_parity.py` (and the resource-contract assertions in
+  `test_push_down_claude_resource_contracts.py` that are filesystem-checkable via
+  the in-memory fake): no-selection publish-everything path performs no manifest
+  read; pack selection restricts published paths and always includes core; legacy
+  C# variant routes reads to the legacy source while writing canonical destination
+  paths; both-C#-packs selection raises the exclusion `ManifestError`; memory
+  modes thread through to `ExcludingFileSystem`; `parsePacksArgument` edge cases;
+  and summary artifact written under the claude artifact directory. Acceptance:
+  suite green.
+
+---
+
+### Phase 4 — Service wiring
+
+- [x] [P4-T1] Create
+  `extensions/drm-copilot/src/lib/push-down/push-down-service-call.ts` providing
+  three exported functions —
+  `pushDownCopilotCustomizationsServiceCall`,
+  `pushDownCodexAndAgentsCustomizationsServiceCall`,
+  `pushDownClaudeCustomizationsServiceCall` — each accepting the injected
+  `PushDownFileSystem`, the `extensionRoot`, the `workspaceRoot` (destination), an
+  optional clock, an optional log sink, and (for claude) `packs`/`csharpVariant`/
+  `memoryMode`. Each function resolves the bundled source/bundle root from
+  `extensionRoot` (copilot -> `resources/customizations`; codex ->
+  `resources/codex-and-agents-customizations`; claude ->
+  `resources/claude-customizations`), invokes the matching in-process
+  `pushDownCustomizations`, and returns a `RepoAutomationExecutionResult`-shaped
+  record preserving the exact prior `tool`, `summary`, and `artifacts` contract:
+  - copilot summary: `"Pushed bundled Copilot customizations into the destination workspace."`
+  - codex summary: `"Pushed bundled Codex and agents customizations into the destination workspace."`
+  - claude summary: `"Pushed bundled Claude Code customizations into the destination workspace."`
+  - `artifacts`: a single-element array with the normalized summary artifact path
+    (same value the prior `stdoutArtifactPattern` parse produced). Use
+    `normalizeGeneratedPath` from `repo-automation-service-support`.
+  Acceptance: file compiles, stays <= 500 lines, exports all three functions.
+
+- [x] [P4-T2] Create
+  `extensions/drm-copilot/test/lib/push-down/push-down-service-call.test.ts`
+  (Jest, AAA, injected fake FS + fixed clock) verifying each of the three service
+  -call functions returns the exact `tool`, `summary`, and single-element
+  normalized `artifacts` path, resolves the correct bundled source root from
+  `extensionRoot`, and threads claude `packs`/`csharpVariant`/`memoryMode`.
+  Acceptance: suite green.
+
+- [x] [P4-T3] Update
+  `extensions/drm-copilot/src/repo-automation-service-push-down.ts` to export a
+  builder/options object (or pass-through input shape) for the claude in-process
+  call that replaces `buildPushDownClaudeCustomizationsOptions`' Python arg-vector
+  construction. Remove the Python `--destination/--packs/--csharp-variant/
+  --memory-mode` arg-building and `bundledRelativePath`/`runtimeKind` fields; the
+  new export carries `workspaceRoot` plus the optional `packs`/`csharpVariant`/
+  `memoryMode` forwarded to `pushDownClaudeCustomizationsServiceCall`. Acceptance:
+  file compiles; no `runtimeKind: "python"` or `resources/templates/...py`
+  reference remains in this file.
+
+- [x] [P4-T4] Update `extensions/drm-copilot/src/repo-automation-service.ts`:
+  replace the bodies of `pushDownCopilotCustomizations`,
+  `pushDownCodexAndAgentsCustomizations`, and `pushDownClaudeCustomizations` so each
+  delegates to the matching `push-down-service-call.ts` function (passing
+  `this.fileSystem` as a `PushDownFileSystem`, `this.extensionRoot`,
+  `input.workspaceRoot`, a log sink wired to `this.output.appendLine`, and — for
+  claude — the optional `packs`/`csharpVariant`/`memoryMode`). Remove the three
+  `this.executeScript({... runtimeKind: "python" ...})` call sites for these
+  methods and the `buildPushDownClaudeCustomizationsOptions` import if it is no
+  longer referenced. Do NOT modify `executeScript`, `command-runtime.ts`, or any
+  other method. Acceptance: `repo-automation-service.ts` compiles, contains no
+  `runtimeKind: "python"` for the three push-down methods, and remains <= 500
+  lines (verify the line count after the edit).
+
+- [x] [P4-T5] Reconcile the `RealFileSystem`/`PushDownFileSystem` injection in the
+  service constructor. The service currently injects an F1 `FileSystem`
+  (`options.fileSystem ?? new RealFileSystem()`). Because `PushDownFileSystem` is a
+  distinct interface, add a `RealPushDownFileSystem` instance to the service
+  (constructed once, default `new RealPushDownFileSystem()`, overridable via a new
+  optional `RepoAutomationServiceOptions.pushDownFileSystem` for tests) and pass it
+  to the three service-call helpers. Do NOT change the existing `fileSystem` field
+  or other methods' behavior. Acceptance: service compiles; existing
+  `validateOrchestrationArtifacts`/`collectCommitContext`/`newPotentialBugEntry`/
+  resolve-prompt wiring is unchanged.
+
+---
+
+### Phase 5 — Update existing extension tests that assert a Python spawn
+
+- [x] [P5-T1] Update
+  `extensions/drm-copilot/test/repo-automation-service.push-down-claude.test.ts`
+  to assert the in-process behavior instead of a Python spawn: replace the
+  `childProcessMock.spawn`/`node:child_process` assertions with assertions on the
+  returned `RepoAutomationExecutionResult` (`tool === "push_down_claude_customizations"`,
+  the exact `summary`, and an `artifacts` entry) using an injected
+  `pushDownFileSystem` fake seeded with a minimal `.claude` tree and pack
+  manifests. Preserve the existing invocationId-default and
+  packs/variant/memory-mode behavioral cases by asserting they reach the
+  in-process port (e.g., pack filtering reflected in copied files / published set),
+  not by inspecting spawn args. Acceptance: suite green; no `spawn` assertion for
+  this command remains.
+
+- [x] [P5-T2] Update the copilot and codex/agents cases in
+  `extensions/drm-copilot/test/extension.integration.test.ts` (the blocks at the
+  `push_down_copilot_customizations.py` / `push_down_codex_and_agents_customizations.py`
+  spawn assertions, currently around lines 400-490) to assert in-process delegation:
+  replace the `executable === "python"` / bundled-template-path spawn assertions
+  with assertions that the service returns the preserved `tool`/`summary`/`artifacts`
+  contract via the in-process port (mirror the F4 `collectCommitContext` precedent
+  that removed its Python spawn integration cases). Use an injected
+  `pushDownFileSystem` fake. Do NOT alter unrelated spawn-based cases (PowerShell
+  commands, still-Python commands such as `collect_pr_context`, `potential_to_issue`).
+  Acceptance: suite green; the two push-down commands no longer assert a Python spawn.
+
+- [x] [P5-T3] Update `extensions/drm-copilot/test/mcp-server.test.ts` and any other
+  suite identified by grep (`push_down_copilot_customizations`,
+  `push_down_codex_and_agents_customizations`, `push_down_claude_customizations`)
+  that asserts a Python spawn or bundled `resources/templates/push_down_*.py`
+  path for these three tools. Convert each such assertion to the in-process
+  contract (or remove it where it duplicates a now-covered service-call unit test),
+  leaving handler-routing and input-resolution assertions intact. Run
+  `Grep push_down_.*customizations` across `extensions/drm-copilot/test` to confirm
+  no remaining suite asserts a Python spawn for the three commands. Acceptance:
+  `node run-jest.cjs` runs the full extension suite green; grep shows no surviving
+  Python-spawn assertion for the three push-down tools.
+
+---
+
+### Phase 6 — Final QA loop (full toolchain, coverage-gated)
+
+Run the loop in order. If any step fails or changes files, restart from P6-T1.
+
+- [x] [P6-T1] Run `npm run format` from `extensions/drm-copilot/`. Write
+  `<EV>/qa-gates/final-ts-format.md` with `Timestamp:`, `Command: npm run format`,
+  `EXIT_CODE:`, `Output Summary:`. Acceptance: EXIT_CODE 0 and no unexpected file
+  changes (if files changed, restart the loop).
+
+- [x] [P6-T2] Run `npm run lint` from `extensions/drm-copilot/`. Write
+  `<EV>/qa-gates/final-ts-lint.md` with `Timestamp:`, `Command: npm run lint`,
+  `EXIT_CODE:`, `Output Summary:`. Acceptance: EXIT_CODE 0, zero lint errors.
+
+- [x] [P6-T3] Run `npm run typecheck` from `extensions/drm-copilot/`. Write
+  `<EV>/qa-gates/final-ts-typecheck.md` with `Timestamp:`,
+  `Command: npm run typecheck`, `EXIT_CODE:`, `Output Summary:`. Acceptance:
+  EXIT_CODE 0, zero type errors.
+
+- [x] [P6-T4] Run
+  `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"` from
+  `extensions/drm-copilot/`. Write `<EV>/qa-gates/final-ts-test-coverage.md` with
+  `Timestamp:`, the exact `Command:`, `EXIT_CODE:`, and `Output Summary:` recording
+  numeric post-change values: total tests passed, overall `src/lib/**` line% and
+  branch%, AND the per-file line%/branch% for each new
+  `src/lib/push-down/*.ts` file. Acceptance: EXIT_CODE 0; every new
+  `src/lib/push-down/*.ts` file reports line >= 85% and branch >= 75%.
+
+- [x] [P6-T5] Coverage delta/threshold verification. Compare the Phase 0 baseline
+  (`<EV>/baseline/baseline-ts-test-coverage.md`) against the final coverage
+  (`<EV>/qa-gates/final-ts-test-coverage.md`). Write
+  `<EV>/qa-gates/coverage-delta.md` with `Timestamp:` and a table reporting:
+  baseline `src/lib/**` line%/branch%, post-change `src/lib/**` line%/branch%, and
+  the new-code (each `src/lib/push-down/*.ts`) line%/branch%. Acceptance: no
+  regression in overall `src/lib/**` line% or branch% versus baseline, and every
+  new push-down file meets line >= 85% / branch >= 75%. If any value is below
+  threshold, the outcome is remediation-required (restart from P6-T1 after adding
+  tests); do NOT report PASS.
+
+- [x] [P6-T6] File-size verification. Confirm no new or modified file under
+  `extensions/drm-copilot/src/lib/push-down/`,
+  `extensions/drm-copilot/src/repo-automation-service.ts`, or
+  `extensions/drm-copilot/src/repo-automation-service-push-down.ts` exceeds 500
+  lines. Write `<EV>/qa-gates/file-size-check.md` with `Timestamp:`,
+  `Command:` (the line-count command used), `EXIT_CODE:`, and `Output Summary:`
+  listing each checked file with its line count. Acceptance: every listed file
+  <= 500 lines; `repo-automation-service.ts` <= 500 lines.
+
+---
+
+## F3 Acceptance Criteria Checklist
+
+- [x] AC-F3-1: `copilot-customizations-engine.ts` + `copilot-customizations.ts`
+  port `push_down_copilot_customizations.py` (split across two files, each <= 500
+  lines) with identical enumeration order, created/overwritten classification,
+  validation error messages, summary JSON shape (keys, sorted, 2-space), and
+  deterministic artifact path naming.
+- [x] AC-F3-2: `filesystem-adapter.ts` ports
+  `push_down_copilot_customizations_filesystem.py` (`PushDownFileSystem` interface
+  + `RealPushDownFileSystem`) with sorted enumeration and LF-normalized writes.
+- [x] AC-F3-3: `reference-rewrites.ts` ports
+  `push_down_copilot_customizations_rewrites.py` with the identical regex, full
+  seven-entry catalog, normalization, trailing-punctuation handling, and
+  deterministic unmatched ordering and counts.
+- [x] AC-F3-4: `codex-agents-customizations.ts` ports
+  `push_down_codex_and_agents_customizations.py` with `.codex`/`.agents` root
+  folders, passthrough rewrite, and the codex/agents artifact directory, reusing
+  the shared engine.
+- [x] AC-F3-5: `claude-pack-selection.ts` ports
+  `push_down_claude_pack_selection.py` with identical manifest validation messages,
+  always-core union semantics, variant source routing, and C# mutual-exclusion
+  assertion.
+- [x] AC-F3-6: `claude-filesystem-adapter.ts` ports
+  `push_down_claude_filesystem.py` with the regex-based frontmatter memory-scope
+  parser (fail-safe `repo` default) and the `ExcludingFileSystem` four-filter
+  enumeration plus legacy C# read redirection.
+- [x] AC-F3-7: `claude-customizations.ts` ports
+  `push_down_claude_customizations.py` with pack selection, C# variant routing,
+  memory modes, exclusion of `settings.local.json`, and the claude artifact
+  directory.
+- [x] AC-F3-8: `repo-automation-service.ts` `pushDownCopilotCustomizations`,
+  `pushDownCodexAndAgentsCustomizations`, and `pushDownClaudeCustomizations` invoke
+  in-process TypeScript (via `push-down-service-call.ts`) instead of spawning
+  Python, preserving the exact `tool`, `summary`, and `artifacts` return contract
+  and (for claude) the `packs`/`csharpVariant`/`memoryMode` inputs.
+- [x] AC-F3-9: `repo-automation-service.ts` remains <= 500 lines; new wiring is
+  routed through `push-down-service-call.ts` and
+  `repo-automation-service-push-down.ts`.
+- [x] AC-F3-10: Existing extension tests that asserted a Python spawn for the three
+  push-down commands are updated to assert the in-process contract; no surviving
+  suite asserts a Python spawn for these three tools.
+- [x] AC-F3-11: New `src/lib/push-down/**` files are covered by Jest tests with
+  line >= 85% and branch >= 75% per file; no overall `src/lib/**` coverage
+  regression versus the Phase 0 baseline.
+- [x] AC-F3-12: Format, lint, type-check, and coverage-enabled test all pass from
+  `extensions/drm-copilot/`.
+- [x] AC-F3-13: No file exceeds 500 lines; tests are hermetic (injected
+  `PushDownFileSystem`, no real subprocess, no temp files).
+- [x] AC-F3-14: No changes to `command-runtime.ts`, the `"python"` branch, or any
+  Python `scripts/dev_tools/**` / `resources/**/*.py` file (removal is F11).

--- a/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/policy-audit.2026-06-26T03-35.md
+++ b/docs/features/active/2026-06-25-port-python-commands-to-typescript-240/policy-audit.2026-06-26T03-35.md
@@ -1,0 +1,416 @@
+# Policy Compliance Audit: F3 ts-push-down-customizations (Issue #240)
+
+**Audit Date:** 2026-06-26
+**Code Under Test:** F3 feature diff against base `main` at merge-base `680d6f2e5d2e6d05b8e837da61a4c72afedee3b1`. TypeScript only.
+
+Production files (new): `extensions/drm-copilot/src/lib/push-down/{copilot-customizations-engine.ts, copilot-customizations.ts, filesystem-adapter.ts, reference-rewrites.ts, codex-agents-customizations.ts, claude-customizations.ts, claude-filesystem-adapter.ts, claude-memory-scope.ts, claude-pack-selection.ts, push-down-service-call.ts}`
+
+Production files (modified): `extensions/drm-copilot/src/repo-automation-service.ts`, `extensions/drm-copilot/src/repo-automation-service-push-down.ts`
+
+Test files (new): 9 suites + 1 shared helper under `extensions/drm-copilot/test/lib/push-down/`. Test files (modified): `extension-test-harness.ts`, `extension.integration.test.ts`, `extension.push-down-claude-customizations.test.ts`, `repo-automation-service.push-down-claude.test.ts`.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| TypeScript | 12 production + 14 test | 825 tests | ✅ 825 pass, 0 fail | `src/lib/**` per F3 baseline evidence (`evidence/baseline/f3-baseline-ts-test-coverage.md`) | `src/lib/**` 96.97% lines, 87.93% branches | `lib/push-down` 98.57% lines, 88.11% branches |
+
+**Note:** No Python, PowerShell, C#, Bash, or JSON production files changed in the F3 diff. Those languages have zero changed files on this branch; their coverage verdicts are N/A on that basis (acceptable per the coverage-verdict rule only because they have zero changed files).
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/baseline/f3-baseline-ts-test-coverage.md`
+- TypeScript post-change coverage artifact: `extensions/drm-copilot/coverage/lcov.info` (regenerated this audit) and `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/qa-gates/f3-final-ts-test-coverage.md`
+- PowerShell baseline coverage artifact: `N/A - no PowerShell files changed`
+- PowerShell post-change coverage artifact: `N/A - no PowerShell files changed`
+- Per-language comparison summary: Section 1.2.1 below and `evidence/qa-gates/f3-coverage-delta.md`
+
+**Non-negotiable verdict rule:** Numeric baseline and post-change coverage are present for the only in-scope language (TypeScript).
+
+---
+
+## Executive Summary
+
+F3 ports the three Python push-down command variants (copilot, codex+agents, claude) to in-process TypeScript under `extensions/drm-copilot/src/lib/push-down/**` and rewires the three `RepoAutomationService` methods to call them through `push-down-service-call.ts` instead of spawning Python. The reviewer independently re-ran the full TypeScript toolchain (format check, lint, typecheck, full test suite with coverage) against the working tree. All stages passed: Prettier check clean, ESLint 0 errors, `tsc --noEmit` 0 errors, 825/825 Jest tests passing across 73 suites. Coverage for every new `src/lib/push-down/*.ts` file meets line >= 85% and branch >= 75%; repo-wide `src/lib/**` is 96.97% line / 87.93% branch with no regression.
+
+The scope is TypeScript-only. No Python source, `command-runtime.ts`, or `resources/**/*.py` file was modified, consistent with the F3 plan (Python removal is deferred to F11). The two surviving `runtimeKind: "python"` call sites in `repo-automation-service.ts` belong to `collectPrContext` and `potentialToIssue`, which are out of F3 scope and were intentionally not altered.
+
+**Policy documents evaluated:**
+- ✅ `general-code-change.md`
+- ✅ `general-unit-test.md`
+
+**Language-specific policies evaluated:**
+- N/A `python-*` (no Python production files changed)
+- N/A `powershell-*` (no PowerShell files changed)
+- ✅ `typescript.md` + `typescript-suppressions.md`
+- N/A C# (no C# files changed)
+- N/A Bash, JSON (no such files changed)
+
+Coverage, toolchain, file size, and architecture-boundary checks all pass. The TypeScript test framework is Jest, not Vitest; this is the documented accepted divergence D1 (spec.md), a pre-existing package-wide condition, not introduced by F3.
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary or one-time scripts were created by this review.
+- ✅ The reviewer made no source changes (audit-only).
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | ✅ PASS | Jest suites under `test/lib/push-down/` use in-memory `PushDownFileSystem` fakes seeded per-test (`push-down.test-helpers.ts`). No shared mutable module state; 825/825 passed in a single run. |
+| **Isolation** - Each test targets single behavior | ✅ PASS | Suites are split per module (filesystem-adapter, reference-rewrites, copilot engine, codex/agents, claude pack selection, claude filesystem adapter, claude customizations, service call). Each `it` exercises one behavior (e.g. one catalog entry, one validation error). |
+| **Fast Execution** - Tests complete quickly | ✅ PASS | Full suite (73 suites, 825 tests) completed in 2.298 s. |
+| **Determinism** - Consistent results | ✅ PASS | Artifact naming routes through an injected clock seam; tests supply a fixed clock. No wall-clock, RNG, network, or real subprocess in push-down tests. |
+| **Readability & Maintainability** - Clear structure | ✅ PASS | Test files follow AAA with descriptive `describe`/`it` names; file sizes 162–306 lines, all under the 500-line limit. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | `evidence/baseline/f3-baseline-ts-test-coverage.md` records the pre-F3 `src/lib/**` baseline. |
+| **No Coverage Regression** | ✅ PASS | Post-change `src/lib/**` 96.97% line / 87.93% branch; `evidence/qa-gates/f3-coverage-delta.md` records no regression vs baseline. Reviewer re-run confirms the same headline numbers. |
+| **New Code Coverage (per-file >= 85% line / 75% branch)** | ✅ PASS | Every `src/lib/push-down/*.ts` file meets the uniform tier thresholds — see Section 5. Lowest line% is `claude-filesystem-adapter.ts` at 94.38%; lowest branch% is `copilot-customizations-engine.ts` at 82%. |
+| **Comprehensive Coverage** | ✅ PASS | Suites cover enumeration order, created/overwritten classification, validation error messages, rewrite catalog (all 7 entries), unmatched ordering, manifest validation error paths, memory-scope frontmatter branches, memory modes, and service-call contract. |
+| **Positive Flows** | ✅ PASS | E.g. `copilot-customizations-engine.test.ts` covers created/overwritten classification and deterministic enumeration. |
+| **Negative Flows** | ✅ PASS | Destination-missing and destination-equals-source errors; manifest missing/invalid-JSON/non-object/bad-name/bad-label/bad-paths error paths in `claude-pack-selection.test.ts`. |
+| **Edge Cases** | ✅ PASS | Trailing-punctuation preservation, `${workspaceFolder}` normalization, empty selection -> undefined, unterminated frontmatter fail-safe to `repo`. |
+| **Error Handling** | ✅ PASS | `assertSingleCsharpToolchain` rejection of both C# packs; legacy C# read redirection. |
+| **Concurrency** | N/A | The push-down port is synchronous file I/O through the injected adapter; no concurrency surface. |
+| **State Transitions** | N/A | No stateful state machine introduced. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- TypeScript: Baseline `src/lib/**` per `evidence/baseline/f3-baseline-ts-test-coverage.md` -> Post-change 96.97% lines / 87.93% branches. New-code (`lib/push-down`) 98.57% lines / 88.11% branches. Disposition: PASS. Evidence: `coverage/lcov.info`, `evidence/qa-gates/f3-final-ts-test-coverage.md`, `evidence/qa-gates/f3-coverage-delta.md`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | ✅ PASS | Tests assert exact error-message strings (manifest validation, C# mutual-exclusion), so a failure pinpoints the parity break. |
+| **Arrange-Act-Assert Pattern** | ✅ PASS | Plan mandates AAA; inspected suites separate arrange/act/assert clearly. |
+| **Document Intent** | ✅ PASS | Descriptive `describe`/`it` names map to ported Python test scenarios. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | In-memory `PushDownFileSystem` fakes; no network, DB, or external process. |
+| **Use Mocks/Stubs** | ✅ PASS | Injected filesystem fake and fixed clock; `node:fs` mocked only in `filesystem-adapter.test.ts` for `RealPushDownFileSystem` behavior. |
+| **Environment Stability** | ✅ PASS | No temp files created in tests (plan constraint; verified by absence of temp-file APIs in push-down test files). |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | ✅ PASS | This audit plus the companion code review and feature audit constitute the required review. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | ✅ PASS | F3 plan defines the objective; epic spec.md AC-E1..E5 frame it. |
+| **Read existing change plans** | ✅ PASS | `plans/F3-push-down-customizations.plan.md` is the executed plan; Phase 0 recorded policy reads. |
+| **Document the plan** | ✅ PASS | Plan checklist phases P0–P6 all checked; evidence under `evidence/baseline` and `evidence/qa-gates`. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | Codex/agents and claude variants delegate to the shared copilot engine rather than duplicating copy logic. |
+| **Reusability** | ✅ PASS | Single `pushDownCustomizations` engine reused by all three variants; `PushDownFileSystem` interface shared. |
+| **Extensibility** | ✅ PASS | Engine accepts injected `rootFolders`, `artifactDirectory`, `rewriteReferences`, and `clock` via a keyword-style options object. |
+| **Separation of concerns** | ✅ PASS | Pure transform logic (`reference-rewrites.ts`, `claude-memory-scope.ts`) separated from I/O (`filesystem-adapter.ts`); service wiring isolated in `push-down-service-call.ts`. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | ✅ PASS | Each file holds one cohesive concern (engine, public surface, adapter, rewrites, pack selection, memory scope, service call). |
+| **Under 500 lines** | ✅ PASS | Largest production file `copilot-customizations-engine.ts` is 448 lines; `repo-automation-service.ts` is exactly 500 (at the limit, compliant). `wc -l` listing in Section 5 / Appendix B. |
+| **Public vs internal** | ✅ PASS | Public entry points exported (`pushDownCustomizations`, the three service-call functions, `PushDownFileSystem`); helpers kept module-local. |
+| **No circular dependencies** | ✅ PASS | Import inspection: push-down modules import siblings and `node:fs`/`node:path` only; the adapter is the sole `node:fs` consumer; no cycle observed. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | ✅ PASS | `pushDownCopilotCustomizationsServiceCall`, `assertSingleCsharpToolchain`, `computePublishedPaths`. |
+| **Docs/docstrings** | ✅ PASS | Files carry header doc comments describing purpose and side effects (e.g. `push-down-service-call.ts`). |
+| **Comment why, not what** | ✅ PASS | Comments explain rationale (e.g. the bundle-root doubling note in the claude service call). |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | `npx prettier --check "src/**/*.ts" "test/**/*.ts"` -> "All matched files use Prettier code style!", exit 0. |
+| **2. Linting** | ✅ PASS | `npm run lint` (`eslint --no-error-on-unmatched-pattern src test`) exit 0, 0 errors. |
+| **3. Type checking** | ✅ PASS | `npm run typecheck` (`tsc -p ./ --noEmit`) exit 0, 0 errors. |
+| **4. Testing** | ✅ PASS | `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"` exit 0, 825/825 pass. |
+| **Full toolchain loop** | ✅ PASS | All four stages passed in a single reviewer pass with no file mutation (format used `--check`). |
+| **Explicit reporting** | ✅ PASS | Commands and results recorded here and in Appendix B. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | ✅ PASS | F3 plan and this audit summarize the delta. |
+| **Design choices explained** | ✅ PASS | Plan documents the copilot file split, the dedicated `PushDownFileSystem` protocol, and the clock seam. |
+| **Update supporting documents** | ✅ PASS | spec.md records divergence D1; plan checklist updated. |
+| **Provide next steps** | ✅ PASS | This audit's verdict and the feature audit identify F11 (Python removal) as the remaining epic step. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3 (TypeScript) — see Section 3T
+
+Python (3A), PowerShell (3B), Bash (3C), and JSON (3D) sections are deleted: no files of those languages changed in the F3 diff.
+
+### Section 3T: TypeScript Code Change Policy Compliance
+
+#### 3T.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with Prettier** | ✅ PASS | `npx prettier --check` clean. |
+| **Linting with ESLint** | ✅ PASS | `npm run lint` 0 errors. |
+| **Type checking with TSC** | ✅ PASS | `npm run typecheck` 0 errors. |
+| **Testing with Jest (D1 divergence)** | ✅ PASS | `node run-jest.cjs` 825/825. The package uses Jest, not Vitest; documented accepted divergence D1 (spec.md). |
+
+#### 3T.2 TypeScript Design & Typing
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Strong typing / avoid `any`** | ✅ PASS | `grep ": any"`/`as any`/`<any>` across `src/lib/push-down/` returned no matches. Literal unions used (`CSharpVariant`, `MemoryMode`). |
+| **ES modules** | ✅ PASS | All push-down files use `import`/`export`; no `require`/`module.exports`. |
+| **Discriminated/precise domain types** | ✅ PASS | `PushDownFileResult`, `PushDownSummary`, `PackManifest` model domain shapes. |
+| **No unauthorized suppressions** | ✅ PASS | `grep eslint-disable`/`@ts-ignore`/`@ts-nocheck` in push-down production files returned no matches. |
+
+#### 3T.3 TypeScript Error Handling and Determinism
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Fail fast with explicit errors** | ✅ PASS | `validateDestination` raises distinct errors for missing dir and destination==source; `ManifestError` for manifest faults. |
+| **Injected clock (Date ban)** | ✅ PASS (see note) | `copilot-customizations-engine.ts:363` uses `const now = clock ?? (() => new Date())` — `new Date()` is the default factory behind an injectable `Clock` seam; production callers and tests inject the clock. This satisfies the typescript.md requirement that `Date` access flow through an injected seam. See Section 8 for the related ESLint-config observation. |
+| **No host-bound imports in domain logic** | ✅ PASS | No Office.js/vscode/Graph imports in `src/lib/push-down/`. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4T: TypeScript Unit Test Policy Compliance
+
+#### 4T.1 Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Test framework** | ✅ PASS (D1) | Jest via `run-jest.cjs` and `@jest/globals`. typescript.md text names Vitest; the runnable/CI toolchain is Jest (divergence D1, spec.md). |
+| **Coverage expectation (line >= 85%, branch >= 75%)** | ✅ PASS | `lib/push-down` 98.57% line / 88.11% branch; every file meets per-file thresholds. |
+
+#### 4T.2 Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Focused unit tests** | ✅ PASS | One behavior per `it`. |
+| **Mocking sparingly** | ✅ PASS | In-memory fakes preferred; `node:fs` mocked only where `RealPushDownFileSystem` is under test. |
+| **Organization (mirrors source)** | ✅ PASS | `test/lib/push-down/*` mirrors `src/lib/push-down/*`; no colocation in `src/`. |
+
+#### 4T.3 Naming and Readability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **`*.test.ts` naming** | ✅ PASS | Suites named `*.test.ts`; shared helper named `push-down.test-helpers.ts` (intentionally not a suite). |
+| **Descriptive names / comments** | ✅ PASS | Test names describe scenario and expected outcome. |
+
+#### 4T.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use the package test runner** | ✅ PASS | `node run-jest.cjs --coverage` exit 0. |
+| **No alternative runners** | ✅ PASS | Only Jest used. |
+
+---
+
+## 5. Test Coverage Detail
+
+Per-file coverage for the F3 production modules (reviewer re-run, `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"`):
+
+| File | % Lines | % Branch | Threshold (85 / 75) | Status |
+|------|---------|----------|---------------------|--------|
+| `copilot-customizations-engine.ts` | 97.99 | 82 | met | ✅ |
+| `copilot-customizations.ts` | 100 | 100 | met | ✅ |
+| `filesystem-adapter.ts` | 98.03 | 86.95 | met | ✅ |
+| `reference-rewrites.ts` | 99.17 | 93.75 | met | ✅ |
+| `codex-agents-customizations.ts` | 100 | 100 | met | ✅ |
+| `claude-customizations.ts` | 100 | 83.33 | met | ✅ |
+| `claude-filesystem-adapter.ts` | 94.38 | 83.33 | met | ✅ |
+| `claude-memory-scope.ts` | 100 | 86.36 | met | ✅ |
+| `claude-pack-selection.ts` | 100 | 98 | met | ✅ |
+| `push-down-service-call.ts` | 100 | 86.66 | met | ✅ |
+| **`lib/push-down` aggregate** | **98.57** | **88.11** | met | ✅ |
+| **`src/lib/**` repo-wide** | **96.97** | **87.93** | met | ✅ |
+
+The two modified service files (`repo-automation-service.ts`, `repo-automation-service-push-down.ts`) are wiring; their changed delegation paths are exercised by `push-down-service-call.test.ts` and the updated `repo-automation-service.push-down-claude.test.ts` / `extension.integration.test.ts` suites.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests | 825 | ✅ |
+| Tests Passed | 825 (100%) | ✅ |
+| Tests Failed | 0 | ✅ |
+| Test Suites | 73 passed / 73 | ✅ |
+| Execution Time | 2.298 s total | ✅ Fast |
+| Code Coverage (src/lib) | 96.97% lines, 87.93% branches | ✅ |
+
+---
+
+## 7. Code Quality Checks
+
+**For TypeScript:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Prettier format | `npx prettier --check "src/**/*.ts" "test/**/*.ts"` | All matched files use Prettier code style | ✅ |
+| ESLint | `npm run lint` | 0 errors | ✅ |
+| TSC typecheck | `npm run typecheck` | 0 errors | ✅ |
+| Jest tests + coverage | `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"` | 825/825 pass | ✅ |
+| File size (<= 500 lines) | `wc -l src/lib/push-down/*.ts src/repo-automation-service*.ts` | all <= 500 | ✅ |
+| Architecture boundaries | manual import inspection (dependency-cruiser not configured for this package) | no host-bound imports, no cycles | ✅ |
+| Evidence locations | `python scripts/dev_tools/validate_evidence_locations.py --root .` | exit 0 | ✅ |
+
+**Notes:** dependency-cruiser is not wired in the `extensions/drm-copilot` package (no `.dependency-cruiser.cjs`, no script, binary not installed). This is a pre-existing package condition not introduced by F3. The architecture-boundary verdict is therefore made by manual import inspection, which is sufficient for this host-neutral domain code.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+**None blocking.** Observations:
+
+- The `extensions/drm-copilot` ESLint config does not implement the `no-restricted-syntax` rule banning `Date.now`/`setTimeout`/`Math.random` that `.claude/rules/typescript.md` prescribes (`grep` of `eslint.config.mjs` found no such rule). F3 nonetheless satisfies the underlying requirement by routing `Date` through an injected `Clock` seam; the default factory `() => new Date()` is the documented seam-default pattern. The missing lint rule is a pre-existing package-config condition, not introduced or worsened by F3. Recommendation: track the ESLint-config hardening at the package/epic level (not an F3 blocker).
+- dependency-cruiser is not configured for this package (Section 7). Pre-existing; recommend epic-level follow-up.
+
+### Approved Exceptions
+
+- **D1 — Jest instead of Vitest.** spec.md decision D1 records the `extensions/drm-copilot` package uses Jest (`ts-jest`, `run-jest.cjs`), a pre-existing package-wide condition. The runnable, CI-exercised toolchain is Jest; `.claude/rules/**` is not modified. Treated as policy-reconciliation, not an F3 defect.
+
+### Removed/Skipped Tests
+
+**None.** F3 updated existing Python-spawn assertions to in-process assertions (P5-T1..T3); no test coverage was lost.
+
+---
+
+## 9. Summary of Changes
+
+### Range
+
+Base `main` @ merge-base `680d6f2e5d2e6d05b8e837da61a4c72afedee3b1` -> F3 head (PR-context head `feat/ts-port-push-down-240` @ `3c217ac839f69bfb1174abef5ae3b9119ee1c4ff`; the worktree HEAD tree is content-identical, `git diff 3c217ac HEAD` empty).
+
+### Files Modified
+
+1. **`src/lib/push-down/copilot-customizations-engine.ts`** (NEW, 448 lines) — engine half of the copilot port: enumeration, classification, validation, summary render, write, orchestration, injected clock seam.
+2. **`src/lib/push-down/copilot-customizations.ts`** (NEW, 102 lines) — public/CLI surface + defaults.
+3. **`src/lib/push-down/filesystem-adapter.ts`** (NEW, 204 lines) — `PushDownFileSystem` interface + `RealPushDownFileSystem`.
+4. **`src/lib/push-down/reference-rewrites.ts`** (NEW, 243 lines) — rewrite catalog + `rewriteTextReferences`.
+5. **`src/lib/push-down/codex-agents-customizations.ts`** (NEW, 80 lines) — `.codex`/`.agents` passthrough variant.
+6. **`src/lib/push-down/claude-customizations.ts`** (NEW, 244 lines) — claude entry, pack arg parsing, published-path resolution.
+7. **`src/lib/push-down/claude-filesystem-adapter.ts`** (NEW, 303 lines) — `ExcludingFileSystem` four-filter enumeration + legacy C# redirection.
+8. **`src/lib/push-down/claude-memory-scope.ts`** (NEW, 136 lines) — frontmatter memory-scope parser (split from adapter to respect 500-line limit).
+9. **`src/lib/push-down/claude-pack-selection.ts`** (NEW, 308 lines) — manifest load/validate, path compute, variant routing, C# mutual exclusion.
+10. **`src/lib/push-down/push-down-service-call.ts`** (NEW, 180 lines) — three service-call helpers preserving tool/summary/artifacts contract.
+11. **`src/repo-automation-service.ts`** (MODIFIED, 500 lines) — three push-down methods now delegate in-process.
+12. **`src/repo-automation-service-push-down.ts`** (MODIFIED, 135 lines) — claude options builder reworked for in-process call.
+13. Test suites (9 new + 1 helper under `test/lib/push-down/`; 4 modified existing suites) — convert Python-spawn assertions to in-process contract.
+
+---
+
+## Rejected Scope Narrowing
+
+The caller prompt supplies F3 scope context ("Feature F3 ... TypeScript port of the three Python push-down command variants") and points to the F3 plan AC checklist. This is legitimate context, not an attempted narrowing: the caller also instructs "Determine scope yourself per the SKILL invariant" and supplies the authoritative base branch (`main`) and merge-base (`680d6f2e...`). The reviewer audited the full branch diff against that merge-base. No instruction attempted to narrow scope to a plan/task/phase subset, exclude changed files, or mark any language with changed files as out-of-scope/informational. **No scope narrowing was rejected because none was attempted.**
+
+Note on baseline choice: the actual `git merge-base HEAD main` is `38a9c11` (the worktree's merge commit), which would also pull in F1/F2/F4/F5/F6. The caller-supplied authoritative merge-base `680d6f2e` (confirmed an ancestor of HEAD and matching the PR-context summary base ref) isolates the F3 diff. Per the SKILL "legitimate scope sources" rule, the resolved base from `pr-base-branch-merge-base` / PR-context artifacts is authoritative; both name `680d6f2e`. The F3-only diff is therefore the correct audit scope.
+
+## Evidence Location Compliance
+
+`python scripts/dev_tools/validate_evidence_locations.py --root .` exited 0 (no violations). `git diff --name-only 680d6f2e..HEAD | grep` for `artifacts/(baselines|baseline|qa|qa-gates|evidence|coverage|regression-testing|post-change)/` returned NONE. All F3 evidence is written under the canonical `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/evidence/<kind>/` tree. No FAIL-level evidence-location findings.
+
+## PR Context Classification Note
+
+`artifacts/pr_context.summary.txt` reports "Core logic changes: 0 files" and "Docs/templates/agents/tooling: 12 files", misclassifying the 26 changed TypeScript files (10 new + 2 modified production, 14 test) as tooling/docs. Per the canonical `git diff --name-status 680d6f2e..HEAD`, the change is core TypeScript logic plus tests. The reviewer used the git name-status and direct diff as authoritative, consistent with the known summary-misclassification condition for epic #240.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+All in-scope (TypeScript) policy requirements are met. Toolchain is clean (format/lint/typecheck/test all pass), coverage exceeds thresholds for every new file and repo-wide, all files are within the 500-line limit, no unauthorized suppressions or `any`, evidence locations are canonical, and no Python/host-bound code was touched. The two observations in Section 8 (missing ESLint `no-restricted-syntax` rule and absent dependency-cruiser config) are pre-existing package-config conditions, not F3 defects, and do not block.
+
+### Metrics Summary
+
+- ✅ 825/825 tests passing (100%)
+- ✅ `lib/push-down` 98.57% line / 88.11% branch coverage; every file >= 85/75
+- ✅ `src/lib/**` 96.97% line / 87.93% branch, no regression
+- ✅ All files <= 500 lines (`repo-automation-service.ts` exactly 500)
+- ✅ Format, lint, typecheck all clean
+- ✅ Evidence locations validator exit 0
+
+### Recommendation
+
+**Ready for merge.** No blocking findings. Recommend tracking the package-level ESLint `no-restricted-syntax` rule and dependency-cruiser configuration as epic-level follow-ups; neither is an F3 blocker.
+
+---
+
+## Appendix A: Test Inventory
+
+New F3 suites under `extensions/drm-copilot/test/lib/push-down/`:
+
+- `filesystem-adapter.test.ts` — `RealPushDownFileSystem` enumeration, predicates, read, write-with-parent-dir.
+- `reference-rewrites.test.ts` — each of 7 catalog entries, trailing punctuation, normalization, unmatched ordering, passthrough.
+- `copilot-customizations-engine.test.ts` — destination errors, created/overwritten, enumeration order, counters, artifact path.
+- `copilot-customizations.test.ts` — `resolveCliPath`, `buildArtifactPath`, summary JSON key set, wrapper defaults.
+- `codex-agents-customizations.test.ts` — `.codex`/`.agents` copy, passthrough zero-counts, artifact directory.
+- `claude-pack-selection.test.ts` — manifest load + each validation error path, always-core, union, variant routing, C# mutual exclusion.
+- `claude-filesystem-adapter.test.ts` — `readMemoryScope` branches, `isGeneralMemoryFile`, `ExcludingFileSystem` filters, memory modes, legacy C# read redirection.
+- `claude-customizations.test.ts` — no-selection publish-all, pack selection, legacy C# routing, both-C#-packs error, memory modes, `parsePacksArgument`, artifact dir.
+- `push-down-service-call.test.ts` — tool/summary/single-artifact contract per variant, source-root resolution, claude pack/variant/memory threading.
+
+Shared helper: `push-down.test-helpers.ts` (in-memory `PushDownFileSystem` fake + builders).
+
+Modified suites: `extension.integration.test.ts`, `extension.push-down-claude-customizations.test.ts`, `repo-automation-service.push-down-claude.test.ts`, `extension-test-harness.ts`.
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+```bash
+# From extensions/drm-copilot/
+npx prettier --check "src/**/*.ts" "test/**/*.ts"   # format check (non-mutating)
+npm run lint                                          # eslint --no-error-on-unmatched-pattern src test
+npm run typecheck                                     # tsc -p ./ --noEmit
+node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"   # tests + coverage
+
+# File sizes
+wc -l src/lib/push-down/*.ts src/repo-automation-service.ts src/repo-automation-service-push-down.ts
+
+# From repo root
+python scripts/dev_tools/validate_evidence_locations.py --root .       # evidence-location validator
+git diff --name-status 680d6f2e5d2e6d05b8e837da61a4c72afedee3b1 HEAD   # authoritative scope
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-06-26
+**Policy Version:** Current (as of audit date)

--- a/extensions/drm-copilot/src/lib/push-down/claude-customizations.ts
+++ b/extensions/drm-copilot/src/lib/push-down/claude-customizations.ts
@@ -1,0 +1,244 @@
+/**
+ * Claude customization push-down publisher.
+ *
+ * Purpose:
+ *     Port `push_down_claude_customizations.py`. Provides the dedicated entry
+ *     point for publishing the bundled `.claude` tree, composing the filtering
+ *     {@link ExcludingFileSystem} over the injected adapter and delegating the
+ *     copy to the shared engine. Settings-local configuration is excluded;
+ *     agent-memory files are filtered by scope and memory mode; pack selection
+ *     restricts the published set; the C# variant routes canonical reads.
+ *
+ * Side effects:
+ *     Reads source files and writes destination files plus the summary artifact
+ *     through the adapter (via the engine).
+ */
+
+import { type PushDownFileSystem } from "./filesystem-adapter";
+import {
+  type Clock,
+  pushDownCustomizations as enginePushDown,
+  type PushDownSummary,
+} from "./copilot-customizations-engine";
+import { ExcludingFileSystem } from "./claude-filesystem-adapter";
+import {
+  assertSingleCsharpToolchain,
+  computePublishedPaths,
+  type CSharpVariant,
+  loadPackManifests,
+  type MemoryMode,
+  type PackManifest,
+} from "./claude-pack-selection";
+
+/** Artifact directory for the Claude push-down summary. */
+export const ARTIFACT_DIRECTORY = "artifacts/claude-customizations";
+
+/** Inlined Claude scoped root folders (enumeration-order contract). */
+export const ROOT_FOLDERS: ReadonlyArray<string> = [".claude"];
+
+/** Repo-relative host-specific paths excluded from push-down. */
+export const EXCLUDED_RELATIVE_PATHS: ReadonlyArray<string> = [
+  ".claude/settings.local.json",
+];
+
+/** Repo-relative location of the bundle root that holds manifests/variants. */
+export const BUNDLE_ROOT_RELATIVE_DIR =
+  "extensions/drm-copilot/resources/claude-customizations";
+
+/** Subdirectory under the bundle root containing pack-manifest JSON files. */
+export const PACK_MANIFEST_SUBDIR = "pack-manifests";
+
+/** Valid CLI choices for the C# variant argument. */
+export const CSHARP_VARIANT_CHOICES: ReadonlyArray<string> = [
+  "modern",
+  "legacy",
+];
+
+/** Valid CLI choices for the memory-mode argument. */
+export const MEMORY_MODE_CHOICES: ReadonlyArray<string> = [
+  "overwrite",
+  "merge",
+  "skip",
+];
+
+export { ManifestError } from "./claude-pack-selection";
+export { type PushDownSummary, type CSharpVariant, type MemoryMode };
+
+/**
+ * Passthrough rewrite for `.claude` content (no command rewrites).
+ *
+ * @param text Source text.
+ * @returns A tuple `[text, 0, 0, []]`.
+ */
+export function passthroughRewrite(
+  text: string,
+): [string, number, number, string[]] {
+  return [text, 0, 0, []];
+}
+
+/**
+ * Join two POSIX path fragments with a single forward slash.
+ *
+ * @param root Base POSIX path.
+ * @param relative Relative POSIX path fragment.
+ * @returns The combined POSIX path.
+ */
+function joinPosix(root: string, relative: string): string {
+  const normalizedRoot = root.replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalizedRelative = relative.replace(/\\/g, "/").replace(/^\/+/, "");
+  return normalizedRoot === ""
+    ? normalizedRelative
+    : `${normalizedRoot}/${normalizedRelative}`;
+}
+
+/**
+ * Parse a comma-separated `--packs` value into a normalized pack-name set.
+ *
+ * @param packsValue The raw comma-separated value, or null/undefined when the
+ *   flag was omitted.
+ * @returns The set of non-empty, trimmed pack names, or null when the value was
+ *   omitted or contained only empty entries (the publish-everything default).
+ */
+export function parsePacksArgument(
+  packsValue: string | null | undefined,
+): ReadonlySet<string> | null {
+  if (packsValue === null || packsValue === undefined) {
+    return null;
+  }
+  // Trim whitespace and drop empty entries so trailing commas do not produce
+  // empty pack names.
+  const names = new Set<string>();
+  for (const entry of packsValue.split(",")) {
+    const trimmed = entry.trim();
+    if (trimmed !== "") {
+      names.add(trimmed);
+    }
+  }
+  return names.size === 0 ? null : names;
+}
+
+/**
+ * Compute the published `.claude`-relative path set for a pack selection.
+ *
+ * Returns null when no pack selection was supplied (publish everything, no
+ * manifest read). Otherwise loads manifests, computes the union (always
+ * including core), and asserts C# mutual exclusion.
+ *
+ * @param packs Selected pack names, or null/empty for the default.
+ * @param bundleRoot Bundle root containing the `pack-manifests` subdirectory.
+ * @param fs Adapter used to read the manifest files.
+ * @returns The union path set, or null for the publish-everything default.
+ * @throws ManifestError When a manifest is missing/malformed or both C# variants
+ *   are selected.
+ */
+export function resolvePublishedPaths(
+  packs: ReadonlySet<string> | null,
+  bundleRoot: string,
+  fs: PushDownFileSystem,
+): ReadonlySet<string> | null {
+  // No explicit selection means publish everything without a manifest read.
+  if (packs === null || packs.size === 0) {
+    return null;
+  }
+
+  const manifestDir = joinPosix(bundleRoot, PACK_MANIFEST_SUBDIR);
+  const manifests: Map<string, PackManifest> = loadPackManifests(
+    manifestDir,
+    packs,
+    fs,
+  );
+  const published = computePublishedPaths(packs, manifests);
+  // computePublishedPaths returns null only for an empty selection, already
+  // excluded above; treat a null here as an empty set so the C# exclusion check
+  // still runs on a concrete value.
+  const effectivePublished: ReadonlySet<string> =
+    published ?? new Set<string>();
+  assertSingleCsharpToolchain(effectivePublished, packs);
+  return effectivePublished;
+}
+
+/** Options for the Claude {@link pushDownCustomizations} entry point. */
+export interface ClaudePushDownOptions {
+  readonly repoRoot: string;
+  readonly destinationRoot: string;
+  readonly fs: PushDownFileSystem;
+  readonly sourceRoot?: string;
+  readonly artifactRoot?: string;
+  readonly packs?: ReadonlySet<string> | null;
+  readonly csharpVariant?: CSharpVariant;
+  readonly memoryMode?: MemoryMode;
+  readonly bundleRoot?: string;
+  readonly clock?: Clock;
+}
+
+/**
+ * Copy the `.claude` tree into the destination workspace.
+ *
+ * Composes {@link ExcludingFileSystem} over the injected adapter and delegates
+ * to the shared engine with the Claude root folders, artifact directory, and the
+ * passthrough rewrite.
+ *
+ * @param options Entry options (roots, filesystem, pack/variant/memory inputs).
+ * @returns The completed run summary including the written artifact path.
+ * @throws ManifestError When a selected manifest is missing/malformed or both C#
+ *   variants are selected.
+ * @throws Error When destination validation fails.
+ */
+export function pushDownCustomizations(
+  options: ClaudePushDownOptions,
+): PushDownSummary {
+  const {
+    repoRoot,
+    destinationRoot,
+    fs,
+    sourceRoot,
+    artifactRoot,
+    packs,
+    csharpVariant,
+    memoryMode,
+    bundleRoot,
+    clock,
+  } = options;
+
+  const effectiveSource = sourceRoot ?? repoRoot;
+  // Resolve the bundle root that holds manifests and the variant subtree. The
+  // repository layout nests the bundle under the source root; an explicit
+  // bundleRoot (the bundled template) overrides this.
+  const effectiveBundle =
+    bundleRoot ?? joinPosix(effectiveSource, BUNDLE_ROOT_RELATIVE_DIR);
+
+  // Resolve the published-path set only when a pack selection is supplied so the
+  // no-argument path performs no manifest I/O.
+  const publishedPaths = resolvePublishedPaths(
+    packs ?? null,
+    effectiveBundle,
+    fs,
+  );
+
+  // Wrap the adapter so enumeration omits excluded paths and honors selections.
+  const excludingFs = new ExcludingFileSystem(
+    fs,
+    repoRoot,
+    EXCLUDED_RELATIVE_PATHS,
+    {
+      sourceRoot: effectiveSource,
+      destinationRoot,
+      publishedPaths,
+      csharpVariant: csharpVariant ?? "modern",
+      memoryMode: memoryMode ?? "overwrite",
+      variantRoot: effectiveBundle,
+    },
+  );
+
+  return enginePushDown({
+    repoRoot,
+    destinationRoot,
+    fs: excludingFs,
+    ...(sourceRoot === undefined ? {} : { sourceRoot }),
+    ...(artifactRoot === undefined ? {} : { artifactRoot }),
+    rootFolders: ROOT_FOLDERS,
+    artifactDirectory: ARTIFACT_DIRECTORY,
+    rewriteReferences: passthroughRewrite,
+    ...(clock === undefined ? {} : { clock }),
+  });
+}

--- a/extensions/drm-copilot/src/lib/push-down/claude-filesystem-adapter.ts
+++ b/extensions/drm-copilot/src/lib/push-down/claude-filesystem-adapter.ts
@@ -1,0 +1,303 @@
+/**
+ * Filtering filesystem wrapper for the `.claude` customization push-down.
+ *
+ * Purpose:
+ *     Port the `ExcludingFileSystem` of `push_down_claude_filesystem.py`. It
+ *     presents a filtered, variant-aware view of the source `.claude` tree to
+ *     the shared publisher engine so the engine's destination derivation stays
+ *     correct while the published set, per-file source content, and agent-memory
+ *     handling all honor the selected packs, C# variant, and memory mode.
+ *
+ * Responsibilities:
+ *     - Exclude host-specific files (for example `settings.local.json`).
+ *     - Apply the general-vs-repo agent-memory scope filter.
+ *     - Restrict enumeration to the published-pack set when a selection is
+ *       active.
+ *     - Redirect legacy C# canonical reads to the bundle-only legacy source.
+ *     - Apply the memory mode (overwrite / skip / merge).
+ *
+ * Path model:
+ *     All paths are forward-slash POSIX strings. The Python resolved-vs-
+ *     unresolved root distinction is replicated by normalizing POSIX strings, so
+ *     comparisons stay hermetic and host-independent.
+ *
+ * Side effects:
+ *     Delegates all I/O to the inner adapter.
+ */
+
+import { type PushDownFileSystem } from "./filesystem-adapter";
+import { isGeneralMemoryFile, isUnderAgentMemory } from "./claude-memory-scope";
+import {
+  CSHARP_CANONICAL_PATHS,
+  type CSharpVariant,
+  type MemoryMode,
+  resolveVariantSourcePath,
+} from "./claude-pack-selection";
+
+export {
+  AGENT_MEMORY_RELATIVE_ROOT,
+  GENERAL_MEMORY_SCOPE,
+  REPO_MEMORY_SCOPE,
+  isGeneralMemoryFile,
+  readMemoryScope,
+} from "./claude-memory-scope";
+
+/**
+ * Normalize a path to forward-slash separators with no trailing slash.
+ *
+ * @param value Path that may use OS-specific separators.
+ * @returns Forward-slash POSIX path without a trailing separator.
+ */
+function normalizePosix(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+/**
+ * Join two POSIX path fragments with a single forward slash.
+ *
+ * @param root Base POSIX path.
+ * @param relative Relative POSIX path.
+ * @returns The combined POSIX path.
+ */
+function joinPosix(root: string, relative: string): string {
+  const normalizedRoot = normalizePosix(root);
+  const normalizedRelative = relative.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (normalizedRoot === "") {
+    return normalizedRelative;
+  }
+  if (normalizedRelative === "") {
+    return normalizedRoot;
+  }
+  return `${normalizedRoot}/${normalizedRelative}`;
+}
+
+/**
+ * Return the POSIX path relative to a root, or null when not under the root.
+ *
+ * @param path Candidate child POSIX path.
+ * @param root Candidate parent POSIX path.
+ * @returns The relative POSIX path, or `null` when not under the root.
+ */
+function relativeToPosix(path: string, root: string): string | null {
+  const normalizedPath = normalizePosix(path);
+  const normalizedRoot = normalizePosix(root);
+  if (normalizedPath === normalizedRoot) {
+    return "";
+  }
+  const prefix = `${normalizedRoot}/`;
+  if (normalizedPath.startsWith(prefix)) {
+    return normalizedPath.slice(prefix.length);
+  }
+  return null;
+}
+
+/** Construction options for {@link ExcludingFileSystem}. */
+export interface ExcludingFileSystemOptions {
+  /** Root the engine enumerates from; defaults to `repoRoot`. */
+  readonly sourceRoot?: string;
+  /** Destination workspace root, required for the `merge` memory mode. */
+  readonly destinationRoot?: string;
+  /** The `.claude`-relative paths to publish, or null to publish everything. */
+  readonly publishedPaths?: ReadonlySet<string> | null;
+  /** Selected C# variant; `legacy` redirects canonical C# reads. */
+  readonly csharpVariant?: CSharpVariant;
+  /** Memory mode: `overwrite` (default), `merge`, or `skip`. */
+  readonly memoryMode?: MemoryMode;
+  /** Bundle root that holds the legacy variant subtree; defaults to source. */
+  readonly variantRoot?: string;
+}
+
+/**
+ * Wrap a {@link PushDownFileSystem} with scope, pack, variant, and memory
+ * filters.
+ *
+ * Mirrors the Python `ExcludingFileSystem`. Enumeration drops hard-excluded
+ * paths, agent-memory files outside the active scope, files outside the active
+ * published set, and agent-memory files excluded by the memory mode. Reads of
+ * canonical C# paths are redirected to the legacy source for the legacy
+ * variant.
+ */
+export class ExcludingFileSystem implements PushDownFileSystem {
+  private readonly inner: PushDownFileSystem;
+  private readonly repoRoot: string;
+  private readonly sourceRoot: string;
+  private readonly variantRoot: string;
+  private readonly destinationRoot: string | undefined;
+  private readonly publishedPaths: ReadonlySet<string> | null;
+  private readonly csharpVariant: CSharpVariant;
+  private readonly memoryMode: MemoryMode;
+  private readonly excluded: ReadonlySet<string>;
+
+  /**
+   * @param inner The wrapped adapter performing real I/O.
+   * @param repoRoot Repository root used to resolve excluded paths and the
+   *   agent-memory scope prefix.
+   * @param excluded Repo-relative POSIX paths to always exclude.
+   * @param options Optional source/destination roots and selection inputs.
+   */
+  constructor(
+    inner: PushDownFileSystem,
+    repoRoot: string,
+    excluded: ReadonlyArray<string>,
+    options: ExcludingFileSystemOptions = {},
+  ) {
+    this.inner = inner;
+    this.repoRoot = normalizePosix(repoRoot);
+    // Keep the source root for relative-path comparisons and redirected reads.
+    this.sourceRoot = normalizePosix(options.sourceRoot ?? repoRoot);
+    // The variant root holds the legacy subtree; legacy reads redirect beneath.
+    this.variantRoot = normalizePosix(
+      options.variantRoot ?? options.sourceRoot ?? repoRoot,
+    );
+    this.destinationRoot =
+      options.destinationRoot === undefined
+        ? undefined
+        : normalizePosix(options.destinationRoot);
+    this.publishedPaths = options.publishedPaths ?? null;
+    this.csharpVariant = options.csharpVariant ?? "modern";
+    this.memoryMode = options.memoryMode ?? "overwrite";
+    // Resolve excluded paths once for O(1) membership checks.
+    this.excluded = new Set(excluded.map((p) => joinPosix(this.repoRoot, p)));
+  }
+
+  /**
+   * Return the source-relative POSIX path, or null when outside the root.
+   *
+   * @param path An absolute candidate POSIX path from the inner adapter.
+   * @returns The source-relative POSIX path, or `null`.
+   */
+  private sourceRelativePosix(path: string): string | null {
+    return relativeToPosix(path, this.sourceRoot);
+  }
+
+  /**
+   * Return whether a candidate path is in the active published set.
+   *
+   * @param path An absolute candidate POSIX path.
+   * @returns True when no pack filter is active or the path is published.
+   */
+  private isPackIncluded(path: string): boolean {
+    // A null published set means no selection: every enumerated file is in.
+    if (this.publishedPaths === null) {
+      return true;
+    }
+    const relative = this.sourceRelativePosix(path);
+    if (relative === null) {
+      return true;
+    }
+    return this.publishedPaths.has(relative);
+  }
+
+  /**
+   * Return whether a candidate file passes the agent-memory scope filter.
+   *
+   * Reads file content only for agent-memory candidates.
+   *
+   * @param path An absolute candidate POSIX path.
+   * @returns True when the file is outside the memory subtree or general-scoped.
+   */
+  private isScopeIncluded(path: string): boolean {
+    const relativePath = relativeToPosix(path, this.repoRoot);
+    if (relativePath === null) {
+      // A path outside the repo root cannot be an agent memory; include it.
+      return true;
+    }
+    // Skip the content read entirely for files outside the memory subtree.
+    if (!isUnderAgentMemory(relativePath)) {
+      return true;
+    }
+    const content = this.readText(path);
+    return isGeneralMemoryFile(relativePath, content);
+  }
+
+  /**
+   * Return whether a candidate file passes the memory-mode filter.
+   *
+   * @param path An absolute candidate POSIX path.
+   * @returns True when the file should be published under the active mode.
+   */
+  private isMemoryModeIncluded(path: string): boolean {
+    const relative = this.sourceRelativePosix(path);
+    if (relative === null) {
+      return true;
+    }
+    // Only agent-memory files are affected by the memory mode.
+    if (!isUnderAgentMemory(relative)) {
+      return true;
+    }
+    // Route by mode: skip drops all memories; merge keeps only those absent at
+    // the destination; overwrite (default) keeps everything.
+    if (this.memoryMode === "skip") {
+      return false;
+    }
+    if (this.memoryMode === "merge") {
+      if (this.destinationRoot === undefined) {
+        return true;
+      }
+      const destinationPath = joinPosix(this.destinationRoot, relative);
+      return !this.inner.isFile(destinationPath);
+    }
+    return true;
+  }
+
+  /**
+   * Return the actual source path to read for a requested path.
+   *
+   * Redirects canonical C# reads to the bundle-only legacy source when the
+   * legacy variant is active; otherwise passes the path through unchanged.
+   *
+   * @param path The absolute POSIX path the engine asked to read.
+   * @returns The redirected legacy source path, or the original path.
+   */
+  private resolveReadSource(path: string): string {
+    if (this.csharpVariant !== "legacy") {
+      return path;
+    }
+    const relative = this.sourceRelativePosix(path);
+    if (relative === null || !CSHARP_CANONICAL_PATHS.includes(relative)) {
+      return path;
+    }
+    const redirectedRelative = resolveVariantSourcePath(relative, "legacy");
+    // Join under the variant (bundle) root so the read lives in the same key
+    // space the engine enumerated from.
+    return joinPosix(this.variantRoot, redirectedRelative);
+  }
+
+  listFiles(root: string): string[] {
+    // Apply the four enumeration filters in sequence: hard exclusions, pack
+    // selection, agent-memory scope, then memory mode.
+    return this.inner
+      .listFiles(root)
+      .filter(
+        (p) =>
+          !this.excluded.has(normalizePosix(p)) &&
+          this.isPackIncluded(p) &&
+          this.isScopeIncluded(p) &&
+          this.isMemoryModeIncluded(p),
+      );
+  }
+
+  isDir(path: string): boolean {
+    return this.inner.isDir(path);
+  }
+
+  isFile(path: string): boolean {
+    return this.inner.isFile(path);
+  }
+
+  readText(path: string): string {
+    return this.inner.readTextFile(this.resolveReadSource(path));
+  }
+
+  readTextFile(path: string): string {
+    return this.readText(path);
+  }
+
+  writeTextFile(path: string, content: string): void {
+    this.inner.writeTextFile(path, content);
+  }
+
+  ensureDir(path: string): void {
+    this.inner.ensureDir(path);
+  }
+}

--- a/extensions/drm-copilot/src/lib/push-down/claude-memory-scope.ts
+++ b/extensions/drm-copilot/src/lib/push-down/claude-memory-scope.ts
@@ -1,0 +1,136 @@
+/**
+ * Memory-scope frontmatter parser for the `.claude` customization push-down.
+ *
+ * Purpose:
+ *     Port the frontmatter scope-reading helpers of
+ *     `push_down_claude_filesystem.py`. Reads the agent-memory scope leaf
+ *     (`metadata.scope`) from leading YAML frontmatter using a narrow regex
+ *     parser (no runtime YAML dependency), and decides per-file inclusion for
+ *     the general-vs-repo memory scope filter.
+ *
+ * Side effects:
+ *     None. All functions are pure.
+ */
+
+/** Relative root beneath which agent-memory files live. */
+export const AGENT_MEMORY_RELATIVE_ROOT = ".claude/agent-memory";
+
+/** Scope value that permits distribution of an agent-memory file. */
+export const GENERAL_MEMORY_SCOPE = "general";
+
+/** Fail-safe default scope that excludes an agent-memory file from push-down. */
+export const REPO_MEMORY_SCOPE = "repo";
+
+/**
+ * Match a leading YAML frontmatter block: the first `---` line, the block body,
+ * and the closing `---` line. The `s` flag lets the body span multiple lines,
+ * mirroring Python `re.DOTALL`.
+ */
+const FRONTMATTER_PATTERN = /^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|$)/s;
+
+/**
+ * Match a `metadata:` mapping key at column zero, then capture the indented
+ * block lines that belong to it (more-indented or blank) until the next
+ * column-zero key or the end of the frontmatter body.
+ */
+const METADATA_BLOCK_PATTERN =
+  /^metadata:[ \t]*\r?\n((?:[ \t]+.*(?:\r?\n|$)|\r?\n)*)/m;
+
+/**
+ * Match a `scope:` leaf inside the metadata block, capturing its scalar value
+ * up to an optional inline comment. Surrounding quotes are stripped later.
+ */
+const SCOPE_LEAF_PATTERN = /^[ \t]+scope:[ \t]*([^\r\n#]*)/m;
+
+/**
+ * Return the declared memory scope from a file's YAML frontmatter.
+ *
+ * Returns `general` only when the frontmatter contains a `metadata:` mapping
+ * whose `scope:` leaf is exactly `general` (quotes and inline comments
+ * stripped). Every other case — missing/unterminated frontmatter, no metadata
+ * block, no scope leaf, or any non-general value — returns `repo` as the
+ * fail-safe default so nothing leaks by accident.
+ *
+ * @param content The full text of a candidate memory file.
+ * @returns `general` or `repo`.
+ */
+export function readMemoryScope(content: string): string {
+  // Isolate the leading frontmatter block; absent/unterminated fails safe.
+  const frontmatterMatch = FRONTMATTER_PATTERN.exec(content);
+  if (frontmatterMatch === null) {
+    return REPO_MEMORY_SCOPE;
+  }
+  const frontmatterBody = frontmatterMatch[1] ?? "";
+
+  // Locate the metadata mapping; without it there is no scope leaf to read.
+  const metadataMatch = METADATA_BLOCK_PATTERN.exec(frontmatterBody);
+  if (metadataMatch === null) {
+    return REPO_MEMORY_SCOPE;
+  }
+  const metadataBlock = metadataMatch[1] ?? "";
+
+  // Read the scope leaf from within the metadata block only; a top-level
+  // `scope:` outside `metadata:` is intentionally ignored.
+  const scopeMatch = SCOPE_LEAF_PATTERN.exec(metadataBlock);
+  if (scopeMatch === null) {
+    return REPO_MEMORY_SCOPE;
+  }
+
+  // Strip surrounding whitespace and matching quotes before exact comparison.
+  let scopeValue = (scopeMatch[1] ?? "").trim();
+  if (
+    scopeValue.length >= 2 &&
+    scopeValue[0] === scopeValue[scopeValue.length - 1] &&
+    (scopeValue[0] === '"' || scopeValue[0] === "'")
+  ) {
+    scopeValue = scopeValue.slice(1, -1).trim();
+  }
+  return scopeValue === GENERAL_MEMORY_SCOPE
+    ? GENERAL_MEMORY_SCOPE
+    : REPO_MEMORY_SCOPE;
+}
+
+/**
+ * Normalize a path to forward-slash separators with no trailing slash.
+ *
+ * @param value Path that may use OS-specific separators.
+ * @returns Forward-slash POSIX path without a trailing separator.
+ */
+function normalizePosix(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+/**
+ * Return whether a relative POSIX path is within the agent-memory subtree.
+ *
+ * @param relativePosixPath A repo-relative POSIX path.
+ * @returns True when the path is `.claude/agent-memory` or beneath it.
+ */
+export function isUnderAgentMemory(relativePosixPath: string): boolean {
+  const normalized = normalizePosix(relativePosixPath);
+  return (
+    normalized === AGENT_MEMORY_RELATIVE_ROOT ||
+    normalized.startsWith(`${AGENT_MEMORY_RELATIVE_ROOT}/`)
+  );
+}
+
+/**
+ * Return whether a candidate file may be distributed by push-down.
+ *
+ * Files under `.claude/agent-memory/` are distributed only when general-scoped;
+ * every other file is always distributed and unaffected by the scope filter.
+ *
+ * @param relativePosixPath The file path relative to the repository root.
+ * @param content The full text of the file (used only for agent-memory paths).
+ * @returns True when the file may be distributed.
+ */
+export function isGeneralMemoryFile(
+  relativePosixPath: string,
+  content: string,
+): boolean {
+  // Files outside the agent-memory subtree are always copied.
+  if (!isUnderAgentMemory(relativePosixPath)) {
+    return true;
+  }
+  return readMemoryScope(content) === GENERAL_MEMORY_SCOPE;
+}

--- a/extensions/drm-copilot/src/lib/push-down/claude-pack-selection.ts
+++ b/extensions/drm-copilot/src/lib/push-down/claude-pack-selection.ts
@@ -1,0 +1,308 @@
+/**
+ * Pack selection, variant routing, and memory-mode helpers for `.claude`
+ * push-down.
+ *
+ * Purpose:
+ *     Port `push_down_claude_pack_selection.py`. Provides the pure logic that
+ *     the Claude push-down entry point uses to decide which `.claude`-relative
+ *     files to publish, which C# variant source to read for each canonical
+ *     destination path, and the C# mutual-exclusion assertion.
+ *
+ * Responsibilities:
+ *     - Load and validate pack-manifest JSON via an injected filesystem adapter.
+ *     - Compute the published `.claude`-relative path set (always including
+ *       `core`).
+ *     - Resolve the source-relative path for a destination path given the C#
+ *       variant.
+ *     - Assert that a single run selects at most one C# variant.
+ *
+ * Side effects:
+ *     None beyond reads performed through the injected adapter.
+ */
+
+import { type PushDownFileSystem } from "./filesystem-adapter";
+
+/** Pack name reserved for the always-included non-language customization set. */
+export const CORE_PACK_NAME = "core";
+
+/**
+ * The four canonical `.claude`-relative C# destination paths shared by the
+ * modern and legacy C# packs.
+ */
+export const CSHARP_CANONICAL_PATHS: ReadonlyArray<string> = [
+  ".claude/rules/csharp.md",
+  ".claude/agents/csharp-typed-engineer.md",
+  ".claude/skills/csharp-qa-gate/SKILL.md",
+  ".claude/skills/invoke-csharp-engineer/SKILL.md",
+];
+
+/** Pack names whose paths are the canonical C# toolchain. */
+export const CSHARP_PACK_NAMES: ReadonlySet<string> = new Set([
+  "csharp-modern",
+  "csharp-legacy",
+]);
+
+/** Bundle-only source prefix for the legacy C# variant subtree. */
+export const LEGACY_VARIANT_SOURCE_PREFIX = ".claude-variants/csharp-legacy";
+
+/** Selected C# toolchain variant. */
+export type CSharpVariant = "modern" | "legacy";
+
+/** Agent-memory handling mode. */
+export type MemoryMode = "overwrite" | "merge" | "skip";
+
+/**
+ * Raised when a pack manifest is missing or structurally invalid.
+ *
+ * Mirrors the Python `ManifestError` (a `ValueError` subclass). A distinct error
+ * class lets callers and tests distinguish manifest problems from unrelated
+ * errors.
+ */
+export class ManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ManifestError";
+  }
+}
+
+/** One loaded, validated pack manifest. */
+export interface PackManifest {
+  /** Stable pack identifier (for example `python`). */
+  readonly name: string;
+  /** Human-readable label used by the command UI. */
+  readonly label: string;
+  /** The `.claude`-relative destination paths this pack contributes. */
+  readonly paths: ReadonlyArray<string>;
+  /** Optional bundle-relative source prefix for variant packs; else null. */
+  readonly sourcePrefix: string | null;
+}
+
+/**
+ * Join a directory and a filename using forward-slash separators.
+ *
+ * @param dir Directory POSIX path.
+ * @param name Filename to append.
+ * @returns The combined POSIX path.
+ */
+function joinPosix(dir: string, name: string): string {
+  const normalizedDir = dir.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalizedDir === "" ? name : `${normalizedDir}/${name}`;
+}
+
+/**
+ * Load and validate the selected pack manifests from the bundle.
+ *
+ * Reads each selected manifest JSON through the injected adapter, validates its
+ * required structure, and returns a map from pack name to its typed manifest.
+ * `core` is always loaded. Iteration is sorted so error order is deterministic.
+ *
+ * @param manifestDir Directory holding `<pack>.json` manifest files.
+ * @param selectedPackNames Pack names to load (core is added automatically).
+ * @param fs Filesystem adapter for existence checks and text reads.
+ * @returns Map of pack name to validated manifest, including `core`.
+ * @throws ManifestError When a manifest is missing, invalid JSON, not an object,
+ *   or has invalid name/label/paths/source_prefix values.
+ */
+export function loadPackManifests(
+  manifestDir: string,
+  selectedPackNames: ReadonlySet<string>,
+  fs: PushDownFileSystem,
+): Map<string, PackManifest> {
+  // Always load core in addition to the explicitly selected packs.
+  const namesToLoad = new Set<string>(selectedPackNames);
+  namesToLoad.add(CORE_PACK_NAME);
+
+  const manifests = new Map<string, PackManifest>();
+  // Load each selected manifest in sorted order so any error order is stable.
+  for (const name of [...namesToLoad].sort()) {
+    const manifestPath = joinPosix(manifestDir, `${name}.json`);
+    if (!fs.isFile(manifestPath)) {
+      throw new ManifestError(
+        `Pack manifest is missing for pack '${name}': ${manifestPath}`,
+      );
+    }
+    const rawText = fs.readTextFile(manifestPath);
+    manifests.set(name, parseManifest(name, manifestPath, rawText));
+  }
+  return manifests;
+}
+
+/**
+ * Parse and validate one manifest's JSON text into a {@link PackManifest}.
+ *
+ * @param name The pack name expected for this manifest (the file stem).
+ * @param manifestPath The manifest path, used only for error messages.
+ * @param rawText The raw JSON text read from the manifest file.
+ * @returns The validated, immutable manifest structure.
+ * @throws ManifestError When the text is not valid JSON, not an object, or has
+ *   missing/wrongly typed name/label/paths/source_prefix values.
+ */
+function parseManifest(
+  name: string,
+  manifestPath: string,
+  rawText: string,
+): PackManifest {
+  let loaded: unknown;
+  try {
+    loaded = JSON.parse(rawText);
+  } catch {
+    throw new ManifestError(
+      `Pack manifest is not valid JSON for pack '${name}': ${manifestPath}`,
+    );
+  }
+
+  // A JSON array, string, or number is not an object manifest.
+  if (loaded === null || typeof loaded !== "object" || Array.isArray(loaded)) {
+    throw new ManifestError(
+      `Pack manifest must be a JSON object for pack '${name}': ${manifestPath}`,
+    );
+  }
+
+  const parsed = loaded as Record<string, unknown>;
+  const manifestName = parsed["name"];
+  const manifestLabel = parsed["label"];
+  const manifestPaths = parsed["paths"];
+  const sourcePrefix = parsed["source_prefix"];
+
+  // Validate the required string keys; both must be non-empty.
+  if (typeof manifestName !== "string" || manifestName === "") {
+    throw new ManifestError(
+      `Pack manifest 'name' must be a non-empty string: ${manifestPath}`,
+    );
+  }
+  if (typeof manifestLabel !== "string" || manifestLabel === "") {
+    throw new ManifestError(
+      `Pack manifest 'label' must be a non-empty string: ${manifestPath}`,
+    );
+  }
+
+  // Validate the paths array is a list of strings.
+  if (!Array.isArray(manifestPaths)) {
+    throw new ManifestError(
+      `Pack manifest 'paths' must be a list of strings: ${manifestPath}`,
+    );
+  }
+  const typedPaths: string[] = [];
+  // Narrow each entry to string so a non-string element is rejected explicitly.
+  for (const entry of manifestPaths) {
+    if (typeof entry !== "string") {
+      throw new ManifestError(
+        `Pack manifest 'paths' must be a list of strings: ${manifestPath}`,
+      );
+    }
+    typedPaths.push(entry);
+  }
+
+  // source_prefix is optional; when present it must be a string.
+  if (
+    sourcePrefix !== undefined &&
+    sourcePrefix !== null &&
+    typeof sourcePrefix !== "string"
+  ) {
+    throw new ManifestError(
+      `Pack manifest 'source_prefix' must be a string when present: ${manifestPath}`,
+    );
+  }
+
+  return {
+    name: manifestName,
+    label: manifestLabel,
+    paths: typedPaths,
+    sourcePrefix:
+      sourcePrefix === undefined || sourcePrefix === null ? null : sourcePrefix,
+  };
+}
+
+/**
+ * Compute the `.claude`-relative destination paths to publish.
+ *
+ * Unions every selected pack's paths plus `core`. Returns `null` when no
+ * explicit selection was made (the caller then publishes the full tree).
+ *
+ * @param selectedPackNames Selected pack names, or null/empty for the default.
+ * @param manifests Loaded manifests for at least the selected packs plus core.
+ * @returns The union path set, or `null` for the publish-everything default.
+ * @throws ManifestError When a selected pack has no loaded manifest.
+ */
+export function computePublishedPaths(
+  selectedPackNames: ReadonlySet<string> | null,
+  manifests: Map<string, PackManifest>,
+): ReadonlySet<string> | null {
+  // An empty or null selection means publish-everything (signalled by null).
+  if (selectedPackNames === null || selectedPackNames.size === 0) {
+    return null;
+  }
+
+  // Always include core so the non-language baseline is published.
+  const effectiveNames = new Set<string>(selectedPackNames);
+  effectiveNames.add(CORE_PACK_NAME);
+
+  const published = new Set<string>();
+  // Union every selected pack's destination paths into the published set.
+  for (const name of effectiveNames) {
+    const manifest = manifests.get(name);
+    if (manifest === undefined) {
+      throw new ManifestError(
+        `No loaded manifest for selected pack '${name}'.`,
+      );
+    }
+    for (const p of manifest.paths) {
+      published.add(p);
+    }
+  }
+  return published;
+}
+
+/**
+ * Resolve the source-relative path to read for a destination path.
+ *
+ * For the legacy C# variant and a canonical C# path, the read is routed to the
+ * bundle-only `.claude-variants/csharp-legacy/` subtree. Non-C# paths and the
+ * modern variant resolve to the destination path unchanged.
+ *
+ * @param destinationRelativePath A `.claude`-relative destination path.
+ * @param csharpVariant `modern` (read from `.claude`) or `legacy`.
+ * @returns The source-relative path to read.
+ */
+export function resolveVariantSourcePath(
+  destinationRelativePath: string,
+  csharpVariant: CSharpVariant,
+): string {
+  // Only the four canonical C# destinations are variant-routed under legacy.
+  if (
+    csharpVariant === "legacy" &&
+    CSHARP_CANONICAL_PATHS.includes(destinationRelativePath)
+  ) {
+    // Replace the leading `.claude/` with the legacy variant prefix.
+    const tail = destinationRelativePath.slice(".claude/".length);
+    return `${LEGACY_VARIANT_SOURCE_PREFIX}/${tail}`;
+  }
+  return destinationRelativePath;
+}
+
+/**
+ * Assert the C# selection yields at most one toolchain at the destination.
+ *
+ * @param publishedPaths The computed destination paths for the run (unused for
+ *   the duplicate check since a set deduplicates; kept for parity with Python).
+ * @param selectedPackNames The selected pack names.
+ * @throws ManifestError When both `csharp-modern` and `csharp-legacy` are
+ *   selected in the same run.
+ */
+export function assertSingleCsharpToolchain(
+  publishedPaths: ReadonlySet<string>,
+  selectedPackNames: ReadonlySet<string>,
+): void {
+  // Selecting both C# packs would route two sources to the same destinations.
+  const selectedCsharp = [...selectedPackNames]
+    .filter((name) => CSHARP_PACK_NAMES.has(name))
+    .sort();
+  if (selectedCsharp.length > 1) {
+    throw new ManifestError(
+      "C# mutual exclusion violated: both modern and legacy C# packs were " +
+        `selected ([${selectedCsharp.map((n) => `'${n}'`).join(", ")}]); select exactly one C# variant.`,
+    );
+  }
+  // Reference publishedPaths so the parameter is intentionally part of the API.
+  void publishedPaths;
+}

--- a/extensions/drm-copilot/src/lib/push-down/codex-agents-customizations.ts
+++ b/extensions/drm-copilot/src/lib/push-down/codex-agents-customizations.ts
@@ -1,0 +1,80 @@
+/**
+ * Codex/agents customization push-down publisher.
+ *
+ * Purpose:
+ *     Port `push_down_codex_and_agents_customizations.py`. Provides a dedicated
+ *     entry point for publishing the bundled `.codex` and `.agents` trees while
+ *     reusing the shared copilot push-down engine.
+ *
+ * Side effects:
+ *     Delegates all filesystem I/O to the injected {@link PushDownFileSystem}
+ *     via the shared engine.
+ */
+
+import { type PushDownFileSystem } from "./filesystem-adapter";
+import {
+  type Clock,
+  pushDownCustomizations as enginePushDown,
+  type PushDownSummary,
+} from "./copilot-customizations-engine";
+
+/** Artifact directory for the Codex/agents push-down summary. */
+export const ARTIFACT_DIRECTORY = "artifacts/codex-and-agents-customizations";
+
+/** Inlined Codex/agents scoped root folders (enumeration-order contract). */
+export const ROOT_FOLDERS: ReadonlyArray<string> = [".codex", ".agents"];
+
+/**
+ * Passthrough rewrite for payloads that do not need command rewrites.
+ *
+ * Mirrors the Python `_passthrough_rewrite`: returns the text unchanged with
+ * zero rewrite/placeholder counts and no unmatched references.
+ *
+ * @param text Source text.
+ * @returns A tuple `[text, 0, 0, []]`.
+ */
+export function passthroughRewrite(
+  text: string,
+): [string, number, number, string[]] {
+  return [text, 0, 0, []];
+}
+
+/** Options for the Codex/agents {@link pushDownCustomizations} entry point. */
+export interface CodexAgentsPushDownOptions {
+  readonly repoRoot: string;
+  readonly destinationRoot: string;
+  readonly fs: PushDownFileSystem;
+  readonly sourceRoot?: string;
+  readonly artifactRoot?: string;
+  readonly clock?: Clock;
+}
+
+/**
+ * Copy the bundled `.codex` and `.agents` trees into the destination workspace.
+ *
+ * Delegates to the shared engine with the Codex/agents root folders, artifact
+ * directory, and the passthrough rewrite (no command-reference rewriting).
+ *
+ * @param options Entry options (roots, filesystem, optional clock).
+ * @returns The completed run summary including the written artifact path.
+ * @throws Error When destination validation fails.
+ */
+export function pushDownCustomizations(
+  options: CodexAgentsPushDownOptions,
+): PushDownSummary {
+  return enginePushDown({
+    repoRoot: options.repoRoot,
+    destinationRoot: options.destinationRoot,
+    fs: options.fs,
+    ...(options.sourceRoot === undefined
+      ? {}
+      : { sourceRoot: options.sourceRoot }),
+    ...(options.artifactRoot === undefined
+      ? {}
+      : { artifactRoot: options.artifactRoot }),
+    rootFolders: ROOT_FOLDERS,
+    artifactDirectory: ARTIFACT_DIRECTORY,
+    rewriteReferences: passthroughRewrite,
+    ...(options.clock === undefined ? {} : { clock: options.clock }),
+  });
+}

--- a/extensions/drm-copilot/src/lib/push-down/copilot-customizations-engine.ts
+++ b/extensions/drm-copilot/src/lib/push-down/copilot-customizations-engine.ts
@@ -1,0 +1,448 @@
+/**
+ * Engine half of the Copilot customization push-down publisher.
+ *
+ * Purpose:
+ *     Port the orchestration core of `push_down_copilot_customizations.py`:
+ *     deterministic source enumeration, destination validation, summary-artifact
+ *     naming and rendering, and the copy/rewrite loop. The public CLI-facing
+ *     surface lives in `copilot-customizations.ts`; this module holds the engine
+ *     so each file stays within the 500-line limit.
+ *
+ * Responsibilities:
+ *     - Enumerate scoped source files in root-order then path-order.
+ *     - Validate the destination (missing dir / destination-equals-source).
+ *     - Build the deterministic JSON artifact path.
+ *     - Render the summary as 2-space, sorted-key JSON.
+ *     - Run the copy/rewrite loop and accumulate counts and unmatched refs.
+ *
+ * Side effects:
+ *     Reads source files and writes destination files plus the summary artifact
+ *     through the injected {@link PushDownFileSystem}.
+ */
+
+import { type PushDownFileSystem, toPosixPath } from "./filesystem-adapter";
+import {
+  rewriteTextReferences,
+  type RewriteFunction,
+} from "./reference-rewrites";
+
+/** Default artifact directory for the Copilot push-down summary. */
+export const ARTIFACT_DIRECTORY = "artifacts/copilot-customizations";
+
+/**
+ * Inlined `agentic_sync.ROOT_FOLDERS` (copilot). The Python source imports
+ * these scoped `.github` roots; the port inlines the typed tuple so no Python
+ * dependency remains. Order is the enumeration contract.
+ */
+export const COPILOT_ROOT_FOLDERS: ReadonlyArray<string> = [
+  ".github/agents",
+  ".github/instructions",
+  ".github/prompts",
+  ".github/skills",
+];
+
+/** Clock seam returning the current instant; injected for determinism. */
+export type Clock = () => Date;
+
+/** Per-file outcome record for the run summary. */
+export interface PushDownFileResult {
+  /** Destination-relative POSIX file path. */
+  readonly relativePath: string;
+  /** Either `created` or `overwritten`. */
+  readonly destinationStatus: "created" | "overwritten";
+  /** Number of non-placeholder rewrites in this file. */
+  readonly rewrittenReferenceCount: number;
+  /** Number of placeholder rewrites in this file. */
+  readonly placeholderRewriteCount: number;
+  /** Unknown references left untouched in this file. */
+  readonly unmatchedReferences: ReadonlyArray<string>;
+}
+
+/** Completed push-down run summary returned to callers. */
+export interface PushDownSummary {
+  readonly repoRoot: string;
+  readonly destinationRoot: string;
+  readonly startedAt: Date;
+  readonly finishedAt: Date;
+  readonly createdCount: number;
+  readonly overwrittenCount: number;
+  readonly rewrittenReferenceCount: number;
+  readonly placeholderRewriteCount: number;
+  readonly unmatchedReferences: ReadonlyArray<string>;
+  readonly files: ReadonlyArray<PushDownFileResult>;
+  readonly artifactPath: string;
+}
+
+/** JSON artifact schema for a push-down run (snake_case keys for parity). */
+interface PushDownSummaryPayload {
+  repo_root: string;
+  destination_root: string;
+  started_at: string;
+  finished_at: string;
+  created_count: number;
+  overwritten_count: number;
+  rewritten_reference_count: number;
+  placeholder_rewrite_count: number;
+  unmatched_references: string[];
+  files: Array<Record<string, unknown>>;
+}
+
+/** Options for the engine {@link pushDownCustomizations} orchestration. */
+export interface PushDownEngineOptions {
+  readonly repoRoot: string;
+  readonly destinationRoot: string;
+  readonly fs: PushDownFileSystem;
+  readonly sourceRoot?: string;
+  readonly artifactRoot?: string;
+  readonly rootFolders?: ReadonlyArray<string>;
+  readonly artifactDirectory?: string;
+  readonly rewriteReferences?: RewriteFunction;
+  readonly clock?: Clock;
+}
+
+/**
+ * Join a root and relative path using forward-slash separators.
+ *
+ * @param root Base path.
+ * @param relative Path relative to the base.
+ * @returns The combined POSIX-style path.
+ */
+function joinPosix(root: string, relative: string): string {
+  const normalizedRoot = toPosixPath(root).replace(/\/+$/, "");
+  const normalizedRelative = toPosixPath(relative).replace(/^\/+/, "");
+  if (normalizedRoot === "") {
+    return normalizedRelative;
+  }
+  if (normalizedRelative === "") {
+    return normalizedRoot;
+  }
+  return `${normalizedRoot}/${normalizedRelative}`;
+}
+
+/**
+ * Return the POSIX path relative to a root, or null when not under the root.
+ *
+ * Mirrors Python `Path.relative_to` containment semantics on normalized POSIX
+ * strings so the port stays host-independent and hermetic.
+ *
+ * @param path Candidate child POSIX path.
+ * @param root Candidate parent POSIX path.
+ * @returns The relative POSIX path, or `null` when `path` is not under `root`.
+ */
+function relativeToPosix(path: string, root: string): string | null {
+  const normalizedPath = toPosixPath(path).replace(/\/+$/, "");
+  const normalizedRoot = toPosixPath(root).replace(/\/+$/, "");
+  if (normalizedPath === normalizedRoot) {
+    return "";
+  }
+  const prefix = `${normalizedRoot}/`;
+  if (normalizedPath.startsWith(prefix)) {
+    return normalizedPath.slice(prefix.length);
+  }
+  return null;
+}
+
+/**
+ * Enumerate scoped source files in deterministic root and path order.
+ *
+ * Preserves the `rootFolders` ordering contract while keeping file order stable
+ * within each scoped root (sorted by the path relative to that root).
+ *
+ * @param fs Filesystem adapter.
+ * @param sourceRoot Effective source root to enumerate from.
+ * @param rootFolders Ordered scoped roots.
+ * @returns Ordered source file POSIX paths.
+ */
+export function enumerateSourceFiles(
+  fs: PushDownFileSystem,
+  sourceRoot: string,
+  rootFolders: ReadonlyArray<string>,
+): string[] {
+  const orderedFiles: string[] = [];
+  // Enumerate by scoped root first so summaries match the feature contract; the
+  // per-root files are sorted by their root-relative POSIX path for stability.
+  for (const root of rootFolders) {
+    const rootPath = joinPosix(sourceRoot, root);
+    const rootFiles = fs.listFiles(rootPath);
+    const sorted = [...rootFiles].sort((left, right) => {
+      const leftRel = relativeToPosix(left, rootPath) ?? left;
+      const rightRel = relativeToPosix(right, rootPath) ?? right;
+      return leftRel < rightRel ? -1 : leftRel > rightRel ? 1 : 0;
+    });
+    orderedFiles.push(...sorted);
+  }
+  return orderedFiles;
+}
+
+/**
+ * Validate the destination before any copy action begins.
+ *
+ * @param destinationRoot Destination workspace root POSIX path.
+ * @param repoRoot Source repository root POSIX path.
+ * @param fs Filesystem adapter.
+ * @throws Error When the destination is missing or equals the source repo root.
+ */
+export function validateDestination(
+  destinationRoot: string,
+  repoRoot: string,
+  fs: PushDownFileSystem,
+): void {
+  if (!fs.isDir(destinationRoot)) {
+    throw new Error(
+      `Invalid destination: destination directory does not exist: ${destinationRoot}`,
+    );
+  }
+  // Compare normalized POSIX paths so the destination-equals-source guard is
+  // host-independent (Python compares resolved paths).
+  if (
+    toPosixPath(destinationRoot).replace(/\/+$/, "") ===
+    toPosixPath(repoRoot).replace(/\/+$/, "")
+  ) {
+    throw new Error(
+      `Invalid destination: destination must not be the source repository root: ${destinationRoot}`,
+    );
+  }
+}
+
+/**
+ * Format a Date as the deterministic `%Y%m%dT%H%M%SZ` UTC timestamp.
+ *
+ * @param value The instant to format.
+ * @returns The compact UTC timestamp string (e.g. `20260626T001500Z`).
+ */
+function formatArtifactTimestamp(value: Date): string {
+  const iso = value.toISOString();
+  // ISO form is `YYYY-MM-DDTHH:mm:ss.sssZ`; strip separators and fractional ms
+  // to produce `YYYYMMDDTHHMMSSZ`, matching Python `strftime("%Y%m%dT%H%M%SZ")`.
+  const compact = iso.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+  return compact;
+}
+
+/**
+ * Build the deterministic JSON summary artifact path for a push-down run.
+ *
+ * @param startedAt UTC timestamp captured at run start.
+ * @param artifactRoot Artifact root POSIX path.
+ * @param artifactDirectory Artifact subdirectory.
+ * @returns Artifact POSIX path beneath the configured artifact directory.
+ */
+export function buildArtifactPath(
+  startedAt: Date,
+  artifactRoot: string,
+  artifactDirectory: string,
+): string {
+  const timestamp = formatArtifactTimestamp(startedAt);
+  return joinPosix(
+    artifactRoot,
+    `${artifactDirectory}/push-down-${timestamp}.json`,
+  );
+}
+
+/**
+ * Render the push-down summary artifact as deterministic JSON.
+ *
+ * Produces 2-space-indented JSON with sorted keys (mirroring Python
+ * `json.dumps(payload, indent=2, sort_keys=True)`). The per-file objects use the
+ * same snake_case field names as the Python `asdict(result)` output.
+ *
+ * @param summary Completed push-down summary.
+ * @returns Deterministic JSON payload string.
+ */
+export function renderPushDownSummary(summary: PushDownSummary): string {
+  const payload: PushDownSummaryPayload = {
+    repo_root: summary.repoRoot,
+    destination_root: summary.destinationRoot,
+    started_at: summary.startedAt.toISOString(),
+    finished_at: summary.finishedAt.toISOString(),
+    created_count: summary.createdCount,
+    overwritten_count: summary.overwrittenCount,
+    rewritten_reference_count: summary.rewrittenReferenceCount,
+    placeholder_rewrite_count: summary.placeholderRewriteCount,
+    unmatched_references: [...summary.unmatchedReferences],
+    files: summary.files.map((result) => ({
+      relative_path: result.relativePath,
+      destination_status: result.destinationStatus,
+      rewritten_reference_count: result.rewrittenReferenceCount,
+      placeholder_rewrite_count: result.placeholderRewriteCount,
+      unmatched_references: [...result.unmatchedReferences],
+    })),
+  };
+  return stringifySorted(payload, 2);
+}
+
+/**
+ * Serialize a value as JSON with recursively sorted object keys.
+ *
+ * Mirrors Python `json.dumps(..., sort_keys=True)`. Arrays preserve order;
+ * object keys are emitted in lexicographic order at every depth.
+ *
+ * @param value The value to serialize.
+ * @param indent Indentation width in spaces.
+ * @returns Sorted-key JSON string.
+ */
+function stringifySorted(value: unknown, indent: number): string {
+  const sortKeys = (input: unknown): unknown => {
+    if (Array.isArray(input)) {
+      return input.map(sortKeys);
+    }
+    if (input !== null && typeof input === "object") {
+      const entries = Object.entries(input as Record<string, unknown>).sort(
+        ([leftKey], [rightKey]) =>
+          leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0,
+      );
+      const result: Record<string, unknown> = {};
+      // Re-insert keys in sorted order so JSON.stringify emits them sorted.
+      for (const [key, val] of entries) {
+        result[key] = sortKeys(val);
+      }
+      return result;
+    }
+    return input;
+  };
+  return JSON.stringify(sortKeys(value), null, indent);
+}
+
+/**
+ * Write the JSON summary artifact under the artifact directory.
+ *
+ * @param fs Filesystem adapter used for writes.
+ * @param summary Summary to serialize.
+ * @param artifactRoot Artifact root POSIX path.
+ * @param artifactDirectory Artifact subdirectory.
+ * @returns The written artifact POSIX path.
+ */
+export function writeSummaryArtifact(
+  fs: PushDownFileSystem,
+  summary: PushDownSummary,
+  artifactRoot: string,
+  artifactDirectory: string,
+): string {
+  const artifactPath = buildArtifactPath(
+    summary.startedAt,
+    artifactRoot,
+    artifactDirectory,
+  );
+  const parent = artifactPath.slice(0, artifactPath.lastIndexOf("/"));
+  fs.ensureDir(parent);
+  fs.writeTextFile(artifactPath, renderPushDownSummary(summary));
+  return artifactPath;
+}
+
+/**
+ * Copy scoped customizations into the destination workspace.
+ *
+ * Executes validation, deterministic enumeration, text rewriting, overwrite-
+ * aware writes, and summary-artifact emission. Mirrors the Python
+ * `push_down_customizations` orchestration exactly, including first-seen
+ * unmatched-reference accumulation and per-file classification.
+ *
+ * @param options Engine options (roots, filesystem, rewrite fn, clock).
+ * @returns The completed run summary including the written artifact path.
+ * @throws Error When destination validation fails.
+ */
+export function pushDownCustomizations(
+  options: PushDownEngineOptions,
+): PushDownSummary {
+  const {
+    repoRoot,
+    destinationRoot,
+    fs,
+    sourceRoot,
+    artifactRoot,
+    rootFolders,
+    artifactDirectory,
+    rewriteReferences,
+    clock,
+  } = options;
+
+  const effectiveSource = sourceRoot ?? repoRoot;
+  const effectiveArtifact = artifactRoot ?? repoRoot;
+  const effectiveRoots = rootFolders ?? COPILOT_ROOT_FOLDERS;
+  const effectiveArtifactDir = artifactDirectory ?? ARTIFACT_DIRECTORY;
+  const rewrite = rewriteReferences ?? rewriteTextReferences;
+  const now = clock ?? (() => new Date());
+
+  validateDestination(destinationRoot, repoRoot, fs);
+  const startedAt = now();
+
+  let createdCount = 0;
+  let overwrittenCount = 0;
+  let rewrittenReferenceCount = 0;
+  let placeholderRewriteCount = 0;
+  const unmatchedReferences: string[] = [];
+  const fileResults: PushDownFileResult[] = [];
+
+  // Process files in stable order so artifacts and test expectations reproduce.
+  for (const sourcePath of enumerateSourceFiles(
+    fs,
+    effectiveSource,
+    effectiveRoots,
+  )) {
+    const relativePath = relativeToPosix(sourcePath, effectiveSource);
+    if (relativePath === null) {
+      // The enumerator only yields files under the source root; skip otherwise.
+      continue;
+    }
+    const destinationPath = joinPosix(destinationRoot, relativePath);
+    const destinationStatus: "created" | "overwritten" = fs.isFile(
+      destinationPath,
+    )
+      ? "overwritten"
+      : "created";
+    if (destinationStatus === "created") {
+      createdCount += 1;
+    } else {
+      overwrittenCount += 1;
+    }
+
+    const sourceText = fs.readTextFile(sourcePath);
+    const [rewrittenText, rewrittenDelta, placeholderDelta, unmatched] =
+      rewrite(sourceText);
+    rewrittenReferenceCount += rewrittenDelta;
+    placeholderRewriteCount += placeholderDelta;
+    // Accumulate unmatched references in first-seen order across all files.
+    for (const reference of unmatched) {
+      if (!unmatchedReferences.includes(reference)) {
+        unmatchedReferences.push(reference);
+      }
+    }
+
+    // Create the destination parent first so both write paths share one
+    // deterministic directory-preparation step.
+    const destParent = destinationPath.slice(
+      0,
+      destinationPath.lastIndexOf("/"),
+    );
+    fs.ensureDir(destParent);
+    fs.writeTextFile(destinationPath, rewrittenText);
+    fileResults.push({
+      relativePath,
+      destinationStatus,
+      rewrittenReferenceCount: rewrittenDelta,
+      placeholderRewriteCount: placeholderDelta,
+      unmatchedReferences: unmatched,
+    });
+  }
+
+  const finishedAt = now();
+  const provisionalSummary: PushDownSummary = {
+    repoRoot: toPosixPath(repoRoot),
+    destinationRoot: toPosixPath(destinationRoot),
+    startedAt,
+    finishedAt,
+    createdCount,
+    overwrittenCount,
+    rewrittenReferenceCount,
+    placeholderRewriteCount,
+    unmatchedReferences,
+    files: fileResults,
+    artifactPath: "",
+  };
+  const artifactPath = writeSummaryArtifact(
+    fs,
+    provisionalSummary,
+    effectiveArtifact,
+    effectiveArtifactDir,
+  );
+  return { ...provisionalSummary, artifactPath };
+}

--- a/extensions/drm-copilot/src/lib/push-down/copilot-customizations.ts
+++ b/extensions/drm-copilot/src/lib/push-down/copilot-customizations.ts
@@ -1,0 +1,102 @@
+/**
+ * Public/CLI-facing surface of the Copilot customization push-down publisher.
+ *
+ * Purpose:
+ *     Port the public entry points of `push_down_copilot_customizations.py`:
+ *     `resolveCliPath`, the `ARTIFACT_DIRECTORY` constant, and a public
+ *     `pushDownCustomizations` wrapper that defaults the rewrite function and
+ *     root folders to the copilot values. The orchestration engine lives in
+ *     `copilot-customizations-engine.ts`.
+ *
+ * Side effects:
+ *     Delegates all filesystem I/O to the injected {@link PushDownFileSystem}
+ *     via the engine.
+ */
+
+import * as nodePath from "node:path";
+
+import { type PushDownFileSystem } from "./filesystem-adapter";
+import {
+  ARTIFACT_DIRECTORY as ENGINE_ARTIFACT_DIRECTORY,
+  type Clock,
+  COPILOT_ROOT_FOLDERS,
+  type PushDownFileResult,
+  pushDownCustomizations as enginePushDown,
+  type PushDownSummary,
+} from "./copilot-customizations-engine";
+import {
+  rewriteTextReferences,
+  type RewriteFunction,
+} from "./reference-rewrites";
+
+export { type PushDownFileResult, type PushDownSummary, type Clock };
+
+/** Default artifact directory for the Copilot push-down summary. */
+export const ARTIFACT_DIRECTORY = ENGINE_ARTIFACT_DIRECTORY;
+
+/**
+ * Resolve CLI paths without breaking Windows-absolute paths on POSIX hosts.
+ *
+ * Purpose:
+ *     Port the Python `resolve_cli_path` guard. On a non-Windows host, a
+ *     Windows-absolute input (drive-letter or UNC) is returned expanded but not
+ *     resolved so test-injected Windows paths stay stable; otherwise the path is
+ *     resolved to an absolute form.
+ *
+ * @param pathValue CLI or test path value to normalize.
+ * @returns The expanded path, resolved only when host semantics match.
+ */
+export function resolveCliPath(pathValue: string): string {
+  const rawValue = pathValue;
+  // Detect a Windows-absolute path: a drive-letter root or a UNC path. On a
+  // POSIX host, Node's path.resolve would mangle these, so return them as-is.
+  const isWindowsAbsolute =
+    /^[A-Za-z]:[\\/]/.test(rawValue) || /^\\\\/.test(rawValue);
+  if (process.platform !== "win32" && isWindowsAbsolute) {
+    return rawValue;
+  }
+  return nodePath.resolve(rawValue);
+}
+
+/** Options for the public Copilot {@link pushDownCustomizations} wrapper. */
+export interface PushDownCustomizationsOptions {
+  readonly repoRoot: string;
+  readonly destinationRoot: string;
+  readonly fs: PushDownFileSystem;
+  readonly sourceRoot?: string;
+  readonly artifactRoot?: string;
+  readonly rootFolders?: ReadonlyArray<string>;
+  readonly artifactDirectory?: string;
+  readonly rewriteReferences?: RewriteFunction;
+  readonly clock?: Clock;
+}
+
+/**
+ * Public Copilot push-down entry point.
+ *
+ * Defaults `rewriteReferences` to {@link rewriteTextReferences} and `rootFolders`
+ * to the inlined copilot tuple, then delegates to the shared engine.
+ *
+ * @param options Public options (roots, filesystem, optional overrides).
+ * @returns The completed run summary including the written artifact path.
+ * @throws Error When destination validation fails.
+ */
+export function pushDownCustomizations(
+  options: PushDownCustomizationsOptions,
+): PushDownSummary {
+  return enginePushDown({
+    repoRoot: options.repoRoot,
+    destinationRoot: options.destinationRoot,
+    fs: options.fs,
+    ...(options.sourceRoot === undefined
+      ? {}
+      : { sourceRoot: options.sourceRoot }),
+    ...(options.artifactRoot === undefined
+      ? {}
+      : { artifactRoot: options.artifactRoot }),
+    rootFolders: options.rootFolders ?? COPILOT_ROOT_FOLDERS,
+    artifactDirectory: options.artifactDirectory ?? ARTIFACT_DIRECTORY,
+    rewriteReferences: options.rewriteReferences ?? rewriteTextReferences,
+    ...(options.clock === undefined ? {} : { clock: options.clock }),
+  });
+}

--- a/extensions/drm-copilot/src/lib/push-down/filesystem-adapter.ts
+++ b/extensions/drm-copilot/src/lib/push-down/filesystem-adapter.ts
@@ -1,0 +1,204 @@
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
+
+/**
+ * Filesystem contract required by the push-down customization publisher.
+ *
+ * Purpose:
+ *     Port the Python `PushDownFileSystem` Protocol
+ *     (`push_down_copilot_customizations_filesystem.py`). It provides the small,
+ *     typed seam the publisher engine uses so the core logic stays deterministic
+ *     in tests while the production CLI works against the real disk.
+ *
+ * Responsibilities:
+ *     - `listFiles`: enumerate every file beneath a root in sorted order so
+ *       summary artifacts and tests remain deterministic.
+ *     - `isDir` / `isFile`: reflect current filesystem state for destination
+ *       validation and created-vs-overwritten classification.
+ *     - `readTextFile` / `writeTextFile`: UTF-8 text I/O (writes LF-normalized).
+ *     - `ensureDir`: idempotent directory creation.
+ *
+ * Path convention:
+ *     All path arguments and returned paths are forward-slash POSIX strings.
+ *     This differs from the F1 `FileSystem` interface and is intentional: it
+ *     mirrors the Python `PushDownFileSystem` protocol shape one-to-one.
+ *
+ * Side effects:
+ *     Concrete implementations may touch the real filesystem.
+ */
+export interface PushDownFileSystem {
+  /**
+   * Return all files beneath `root` as sorted forward-slash POSIX paths.
+   *
+   * @param root Root directory to enumerate (POSIX path).
+   * @returns Sorted file paths beneath `root`; empty when `root` is not a
+   *   directory.
+   */
+  listFiles(root: string): string[];
+
+  /** Return true when `path` exists and is a directory. */
+  isDir(path: string): boolean;
+
+  /** Return true when `path` exists and is a regular file. */
+  isFile(path: string): boolean;
+
+  /** Read the file at `path` as UTF-8 text. */
+  readTextFile(path: string): string;
+
+  /** Write `content` to `path` as UTF-8 text (LF-normalized). */
+  writeTextFile(path: string, content: string): void;
+
+  /** Ensure the directory at `path` exists, creating parents as needed. */
+  ensureDir(path: string): void;
+}
+
+/**
+ * Normalize a path to forward-slash separators.
+ *
+ * @param value A path that may contain OS-specific separators.
+ * @returns The path with all backslashes converted to forward slashes.
+ */
+export function toPosixPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+/**
+ * Join a root and a relative path using forward-slash separators.
+ *
+ * @param root Base path.
+ * @param relative Path relative to the base.
+ * @returns The combined POSIX-style path.
+ */
+function joinPosix(root: string, relative: string): string {
+  const normalizedRoot = toPosixPath(root).replace(/\/+$/, "");
+  const normalizedRelative = toPosixPath(relative).replace(/^\/+/, "");
+  if (normalizedRoot === "") {
+    return normalizedRelative;
+  }
+  if (normalizedRelative === "") {
+    return normalizedRoot;
+  }
+  return `${normalizedRoot}/${normalizedRelative}`;
+}
+
+/**
+ * Production {@link PushDownFileSystem} backed by `node:fs`.
+ *
+ * Purpose:
+ *     Provide the real-disk behavior for source enumeration, destination writes,
+ *     and summary-artifact emission. Mirrors the Python
+ *     `RealPushDownFileSystem`: recursive sorted enumeration, UTF-8 reads, and
+ *     LF-normalized writes (Python `newline="\n"`).
+ *
+ * Invariants / Constraints:
+ *     The scoped customization trees contain repository text content, so this
+ *     adapter reads and writes UTF-8 text.
+ *
+ * Side effects:
+ *     Reads from and writes to the real filesystem.
+ */
+export class RealPushDownFileSystem implements PushDownFileSystem {
+  /**
+   * Return all files beneath a root path in sorted order.
+   *
+   * Mirrors Python `RealPushDownFileSystem.list_files`: returns an empty list
+   * when the root is not a directory, otherwise recursively collects every file
+   * and sorts the result so summary artifacts remain deterministic.
+   *
+   * @param root Root directory to enumerate (POSIX path).
+   * @returns Sorted forward-slash POSIX file paths beneath `root`.
+   */
+  listFiles(root: string): string[] {
+    const normalizedRoot = toPosixPath(root);
+    if (!this.isDir(normalizedRoot)) {
+      return [];
+    }
+
+    const files: string[] = [];
+    // Walk the tree recursively so every nested file is collected; sorting is
+    // applied once at the end to keep enumeration order stable for artifacts.
+    const walk = (currentDir: string): void => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(currentDir, { withFileTypes: true });
+      } catch {
+        // A directory that becomes unreadable mid-walk contributes no files.
+        return;
+      }
+      // Inspect each entry: record files and descend into subdirectories.
+      for (const entry of entries) {
+        const childPosix = joinPosix(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          walk(childPosix);
+        } else if (entry.isFile()) {
+          files.push(childPosix);
+        }
+      }
+    };
+
+    walk(normalizedRoot);
+    // Sort lexicographically to match Python's `sorted(files)` on POSIX paths.
+    return files.sort((left, right) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    );
+  }
+
+  /**
+   * @param path Path to inspect.
+   * @returns True when `path` exists and is a directory.
+   */
+  isDir(path: string): boolean {
+    try {
+      return fs.statSync(path).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * @param path Path to inspect.
+   * @returns True when `path` exists and is a regular file.
+   */
+  isFile(path: string): boolean {
+    try {
+      return fs.statSync(path).isFile();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * @param path File to read.
+   * @returns The file content decoded as UTF-8.
+   */
+  readTextFile(path: string): string {
+    return fs.readFileSync(path, "utf8");
+  }
+
+  /**
+   * Write UTF-8 text to a file path, creating parent directories first.
+   *
+   * Mirrors Python `RealPushDownFileSystem.write_text`, which creates the parent
+   * directory and writes with `newline="\n"`. Content is LF-normalized so the
+   * write is byte-stable regardless of the host line-ending convention.
+   *
+   * @param path Destination file path.
+   * @param content UTF-8 text to write.
+   */
+  writeTextFile(path: string, content: string): void {
+    const parent = nodePath.dirname(path);
+    fs.mkdirSync(parent, { recursive: true });
+    // Normalize CRLF/CR to LF so writes match Python's newline="\n" behavior.
+    const lfNormalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    fs.writeFileSync(path, lfNormalized, "utf8");
+  }
+
+  /**
+   * Ensure a directory exists, creating any missing parents.
+   *
+   * @param path Directory path to create.
+   */
+  ensureDir(path: string): void {
+    fs.mkdirSync(path, { recursive: true });
+  }
+}

--- a/extensions/drm-copilot/src/lib/push-down/push-down-service-call.ts
+++ b/extensions/drm-copilot/src/lib/push-down/push-down-service-call.ts
@@ -1,0 +1,180 @@
+/**
+ * In-process service wiring for the three push-down command variants.
+ *
+ * Purpose:
+ *     Hold the bodies that the three `RepoAutomationService` push-down methods
+ *     delegate to, so the service file stays within the 500-line limit while
+ *     preserving each method's observable return contract exactly. Mirrors the
+ *     F2/F4/F5 service-call precedents. Each function resolves the bundled
+ *     source root from the extension root, invokes the matching in-process
+ *     {@link pushDownCustomizations} port, and returns a
+ *     `RepoAutomationExecutionResult`-shaped record preserving the prior `tool`,
+ *     `summary`, and single-element `artifacts` contract.
+ *
+ * Side effects:
+ *     Reads bundled source files and writes destination files plus the summary
+ *     artifact through the injected {@link PushDownFileSystem}.
+ */
+
+import { normalizeGeneratedPath } from "../../repo-automation-service-support";
+import { type RepoAutomationToolName } from "../../repo-automation-tool-names";
+import { type PushDownFileSystem, toPosixPath } from "./filesystem-adapter";
+import { type Clock } from "./copilot-customizations-engine";
+import { pushDownCustomizations as pushDownCopilot } from "./copilot-customizations";
+import { pushDownCustomizations as pushDownCodexAgents } from "./codex-agents-customizations";
+import {
+  type CSharpVariant,
+  type MemoryMode,
+  pushDownCustomizations as pushDownClaude,
+} from "./claude-customizations";
+
+/** Preserved result shape of a push-down service call. */
+export interface PushDownServiceCallResult {
+  readonly tool: RepoAutomationToolName;
+  readonly workspaceRoot: string;
+  readonly summary: string;
+  readonly artifacts: ReadonlyArray<string>;
+}
+
+/** Common input for the copilot and codex/agents service calls. */
+export interface PushDownServiceCallInput {
+  /** Injected push-down filesystem (in-memory in tests, real in production). */
+  readonly fs: PushDownFileSystem;
+  /** Extension root used to resolve the bundled source tree. */
+  readonly extensionRoot: string;
+  /** Destination workspace root that receives the copied tree. */
+  readonly workspaceRoot: string;
+  /** Optional injected clock for deterministic artifact naming. */
+  readonly clock?: Clock;
+  /** Optional log sink wired to the service output channel. */
+  readonly log?: (message: string) => void;
+}
+
+/** Input for the Claude service call (adds pack/variant/memory selection). */
+export interface PushDownClaudeServiceCallInput extends PushDownServiceCallInput {
+  readonly packs?: ReadonlyArray<string>;
+  readonly csharpVariant?: CSharpVariant;
+  readonly memoryMode?: MemoryMode;
+}
+
+/**
+ * Join the extension root and a bundled relative directory using POSIX slashes.
+ *
+ * @param extensionRoot Extension root path.
+ * @param relativeDir Bundled relative directory.
+ * @returns The combined POSIX source root path.
+ */
+function bundledSourceRoot(extensionRoot: string, relativeDir: string): string {
+  const root = toPosixPath(extensionRoot).replace(/\/+$/, "");
+  return `${root}/${relativeDir}`;
+}
+
+/**
+ * Push the bundled Copilot customizations into the destination workspace.
+ *
+ * @param input Filesystem, extension root, workspace root, optional clock/log.
+ * @returns The preserved result record with the normalized artifact path.
+ */
+export function pushDownCopilotCustomizationsServiceCall(
+  input: PushDownServiceCallInput,
+): PushDownServiceCallResult {
+  const sourceRoot = bundledSourceRoot(
+    input.extensionRoot,
+    "resources/customizations",
+  );
+  const destinationRoot = toPosixPath(input.workspaceRoot);
+  const summary = pushDownCopilot({
+    repoRoot: sourceRoot,
+    destinationRoot,
+    fs: input.fs,
+    sourceRoot,
+    artifactRoot: destinationRoot,
+    ...(input.clock === undefined ? {} : { clock: input.clock }),
+  });
+  return {
+    tool: "push_down_copilot_customizations",
+    workspaceRoot: input.workspaceRoot,
+    summary:
+      "Pushed bundled Copilot customizations into the destination workspace.",
+    artifacts: [normalizeGeneratedPath(summary.artifactPath)],
+  };
+}
+
+/**
+ * Push the bundled Codex and agents customizations into the workspace.
+ *
+ * @param input Filesystem, extension root, workspace root, optional clock/log.
+ * @returns The preserved result record with the normalized artifact path.
+ */
+export function pushDownCodexAndAgentsCustomizationsServiceCall(
+  input: PushDownServiceCallInput,
+): PushDownServiceCallResult {
+  const sourceRoot = bundledSourceRoot(
+    input.extensionRoot,
+    "resources/codex-and-agents-customizations",
+  );
+  const destinationRoot = toPosixPath(input.workspaceRoot);
+  const summary = pushDownCodexAgents({
+    repoRoot: sourceRoot,
+    destinationRoot,
+    fs: input.fs,
+    sourceRoot,
+    artifactRoot: destinationRoot,
+    ...(input.clock === undefined ? {} : { clock: input.clock }),
+  });
+  return {
+    tool: "push_down_codex_and_agents_customizations",
+    workspaceRoot: input.workspaceRoot,
+    summary:
+      "Pushed bundled Codex and agents customizations into the destination workspace.",
+    artifacts: [normalizeGeneratedPath(summary.artifactPath)],
+  };
+}
+
+/**
+ * Push the bundled Claude Code customizations into the workspace.
+ *
+ * Threads the optional pack selection, C# variant, and memory mode into the
+ * in-process Claude port. The bundled source root is also the bundle root that
+ * holds the pack manifests and the legacy variant subtree.
+ *
+ * @param input Filesystem, extension root, workspace root, and optional
+ *   packs/csharpVariant/memoryMode plus clock/log.
+ * @returns The preserved result record with the normalized artifact path.
+ */
+export function pushDownClaudeCustomizationsServiceCall(
+  input: PushDownClaudeServiceCallInput,
+): PushDownServiceCallResult {
+  const sourceRoot = bundledSourceRoot(
+    input.extensionRoot,
+    "resources/claude-customizations",
+  );
+  const destinationRoot = toPosixPath(input.workspaceRoot);
+  // The bundled source root already is the claude-customizations directory, so
+  // it doubles as the bundle root (manifests and legacy variant live beneath).
+  const packs =
+    input.packs === undefined || input.packs.length === 0
+      ? null
+      : new Set(input.packs);
+  const summary = pushDownClaude({
+    repoRoot: sourceRoot,
+    destinationRoot,
+    fs: input.fs,
+    sourceRoot,
+    artifactRoot: destinationRoot,
+    bundleRoot: sourceRoot,
+    packs,
+    ...(input.csharpVariant === undefined
+      ? {}
+      : { csharpVariant: input.csharpVariant }),
+    ...(input.memoryMode === undefined ? {} : { memoryMode: input.memoryMode }),
+    ...(input.clock === undefined ? {} : { clock: input.clock }),
+  });
+  return {
+    tool: "push_down_claude_customizations",
+    workspaceRoot: input.workspaceRoot,
+    summary:
+      "Pushed bundled Claude Code customizations into the destination workspace.",
+    artifacts: [normalizeGeneratedPath(summary.artifactPath)],
+  };
+}

--- a/extensions/drm-copilot/src/lib/push-down/reference-rewrites.ts
+++ b/extensions/drm-copilot/src/lib/push-down/reference-rewrites.ts
@@ -1,0 +1,243 @@
+/**
+ * Reference rewrite helpers for the push-down customization publisher.
+ *
+ * Purpose:
+ *     Port `push_down_copilot_customizations_rewrites.py`. Keeps command-
+ *     reference normalization and the rewrite catalog separate from the
+ *     publisher's orchestration flow so each module stays cohesive and testable.
+ *
+ * Responsibilities:
+ *     - Recognize documented script references in copied text via a single
+ *       regex (`SCRIPT_REFERENCE_PATTERN`).
+ *     - Normalize a matched reference onto a canonical catalog key.
+ *     - Replace a known reference with a stable VS Code command reference while
+ *       preserving trailing prose punctuation.
+ *     - Report unknown references in deterministic first-seen order without
+ *       changing them.
+ *
+ * Side effects:
+ *     None. All functions are pure transformations from inputs to outputs.
+ */
+
+/** Trailing punctuation characters preserved during a rewrite. */
+export const TRAILING_PUNCTUATION = ".,;:!?)";
+
+/**
+ * Regex matching a documented script reference.
+ *
+ * Ported one-to-one from the Python `SCRIPT_REFERENCE_PATTERN`. It matches an
+ * optional `poetry run python -m` prefix, an optional `${workspaceFolder}`
+ * prefix (forward- or back-slash separated), then either a dotted
+ * `scripts.dev_tools.<...>` module path or a slash-separated
+ * `scripts/dev_tools/<...>` (or `dev-tools`) path. The global flag mirrors
+ * Python `re.sub` replacing every non-overlapping match.
+ */
+export const SCRIPT_REFERENCE_PATTERN =
+  /(?:(?:poetry\s+run\s+python\s+-m)\s+)?(?:\$\{workspaceFolder\}[\\/])?scripts(?:\.dev_tools\.[A-Za-z0-9_.]+|[\\/](?:dev_tools|dev-tools)[A-Za-z0-9_.\\/-]+)/g;
+
+/**
+ * Catalog entry mapping a normalized script reference to a VS Code command.
+ *
+ * Mirrors the Python frozen `RewriteTarget` dataclass.
+ */
+export interface RewriteTarget {
+  /** Canonical lookup key for a script reference. */
+  readonly normalizedKey: string;
+  /** VS Code command identifier. */
+  readonly commandId: string;
+  /** User-facing command title. */
+  readonly title: string;
+  /** Original script reference documented by the placeholder contract. */
+  readonly scriptReference: string;
+  /** Whether the command intentionally remains a placeholder. */
+  readonly isPlaceholder: boolean;
+}
+
+/**
+ * Build the command rewrite catalog for supported script references.
+ *
+ * Replicates the seven Python catalog entries exactly (key, command id, title,
+ * script reference, placeholder flag), keyed by normalized reference.
+ *
+ * @returns Catalog keyed by normalized reference.
+ */
+export function buildRewriteCatalog(): Map<string, RewriteTarget> {
+  const targets: ReadonlyArray<RewriteTarget> = [
+    {
+      normalizedKey: "scripts.dev_tools.pr_context.collector",
+      commandId: "drmCopilotExtension.collectPrContext",
+      title: "drm-copilot: Collect PR Context",
+      scriptReference: "scripts.dev_tools.pr_context.collector",
+      isPlaceholder: false,
+    },
+    {
+      normalizedKey: "scripts.dev_tools.new_active_feature_folder",
+      commandId: "drmCopilotExtension.newActiveFeatureFolder",
+      title: "drm-copilot: New Active Feature Folder",
+      scriptReference: "scripts.dev_tools.new_active_feature_folder",
+      isPlaceholder: false,
+    },
+    {
+      normalizedKey: "scripts.dev_tools.potential_to_issue",
+      commandId: "drmCopilotExtension.potentialToIssue",
+      title: "drm-copilot: Potential To Issue",
+      scriptReference: "scripts.dev_tools.potential_to_issue",
+      isPlaceholder: false,
+    },
+    {
+      normalizedKey: "scripts/dev_tools/new_potential_bug_entry.py",
+      commandId: "drmCopilotExtension.newPotentialBugEntry",
+      title: "drm-copilot: New Potential Bug Entry",
+      scriptReference: "scripts/dev_tools/new_potential_bug_entry.py",
+      isPlaceholder: false,
+    },
+    {
+      normalizedKey: "scripts/dev_tools/new-potential-entry.ps1",
+      commandId: "drmCopilotExtension.newPotentialEntry",
+      title: "drm-copilot: New Potential Entry",
+      scriptReference: "scripts/dev-tools/new-potential-entry.ps1",
+      isPlaceholder: false,
+    },
+    {
+      normalizedKey: "scripts.dev_tools.push_down_copilot_customizations",
+      commandId: "drmCopilotExtension.pushDownCopilotCustomizations",
+      title: "drm-copilot: Push Down Copilot Customizations",
+      scriptReference: "scripts.dev_tools.push_down_copilot_customizations",
+      isPlaceholder: false,
+    },
+    {
+      normalizedKey: "scripts/dev_tools/sync-agents-from-instructions.ps1",
+      commandId: "drmCopilotExtension.syncAgentsFromInstructions",
+      title: "drm-copilot: Sync AGENTS.md from Instructions",
+      scriptReference: "scripts/dev-tools/sync-agents-from-instructions.ps1",
+      isPlaceholder: false,
+    },
+  ];
+  const catalog = new Map<string, RewriteTarget>();
+  // Key each target by its normalized reference for O(1) lookup during rewrite.
+  for (const target of targets) {
+    catalog.set(target.normalizedKey, target);
+  }
+  return catalog;
+}
+
+/**
+ * Render a canonical textual command reference for copied files.
+ *
+ * @param target Catalog entry for the matched reference.
+ * @returns Stable textual command reference identical to the Python output.
+ */
+export function renderCommandReference(target: RewriteTarget): string {
+  return `VS Code command: \`${target.title}\` (command ID: \`${target.commandId}\`)`;
+}
+
+/**
+ * Normalize a matched textual reference before catalog lookup.
+ *
+ * Collapses the `poetry run python -m` prefix, `${workspaceFolder}` prefixes,
+ * backslash separators, and the `dev-tools` slash variant onto a single
+ * canonical key, mirroring the Python normalization order.
+ *
+ * @param referenceText Raw matched script reference.
+ * @returns Canonical lookup key.
+ */
+export function normalizeReferenceForLookup(referenceText: string): string {
+  let normalized = referenceText.trim();
+  normalized = normalized.replace(/^poetry\s+run\s+python\s+-m\s+/, "");
+  normalized = normalized.split("${workspaceFolder}\\").join("");
+  normalized = normalized.split("${workspaceFolder}/").join("");
+  normalized = normalized.split("\\").join("/");
+  normalized = normalized
+    .split("scripts/dev-tools/")
+    .join("scripts/dev_tools/");
+  return normalized;
+}
+
+/**
+ * Split a matched reference into its core text and trailing punctuation.
+ *
+ * @param referenceText Matched reference including any trailing punctuation.
+ * @returns A tuple of `[core, suffix]`.
+ */
+export function splitTrailingPunctuation(
+  referenceText: string,
+): [string, string] {
+  let core = referenceText;
+  let suffix = "";
+  // Peel trailing sentence punctuation so prose around a reference is preserved.
+  while (
+    core.length > 0 &&
+    TRAILING_PUNCTUATION.includes(core[core.length - 1]!)
+  ) {
+    suffix = core[core.length - 1]! + suffix;
+    core = core.slice(0, -1);
+  }
+  return [core, suffix];
+}
+
+/**
+ * Rewrite one matched script reference when it belongs to the catalog.
+ *
+ * @param referenceText Matched script reference text.
+ * @param catalog Lookup table keyed by normalized reference.
+ * @returns A tuple `[replacement, rewrittenDelta, placeholderDelta, unmatched]`.
+ */
+export function rewriteMatchedReference(
+  referenceText: string,
+  catalog: Map<string, RewriteTarget>,
+): [string, number, number, string[]] {
+  const [coreReference, suffix] = splitTrailingPunctuation(referenceText);
+  const normalizedReference = normalizeReferenceForLookup(coreReference);
+  const target = catalog.get(normalizedReference);
+  if (target === undefined) {
+    return [referenceText, 0, 0, [normalizedReference]];
+  }
+  const replacement = renderCommandReference(target) + suffix;
+  if (target.isPlaceholder) {
+    return [replacement, 0, 1, []];
+  }
+  return [replacement, 1, 0, []];
+}
+
+/**
+ * Rewrite supported script references within text content.
+ *
+ * Applies replacements only to matched references and reports unknown
+ * references without changing them, in deterministic first-seen order. Mirrors
+ * the Python `rewrite_text_references` return shape exactly.
+ *
+ * @param text Source text to rewrite.
+ * @returns A tuple `[rewrittenText, rewrittenCount, placeholderCount,
+ *   unmatchedRefs]`.
+ */
+export function rewriteTextReferences(
+  text: string,
+): [string, number, number, string[]] {
+  const catalog = buildRewriteCatalog();
+  let rewrittenCount = 0;
+  let placeholderCount = 0;
+  const unmatchedReferences: string[] = [];
+
+  // Replace every regex match while accumulating deterministic counters and
+  // preserving first-seen unmatched-reference order.
+  const rewrittenText = text.replace(SCRIPT_REFERENCE_PATTERN, (match) => {
+    const [replacement, rewrittenDelta, placeholderDelta, unmatched] =
+      rewriteMatchedReference(match, catalog);
+    rewrittenCount += rewrittenDelta;
+    placeholderCount += placeholderDelta;
+    // Record each new unmatched reference once, preserving first-seen order.
+    for (const reference of unmatched) {
+      if (!unmatchedReferences.includes(reference)) {
+        unmatchedReferences.push(reference);
+      }
+    }
+    return replacement;
+  });
+
+  return [rewrittenText, rewrittenCount, placeholderCount, unmatchedReferences];
+}
+
+/** Rewrite-function signature shared by the publisher engine. */
+export type RewriteFunction = (
+  text: string,
+) => [string, number, number, string[]];

--- a/extensions/drm-copilot/src/repo-automation-service-push-down.ts
+++ b/extensions/drm-copilot/src/repo-automation-service-push-down.ts
@@ -1,33 +1,135 @@
-import { type PushDownClaudeCustomizationsInput } from "./repo-automation-service";
-import { type ScriptExecutionOptions } from "./repo-automation-service-support";
-import { type RepoAutomationToolName } from "./repo-automation-tool-names";
+import {
+  type PushDownClaudeCustomizationsInput,
+  type RepoAutomationExecutionResult,
+} from "./repo-automation-service";
+import {
+  type CSharpVariant,
+  type MemoryMode,
+} from "./lib/push-down/claude-customizations";
+import { type PushDownFileSystem } from "./lib/push-down/filesystem-adapter";
+import {
+  pushDownClaudeCustomizationsServiceCall,
+  pushDownCodexAndAgentsCustomizationsServiceCall,
+  pushDownCopilotCustomizationsServiceCall,
+} from "./lib/push-down/push-down-service-call";
 
+/**
+ * Forwarded options for the in-process Claude customization push-down call.
+ *
+ * Replaces the prior Python arg-vector builder. The three push-down service
+ * methods now invoke the in-process TypeScript port (F3), so this builder only
+ * carries the destination workspace root plus the optional pack selection, C#
+ * variant, and memory mode forwarded to `pushDownClaudeCustomizationsServiceCall`.
+ */
+export interface PushDownClaudeServiceForwardedOptions {
+  /** Destination workspace root that receives the copied `.claude` tree. */
+  readonly workspaceRoot: string;
+  /** Optional language-pack selection. */
+  readonly packs?: ReadonlyArray<string>;
+  /** Optional C# toolchain variant. */
+  readonly csharpVariant?: CSharpVariant;
+  /** Optional agent-memory handling mode. */
+  readonly memoryMode?: MemoryMode;
+}
+
+/**
+ * Build the forwarded options for the in-process Claude push-down call.
+ *
+ * Carries the workspace root and only the optional selection fields that were
+ * supplied, so a no-field input forwards just the workspace root (matching the
+ * backward-compatible publish-everything default).
+ *
+ * @param input The Claude push-down service input.
+ * @returns Forwarded options for `pushDownClaudeCustomizationsServiceCall`.
+ */
 export function buildPushDownClaudeCustomizationsOptions(
   input: PushDownClaudeCustomizationsInput,
-): ScriptExecutionOptions & { tool: RepoAutomationToolName } {
-  // Start from the backward-compatible destination-only arg vector and append
-  // optional pack, variant, and memory-mode flags only when supplied so a
-  // no-field input spawns exactly ["--destination", workspaceRoot].
-  const args: string[] = ["--destination", input.workspaceRoot];
-  if (input.packs !== undefined && input.packs.length > 0) {
-    args.push("--packs", input.packs.join(","));
-  }
-  if (input.csharpVariant !== undefined) {
-    args.push("--csharp-variant", input.csharpVariant);
-  }
-  if (input.memoryMode !== undefined) {
-    args.push("--memory-mode", input.memoryMode);
-  }
+): PushDownClaudeServiceForwardedOptions {
   return {
-    tool: "push_down_claude_customizations",
-    runtimeKind: "python",
-    bundledRelativePath:
-      "resources/templates/push_down_claude_customizations.py",
     workspaceRoot: input.workspaceRoot,
-    invocationId: input.invocationId ?? "push_down_claude_customizations",
-    args,
-    summary:
-      "Pushed bundled Claude Code customizations into the destination workspace.",
-    stdoutArtifactPattern: /Wrote push-down summary artifact to:\s*(.+)/i,
+    ...(input.packs === undefined ? {} : { packs: input.packs }),
+    ...(input.csharpVariant === undefined
+      ? {}
+      : { csharpVariant: input.csharpVariant }),
+    ...(input.memoryMode === undefined ? {} : { memoryMode: input.memoryMode }),
   };
+}
+
+/** Dependencies the push-down service calls need from the service. */
+export interface PushDownServiceDeps {
+  /** Injected push-down filesystem. */
+  readonly fs: PushDownFileSystem;
+  /** Extension root used to resolve the bundled source tree. */
+  readonly extensionRoot: string;
+  /** Log sink wired to the service output channel. */
+  readonly log: (message: string) => void;
+}
+
+/**
+ * Run the in-process Copilot push-down service call.
+ *
+ * @param workspaceRoot Destination workspace root.
+ * @param deps The filesystem, extension root, and log sink from the service.
+ * @returns The preserved push-down execution result.
+ */
+export function runPushDownCopilotCustomizations(
+  workspaceRoot: string,
+  deps: PushDownServiceDeps,
+): RepoAutomationExecutionResult {
+  return pushDownCopilotCustomizationsServiceCall({
+    fs: deps.fs,
+    extensionRoot: deps.extensionRoot,
+    workspaceRoot,
+    log: deps.log,
+  });
+}
+
+/**
+ * Run the in-process Codex/agents push-down service call.
+ *
+ * @param workspaceRoot Destination workspace root.
+ * @param deps The filesystem, extension root, and log sink from the service.
+ * @returns The preserved push-down execution result.
+ */
+export function runPushDownCodexAndAgentsCustomizations(
+  workspaceRoot: string,
+  deps: PushDownServiceDeps,
+): RepoAutomationExecutionResult {
+  return pushDownCodexAndAgentsCustomizationsServiceCall({
+    fs: deps.fs,
+    extensionRoot: deps.extensionRoot,
+    workspaceRoot,
+    log: deps.log,
+  });
+}
+
+/**
+ * Run the in-process Claude push-down service call from a service input.
+ *
+ * Keeps the optional pack/variant/memory forwarding out of the service file so
+ * `repo-automation-service.ts` stays within the 500-line limit. Forwards only
+ * the optional fields that were supplied.
+ *
+ * @param input The Claude push-down service input.
+ * @param deps The filesystem, extension root, and log sink from the service.
+ * @returns The preserved push-down execution result.
+ */
+export function runPushDownClaudeCustomizations(
+  input: PushDownClaudeCustomizationsInput,
+  deps: PushDownServiceDeps,
+): RepoAutomationExecutionResult {
+  const forwarded = buildPushDownClaudeCustomizationsOptions(input);
+  return pushDownClaudeCustomizationsServiceCall({
+    fs: deps.fs,
+    extensionRoot: deps.extensionRoot,
+    workspaceRoot: forwarded.workspaceRoot,
+    log: deps.log,
+    ...(forwarded.packs === undefined ? {} : { packs: forwarded.packs }),
+    ...(forwarded.csharpVariant === undefined
+      ? {}
+      : { csharpVariant: forwarded.csharpVariant }),
+    ...(forwarded.memoryMode === undefined
+      ? {}
+      : { memoryMode: forwarded.memoryMode }),
+  });
 }

--- a/extensions/drm-copilot/src/repo-automation-service.ts
+++ b/extensions/drm-copilot/src/repo-automation-service.ts
@@ -11,7 +11,12 @@ import {
 } from "./repo-automation-service-support";
 import { type RepoAutomationToolName } from "./repo-automation-tool-names";
 import { buildPoshQcWorkflowArguments } from "./repo-automation-args";
-import { buildPushDownClaudeCustomizationsOptions } from "./repo-automation-service-push-down";
+import {
+  type PushDownServiceDeps,
+  runPushDownClaudeCustomizations,
+  runPushDownCodexAndAgentsCustomizations,
+  runPushDownCopilotCustomizations,
+} from "./repo-automation-service-push-down";
 import {
   buildNewActiveFeatureFolderOptions,
   buildRunCodexNativeConverterOptions,
@@ -31,6 +36,10 @@ import { type FileSystem, RealFileSystem } from "./lib/file-system";
 import { type CommandRunner, SubprocessRunner } from "./lib/subprocess-runner";
 import { validateOrchestrationServiceCall } from "./lib/validate/validate-orchestration-service-call";
 import { newPotentialBugEntryServiceCall } from "./lib/new-potential-bug-entry-service-call";
+import {
+  type PushDownFileSystem,
+  RealPushDownFileSystem,
+} from "./lib/push-down/filesystem-adapter";
 
 export interface RepoAutomationExecutionResult {
   readonly tool: RepoAutomationToolName;
@@ -160,6 +169,8 @@ export interface RepoAutomationServiceOptions {
   readonly fileSystem?: FileSystem;
   /** Command-runner for the in-process `collectCommitContext` git calls; defaults to {@link SubprocessRunner}, faked in tests. */
   readonly runner?: CommandRunner;
+  /** Optional push-down filesystem (distinct from {@link FileSystem}); tests inject an in-memory fake, production defaults to {@link RealPushDownFileSystem}. */
+  readonly pushDownFileSystem?: PushDownFileSystem;
 }
 
 class DefaultRepoAutomationService implements RepoAutomationService {
@@ -169,6 +180,7 @@ class DefaultRepoAutomationService implements RepoAutomationService {
   private readonly fileSystem: FileSystem;
   private readonly runner: CommandRunner;
   private readonly resolvePromptDeps: ResolvePromptServiceDeps;
+  private readonly pushDownDeps: PushDownServiceDeps;
 
   constructor(options: RepoAutomationServiceOptions) {
     this.extensionRoot = options.extensionRoot;
@@ -178,6 +190,11 @@ class DefaultRepoAutomationService implements RepoAutomationService {
     this.runner = options.runner ?? new SubprocessRunner();
     this.resolvePromptDeps = {
       fileSystem: this.fileSystem,
+      extensionRoot: this.extensionRoot,
+      log: (message) => this.output.appendLine(message),
+    };
+    this.pushDownDeps = {
+      fs: options.pushDownFileSystem ?? new RealPushDownFileSystem(),
       extensionRoot: this.extensionRoot,
       log: (message) => this.output.appendLine(message),
     };
@@ -232,40 +249,25 @@ class DefaultRepoAutomationService implements RepoAutomationService {
   async pushDownCopilotCustomizations(
     input: WorkspaceExecutionInput,
   ): Promise<RepoAutomationExecutionResult> {
-    return this.executeScript({
-      tool: "push_down_copilot_customizations",
-      runtimeKind: "python",
-      bundledRelativePath:
-        "resources/templates/push_down_copilot_customizations.py",
-      workspaceRoot: input.workspaceRoot,
-      invocationId: input.invocationId ?? "push_down_copilot_customizations",
-      args: ["--destination", input.workspaceRoot],
-      summary:
-        "Pushed bundled Copilot customizations into the destination workspace.",
-      stdoutArtifactPattern: /Wrote push-down summary artifact to:\s*(.+)/i,
-    });
+    // In-process TS port (F3): delegate to the push-down helper.
+    return runPushDownCopilotCustomizations(
+      input.workspaceRoot,
+      this.pushDownDeps,
+    );
   }
   async pushDownCodexAndAgentsCustomizations(
     input: WorkspaceExecutionInput,
   ): Promise<RepoAutomationExecutionResult> {
-    return this.executeScript({
-      tool: "push_down_codex_and_agents_customizations",
-      runtimeKind: "python",
-      bundledRelativePath:
-        "resources/templates/push_down_codex_and_agents_customizations.py",
-      workspaceRoot: input.workspaceRoot,
-      invocationId:
-        input.invocationId ?? "push_down_codex_and_agents_customizations",
-      args: ["--destination", input.workspaceRoot],
-      summary:
-        "Pushed bundled Codex and agents customizations into the destination workspace.",
-      stdoutArtifactPattern: /Wrote push-down summary artifact to:\s*(.+)/i,
-    });
+    return runPushDownCodexAndAgentsCustomizations(
+      input.workspaceRoot,
+      this.pushDownDeps,
+    );
   }
   async pushDownClaudeCustomizations(
     input: PushDownClaudeCustomizationsInput,
   ): Promise<RepoAutomationExecutionResult> {
-    return this.executeScript(buildPushDownClaudeCustomizationsOptions(input));
+    // In-process TS port (F3): the helper forwards optional pack/variant/memory.
+    return runPushDownClaudeCustomizations(input, this.pushDownDeps);
   }
   async newPotentialBugEntry(
     input: WorkspaceExecutionInput & { readonly shortName: string },

--- a/extensions/drm-copilot/test/extension-test-harness.ts
+++ b/extensions/drm-copilot/test/extension-test-harness.ts
@@ -127,6 +127,13 @@ jest.mock("node:fs", () => ({
   mkdirSync: jest.fn(),
   readFileSync: jest.fn(),
   writeFileSync: jest.fn(),
+  // statSync/readdirSync support the in-process push-down filesystem adapter
+  // (F3). They default to "not found"/"empty" so suites that do not seed a
+  // push-down tree are unaffected.
+  statSync: jest.fn(() => {
+    throw new Error("ENOENT");
+  }),
+  readdirSync: jest.fn(() => []),
 }));
 
 jest.mock("node:child_process", () => ({
@@ -145,6 +152,8 @@ const fsMock = jest.requireMock("node:fs") as {
   mkdirSync: jest.MockedFunction<
     (dirPath: string, options?: { recursive?: boolean }) => void
   >;
+  statSync: jest.MockedFunction<(filePath: string) => unknown>;
+  readdirSync: jest.MockedFunction<(dirPath: string) => unknown[]>;
 };
 
 const childProcessMock = jest.requireMock("node:child_process") as {
@@ -303,6 +312,12 @@ export function resetExtensionHarnessState(): void {
   fsMock.readFileSync.mockReset();
   fsMock.writeFileSync.mockReset();
   fsMock.mkdirSync.mockReset();
+  fsMock.statSync.mockReset();
+  fsMock.statSync.mockImplementation(() => {
+    throw new Error("ENOENT");
+  });
+  fsMock.readdirSync.mockReset();
+  fsMock.readdirSync.mockReturnValue([]);
   pyprojectFixtureContent = undefined;
   showInputBoxMock.mockReset();
   showQuickPickMock.mockReset();

--- a/extensions/drm-copilot/test/extension.integration.test.ts
+++ b/extensions/drm-copilot/test/extension.integration.test.ts
@@ -397,97 +397,17 @@ describe("drm-copilot integration behavior", () => {
     ).toBe(false);
   });
 
-  it("pushDownCopilotCustomizations executes bundled wrapper script in workspace", async () => {
-    await handlerFor("drmCopilotExtension.pushDownCopilotCustomizations")();
-
-    const [executable, args, options] = childProcessMock.spawn.mock
-      .calls[0] as [string, string[], { cwd: string }];
-    expect(executable).toBe("python");
-    expect(
-      normalizePath(args[0]).endsWith(
-        "resources/templates/push_down_copilot_customizations.py",
-      ),
-    ).toBe(true);
-    expect(options.cwd).toBe("C:/workspace");
-  });
-
-  it("pushDownCopilotCustomizations passes workspace root as --destination", async () => {
-    await handlerFor("drmCopilotExtension.pushDownCopilotCustomizations")();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    const destinationIndex = args.indexOf("--destination");
-    expect(destinationIndex).toBeGreaterThan(-1);
-    expect(args[destinationIndex + 1]).toBe("C:/workspace");
-  });
-
-  it("pushDownCopilotCustomizations falls back to py -3 when python is unavailable", async () => {
-    setExecutablePresence({ python: false, py: true, pwsh: true });
-
-    await handlerFor("drmCopilotExtension.pushDownCopilotCustomizations")();
-
-    const [executable, args, options] = childProcessMock.spawn.mock
-      .calls[0] as [string, string[], { cwd: string }];
-    expect(executable).toBe("py");
-    expect(args[0]).toBe("-3");
-    expect(
-      normalizePath(args[1]).endsWith(
-        "resources/templates/push_down_copilot_customizations.py",
-      ),
-    ).toBe(true);
-    const destinationIndex = args.indexOf("--destination");
-    expect(destinationIndex).toBeGreaterThan(-1);
-    expect(args[destinationIndex + 1]).toBe("C:/workspace");
-    expect(options.cwd).toBe("C:/workspace");
-  });
-
-  it("pushDownCodexAndAgentsCustomizations executes bundled wrapper script in workspace", async () => {
-    await handlerFor(
-      "drmCopilotExtension.pushDownCodexAndAgentsCustomizations",
-    )();
-
-    const [executable, args, options] = childProcessMock.spawn.mock
-      .calls[0] as [string, string[], { cwd: string }];
-    expect(executable).toBe("python");
-    expect(
-      normalizePath(args[0]).endsWith(
-        "resources/templates/push_down_codex_and_agents_customizations.py",
-      ),
-    ).toBe(true);
-    expect(options.cwd).toBe("C:/workspace");
-  });
-
-  it("pushDownCodexAndAgentsCustomizations passes workspace root as --destination", async () => {
-    await handlerFor(
-      "drmCopilotExtension.pushDownCodexAndAgentsCustomizations",
-    )();
-
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    const destinationIndex = args.indexOf("--destination");
-    expect(destinationIndex).toBeGreaterThan(-1);
-    expect(args[destinationIndex + 1]).toBe("C:/workspace");
-  });
-
-  it("pushDownCodexAndAgentsCustomizations falls back to py -3 when python is unavailable", async () => {
-    setExecutablePresence({ python: false, py: true, pwsh: true });
-
-    await handlerFor(
-      "drmCopilotExtension.pushDownCodexAndAgentsCustomizations",
-    )();
-
-    const [executable, args, options] = childProcessMock.spawn.mock
-      .calls[0] as [string, string[], { cwd: string }];
-    expect(executable).toBe("py");
-    expect(args[0]).toBe("-3");
-    expect(
-      normalizePath(args[1]).endsWith(
-        "resources/templates/push_down_codex_and_agents_customizations.py",
-      ),
-    ).toBe(true);
-    const destinationIndex = args.indexOf("--destination");
-    expect(destinationIndex).toBeGreaterThan(-1);
-    expect(args[destinationIndex + 1]).toBe("C:/workspace");
-    expect(options.cwd).toBe("C:/workspace");
-  });
+  // NOTE: The push-down copilot and codex/agents integration cases previously
+  // here asserted a bundled-Python spawn (executable === "python", bundled
+  // `resources/templates/push_down_*.py` path, py -3 fallback). F3 ported these
+  // two commands to the in-process TS path, so they no longer spawn Python. The
+  // in-process delegation and the preserved `tool`/`summary`/`artifacts`
+  // contract are covered by the service-call unit suite
+  // (`test/lib/push-down/push-down-service-call.test.ts`), mirroring the F4
+  // `collectCommitContext` precedent that removed its Python-spawn integration
+  // cases. Unrelated spawn-based cases (PowerShell commands and the still-Python
+  // commands such as `collect_pr_context` and `potential_to_issue`) are
+  // unchanged below.
 
   it("syncAgentsFromInstructions runs the bundled PowerShell template against the active workspace root", async () => {
     await handlerFor("drmCopilotExtension.syncAgentsFromInstructions")();

--- a/extensions/drm-copilot/test/extension.push-down-claude-customizations.test.ts
+++ b/extensions/drm-copilot/test/extension.push-down-claude-customizations.test.ts
@@ -9,10 +9,8 @@ import {
 
 import {
   activateAndGetHandler,
-  childProcessMock,
-  createMockProcess,
+  fsMock,
   resetExtensionHarnessState,
-  setExecutablePresence,
   showQuickPickMock,
 } from "./extension-test-harness";
 
@@ -22,12 +20,121 @@ interface PackQuickPickItem {
   readonly picked: boolean;
 }
 
+const EXT = "C:/extension";
+const WS = "C:/workspace";
+const BUNDLE = `${EXT}/resources/claude-customizations`;
+
 /**
- * Configure the shared showQuickPick mock to answer the push-down command's
- * three prompts in order: the multi-select pack QuickPick, the optional C#
- * variant prompt, and the memory-mode prompt. Passing `undefined` for any step
- * simulates cancellation at that step. The C# variant answer is consumed only
- * when the selected packs include C#.
+ * Seed the harness `node:fs` mock to back the in-process push-down filesystem
+ * with a minimal bundled `.claude` tree, a legacy C# variant subtree, and pack
+ * manifests, plus an existing destination workspace directory.
+ *
+ * Records destination writes so the test can assert which files were published.
+ *
+ * @returns A map of written destination paths to their content.
+ */
+function seedInProcessFileSystem(): Map<string, string> {
+  const files = new Map<string, string>([
+    [`${BUNDLE}/.claude/rules/typescript.md`, "# TS\n"],
+    [`${BUNDLE}/.claude/rules/csharp.md`, "# Modern C#\n"],
+    [`${BUNDLE}/.claude/agents/orchestrator.md`, "# Orchestrator\n"],
+    [
+      `${BUNDLE}/.claude-variants/csharp-legacy/rules/csharp.md`,
+      "# Legacy C#\n",
+    ],
+    [
+      `${BUNDLE}/pack-manifests/core.json`,
+      JSON.stringify({
+        name: "core",
+        label: "Core",
+        paths: [".claude/agents/orchestrator.md"],
+      }),
+    ],
+    [
+      `${BUNDLE}/pack-manifests/typescript.json`,
+      JSON.stringify({
+        name: "typescript",
+        label: "TypeScript",
+        paths: [".claude/rules/typescript.md"],
+      }),
+    ],
+    [
+      `${BUNDLE}/pack-manifests/csharp.json`,
+      JSON.stringify({
+        name: "csharp",
+        label: "C#",
+        paths: [".claude/rules/csharp.md"],
+      }),
+    ],
+  ]);
+  const dirs = new Set<string>([WS]);
+  // Register every ancestor directory of each seeded file as a directory.
+  for (const filePath of files.keys()) {
+    const segments = filePath.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      dirs.add(segments.slice(0, index).join("/"));
+    }
+  }
+
+  const writes = new Map<string, string>();
+
+  fsMock.statSync.mockImplementation((rawPath: string) => {
+    const path = rawPath.replace(/\\/g, "/").replace(/\/+$/, "");
+    if (files.has(path) || writes.has(path)) {
+      return { isFile: () => true, isDirectory: () => false };
+    }
+    if (dirs.has(path)) {
+      return { isFile: () => false, isDirectory: () => true };
+    }
+    throw new Error(`ENOENT: ${path}`);
+  });
+
+  fsMock.readdirSync.mockImplementation((rawDir: string) => {
+    const dir = rawDir.replace(/\\/g, "/").replace(/\/+$/, "");
+    const children = new Map<string, boolean>();
+    // Collect immediate children (files and subdirectories) of the directory.
+    for (const filePath of [...files.keys(), ...writes.keys()]) {
+      if (filePath.startsWith(`${dir}/`)) {
+        const remainder = filePath.slice(dir.length + 1);
+        const slash = remainder.indexOf("/");
+        if (slash === -1) {
+          children.set(remainder, false);
+        } else {
+          children.set(remainder.slice(0, slash), true);
+        }
+      }
+    }
+    return [...children.entries()].map(([name, isDir]) => ({
+      name,
+      isDirectory: () => isDir,
+      isFile: () => !isDir,
+    }));
+  });
+
+  fsMock.readFileSync.mockImplementation((rawPath: string) => {
+    const path = rawPath.replace(/\\/g, "/").replace(/\/+$/, "");
+    const content = writes.get(path) ?? files.get(path);
+    if (content === undefined) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    return content;
+  });
+
+  fsMock.writeFileSync.mockImplementation(
+    (rawPath: string, content: string) => {
+      writes.set(rawPath.replace(/\\/g, "/").replace(/\/+$/, ""), content);
+    },
+  );
+
+  fsMock.mkdirSync.mockReturnValue(undefined as never);
+
+  return writes;
+}
+
+/**
+ * Queue the push-down command's QuickPick prompt responses in order.
+ *
+ * @param input The pack selection and optional variant/memory responses.
  */
 function queuePushDownPrompts(input: {
   readonly packs: ReadonlyArray<string> | undefined;
@@ -35,7 +142,6 @@ function queuePushDownPrompts(input: {
   readonly memoryMode?: string | undefined;
 }): void {
   const responses: unknown[] = [];
-  // Multi-select returns an array of picked items; undefined is cancellation.
   if (input.packs === undefined) {
     responses.push(undefined);
   } else {
@@ -44,7 +150,6 @@ function queuePushDownPrompts(input: {
         (pack): PackQuickPickItem => ({ label: pack, pack, picked: true }),
       ),
     );
-    // The C# variant prompt only fires when C# was selected.
     if (input.packs.includes("csharp")) {
       responses.push(input.csharpVariant);
     }
@@ -73,107 +178,115 @@ describe("drm-copilot pushDownClaudeCustomizations command", () => {
     activateAndGetHandler("drmCopilotExtension.pushDownClaudeCustomizations");
   });
 
-  it("maps pack, C# variant, and memory selections to the spawned CLI args", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("maps pack and memory selections through to the in-process port", async () => {
+    // Arrange
+    const writes = seedInProcessFileSystem();
     queuePushDownPrompts({
-      packs: ["typescript", "csharp"],
-      csharpVariant: "legacy",
+      packs: ["typescript"],
       memoryMode: "merge",
     });
 
+    // Act
     const handler = activateAndGetHandler(
       "drmCopilotExtension.pushDownClaudeCustomizations",
     );
     await handler();
 
-    const [executable, args, options] = childProcessMock.spawn.mock
-      .calls[0] as [string, string[], { cwd: string }];
-    expect(executable).toBe("python");
-    expect(args).toContain("--destination");
-    expect(args).toContain("C:/workspace");
-    // The selected packs are joined into a single comma-separated value.
-    const packsIndex = args.indexOf("--packs");
-    expect(packsIndex).toBeGreaterThanOrEqual(0);
-    expect(args[packsIndex + 1]).toBe("typescript,csharp");
-    const variantIndex = args.indexOf("--csharp-variant");
-    expect(variantIndex).toBeGreaterThanOrEqual(0);
-    expect(args[variantIndex + 1]).toBe("legacy");
-    const memoryIndex = args.indexOf("--memory-mode");
-    expect(memoryIndex).toBeGreaterThanOrEqual(0);
-    expect(args[memoryIndex + 1]).toBe("merge");
-    expect(
-      args.some((a) => a.includes("push_down_claude_customizations")),
-    ).toBe(true);
-    expect(options.cwd).toBe("C:/workspace");
+    // Assert: the selected pack (plus always-core) reaches the in-process port,
+    // reflected in the destination writes.
+    expect(writes.has(`${WS}/.claude/rules/typescript.md`)).toBe(true);
+    expect(writes.has(`${WS}/.claude/agents/orchestrator.md`)).toBe(true);
+    // csharp was not selected, so its canonical path is not published.
+    expect(writes.has(`${WS}/.claude/rules/csharp.md`)).toBe(false);
   });
 
   it("skips the C# variant prompt when C# is not selected", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+    // Arrange
+    seedInProcessFileSystem();
     queuePushDownPrompts({
-      packs: ["python", "typescript"],
+      packs: ["typescript"],
       memoryMode: "overwrite",
     });
 
+    // Act
     const handler = activateAndGetHandler(
       "drmCopilotExtension.pushDownClaudeCustomizations",
     );
     await handler();
 
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    // No C# variant flag is added when C# was not among the selected packs.
-    expect(args).not.toContain("--csharp-variant");
-    const packsIndex = args.indexOf("--packs");
-    expect(args[packsIndex + 1]).toBe("python,typescript");
-    expect(args).toContain("--memory-mode");
-    // Only two QuickPick prompts are shown (packs, memory) without the variant.
+    // Assert: only two QuickPick prompts (packs, memory) without the variant.
     expect(showQuickPickMock.mock.calls).toHaveLength(2);
   });
 
-  it("aborts without invoking the service when the pack selection is cancelled", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
-    queuePushDownPrompts({ packs: undefined });
+  it("prompts for the C# variant when C# is selected", async () => {
+    // Arrange
+    seedInProcessFileSystem();
+    queuePushDownPrompts({
+      packs: ["csharp"],
+      csharpVariant: "legacy",
+      memoryMode: "overwrite",
+    });
 
+    // Act
     const handler = activateAndGetHandler(
       "drmCopilotExtension.pushDownClaudeCustomizations",
     );
     await handler();
 
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+    // Assert: three prompts fire (packs, variant, memory).
+    expect(showQuickPickMock.mock.calls).toHaveLength(3);
   });
 
-  it("aborts without invoking the service when the C# variant prompt is cancelled", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("aborts without publishing when the pack selection is cancelled", async () => {
+    // Arrange
+    const writes = seedInProcessFileSystem();
+    queuePushDownPrompts({ packs: undefined });
+
+    // Act
+    const handler = activateAndGetHandler(
+      "drmCopilotExtension.pushDownClaudeCustomizations",
+    );
+    await handler();
+
+    // Assert: no destination files were written.
+    expect(writes.size).toBe(0);
+    expect(showQuickPickMock.mock.calls).toHaveLength(1);
+  });
+
+  it("aborts without publishing when the C# variant prompt is cancelled", async () => {
+    // Arrange
+    const writes = seedInProcessFileSystem();
     queuePushDownPrompts({
       packs: ["csharp"],
       csharpVariant: undefined,
       memoryMode: "overwrite",
     });
 
+    // Act
     const handler = activateAndGetHandler(
       "drmCopilotExtension.pushDownClaudeCustomizations",
     );
     await handler();
 
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+    // Assert
+    expect(writes.size).toBe(0);
   });
 
-  it("aborts without invoking the service when the memory-mode prompt is cancelled", async () => {
-    setExecutablePresence({ python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("aborts without publishing when the memory-mode prompt is cancelled", async () => {
+    // Arrange
+    const writes = seedInProcessFileSystem();
     queuePushDownPrompts({
-      packs: ["python"],
+      packs: ["typescript"],
       memoryMode: undefined,
     });
 
+    // Act
     const handler = activateAndGetHandler(
       "drmCopilotExtension.pushDownClaudeCustomizations",
     );
     await handler();
 
-    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+    // Assert
+    expect(writes.size).toBe(0);
   });
 });

--- a/extensions/drm-copilot/test/lib/push-down/claude-customizations.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/claude-customizations.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  ARTIFACT_DIRECTORY,
+  ManifestError,
+  parsePacksArgument,
+  pushDownCustomizations,
+  ROOT_FOLDERS,
+} from "../../../src/lib/push-down/claude-customizations";
+import { buildInMemoryFileSystem, fixedClock } from "./push-down.test-helpers";
+
+const CLOCK = fixedClock("2026-06-26T00:15:00.000Z");
+const SRC = "/src";
+const DEST = "/dest";
+const BUNDLE = `${SRC}/extensions/drm-copilot/resources/claude-customizations`;
+const MANIFEST_DIR = `${BUNDLE}/pack-manifests`;
+const LEGACY_BASE = `${BUNDLE}/.claude-variants/csharp-legacy`;
+const CSHARP_PATHS = [
+  ".claude/rules/csharp.md",
+  ".claude/agents/csharp-typed-engineer.md",
+  ".claude/skills/csharp-qa-gate/SKILL.md",
+  ".claude/skills/invoke-csharp-engineer/SKILL.md",
+];
+
+/**
+ * Build a manifest JSON string for seeding.
+ *
+ * @param manifest Manifest fields to serialize.
+ * @returns Serialized manifest JSON.
+ */
+function manifest(manifest: Record<string, unknown>): string {
+  return JSON.stringify(manifest);
+}
+
+/**
+ * Seed a representative `.claude` tree, legacy variant subtree, and manifests.
+ *
+ * @returns A seeded in-memory filesystem with `/dest` ensured.
+ */
+function seedFullTree(): ReturnType<typeof buildInMemoryFileSystem> {
+  return buildInMemoryFileSystem(
+    {
+      [`${SRC}/.claude/settings.json`]: '{"core": true}\n',
+      [`${SRC}/.claude/settings.local.json`]: '{"host": true}\n',
+      [`${SRC}/.claude/agents/orchestrator.md`]: "# Orchestrator\n",
+      [`${SRC}/.claude/rules/typescript.md`]: "# TS rules\n",
+      [`${SRC}/.claude/rules/python.md`]: "# Python rules\n",
+      [`${SRC}/.claude/rules/csharp.md`]: "# Modern C#\n",
+      [`${SRC}/.claude/agents/csharp-typed-engineer.md`]: "# Modern engineer\n",
+      [`${SRC}/.claude/skills/csharp-qa-gate/SKILL.md`]: "# Modern qa\n",
+      [`${SRC}/.claude/skills/invoke-csharp-engineer/SKILL.md`]:
+        "# Modern inv\n",
+      [`${LEGACY_BASE}/rules/csharp.md`]: "# Legacy C#\n",
+      [`${LEGACY_BASE}/agents/csharp-typed-engineer.md`]: "# Legacy engineer\n",
+      [`${LEGACY_BASE}/skills/csharp-qa-gate/SKILL.md`]: "# Legacy qa\n",
+      [`${LEGACY_BASE}/skills/invoke-csharp-engineer/SKILL.md`]:
+        "# Legacy inv\n",
+      [`${MANIFEST_DIR}/core.json`]: manifest({
+        name: "core",
+        label: "Core",
+        paths: [".claude/settings.json", ".claude/agents/orchestrator.md"],
+      }),
+      [`${MANIFEST_DIR}/typescript.json`]: manifest({
+        name: "typescript",
+        label: "TypeScript",
+        paths: [".claude/rules/typescript.md"],
+      }),
+      [`${MANIFEST_DIR}/python.json`]: manifest({
+        name: "python",
+        label: "Python",
+        paths: [".claude/rules/python.md"],
+      }),
+      [`${MANIFEST_DIR}/csharp-modern.json`]: manifest({
+        name: "csharp-modern",
+        label: "C# Modern",
+        paths: CSHARP_PATHS,
+      }),
+      [`${MANIFEST_DIR}/csharp-legacy.json`]: manifest({
+        name: "csharp-legacy",
+        label: "C# Legacy",
+        paths: CSHARP_PATHS,
+        source_prefix: ".claude-variants/csharp-legacy",
+      }),
+    },
+    [DEST],
+  );
+}
+
+describe("parsePacksArgument", () => {
+  it("returns null when the value is null or undefined", () => {
+    // Arrange / Act / Assert
+    expect(parsePacksArgument(null)).toBeNull();
+    expect(parsePacksArgument(undefined)).toBeNull();
+  });
+
+  it("returns null when the value contains only empty entries", () => {
+    // Arrange / Act / Assert
+    expect(parsePacksArgument(" , , ")).toBeNull();
+  });
+
+  it("trims entries and drops empties", () => {
+    // Arrange / Act
+    const result = parsePacksArgument("core, typescript ,, python,");
+
+    // Assert
+    expect([...(result ?? [])].sort()).toEqual([
+      "core",
+      "python",
+      "typescript",
+    ]);
+  });
+});
+
+describe("pushDownCustomizations (claude)", () => {
+  it("publishes the full tree with no manifest read when no packs are selected", () => {
+    // Arrange: no manifests seeded; a manifest read would throw.
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${SRC}/.claude/rules/typescript.md`]: "# TS\n",
+        [`${SRC}/.claude/settings.local.json`]: "{}",
+      },
+      [DEST],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: SRC,
+      destinationRoot: DEST,
+      fs,
+      sourceRoot: SRC,
+      artifactRoot: DEST,
+      clock: CLOCK,
+    });
+
+    // Assert: everything except settings.local.json is published.
+    const relativePaths = summary.files.map((f) => f.relativePath);
+    expect(relativePaths).toContain(".claude/rules/typescript.md");
+    expect(relativePaths).not.toContain(".claude/settings.local.json");
+  });
+
+  it("restricts published paths to the selection and always includes core", () => {
+    // Arrange
+    const fs = seedFullTree();
+
+    // Act: select only typescript; core must still be published.
+    const summary = pushDownCustomizations({
+      repoRoot: SRC,
+      destinationRoot: DEST,
+      fs,
+      sourceRoot: SRC,
+      artifactRoot: DEST,
+      packs: new Set(["typescript"]),
+      bundleRoot: BUNDLE,
+      clock: CLOCK,
+    });
+
+    // Assert
+    const relativePaths = summary.files.map((f) => f.relativePath).sort();
+    expect(relativePaths).toEqual(
+      [
+        ".claude/settings.json",
+        ".claude/agents/orchestrator.md",
+        ".claude/rules/typescript.md",
+      ].sort(),
+    );
+  });
+
+  it("routes legacy C# reads to the legacy source while writing canonical paths", () => {
+    // Arrange
+    const fs = seedFullTree();
+
+    // Act
+    pushDownCustomizations({
+      repoRoot: SRC,
+      destinationRoot: DEST,
+      fs,
+      sourceRoot: SRC,
+      artifactRoot: DEST,
+      packs: new Set(["csharp-legacy"]),
+      csharpVariant: "legacy",
+      bundleRoot: BUNDLE,
+      clock: CLOCK,
+    });
+
+    // Assert: the canonical destination path receives legacy content.
+    expect(fs.readTextFile(`${DEST}/.claude/rules/csharp.md`)).toBe(
+      "# Legacy C#\n",
+    );
+  });
+
+  it("raises the exclusion ManifestError when both C# packs are selected", () => {
+    // Arrange
+    const fs = seedFullTree();
+
+    // Act / Assert
+    expect(() =>
+      pushDownCustomizations({
+        repoRoot: SRC,
+        destinationRoot: DEST,
+        fs,
+        sourceRoot: SRC,
+        artifactRoot: DEST,
+        packs: new Set(["csharp-modern", "csharp-legacy"]),
+        bundleRoot: BUNDLE,
+        clock: CLOCK,
+      }),
+    ).toThrow(ManifestError);
+  });
+
+  it("threads the skip memory mode through to ExcludingFileSystem", () => {
+    // Arrange: a general agent memory that skip mode must exclude.
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${SRC}/.claude/agent-memory/o/g.md`]:
+          "---\nmetadata:\n  scope: general\n---\nbody\n",
+        [`${SRC}/.claude/rules/python.md`]: "# Python\n",
+      },
+      [DEST],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: SRC,
+      destinationRoot: DEST,
+      fs,
+      sourceRoot: SRC,
+      artifactRoot: DEST,
+      memoryMode: "skip",
+      clock: CLOCK,
+    });
+
+    // Assert: the memory is skipped; the rule survives.
+    const relativePaths = summary.files.map((f) => f.relativePath);
+    expect(relativePaths).toContain(".claude/rules/python.md");
+    expect(relativePaths).not.toContain(".claude/agent-memory/o/g.md");
+  });
+
+  it("excludes settings.local.json from the published set", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${SRC}/.claude/settings.local.json`]: "{}",
+        [`${SRC}/.claude/rules/python.md`]: "# Python\n",
+      },
+      [DEST],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: SRC,
+      destinationRoot: DEST,
+      fs,
+      sourceRoot: SRC,
+      artifactRoot: DEST,
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(summary.files.map((f) => f.relativePath)).not.toContain(
+      ".claude/settings.local.json",
+    );
+  });
+
+  it("writes the summary artifact under the claude artifact directory", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      { [`${SRC}/.claude/rules/python.md`]: "# Python\n" },
+      [DEST],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: SRC,
+      destinationRoot: DEST,
+      fs,
+      sourceRoot: SRC,
+      artifactRoot: DEST,
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(summary.artifactPath).toBe(
+      `${DEST}/artifacts/claude-customizations/push-down-20260626T001500Z.json`,
+    );
+    expect(ARTIFACT_DIRECTORY).toBe("artifacts/claude-customizations");
+    expect(ROOT_FOLDERS).toEqual([".claude"]);
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/claude-filesystem-adapter.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/claude-filesystem-adapter.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  ExcludingFileSystem,
+  isGeneralMemoryFile,
+  readMemoryScope,
+} from "../../../src/lib/push-down/claude-filesystem-adapter";
+import { buildInMemoryFileSystem } from "./push-down.test-helpers";
+
+describe("readMemoryScope", () => {
+  it("returns general for an exact metadata.scope: general value", () => {
+    // Arrange
+    const content =
+      "---\nname: x\nmetadata:\n  type: feedback\n  scope: general\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("general");
+  });
+
+  it("returns general for a double-quoted general value", () => {
+    // Arrange
+    const content = '---\nname: x\nmetadata:\n  scope: "general"\n---\nbody\n';
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("general");
+  });
+
+  it("returns general for a single-quoted general value", () => {
+    // Arrange: exercise the single-quote stripping branch.
+    const content = "---\nname: x\nmetadata:\n  scope: 'general'\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("general");
+  });
+
+  it("returns general when an inline comment follows the value", () => {
+    // Arrange
+    const content =
+      "---\nname: x\nmetadata:\n  scope: general # distribute\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("general");
+  });
+
+  it("returns repo for an exact repo value", () => {
+    // Arrange
+    const content =
+      "---\nname: x\nmetadata:\n  type: project\n  scope: repo\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("repo");
+  });
+
+  it("defaults to repo when the scope leaf is absent", () => {
+    // Arrange
+    const content = "---\nname: x\nmetadata:\n  type: feedback\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("repo");
+  });
+
+  it("defaults to repo when the metadata block is absent", () => {
+    // Arrange
+    const content = "---\nname: x\ntype: feedback\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("repo");
+  });
+
+  it("defaults to repo when frontmatter is missing", () => {
+    // Arrange
+    const content = "# A plain markdown file\n\nNo frontmatter here.\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("repo");
+  });
+
+  it("defaults to repo when frontmatter has no closing delimiter", () => {
+    // Arrange
+    const content =
+      "---\nname: x\nmetadata:\n  scope: general\nbody without close\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("repo");
+  });
+
+  it("defaults to repo for any non-general scope value", () => {
+    // Arrange
+    const content = "---\nname: x\nmetadata:\n  scope: worldwide\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("repo");
+  });
+
+  it("ignores a top-level scope outside the metadata block (fail-safe repo)", () => {
+    // Arrange: scope is at column zero, not inside metadata.
+    const content =
+      "---\nname: x\nscope: general\nmetadata:\n  type: feedback\n---\nbody\n";
+
+    // Act / Assert
+    expect(readMemoryScope(content)).toBe("repo");
+  });
+});
+
+describe("isGeneralMemoryFile", () => {
+  it("returns true for a general-scoped agent-memory file", () => {
+    // Arrange
+    const content = "---\nmetadata:\n  scope: general\n---\nbody\n";
+
+    // Act / Assert
+    expect(
+      isGeneralMemoryFile(".claude/agent-memory/orchestrator/m.md", content),
+    ).toBe(true);
+  });
+
+  it("returns false for a repo-scoped agent-memory file", () => {
+    // Arrange
+    const content = "---\nmetadata:\n  scope: repo\n---\nbody\n";
+
+    // Act / Assert
+    expect(
+      isGeneralMemoryFile(".claude/agent-memory/orchestrator/m.md", content),
+    ).toBe(false);
+  });
+
+  it("returns true for a file outside the agent-memory subtree regardless of scope", () => {
+    // Arrange
+    const content = "---\nmetadata:\n  scope: repo\n---\nbody\n";
+
+    // Act / Assert
+    expect(isGeneralMemoryFile(".claude/rules/python.md", content)).toBe(true);
+  });
+});
+
+describe("ExcludingFileSystem", () => {
+  it("excludes a hard-excluded settings.local.json from enumeration", () => {
+    // Arrange
+    const inner = buildInMemoryFileSystem({
+      "/repo/.claude/settings.local.json": "{}",
+      "/repo/.claude/rules/general.md": "rule",
+    });
+    const sut = new ExcludingFileSystem(
+      inner,
+      "/repo",
+      [".claude/settings.local.json"],
+      { sourceRoot: "/repo" },
+    );
+
+    // Act
+    const listed = sut.listFiles("/repo/.claude");
+
+    // Assert
+    expect(listed).toEqual(["/repo/.claude/rules/general.md"]);
+  });
+
+  it("restricts enumeration to the active published set", () => {
+    // Arrange
+    const inner = buildInMemoryFileSystem({
+      "/repo/.claude/rules/general.md": "core rule",
+      "/repo/.claude/rules/python.md": "python rule",
+    });
+    const sut = new ExcludingFileSystem(inner, "/repo", [], {
+      sourceRoot: "/repo",
+      publishedPaths: new Set([".claude/rules/general.md"]),
+    });
+
+    // Act
+    const listed = sut.listFiles("/repo/.claude");
+
+    // Assert: only the published path survives the pack filter.
+    expect(listed).toEqual(["/repo/.claude/rules/general.md"]);
+  });
+
+  it("excludes a non-general agent memory via the scope filter", () => {
+    // Arrange
+    const inner = buildInMemoryFileSystem({
+      "/repo/.claude/agent-memory/o/m.md":
+        "---\nmetadata:\n  scope: repo\n---\nbody\n",
+      "/repo/.claude/agent-memory/o/g.md":
+        "---\nmetadata:\n  scope: general\n---\nbody\n",
+    });
+    const sut = new ExcludingFileSystem(inner, "/repo", [], {
+      sourceRoot: "/repo",
+    });
+
+    // Act
+    const listed = sut.listFiles("/repo/.claude");
+
+    // Assert: only the general-scoped memory passes the scope filter.
+    expect(listed).toEqual(["/repo/.claude/agent-memory/o/g.md"]);
+  });
+
+  it("memory mode skip excludes the entire agent-memory subtree", () => {
+    // Arrange
+    const inner = buildInMemoryFileSystem({
+      "/repo/.claude/agent-memory/o/g.md":
+        "---\nmetadata:\n  scope: general\n---\nbody\n",
+      "/repo/.claude/rules/general.md": "rule",
+    });
+    const sut = new ExcludingFileSystem(inner, "/repo", [], {
+      sourceRoot: "/repo",
+      memoryMode: "skip",
+    });
+
+    // Act
+    const listed = sut.listFiles("/repo/.claude");
+
+    // Assert: the rule survives; all agent memories are dropped.
+    expect(listed).toEqual(["/repo/.claude/rules/general.md"]);
+  });
+
+  it("memory mode merge excludes only memories already present at destination", () => {
+    // Arrange: g1 exists at destination, g2 does not.
+    const inner = buildInMemoryFileSystem({
+      "/repo/.claude/agent-memory/o/g1.md":
+        "---\nmetadata:\n  scope: general\n---\nbody\n",
+      "/repo/.claude/agent-memory/o/g2.md":
+        "---\nmetadata:\n  scope: general\n---\nbody\n",
+      "/dest/.claude/agent-memory/o/g1.md": "existing destination memory",
+    });
+    const sut = new ExcludingFileSystem(inner, "/repo", [], {
+      sourceRoot: "/repo",
+      destinationRoot: "/dest",
+      memoryMode: "merge",
+    });
+
+    // Act
+    const listed = sut.listFiles("/repo/.claude");
+
+    // Assert: g1 (present at dest) excluded; g2 (new) included.
+    expect(listed).toEqual(["/repo/.claude/agent-memory/o/g2.md"]);
+  });
+
+  it("memory mode overwrite includes every general agent memory", () => {
+    // Arrange
+    const inner = buildInMemoryFileSystem({
+      "/repo/.claude/agent-memory/o/g1.md":
+        "---\nmetadata:\n  scope: general\n---\nbody\n",
+      "/dest/.claude/agent-memory/o/g1.md": "existing",
+    });
+    const sut = new ExcludingFileSystem(inner, "/repo", [], {
+      sourceRoot: "/repo",
+      destinationRoot: "/dest",
+      memoryMode: "overwrite",
+    });
+
+    // Act
+    const listed = sut.listFiles("/repo/.claude");
+
+    // Assert
+    expect(listed).toEqual(["/repo/.claude/agent-memory/o/g1.md"]);
+  });
+
+  it("redirects legacy C# canonical reads to the legacy variant source", () => {
+    // Arrange: canonical destination path read should come from the legacy tree.
+    const inner = buildInMemoryFileSystem({
+      "/bundle/.claude-variants/csharp-legacy/rules/csharp.md": "legacy body",
+      "/bundle/.claude/rules/csharp.md": "modern body",
+    });
+    const sut = new ExcludingFileSystem(inner, "/bundle", [], {
+      sourceRoot: "/bundle",
+      variantRoot: "/bundle",
+      csharpVariant: "legacy",
+    });
+
+    // Act
+    const text = sut.readTextFile("/bundle/.claude/rules/csharp.md");
+
+    // Assert: the read is served from the legacy variant subtree.
+    expect(text).toBe("legacy body");
+  });
+
+  it("passes a modern C# read through to the canonical source", () => {
+    // Arrange
+    const inner = buildInMemoryFileSystem({
+      "/bundle/.claude/rules/csharp.md": "modern body",
+    });
+    const sut = new ExcludingFileSystem(inner, "/bundle", [], {
+      sourceRoot: "/bundle",
+      variantRoot: "/bundle",
+      csharpVariant: "modern",
+    });
+
+    // Act / Assert
+    expect(sut.readTextFile("/bundle/.claude/rules/csharp.md")).toBe(
+      "modern body",
+    );
+  });
+
+  it("delegates isDir, isFile, writeTextFile, and ensureDir to the inner adapter", () => {
+    // Arrange
+    const inner = buildInMemoryFileSystem({}, ["/repo/.claude"]);
+    const sut = new ExcludingFileSystem(inner, "/repo", [], {
+      sourceRoot: "/repo",
+    });
+
+    // Act
+    sut.ensureDir("/repo/out");
+    sut.writeTextFile("/repo/out/a.md", "x");
+
+    // Assert
+    expect(sut.isDir("/repo/.claude")).toBe(true);
+    expect(sut.isFile("/repo/out/a.md")).toBe(true);
+    expect(inner.readTextFile("/repo/out/a.md")).toBe("x");
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/claude-pack-selection.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/claude-pack-selection.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  assertSingleCsharpToolchain,
+  computePublishedPaths,
+  loadPackManifests,
+  ManifestError,
+  resolveVariantSourcePath,
+  type PackManifest,
+} from "../../../src/lib/push-down/claude-pack-selection";
+import { buildInMemoryFileSystem } from "./push-down.test-helpers";
+
+const MANIFEST_DIR = "/bundle/pack-manifests";
+
+/**
+ * Build a manifest JSON string for seeding the in-memory filesystem.
+ *
+ * @param manifest Partial manifest fields to serialize.
+ * @returns A JSON manifest string.
+ */
+function manifestJson(manifest: Record<string, unknown>): string {
+  return JSON.stringify(manifest);
+}
+
+describe("loadPackManifests", () => {
+  it("loads selected manifests and always includes core", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson({
+        name: "core",
+        label: "Core",
+        paths: [".claude/rules/general.md"],
+      }),
+      [`${MANIFEST_DIR}/python.json`]: manifestJson({
+        name: "python",
+        label: "Python",
+        paths: [".claude/rules/python.md"],
+      }),
+    });
+
+    // Act
+    const manifests = loadPackManifests(MANIFEST_DIR, new Set(["python"]), fs);
+
+    // Assert: core loaded even though only python was selected.
+    expect([...manifests.keys()].sort()).toEqual(["core", "python"]);
+    expect(manifests.get("python")?.paths).toEqual([".claude/rules/python.md"]);
+  });
+
+  it("rejects a missing manifest with the exact message", () => {
+    // Arrange: only core present, python missing.
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson({
+        name: "core",
+        label: "Core",
+        paths: [],
+      }),
+    });
+
+    // Act / Assert
+    expect(() =>
+      loadPackManifests(MANIFEST_DIR, new Set(["python"]), fs),
+    ).toThrow(
+      `Pack manifest is missing for pack 'python': ${MANIFEST_DIR}/python.json`,
+    );
+  });
+
+  it("rejects invalid JSON with the exact message", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: "{ not json",
+    });
+
+    // Act / Assert
+    expect(() => loadPackManifests(MANIFEST_DIR, new Set(), fs)).toThrow(
+      `Pack manifest is not valid JSON for pack 'core': ${MANIFEST_DIR}/core.json`,
+    );
+  });
+
+  it("rejects a non-object manifest with the exact message", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson([1, 2, 3]),
+    });
+
+    // Act / Assert
+    expect(() => loadPackManifests(MANIFEST_DIR, new Set(), fs)).toThrow(
+      `Pack manifest must be a JSON object for pack 'core': ${MANIFEST_DIR}/core.json`,
+    );
+  });
+
+  it("rejects a manifest with an empty name", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson({
+        name: "",
+        label: "Core",
+        paths: [],
+      }),
+    });
+
+    // Act / Assert
+    expect(() => loadPackManifests(MANIFEST_DIR, new Set(), fs)).toThrow(
+      `Pack manifest 'name' must be a non-empty string: ${MANIFEST_DIR}/core.json`,
+    );
+  });
+
+  it("rejects a manifest with an empty label", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson({
+        name: "core",
+        label: "",
+        paths: [],
+      }),
+    });
+
+    // Act / Assert
+    expect(() => loadPackManifests(MANIFEST_DIR, new Set(), fs)).toThrow(
+      `Pack manifest 'label' must be a non-empty string: ${MANIFEST_DIR}/core.json`,
+    );
+  });
+
+  it("rejects a manifest whose paths is not a list", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson({
+        name: "core",
+        label: "Core",
+        paths: "not-a-list",
+      }),
+    });
+
+    // Act / Assert
+    expect(() => loadPackManifests(MANIFEST_DIR, new Set(), fs)).toThrow(
+      `Pack manifest 'paths' must be a list of strings: ${MANIFEST_DIR}/core.json`,
+    );
+  });
+
+  it("rejects a manifest with a non-string path entry", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson({
+        name: "core",
+        label: "Core",
+        paths: [".claude/rules/general.md", 42],
+      }),
+    });
+
+    // Act / Assert
+    expect(() => loadPackManifests(MANIFEST_DIR, new Set(), fs)).toThrow(
+      `Pack manifest 'paths' must be a list of strings: ${MANIFEST_DIR}/core.json`,
+    );
+  });
+
+  it("rejects a manifest whose source_prefix is not a string", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({
+      [`${MANIFEST_DIR}/core.json`]: manifestJson({
+        name: "core",
+        label: "Core",
+        paths: [],
+        source_prefix: 5,
+      }),
+    });
+
+    // Act / Assert
+    expect(() => loadPackManifests(MANIFEST_DIR, new Set(), fs)).toThrow(
+      `Pack manifest 'source_prefix' must be a string when present: ${MANIFEST_DIR}/core.json`,
+    );
+  });
+});
+
+describe("computePublishedPaths", () => {
+  const manifests = new Map<string, PackManifest>([
+    [
+      "core",
+      {
+        name: "core",
+        label: "Core",
+        paths: [".claude/rules/general.md"],
+        sourcePrefix: null,
+      },
+    ],
+    [
+      "python",
+      {
+        name: "python",
+        label: "Python",
+        paths: [".claude/rules/python.md"],
+        sourcePrefix: null,
+      },
+    ],
+  ]);
+
+  it("returns null for an empty selection (publish everything)", () => {
+    // Arrange / Act / Assert
+    expect(computePublishedPaths(null, manifests)).toBeNull();
+    expect(computePublishedPaths(new Set(), manifests)).toBeNull();
+  });
+
+  it("unions selected pack paths and always includes core", () => {
+    // Arrange / Act
+    const published = computePublishedPaths(new Set(["python"]), manifests);
+
+    // Assert
+    expect([...(published ?? [])].sort()).toEqual([
+      ".claude/rules/general.md",
+      ".claude/rules/python.md",
+    ]);
+  });
+
+  it("throws when a selected pack has no loaded manifest", () => {
+    // Arrange / Act / Assert
+    expect(() =>
+      computePublishedPaths(new Set(["missing"]), manifests),
+    ).toThrow("No loaded manifest for selected pack 'missing'.");
+  });
+});
+
+describe("resolveVariantSourcePath", () => {
+  it("routes a canonical C# path to the legacy source for the legacy variant", () => {
+    // Arrange / Act / Assert
+    expect(resolveVariantSourcePath(".claude/rules/csharp.md", "legacy")).toBe(
+      ".claude-variants/csharp-legacy/rules/csharp.md",
+    );
+  });
+
+  it("passes a canonical C# path through unchanged for the modern variant", () => {
+    // Arrange / Act / Assert
+    expect(resolveVariantSourcePath(".claude/rules/csharp.md", "modern")).toBe(
+      ".claude/rules/csharp.md",
+    );
+  });
+
+  it("passes a non-C# path through unchanged even for the legacy variant", () => {
+    // Arrange / Act / Assert
+    expect(resolveVariantSourcePath(".claude/rules/python.md", "legacy")).toBe(
+      ".claude/rules/python.md",
+    );
+  });
+});
+
+describe("assertSingleCsharpToolchain", () => {
+  it("rejects selecting both C# packs", () => {
+    // Arrange / Act / Assert
+    expect(() =>
+      assertSingleCsharpToolchain(
+        new Set([".claude/rules/csharp.md"]),
+        new Set(["csharp-modern", "csharp-legacy"]),
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  it("accepts selecting a single C# variant", () => {
+    // Arrange / Act / Assert: no throw.
+    expect(() =>
+      assertSingleCsharpToolchain(
+        new Set([".claude/rules/csharp.md"]),
+        new Set(["csharp-legacy"]),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/codex-agents-customizations.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/codex-agents-customizations.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  ARTIFACT_DIRECTORY,
+  ROOT_FOLDERS,
+  passthroughRewrite,
+  pushDownCustomizations,
+} from "../../../src/lib/push-down/codex-agents-customizations";
+import { buildInMemoryFileSystem, fixedClock } from "./push-down.test-helpers";
+
+const CLOCK = fixedClock("2026-06-26T00:15:00.000Z");
+
+describe("passthroughRewrite", () => {
+  it("returns the text unchanged with zero counts and no unmatched refs", () => {
+    // Arrange
+    const text = "Run scripts.dev_tools.potential_to_issue here.";
+
+    // Act
+    const [out, rewritten, placeholder, unmatched] = passthroughRewrite(text);
+
+    // Assert: the passthrough never rewrites known references.
+    expect(out).toBe(text);
+    expect(rewritten).toBe(0);
+    expect(placeholder).toBe(0);
+    expect(unmatched).toEqual([]);
+  });
+});
+
+describe("pushDownCustomizations (codex/agents)", () => {
+  it("copies the .codex and .agents trees in deterministic root then path order", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      {
+        "/src/.agents/z.md": "agents z",
+        "/src/.agents/a.md": "agents a",
+        "/src/.codex/config.md": "codex config",
+      },
+      ["/dest"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert: .codex root enumerated before .agents; .agents sorted a,z.
+    expect(summary.files.map((f) => f.relativePath)).toEqual([
+      ".codex/config.md",
+      ".agents/a.md",
+      ".agents/z.md",
+    ]);
+  });
+
+  it("leaves content byte-identical and yields zero rewrite counts", () => {
+    // Arrange: content contains a reference the copilot rewrite would change.
+    const fs = buildInMemoryFileSystem(
+      {
+        "/src/.codex/config.md":
+          "Run scripts.dev_tools.potential_to_issue then scripts.dev_tools.unknown_x.",
+      },
+      ["/dest"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert: passthrough leaves the text untouched and reports no rewrites.
+    expect(fs.readTextFile("/dest/.codex/config.md")).toBe(
+      "Run scripts.dev_tools.potential_to_issue then scripts.dev_tools.unknown_x.",
+    );
+    expect(summary.rewrittenReferenceCount).toBe(0);
+    expect(summary.placeholderRewriteCount).toBe(0);
+    expect(summary.unmatchedReferences).toEqual([]);
+  });
+
+  it("writes the artifact under the codex/agents artifact directory", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({ "/src/.codex/config.md": "body" }, [
+      "/dest",
+    ]);
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(summary.artifactPath).toBe(
+      "/dest/artifacts/codex-and-agents-customizations/push-down-20260626T001500Z.json",
+    );
+    expect(ARTIFACT_DIRECTORY).toBe(
+      "artifacts/codex-and-agents-customizations",
+    );
+    expect(ROOT_FOLDERS).toEqual([".codex", ".agents"]);
+  });
+
+  it("defaults sourceRoot/artifactRoot to repoRoot and uses a real clock when omitted", () => {
+    // Arrange: omit sourceRoot, artifactRoot, and clock to exercise the
+    // option-defaulting branches (repoRoot fallback + real Date).
+    const fs = buildInMemoryFileSystem({ "/repo/.codex/config.md": "body" }, [
+      "/dest-omit",
+    ]);
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/repo",
+      destinationRoot: "/dest-omit",
+      fs,
+    });
+
+    // Assert: artifact path is rooted at repoRoot (the default artifact root)
+    // and the deterministic JSON shape still holds.
+    expect(summary.artifactPath).toContain(
+      "/repo/artifacts/codex-and-agents-customizations/push-down-",
+    );
+    expect(summary.files.map((f) => f.relativePath)).toEqual([
+      ".codex/config.md",
+    ]);
+  });
+
+  it("classifies created vs overwritten files", () => {
+    // Arrange: one destination file preexists.
+    const fs = buildInMemoryFileSystem(
+      {
+        "/src/.codex/config.md": "new",
+        "/src/.agents/a.md": "new agent",
+        "/dest/.codex/config.md": "old",
+      },
+      ["/dest"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(summary.createdCount).toBe(1);
+    expect(summary.overwrittenCount).toBe(1);
+    const codexResult = summary.files.find(
+      (f) => f.relativePath === ".codex/config.md",
+    );
+    expect(codexResult?.destinationStatus).toBe("overwritten");
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/copilot-customizations-engine.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/copilot-customizations-engine.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  COPILOT_ROOT_FOLDERS,
+  enumerateSourceFiles,
+  pushDownCustomizations,
+} from "../../../src/lib/push-down/copilot-customizations-engine";
+import { buildInMemoryFileSystem, fixedClock } from "./push-down.test-helpers";
+
+const CLOCK = fixedClock("2026-06-26T00:15:00.000Z");
+const ARTIFACT_PATH =
+  "/dest/artifacts/copilot-customizations/push-down-20260626T001500Z.json";
+
+describe("pushDownCustomizations (engine)", () => {
+  it("throws when the destination directory does not exist", () => {
+    // Arrange: destination root not seeded as a directory.
+    const fs = buildInMemoryFileSystem({}, ["/src"]);
+
+    // Act / Assert
+    expect(() =>
+      pushDownCustomizations({
+        repoRoot: "/src",
+        destinationRoot: "/dest",
+        fs,
+        sourceRoot: "/src",
+        artifactRoot: "/dest",
+        clock: CLOCK,
+      }),
+    ).toThrow(
+      "Invalid destination: destination directory does not exist: /dest",
+    );
+  });
+
+  it("throws when the destination equals the source repository root", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem({}, ["/src"]);
+
+    // Act / Assert
+    expect(() =>
+      pushDownCustomizations({
+        repoRoot: "/src",
+        destinationRoot: "/src",
+        fs,
+        sourceRoot: "/src",
+        artifactRoot: "/src",
+        clock: CLOCK,
+      }),
+    ).toThrow(
+      "Invalid destination: destination must not be the source repository root: /src",
+    );
+  });
+
+  it("classifies created vs overwritten and enumerates in root then path order", () => {
+    // Arrange: seed files across roots out of order; one destination preexists.
+    const fs = buildInMemoryFileSystem(
+      {
+        "/src/.github/prompts/b.prompt.md": "no references here",
+        "/src/.github/prompts/a.prompt.md": "also plain",
+        "/src/.github/agents/agent.md": "agent body",
+        "/src/.github/skills/s/SKILL.md": "skill body",
+        "/dest/.github/agents/agent.md": "old destination content",
+      },
+      ["/dest"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert: agents root first (overwritten), then prompts sorted a,b, then skills.
+    expect(summary.files.map((f) => f.relativePath)).toEqual([
+      ".github/agents/agent.md",
+      ".github/prompts/a.prompt.md",
+      ".github/prompts/b.prompt.md",
+      ".github/skills/s/SKILL.md",
+    ]);
+    expect(summary.files[0]!.destinationStatus).toBe("overwritten");
+    expect(summary.files[1]!.destinationStatus).toBe("created");
+    expect(summary.createdCount).toBe(3);
+    expect(summary.overwrittenCount).toBe(1);
+  });
+
+  it("accumulates rewrite counters and first-seen unmatched references", () => {
+    // Arrange: one known reference and two distinct unknown references.
+    const fs = buildInMemoryFileSystem(
+      {
+        "/src/.github/prompts/a.prompt.md":
+          "Run scripts.dev_tools.potential_to_issue here.",
+        "/src/.github/skills/s/SKILL.md":
+          "Use scripts.dev_tools.unknown_x then scripts.dev_tools.unknown_y.",
+      },
+      ["/dest"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(summary.rewrittenReferenceCount).toBe(1);
+    expect(summary.placeholderRewriteCount).toBe(0);
+    expect(summary.unmatchedReferences).toEqual([
+      "scripts.dev_tools.unknown_x",
+      "scripts.dev_tools.unknown_y",
+    ]);
+  });
+
+  it("writes the summary artifact at the deterministic path and returns it", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      { "/src/.github/agents/agent.md": "body" },
+      ["/dest"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert: deterministic artifact path, written through the filesystem.
+    expect(summary.artifactPath).toBe(ARTIFACT_PATH);
+    expect(fs.isFile(ARTIFACT_PATH)).toBe(true);
+  });
+
+  it("copies file content into the destination via the injected filesystem", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      { "/src/.github/agents/agent.md": "verbatim body" },
+      ["/dest"],
+    );
+
+    // Act
+    pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(fs.readTextFile("/dest/.github/agents/agent.md")).toBe(
+      "verbatim body",
+    );
+  });
+
+  it("exposes the inlined copilot root-folder enumeration order", () => {
+    // Arrange / Act / Assert
+    expect(COPILOT_ROOT_FOLDERS).toEqual([
+      ".github/agents",
+      ".github/instructions",
+      ".github/prompts",
+      ".github/skills",
+    ]);
+  });
+
+  it("defaults sourceRoot and artifactRoot to repoRoot when omitted", () => {
+    // Arrange: omit sourceRoot and artifactRoot to exercise the repoRoot
+    // fallback branches; use the default copilot roots.
+    const fs = buildInMemoryFileSystem(
+      { "/repo/.github/agents/a.md": "body" },
+      ["/dest-omit"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/repo",
+      destinationRoot: "/dest-omit",
+      fs,
+      rootFolders: [".github/agents"],
+      clock: CLOCK,
+    });
+
+    // Assert: artifact rooted at repoRoot (the default artifact root).
+    expect(summary.artifactPath).toBe(
+      "/repo/artifacts/copilot-customizations/push-down-20260626T001500Z.json",
+    );
+    expect(summary.files[0]!.relativePath).toBe(".github/agents/a.md");
+  });
+});
+
+describe("enumerateSourceFiles", () => {
+  it("returns an empty list when a root folder has no files", () => {
+    // Arrange: a source root with no files under the requested scoped root.
+    const fs = buildInMemoryFileSystem({}, ["/src"]);
+
+    // Act
+    const result = enumerateSourceFiles(fs, "/src", [".github/agents"]);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("treats an empty-string scoped root as the source root itself", () => {
+    // Arrange: an empty root folder makes the scoped root equal the source root,
+    // exercising the empty-relative join branch and the equal-path relative
+    // branch (the file directly under the source root sorts by its full path).
+    const fs = buildInMemoryFileSystem({
+      "/src/top.md": "top",
+      "/src/sub/b.md": "b",
+    });
+
+    // Act
+    const result = enumerateSourceFiles(fs, "/src", [""]);
+
+    // Assert: both files enumerate, sorted by their source-relative path.
+    expect(result).toEqual(["/src/sub/b.md", "/src/top.md"]);
+  });
+
+  it("sorts files within a scoped root by their root-relative path", () => {
+    // Arrange: nested + top-level files under one scoped root.
+    const fs = buildInMemoryFileSystem({
+      "/src/.github/agents/z.md": "z",
+      "/src/.github/agents/nested/a.md": "a",
+    });
+
+    // Act
+    const result = enumerateSourceFiles(fs, "/src", [".github/agents"]);
+
+    // Assert: sorted by root-relative POSIX path.
+    expect(result).toEqual([
+      "/src/.github/agents/nested/a.md",
+      "/src/.github/agents/z.md",
+    ]);
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/copilot-customizations.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/copilot-customizations.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it } from "@jest/globals";
+
+import {
+  ARTIFACT_DIRECTORY,
+  pushDownCustomizations,
+  resolveCliPath,
+} from "../../../src/lib/push-down/copilot-customizations";
+import {
+  buildArtifactPath,
+  renderPushDownSummary,
+  type PushDownSummary,
+} from "../../../src/lib/push-down/copilot-customizations-engine";
+import { buildInMemoryFileSystem, fixedClock } from "./push-down.test-helpers";
+
+const CLOCK = fixedClock("2026-06-26T00:15:00.000Z");
+
+describe("resolveCliPath", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    // Restore the real platform after any override.
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  it("returns a Windows-absolute drive-letter path unchanged on a POSIX host", () => {
+    // Arrange: force a POSIX host so the Windows-absolute guard branch runs.
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
+    // Act
+    const result = resolveCliPath("C:\\workspace\\dest");
+
+    // Assert: the drive-letter path is returned verbatim, not mangled.
+    expect(result).toBe("C:\\workspace\\dest");
+  });
+
+  it("returns a Windows UNC path unchanged on a POSIX host", () => {
+    // Arrange
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
+    // Act / Assert
+    expect(resolveCliPath("\\\\server\\share\\dir")).toBe(
+      "\\\\server\\share\\dir",
+    );
+  });
+
+  it("resolves a relative path to an absolute path", () => {
+    // Arrange / Act
+    const result = resolveCliPath(".");
+
+    // Assert
+    expect(result.length).toBeGreaterThan(1);
+  });
+});
+
+describe("buildArtifactPath", () => {
+  it("names the artifact deterministically under the artifact directory", () => {
+    // Arrange
+    const startedAt = new Date("2026-06-26T00:15:00.000Z");
+
+    // Act
+    const result = buildArtifactPath(startedAt, "/dest", ARTIFACT_DIRECTORY);
+
+    // Assert
+    expect(result).toBe(
+      "/dest/artifacts/copilot-customizations/push-down-20260626T001500Z.json",
+    );
+  });
+});
+
+describe("renderPushDownSummary", () => {
+  it("renders the exact top-level JSON key set, sorted, with 2-space indent", () => {
+    // Arrange
+    const summary: PushDownSummary = {
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      startedAt: new Date("2026-06-26T00:15:00.000Z"),
+      finishedAt: new Date("2026-06-26T00:15:01.000Z"),
+      createdCount: 1,
+      overwrittenCount: 0,
+      rewrittenReferenceCount: 0,
+      placeholderRewriteCount: 0,
+      unmatchedReferences: [],
+      files: [
+        {
+          relativePath: ".github/agents/a.md",
+          destinationStatus: "created",
+          rewrittenReferenceCount: 0,
+          placeholderRewriteCount: 0,
+          unmatchedReferences: [],
+        },
+      ],
+      artifactPath: "",
+    };
+
+    // Act
+    const rendered = renderPushDownSummary(summary);
+    const parsed = JSON.parse(rendered) as Record<string, unknown>;
+
+    // Assert: exact top-level key set (order-independent membership).
+    expect(Object.keys(parsed).sort()).toEqual(
+      [
+        "repo_root",
+        "destination_root",
+        "started_at",
+        "finished_at",
+        "created_count",
+        "overwritten_count",
+        "rewritten_reference_count",
+        "placeholder_rewrite_count",
+        "unmatched_references",
+        "files",
+      ].sort(),
+    );
+
+    // Assert: keys are emitted in sorted order and indentation is two spaces.
+    const emittedKeyOrder = rendered
+      .split("\n")
+      .map((line) => /^ {2}"([a-z_]+)":/.exec(line)?.[1])
+      .filter((key): key is string => key !== undefined);
+    expect(emittedKeyOrder).toEqual([...emittedKeyOrder].sort());
+    expect(rendered).toContain('\n  "created_count": 1');
+  });
+
+  it("renders per-file objects with the parity snake_case field names", () => {
+    // Arrange
+    const summary: PushDownSummary = {
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      startedAt: new Date("2026-06-26T00:15:00.000Z"),
+      finishedAt: new Date("2026-06-26T00:15:01.000Z"),
+      createdCount: 1,
+      overwrittenCount: 0,
+      rewrittenReferenceCount: 0,
+      placeholderRewriteCount: 0,
+      unmatchedReferences: [],
+      files: [
+        {
+          relativePath: ".github/agents/a.md",
+          destinationStatus: "created",
+          rewrittenReferenceCount: 0,
+          placeholderRewriteCount: 0,
+          unmatchedReferences: ["scripts.dev_tools.unknown"],
+        },
+      ],
+      artifactPath: "",
+    };
+
+    // Act
+    const parsed = JSON.parse(renderPushDownSummary(summary)) as {
+      files: Array<Record<string, unknown>>;
+    };
+
+    // Assert
+    expect(Object.keys(parsed.files[0]!).sort()).toEqual(
+      [
+        "relative_path",
+        "destination_status",
+        "rewritten_reference_count",
+        "placeholder_rewrite_count",
+        "unmatched_references",
+      ].sort(),
+    );
+  });
+});
+
+describe("pushDownCustomizations (public wrapper)", () => {
+  it("defaults the copilot root folders and rewrite function", () => {
+    // Arrange: a known rewrite reference under a copilot root proves both
+    // defaults (root folders enumerated, rewrite applied) without overrides.
+    const fs = buildInMemoryFileSystem(
+      {
+        "/src/.github/prompts/p.prompt.md":
+          "Run scripts.dev_tools.potential_to_issue now.",
+      },
+      ["/dest"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/src",
+      destinationRoot: "/dest",
+      fs,
+      sourceRoot: "/src",
+      artifactRoot: "/dest",
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(summary.rewrittenReferenceCount).toBe(1);
+    expect(fs.readTextFile("/dest/.github/prompts/p.prompt.md")).toContain(
+      "command ID: `drmCopilotExtension.potentialToIssue`",
+    );
+    expect(ARTIFACT_DIRECTORY).toBe("artifacts/copilot-customizations");
+  });
+
+  it("defaults sourceRoot/artifactRoot to repoRoot and uses a real clock when omitted", () => {
+    // Arrange: omit sourceRoot, artifactRoot, and clock to exercise the
+    // option-defaulting branches in the public wrapper.
+    const fs = buildInMemoryFileSystem(
+      { "/repo/.github/agents/a.md": "body" },
+      ["/dest-omit"],
+    );
+
+    // Act
+    const summary = pushDownCustomizations({
+      repoRoot: "/repo",
+      destinationRoot: "/dest-omit",
+      fs,
+    });
+
+    // Assert: artifact path is rooted at repoRoot (the default artifact root).
+    expect(summary.artifactPath).toContain(
+      "/repo/artifacts/copilot-customizations/push-down-",
+    );
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/filesystem-adapter.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/filesystem-adapter.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import * as fs from "node:fs";
+
+import { RealPushDownFileSystem } from "../../../src/lib/push-down/filesystem-adapter";
+
+jest.mock("node:fs", () => ({
+  readdirSync: jest.fn(),
+  statSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+const readdirSyncMock = fs.readdirSync as jest.MockedFunction<
+  typeof fs.readdirSync
+>;
+const statSyncMock = fs.statSync as jest.MockedFunction<typeof fs.statSync>;
+const readFileSyncMock = fs.readFileSync as jest.MockedFunction<
+  typeof fs.readFileSync
+>;
+const writeFileSyncMock = fs.writeFileSync as jest.MockedFunction<
+  typeof fs.writeFileSync
+>;
+const mkdirSyncMock = fs.mkdirSync as jest.MockedFunction<typeof fs.mkdirSync>;
+
+/**
+ * Build a minimal Dirent-like entry for mocking readdirSync results.
+ *
+ * @param name Entry name.
+ * @param isDir Whether the entry is a directory.
+ * @returns A Dirent-shaped stub.
+ */
+function dirent(name: string, isDir: boolean): fs.Dirent {
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+  } as unknown as fs.Dirent;
+}
+
+/**
+ * Build a Stats-like stub for statSync mocking.
+ *
+ * @param kind The filesystem entry kind to report.
+ * @returns A Stats-shaped stub.
+ */
+function stats(kind: "file" | "dir"): fs.Stats {
+  return {
+    isFile: () => kind === "file",
+    isDirectory: () => kind === "dir",
+  } as unknown as fs.Stats;
+}
+
+describe("RealPushDownFileSystem", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("listFiles", () => {
+    it("returns an empty list when the root is not a directory", () => {
+      // Arrange
+      statSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const sut = new RealPushDownFileSystem();
+
+      // Act
+      const result = sut.listFiles("/missing/root");
+
+      // Assert
+      expect(result).toEqual([]);
+      expect(readdirSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("returns files beneath the root in sorted POSIX order", () => {
+      // Arrange: root is a dir; readdir returns nested entries by directory.
+      statSyncMock.mockReturnValue(stats("dir"));
+      readdirSyncMock.mockImplementation(((dir: string) => {
+        const posix = dir.replace(/\\/g, "/");
+        if (posix === "/repo/.github") {
+          return [dirent("zeta.md", false), dirent("nested", true)];
+        }
+        if (posix === "/repo/.github/nested") {
+          return [dirent("alpha.md", false)];
+        }
+        return [];
+      }) as unknown as typeof fs.readdirSync);
+      const sut = new RealPushDownFileSystem();
+
+      // Act
+      const result = sut.listFiles("/repo/.github");
+
+      // Assert: sorted lexicographically; nested path precedes top-level zeta.
+      expect(result).toEqual([
+        "/repo/.github/nested/alpha.md",
+        "/repo/.github/zeta.md",
+      ]);
+    });
+
+    it("skips a subdirectory that becomes unreadable mid-walk", () => {
+      // Arrange
+      statSyncMock.mockReturnValue(stats("dir"));
+      readdirSyncMock.mockImplementation(((dir: string) => {
+        const posix = dir.replace(/\\/g, "/");
+        if (posix === "/repo/root") {
+          return [dirent("file.md", false), dirent("locked", true)];
+        }
+        throw new Error("EACCES");
+      }) as unknown as typeof fs.readdirSync);
+      const sut = new RealPushDownFileSystem();
+
+      // Act
+      const result = sut.listFiles("/repo/root");
+
+      // Assert: the unreadable subdirectory yields no files.
+      expect(result).toEqual(["/repo/root/file.md"]);
+    });
+  });
+
+  describe("isDir / isFile", () => {
+    it("isDir reflects a directory stat", () => {
+      // Arrange
+      statSyncMock.mockReturnValue(stats("dir"));
+      const sut = new RealPushDownFileSystem();
+
+      // Act / Assert
+      expect(sut.isDir("/repo")).toBe(true);
+    });
+
+    it("isDir returns false when stat throws", () => {
+      // Arrange
+      statSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const sut = new RealPushDownFileSystem();
+
+      // Act / Assert
+      expect(sut.isDir("/missing")).toBe(false);
+    });
+
+    it("isFile reflects a file stat", () => {
+      // Arrange
+      statSyncMock.mockReturnValue(stats("file"));
+      const sut = new RealPushDownFileSystem();
+
+      // Act / Assert
+      expect(sut.isFile("/repo/a.md")).toBe(true);
+    });
+
+    it("isFile returns false when stat throws", () => {
+      // Arrange
+      statSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const sut = new RealPushDownFileSystem();
+
+      // Act / Assert
+      expect(sut.isFile("/missing")).toBe(false);
+    });
+  });
+
+  describe("readTextFile", () => {
+    it("reads UTF-8 text", () => {
+      // Arrange
+      readFileSyncMock.mockReturnValue("content" as unknown as Buffer);
+      const sut = new RealPushDownFileSystem();
+
+      // Act
+      const result = sut.readTextFile("/repo/a.md");
+
+      // Assert
+      expect(result).toBe("content");
+      expect(readFileSyncMock).toHaveBeenCalledWith("/repo/a.md", "utf8");
+    });
+  });
+
+  describe("writeTextFile", () => {
+    it("creates the parent directory and writes LF-normalized UTF-8 text", () => {
+      // Arrange
+      const sut = new RealPushDownFileSystem();
+
+      // Act
+      sut.writeTextFile("/dest/sub/a.md", "line1\r\nline2\rline3");
+
+      // Assert: parent dir created recursively, then CRLF/CR normalized to LF.
+      expect(mkdirSyncMock).toHaveBeenCalledWith(
+        expect.stringContaining("sub"),
+        { recursive: true },
+      );
+      expect(writeFileSyncMock).toHaveBeenCalledWith(
+        "/dest/sub/a.md",
+        "line1\nline2\nline3",
+        "utf8",
+      );
+    });
+  });
+
+  describe("ensureDir", () => {
+    it("creates the directory recursively", () => {
+      // Arrange
+      const sut = new RealPushDownFileSystem();
+
+      // Act
+      sut.ensureDir("/dest/sub");
+
+      // Assert
+      expect(mkdirSyncMock).toHaveBeenCalledWith("/dest/sub", {
+        recursive: true,
+      });
+    });
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/push-down-service-call.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/push-down-service-call.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  pushDownClaudeCustomizationsServiceCall,
+  pushDownCodexAndAgentsCustomizationsServiceCall,
+  pushDownCopilotCustomizationsServiceCall,
+} from "../../../src/lib/push-down/push-down-service-call";
+import { buildInMemoryFileSystem, fixedClock } from "./push-down.test-helpers";
+
+const CLOCK = fixedClock("2026-06-26T00:15:00.000Z");
+const EXT = "/ext";
+const WS = "/workspace";
+
+describe("pushDownCopilotCustomizationsServiceCall", () => {
+  it("returns the preserved tool, summary, and single normalized artifact path", () => {
+    // Arrange: seed a copilot source tree under the bundled resources root.
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${EXT}/resources/customizations/.github/agents/a.md`]: "body",
+      },
+      [WS],
+    );
+
+    // Act
+    const result = pushDownCopilotCustomizationsServiceCall({
+      fs,
+      extensionRoot: EXT,
+      workspaceRoot: WS,
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(result.tool).toBe("push_down_copilot_customizations");
+    expect(result.summary).toBe(
+      "Pushed bundled Copilot customizations into the destination workspace.",
+    );
+    expect(result.artifacts).toEqual([
+      "/workspace/artifacts/copilot-customizations/push-down-20260626T001500Z.json",
+    ]);
+  });
+
+  it("resolves the copilot bundled source root and copies into the workspace", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${EXT}/resources/customizations/.github/prompts/p.prompt.md`]:
+          "plain",
+      },
+      [WS],
+    );
+
+    // Act
+    pushDownCopilotCustomizationsServiceCall({
+      fs,
+      extensionRoot: EXT,
+      workspaceRoot: WS,
+      clock: CLOCK,
+    });
+
+    // Assert: the file landed at the workspace destination path.
+    expect(fs.isFile(`${WS}/.github/prompts/p.prompt.md`)).toBe(true);
+  });
+});
+
+describe("pushDownCodexAndAgentsCustomizationsServiceCall", () => {
+  it("returns the preserved tool, summary, and artifact path", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${EXT}/resources/codex-and-agents-customizations/.codex/config.md`]:
+          "body",
+      },
+      [WS],
+    );
+
+    // Act
+    const result = pushDownCodexAndAgentsCustomizationsServiceCall({
+      fs,
+      extensionRoot: EXT,
+      workspaceRoot: WS,
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(result.tool).toBe("push_down_codex_and_agents_customizations");
+    expect(result.summary).toBe(
+      "Pushed bundled Codex and agents customizations into the destination workspace.",
+    );
+    expect(result.artifacts).toEqual([
+      "/workspace/artifacts/codex-and-agents-customizations/push-down-20260626T001500Z.json",
+    ]);
+  });
+});
+
+describe("pushDownClaudeCustomizationsServiceCall", () => {
+  it("returns the preserved tool, summary, and artifact path with no selection", () => {
+    // Arrange
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${EXT}/resources/claude-customizations/.claude/rules/python.md`]:
+          "rule",
+      },
+      [WS],
+    );
+
+    // Act
+    const result = pushDownClaudeCustomizationsServiceCall({
+      fs,
+      extensionRoot: EXT,
+      workspaceRoot: WS,
+      clock: CLOCK,
+    });
+
+    // Assert
+    expect(result.tool).toBe("push_down_claude_customizations");
+    expect(result.summary).toBe(
+      "Pushed bundled Claude Code customizations into the destination workspace.",
+    );
+    expect(result.artifacts).toEqual([
+      "/workspace/artifacts/claude-customizations/push-down-20260626T001500Z.json",
+    ]);
+  });
+
+  it("threads packs, csharpVariant, and memoryMode into the in-process port", () => {
+    // Arrange: seed manifests + a legacy variant; select csharp-legacy.
+    const bundle = `${EXT}/resources/claude-customizations`;
+    const fs = buildInMemoryFileSystem(
+      {
+        [`${bundle}/.claude/rules/csharp.md`]: "# Modern\n",
+        [`${bundle}/.claude-variants/csharp-legacy/rules/csharp.md`]:
+          "# Legacy\n",
+        [`${bundle}/pack-manifests/core.json`]: JSON.stringify({
+          name: "core",
+          label: "Core",
+          paths: [],
+        }),
+        [`${bundle}/pack-manifests/csharp-legacy.json`]: JSON.stringify({
+          name: "csharp-legacy",
+          label: "C# Legacy",
+          paths: [".claude/rules/csharp.md"],
+          source_prefix: ".claude-variants/csharp-legacy",
+        }),
+      },
+      [WS],
+    );
+
+    // Act
+    pushDownClaudeCustomizationsServiceCall({
+      fs,
+      extensionRoot: EXT,
+      workspaceRoot: WS,
+      packs: ["csharp-legacy"],
+      csharpVariant: "legacy",
+      memoryMode: "overwrite",
+      clock: CLOCK,
+    });
+
+    // Assert: the canonical destination received legacy content (variant routed)
+    // and only the selected pack path was published (pack filter threaded).
+    expect(fs.readTextFile(`${WS}/.claude/rules/csharp.md`)).toBe("# Legacy\n");
+  });
+});

--- a/extensions/drm-copilot/test/lib/push-down/push-down.test-helpers.ts
+++ b/extensions/drm-copilot/test/lib/push-down/push-down.test-helpers.ts
@@ -1,0 +1,176 @@
+import { type PushDownFileSystem } from "../../../src/lib/push-down/filesystem-adapter";
+
+/**
+ * Normalize a path to forward-slash separators with no trailing slash.
+ *
+ * @param value Path that may use OS-specific separators.
+ * @returns Forward-slash POSIX path without a trailing separator (except root).
+ */
+function normalize(value: string): string {
+  const posix = value.replace(/\\/g, "/");
+  if (posix.length > 1 && posix.endsWith("/")) {
+    return posix.replace(/\/+$/, "");
+  }
+  return posix;
+}
+
+/**
+ * In-memory {@link PushDownFileSystem} fake for hermetic push-down tests.
+ *
+ * Purpose:
+ *     Mirror the Python `RecordingFileSystem` test double: an in-memory text
+ *     store keyed by POSIX path, a deterministic sorted `listFiles`, and tracked
+ *     directories. It records writes and ensured directories so tests can assert
+ *     the publisher's filesystem interactions without touching real disk.
+ *
+ * Responsibilities:
+ *     - `listFiles`: return, in sorted order, every stored file whose path is
+ *       beneath the requested root.
+ *     - `isDir`: true for any directory seeded/ensured or implied by a stored
+ *       file's ancestry.
+ *     - `isFile`: true only for an exact stored file path.
+ *     - `readTextFile` / `writeTextFile`: in-memory UTF-8 text (LF-normalized
+ *       writes to match the real adapter).
+ *     - `ensureDir`: record the directory as existing.
+ *
+ * Invariants / Constraints:
+ *     All keys are normalized to forward-slash POSIX form. A write implies the
+ *     parent directory chain exists (matching the real adapter's mkdir).
+ *
+ * Side effects:
+ *     None beyond mutating its own in-memory maps.
+ */
+export class InMemoryPushDownFileSystem implements PushDownFileSystem {
+  /** Stored file contents keyed by normalized POSIX path. */
+  private readonly files = new Map<string, string>();
+  /** Directories that exist (seeded, ensured, or implied by file ancestry). */
+  private readonly directories = new Set<string>();
+  /** Recorded write calls in invocation order, for assertions. */
+  readonly writtenPaths: string[] = [];
+  /** Recorded ensureDir calls in invocation order, for assertions. */
+  readonly ensuredDirs: string[] = [];
+
+  /**
+   * Seed a file and its ancestor directories.
+   *
+   * @param path File path (any separator style).
+   * @param content UTF-8 file content.
+   */
+  seedFile(path: string, content: string): void {
+    const normalized = normalize(path);
+    this.files.set(normalized, content);
+    this.recordAncestors(normalized);
+  }
+
+  /**
+   * Seed a directory as existing without any file content.
+   *
+   * @param path Directory path (any separator style).
+   */
+  seedDir(path: string): void {
+    const normalized = normalize(path);
+    this.directories.add(normalized);
+    this.recordAncestors(normalized);
+  }
+
+  /**
+   * Record every ancestor directory of a normalized path as existing.
+   *
+   * @param normalizedPath A normalized POSIX path whose parents to record.
+   */
+  private recordAncestors(normalizedPath: string): void {
+    const segments = normalizedPath.split("/");
+    // Walk from the second segment upward, registering each parent prefix as a
+    // directory so isDir reflects implied ancestry the same way real disk does.
+    for (let index = 1; index < segments.length; index += 1) {
+      const prefix = segments.slice(0, index).join("/");
+      if (prefix !== "") {
+        this.directories.add(prefix);
+      }
+    }
+  }
+
+  listFiles(root: string): string[] {
+    const normalizedRoot = normalize(root);
+    if (!this.isDir(normalizedRoot)) {
+      return [];
+    }
+    const prefix = `${normalizedRoot}/`;
+    // Collect every stored file that lives beneath the requested root.
+    const matches: string[] = [];
+    for (const key of this.files.keys()) {
+      if (key === normalizedRoot || key.startsWith(prefix)) {
+        matches.push(key);
+      }
+    }
+    return matches.sort((left, right) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    );
+  }
+
+  isDir(path: string): boolean {
+    return this.directories.has(normalize(path));
+  }
+
+  isFile(path: string): boolean {
+    return this.files.has(normalize(path));
+  }
+
+  readTextFile(path: string): string {
+    const normalized = normalize(path);
+    const content = this.files.get(normalized);
+    if (content === undefined) {
+      throw new Error(`InMemoryPushDownFileSystem: missing file ${normalized}`);
+    }
+    return content;
+  }
+
+  writeTextFile(path: string, content: string): void {
+    const normalized = normalize(path);
+    // Normalize line endings to match the real adapter's LF-normalized write.
+    const lfNormalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    this.files.set(normalized, lfNormalized);
+    this.recordAncestors(normalized);
+    this.writtenPaths.push(normalized);
+  }
+
+  ensureDir(path: string): void {
+    const normalized = normalize(path);
+    this.directories.add(normalized);
+    this.recordAncestors(normalized);
+    this.ensuredDirs.push(normalized);
+  }
+}
+
+/**
+ * Build an {@link InMemoryPushDownFileSystem} pre-seeded with files.
+ *
+ * @param seedFiles Map of POSIX path to UTF-8 content to seed.
+ * @param seedDirs Optional directory paths to seed as existing.
+ * @returns A seeded in-memory push-down filesystem fake.
+ */
+export function buildInMemoryFileSystem(
+  seedFiles: Readonly<Record<string, string>> = {},
+  seedDirs: ReadonlyArray<string> = [],
+): InMemoryPushDownFileSystem {
+  const fs = new InMemoryPushDownFileSystem();
+  // Seed directories first so an explicitly empty destination directory exists.
+  for (const dir of seedDirs) {
+    fs.seedDir(dir);
+  }
+  for (const [path, content] of Object.entries(seedFiles)) {
+    fs.seedFile(path, content);
+  }
+  return fs;
+}
+
+/**
+ * Create a fixed-instant clock for deterministic `startedAt`/`finishedAt`.
+ *
+ * @param isoInstant ISO-8601 instant the clock always returns.
+ * @returns A zero-argument function returning the same `Date` each call.
+ */
+export function fixedClock(isoInstant: string): () => Date {
+  const instant = new Date(isoInstant);
+  return () => instant;
+}

--- a/extensions/drm-copilot/test/lib/push-down/reference-rewrites.test.ts
+++ b/extensions/drm-copilot/test/lib/push-down/reference-rewrites.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  buildRewriteCatalog,
+  normalizeReferenceForLookup,
+  rewriteTextReferences,
+  splitTrailingPunctuation,
+} from "../../../src/lib/push-down/reference-rewrites";
+
+describe("buildRewriteCatalog", () => {
+  it("contains all seven catalog entries keyed by normalized reference", () => {
+    // Arrange / Act
+    const catalog = buildRewriteCatalog();
+
+    // Assert
+    expect([...catalog.keys()].sort()).toEqual(
+      [
+        "scripts.dev_tools.pr_context.collector",
+        "scripts.dev_tools.new_active_feature_folder",
+        "scripts.dev_tools.potential_to_issue",
+        "scripts/dev_tools/new_potential_bug_entry.py",
+        "scripts/dev_tools/new-potential-entry.ps1",
+        "scripts.dev_tools.push_down_copilot_customizations",
+        "scripts/dev_tools/sync-agents-from-instructions.ps1",
+      ].sort(),
+    );
+  });
+});
+
+describe("normalizeReferenceForLookup", () => {
+  it("strips the poetry run python -m prefix", () => {
+    // Arrange / Act / Assert
+    expect(
+      normalizeReferenceForLookup(
+        "poetry run python -m scripts.dev_tools.potential_to_issue",
+      ),
+    ).toBe("scripts.dev_tools.potential_to_issue");
+  });
+
+  it("strips a ${workspaceFolder} forward-slash prefix and normalizes dev-tools", () => {
+    // Arrange / Act / Assert
+    expect(
+      normalizeReferenceForLookup(
+        "${workspaceFolder}/scripts/dev-tools/new-potential-entry.ps1",
+      ),
+    ).toBe("scripts/dev_tools/new-potential-entry.ps1");
+  });
+
+  it("strips a ${workspaceFolder} backslash prefix and normalizes separators", () => {
+    // Arrange / Act / Assert
+    expect(
+      normalizeReferenceForLookup(
+        "${workspaceFolder}\\scripts\\dev_tools\\new_potential_bug_entry.py",
+      ),
+    ).toBe("scripts/dev_tools/new_potential_bug_entry.py");
+  });
+});
+
+describe("splitTrailingPunctuation", () => {
+  it("peels trailing sentence punctuation while preserving the core", () => {
+    // Arrange / Act
+    const [core, suffix] = splitTrailingPunctuation(
+      "scripts.dev_tools.potential_to_issue).",
+    );
+
+    // Assert
+    expect(core).toBe("scripts.dev_tools.potential_to_issue");
+    expect(suffix).toBe(").");
+  });
+
+  it("returns the reference unchanged when there is no trailing punctuation", () => {
+    // Arrange / Act
+    const [core, suffix] = splitTrailingPunctuation("scripts.dev_tools.foo");
+
+    // Assert
+    expect(core).toBe("scripts.dev_tools.foo");
+    expect(suffix).toBe("");
+  });
+});
+
+describe("rewriteTextReferences", () => {
+  it("rewrites the pr_context collector reference to the live command", () => {
+    // Arrange
+    const text =
+      "Run poetry run python -m scripts.dev_tools.pr_context.collector before review.";
+
+    // Act
+    const [rewritten, rewrittenCount, placeholderCount, unmatched] =
+      rewriteTextReferences(text);
+
+    // Assert
+    expect(rewrittenCount).toBe(1);
+    expect(placeholderCount).toBe(0);
+    expect(unmatched).toEqual([]);
+    expect(rewritten).toContain(
+      "VS Code command: `drm-copilot: Collect PR Context`",
+    );
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.collectPrContext`",
+    );
+    expect(rewritten).not.toContain("scripts.dev_tools.pr_context.collector");
+  });
+
+  it("rewrites the new_active_feature_folder reference", () => {
+    // Arrange
+    const text =
+      "Use poetry run python -m scripts.dev_tools.new_active_feature_folder now.";
+
+    // Act
+    const [rewritten, rewrittenCount] = rewriteTextReferences(text);
+
+    // Assert
+    expect(rewrittenCount).toBe(1);
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.newActiveFeatureFolder`",
+    );
+  });
+
+  it("rewrites the potential_to_issue reference", () => {
+    // Arrange
+    const text = "See scripts.dev_tools.potential_to_issue here.";
+
+    // Act
+    const [rewritten, rewrittenCount] = rewriteTextReferences(text);
+
+    // Assert
+    expect(rewrittenCount).toBe(1);
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.potentialToIssue`",
+    );
+  });
+
+  it("normalizes both ${workspaceFolder} dev-tools slash variants", () => {
+    // Arrange
+    const text =
+      "Run ${workspaceFolder}/scripts/dev_tools/new_potential_bug_entry.py and " +
+      "${workspaceFolder}/scripts/dev-tools/new-potential-entry.ps1.";
+
+    // Act
+    const [rewritten, rewrittenCount, placeholderCount] =
+      rewriteTextReferences(text);
+
+    // Assert
+    expect(rewrittenCount).toBe(2);
+    expect(placeholderCount).toBe(0);
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.newPotentialBugEntry`",
+    );
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.newPotentialEntry`",
+    );
+    expect(rewritten).not.toContain(
+      "scripts/dev_tools/new_potential_bug_entry.py",
+    );
+    expect(rewritten).not.toContain(
+      "scripts/dev-tools/new-potential-entry.ps1",
+    );
+  });
+
+  it("rewrites the push_down_copilot_customizations reference", () => {
+    // Arrange
+    const text =
+      "Run poetry run python -m scripts.dev_tools.push_down_copilot_customizations to push.";
+
+    // Act
+    const [rewritten, rewrittenCount] = rewriteTextReferences(text);
+
+    // Assert
+    expect(rewrittenCount).toBeGreaterThanOrEqual(1);
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.pushDownCopilotCustomizations`",
+    );
+  });
+
+  it("rewrites the sync-agents-from-instructions reference", () => {
+    // Arrange
+    const text =
+      "Run ${workspaceFolder}/scripts/dev-tools/sync-agents-from-instructions.ps1 to regenerate.";
+
+    // Act
+    const [rewritten, rewrittenCount] = rewriteTextReferences(text);
+
+    // Assert
+    expect(rewrittenCount).toBe(1);
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.syncAgentsFromInstructions`",
+    );
+    expect(rewritten).not.toContain("sync-agents-from-instructions.ps1");
+  });
+
+  it("preserves trailing punctuation around a rewritten reference", () => {
+    // Arrange
+    const text = "See scripts.dev_tools.potential_to_issue.";
+
+    // Act
+    const [rewritten] = rewriteTextReferences(text);
+
+    // Assert: the trailing period is preserved immediately after the rendered
+    // command reference, and the reference text itself is gone.
+    expect(rewritten).toContain(
+      "command ID: `drmCopilotExtension.potentialToIssue`).",
+    );
+    expect(rewritten).not.toContain("scripts.dev_tools.potential_to_issue");
+  });
+
+  it("reports unmatched references without rewriting them, in first-seen order", () => {
+    // Arrange
+    const text =
+      "Run scripts.dev_tools.unknown_b then scripts.dev_tools.unknown_a then scripts.dev_tools.unknown_b again.";
+
+    // Act
+    const [rewritten, rewrittenCount, placeholderCount, unmatched] =
+      rewriteTextReferences(text);
+
+    // Assert: unchanged text, zero counts, deterministic first-seen order, dedup.
+    expect(rewritten).toBe(text);
+    expect(rewrittenCount).toBe(0);
+    expect(placeholderCount).toBe(0);
+    expect(unmatched).toEqual([
+      "scripts.dev_tools.unknown_b",
+      "scripts.dev_tools.unknown_a",
+    ]);
+  });
+
+  it("leaves text with no script references unchanged", () => {
+    // Arrange
+    const text = "This prose mentions no scripts at all.";
+
+    // Act
+    const [rewritten, rewrittenCount, placeholderCount, unmatched] =
+      rewriteTextReferences(text);
+
+    // Assert
+    expect(rewritten).toBe(text);
+    expect(rewrittenCount).toBe(0);
+    expect(placeholderCount).toBe(0);
+    expect(unmatched).toEqual([]);
+  });
+});

--- a/extensions/drm-copilot/test/repo-automation-service.push-down-claude.test.ts
+++ b/extensions/drm-copilot/test/repo-automation-service.push-down-claude.test.ts
@@ -7,176 +7,206 @@ import {
   jest,
 } from "@jest/globals";
 
-import {
-  createMockProcess,
-  setExecutablePresenceOnFsMock,
-} from "./runtime-test-helpers";
+import { InMemoryPushDownFileSystem } from "./lib/push-down/push-down.test-helpers";
 
 const appendLineMock = jest.fn<(line: string) => void>();
 
 jest.mock("vscode", () => ({}), { virtual: true });
 
-jest.mock("node:fs", () => ({
-  copyFileSync: jest.fn(),
-  existsSync: jest.fn(),
-  mkdirSync: jest.fn(),
-}));
-
-jest.mock("node:child_process", () => ({
-  spawn: jest.fn(),
-}));
-
 import { createRepoAutomationService } from "../src/repo-automation-service";
 
-const fsMock = jest.requireMock("node:fs") as {
-  existsSync: jest.MockedFunction<(filePath: string) => boolean>;
-};
+const EXT = "C:/extension";
+const WS = "C:/workspace";
+const BUNDLE = `${EXT}/resources/claude-customizations`;
 
-const childProcessMock = jest.requireMock("node:child_process") as {
-  spawn: jest.Mock;
-};
+/**
+ * Build an in-memory push-down filesystem seeded with a minimal `.claude`
+ * tree, a legacy C# variant subtree, and pack manifests.
+ *
+ * @returns A seeded in-memory push-down filesystem with the workspace ensured.
+ */
+function seedClaudeBundle(): InMemoryPushDownFileSystem {
+  const fs = new InMemoryPushDownFileSystem();
+  fs.seedDir(WS);
+  fs.seedFile(`${BUNDLE}/.claude/rules/typescript.md`, "# TS\n");
+  fs.seedFile(`${BUNDLE}/.claude/rules/csharp.md`, "# Modern C#\n");
+  fs.seedFile(`${BUNDLE}/.claude/agents/orchestrator.md`, "# Orchestrator\n");
+  fs.seedFile(
+    `${BUNDLE}/.claude-variants/csharp-legacy/rules/csharp.md`,
+    "# Legacy C#\n",
+  );
+  fs.seedFile(
+    `${BUNDLE}/pack-manifests/core.json`,
+    JSON.stringify({
+      name: "core",
+      label: "Core",
+      paths: [".claude/agents/orchestrator.md"],
+    }),
+  );
+  fs.seedFile(
+    `${BUNDLE}/pack-manifests/typescript.json`,
+    JSON.stringify({
+      name: "typescript",
+      label: "TypeScript",
+      paths: [".claude/rules/typescript.md"],
+    }),
+  );
+  fs.seedFile(
+    `${BUNDLE}/pack-manifests/csharp-legacy.json`,
+    JSON.stringify({
+      name: "csharp-legacy",
+      label: "C# Legacy",
+      paths: [".claude/rules/csharp.md"],
+      source_prefix: ".claude-variants/csharp-legacy",
+    }),
+  );
+  return fs;
+}
 
-describe("repo automation service pushDownClaudeCustomizations", () => {
+describe("repo automation service pushDownClaudeCustomizations (in-process)", () => {
   beforeEach(() => {
-    process.env.PATH = "C:/bin";
-    process.env.PATHEXT = ".EXE;.CMD";
     appendLineMock.mockReset();
-    childProcessMock.spawn.mockReset();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("invokes executeScript with the correct tool, runtimeKind, bundledRelativePath, args, summary, and stdoutArtifactPattern", async () => {
-    setExecutablePresenceOnFsMock(fsMock, { python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("returns the preserved tool, summary, and a single artifact entry", async () => {
+    // Arrange
+    const pushDownFileSystem = seedClaudeBundle();
     const service = createRepoAutomationService({
-      extensionRoot: "C:/extension",
+      extensionRoot: EXT,
       output: { appendLine: appendLineMock },
+      pushDownFileSystem,
     });
-    const workspaceRoot = "C:/workspace";
 
+    // Act
     const result = await service.pushDownClaudeCustomizations({
-      workspaceRoot,
+      workspaceRoot: WS,
       invocationId: "push_down_claude_customizations",
     });
 
-    // Verify the bundled script path and arguments passed to spawn.
-    const [executable, args, options] = childProcessMock.spawn.mock
-      .calls[0] as [string, string[], { cwd: string; shell: boolean }];
-    expect(executable).toBe("python");
-    expect(args[0]).toBe(
-      "C:/extension/resources/templates/push_down_claude_customizations.py",
-    );
-    expect(args).toContain("--destination");
-    expect(args).toContain(workspaceRoot);
-    expect(options.cwd).toBe(workspaceRoot);
-    expect(options.shell).toBe(false);
+    // Assert: the in-process port preserves the return contract.
     expect(result.tool).toBe("push_down_claude_customizations");
     expect(result.summary).toContain(
       "Pushed bundled Claude Code customizations",
     );
+    expect(result.workspaceRoot).toBe(WS);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts?.[0]).toContain(
+      "artifacts/claude-customizations/push-down-",
+    );
   });
 
-  it("defaults invocationId to 'push_down_claude_customizations' when omitted from input", async () => {
-    setExecutablePresenceOnFsMock(fsMock, { python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("defaults to the in-process port when invocationId is omitted", async () => {
+    // Arrange
+    const pushDownFileSystem = seedClaudeBundle();
     const service = createRepoAutomationService({
-      extensionRoot: "C:/extension",
+      extensionRoot: EXT,
       output: { appendLine: appendLineMock },
+      pushDownFileSystem,
     });
 
-    // Omit invocationId — the service should supply the default.
+    // Act
     const result = await service.pushDownClaudeCustomizations({
-      workspaceRoot: "C:/workspace",
+      workspaceRoot: WS,
     });
 
+    // Assert
     expect(result.tool).toBe("push_down_claude_customizations");
   });
 
-  it("forwards an explicit invocationId when provided", async () => {
-    setExecutablePresenceOnFsMock(fsMock, { python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("preserves the canonical tool name even with an explicit invocationId", async () => {
+    // Arrange
+    const pushDownFileSystem = seedClaudeBundle();
     const service = createRepoAutomationService({
-      extensionRoot: "C:/extension",
+      extensionRoot: EXT,
       output: { appendLine: appendLineMock },
+      pushDownFileSystem,
     });
 
+    // Act
     const result = await service.pushDownClaudeCustomizations({
-      workspaceRoot: "C:/workspace",
+      workspaceRoot: WS,
       invocationId: "custom-id-123",
     });
 
-    // The result.tool reflects the canonical tool name, not the invocationId.
+    // Assert
     expect(result.tool).toBe("push_down_claude_customizations");
-    expect(result.workspaceRoot).toBe("C:/workspace");
+    expect(result.workspaceRoot).toBe(WS);
   });
 
-  it("appends --packs, --csharp-variant, and --memory-mode when supplied", async () => {
-    setExecutablePresenceOnFsMock(fsMock, { python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("threads packs, csharpVariant, and memoryMode into the in-process port", async () => {
+    // Arrange: select csharp-legacy with the legacy variant.
+    const pushDownFileSystem = seedClaudeBundle();
     const service = createRepoAutomationService({
-      extensionRoot: "C:/extension",
+      extensionRoot: EXT,
       output: { appendLine: appendLineMock },
+      pushDownFileSystem,
     });
 
+    // Act
     await service.pushDownClaudeCustomizations({
-      workspaceRoot: "C:/workspace",
-      packs: ["core", "typescript"],
+      workspaceRoot: WS,
+      packs: ["core", "csharp-legacy"],
       csharpVariant: "legacy",
       memoryMode: "merge",
     });
 
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    // The packs array is joined into a single comma-separated CLI value.
-    const packsIndex = args.indexOf("--packs");
-    expect(packsIndex).toBeGreaterThanOrEqual(0);
-    expect(args[packsIndex + 1]).toBe("core,typescript");
-    const variantIndex = args.indexOf("--csharp-variant");
-    expect(variantIndex).toBeGreaterThanOrEqual(0);
-    expect(args[variantIndex + 1]).toBe("legacy");
-    const memoryIndex = args.indexOf("--memory-mode");
-    expect(memoryIndex).toBeGreaterThanOrEqual(0);
-    expect(args[memoryIndex + 1]).toBe("merge");
+    // Assert: pack filtering and legacy variant routing are reflected in the
+    // copied destination files (the in-process port received the inputs).
+    expect(
+      pushDownFileSystem.readTextFile(`${WS}/.claude/rules/csharp.md`),
+    ).toBe("# Legacy C#\n");
+    expect(
+      pushDownFileSystem.isFile(`${WS}/.claude/agents/orchestrator.md`),
+    ).toBe(true);
+    // typescript was not selected, so it is excluded from the published set.
+    expect(pushDownFileSystem.isFile(`${WS}/.claude/rules/typescript.md`)).toBe(
+      false,
+    );
   });
 
-  it("spawns exactly the destination args for a no-field input (backward compatible)", async () => {
-    setExecutablePresenceOnFsMock(fsMock, { python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("publishes the full tree for a no-field input (backward compatible)", async () => {
+    // Arrange
+    const pushDownFileSystem = seedClaudeBundle();
     const service = createRepoAutomationService({
-      extensionRoot: "C:/extension",
+      extensionRoot: EXT,
       output: { appendLine: appendLineMock },
+      pushDownFileSystem,
     });
 
-    await service.pushDownClaudeCustomizations({
-      workspaceRoot: "C:/workspace",
-    });
+    // Act
+    await service.pushDownClaudeCustomizations({ workspaceRoot: WS });
 
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    // The first arg is the bundled script path; the rest are exactly the
-    // destination flag and the workspace root, with no optional flags appended.
-    expect(args.slice(1)).toStrictEqual(["--destination", "C:/workspace"]);
-    expect(args).not.toContain("--packs");
-    expect(args).not.toContain("--csharp-variant");
-    expect(args).not.toContain("--memory-mode");
+    // Assert: no pack selection publishes everything under `.claude`.
+    expect(pushDownFileSystem.isFile(`${WS}/.claude/rules/typescript.md`)).toBe(
+      true,
+    );
+    expect(pushDownFileSystem.isFile(`${WS}/.claude/rules/csharp.md`)).toBe(
+      true,
+    );
   });
 
-  it("omits --packs when the packs array is empty", async () => {
-    setExecutablePresenceOnFsMock(fsMock, { python: true });
-    childProcessMock.spawn.mockReturnValue(createMockProcess(0));
+  it("publishes the full tree when the packs array is empty", async () => {
+    // Arrange
+    const pushDownFileSystem = seedClaudeBundle();
     const service = createRepoAutomationService({
-      extensionRoot: "C:/extension",
+      extensionRoot: EXT,
       output: { appendLine: appendLineMock },
+      pushDownFileSystem,
     });
 
+    // Act
     await service.pushDownClaudeCustomizations({
-      workspaceRoot: "C:/workspace",
+      workspaceRoot: WS,
       packs: [],
     });
 
-    const [, args] = childProcessMock.spawn.mock.calls[0] as [string, string[]];
-    // An empty packs array must not produce a --packs flag.
-    expect(args).not.toContain("--packs");
+    // Assert: an empty packs array behaves like no selection (publish all).
+    expect(pushDownFileSystem.isFile(`${WS}/.claude/rules/typescript.md`)).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Ports the three push-down customization command variants — copilot, codex/agents, and claude — from Python to TypeScript as Feature F3 of epic #240.
- Adds 10 new TypeScript production source files under `extensions/drm-copilot/src/lib/push-down/` and wires them into `RepoAutomationService` so all three push-down methods now execute in-process rather than spawning a Python interpreter.
- Adds 9 new Jest test files plus a shared test-helper module, and updates 4 existing test files; the full Jest suite runs 825 tests across 73 suites — all pass.
- All 10 new `src/lib/push-down/*.ts` files meet the repository coverage policy: every file achieves line >= 85% and branch >= 75%, with aggregate `src/lib/**` coverage at 96.97% line / 87.93% branch — no regression from baseline.
- All 14 per-feature acceptance criteria (AC-F3-1..AC-F3-14) are confirmed PASS by independent toolchain re-run and audit.
- Python source files are retained (removal is deferred to F11 per spec); no changes to `command-runtime.ts`, `scripts/dev_tools/**`, or any `resources/**/*.py`.

## Why

Epic #240 replaces Python as the runtime for extension and MCP server command execution. Python scripts currently require a Python interpreter on the end-user's PATH, which is a hard runtime dependency. Porting to TypeScript removes that dependency and enables in-process invocation from the Node/TypeScript extension process.

F3 targets the three push-down commands specifically (`pushDownCopilotCustomizations`, `pushDownCodexAgentsCustomizations`, `pushDownClaudeCustomizations`). These commands perform tree copy, reference rewrites, pack selection, memory-scope frontmatter filtering, and structured JSON summary generation — all behaviors that are now implemented in TypeScript with verified parity.

## What Changed

### Core feature (10 new production TS files)

| File | Lines | Description |
|---|---|---|
| `src/lib/push-down/copilot-customizations-engine.ts` | 448 | Shared engine: tree enumeration, classification, reference rewriting, validation, JSON summary |
| `src/lib/push-down/copilot-customizations.ts` | 102 | Copilot entry point; delegates to shared engine |
| `src/lib/push-down/codex-agents-customizations.ts` | 80 | Codex/agents entry point; reuses engine with `.codex`/`.agents` roots and passthrough rewrites |
| `src/lib/push-down/claude-customizations.ts` | 244 | Claude entry; pack selection, variant routing, memory modes, `settings.local.json` exclusion |
| `src/lib/push-down/claude-pack-selection.ts` | 308 | Pack selection: validation messages, always-core union, variant routing, C# mutual-exclusion |
| `src/lib/push-down/claude-filesystem-adapter.ts` | 303 | `ExcludingFileSystem` four-filter enumeration; legacy C# read redirection |
| `src/lib/push-down/claude-memory-scope.ts` | 136 | Frontmatter memory-scope regex parser with fail-safe `repo` default |
| `src/lib/push-down/filesystem-adapter.ts` | 204 | `PushDownFileSystem` / `RealPushDownFileSystem`; sorted enumeration, LF-normalized writes |
| `src/lib/push-down/reference-rewrites.ts` | 243 | Seven-entry rewrite catalog; normalization, trailing-punctuation handling, deterministic unmatched ordering |
| `src/lib/push-down/push-down-service-call.ts` | 180 | Service-call helper: wraps each command, returns `tool/summary/artifacts` shape |

### Modified production files (2 files)

- `src/repo-automation-service.ts` — three push-down methods now delegate to `runPushDown*` helpers via `push-down-service-call.ts`; file is exactly 500 lines (at the limit, compliant).
- `src/repo-automation-service-push-down.ts` — extended with push-down support wiring (135 lines total).

### Tests (9 new + 1 new helper + 4 modified)

New test files under `test/lib/push-down/`:
- `claude-customizations.test.ts`, `claude-filesystem-adapter.test.ts`, `claude-pack-selection.test.ts`
- `codex-agents-customizations.test.ts`, `copilot-customizations-engine.test.ts`, `copilot-customizations.test.ts`
- `filesystem-adapter.test.ts`, `push-down-service-call.test.ts`, `reference-rewrites.test.ts`
- `push-down.test-helpers.ts` (shared in-memory FS and fixture helpers)

Modified test files:
- `test/repo-automation-service.push-down-claude.test.ts` — updated to assert in-process contract; removed Python-spawn assertions.
- `test/extension.push-down-claude-customizations.test.ts` — updated to assert in-process contract.
- `test/extension.integration.test.ts` — removed the two push-down Python-spawn case blocks (now 493 lines).
- `test/extension-test-harness.ts` — added `statSync`/`readdirSync` mock support for the in-process push-down filesystem.

### Documentation / evidence (15 files)

Plan, feature audit, policy audit, code review, and per-gate QA evidence files under `docs/features/active/2026-06-25-port-python-commands-to-typescript-240/`.

## Architecture / How It Fits Together

The three `RepoAutomationService` push-down methods previously called `executeScript` with `runtimeKind:"python"`. After this change, each method calls a corresponding `runPushDown*` helper (defined in `repo-automation-service-push-down.ts`) that invokes `push-down-service-call.ts`. The service-call helper instantiates the appropriate command module from `src/lib/push-down/`, runs it with an injected `RealPushDownFileSystem` (or `RealClaudeFileSystem`), and returns the `{ tool, summary, artifacts }` shape expected by the service layer unchanged.

The two remaining `runtimeKind:"python"` sites in `repo-automation-service.ts` (`collectPrContext` and `potentialToIssue`) are out of F3 scope and are unchanged.

The injected filesystem interfaces (`PushDownFileSystem`, `ClaudeFileSystem`) keep all I/O behind a seam, making every push-down module testable with in-memory fakes and no subprocess calls or temp files.

An injected clock seam is included for any time-dependent paths; `agentic_sync.ROOT_FOLDERS` is inlined rather than imported from a shared config to avoid adding a cross-module dependency.

## Verification

### Completed (from evidence)

| Gate | Command | Result |
|---|---|---|
| Format | `npm run format` | PASS (exit 0, 2026-06-26T01-30) |
| Lint | `npm run lint` | PASS (exit 0, 2026-06-26T01-31) |
| Type check | `npm run typecheck` | PASS (exit 0, 2026-06-26T01-32) |
| Test + coverage | `node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"` | PASS — 73 suites / 825 tests, 96.97% line / 87.93% branch (exit 0, 2026-06-26T01-35) |
| File-size check | `wc -l src/lib/push-down/*.ts src/repo-automation-service.ts ...` | PASS — all files <= 500 lines (exit 0, 2026-06-26T01-39) |
| Coverage delta | Baseline vs post-change | PASS — +0.64 line / +0.06 branch; every new file meets >= 85% / >= 75% |
| Scope verification | `git diff --name-only` + `git ls-files --others` | PASS — no unintended files (exit 0, 2026-06-26T02-23) |

Per-file coverage for all 10 new production files (line% / branch%):

| File | Line% | Branch% |
|---|---|---|
| `claude-customizations.ts` | 100 | 83.33 |
| `claude-filesystem-adapter.ts` | 94.38 | 83.33 |
| `claude-memory-scope.ts` | 100 | 86.36 |
| `claude-pack-selection.ts` | 100 | 98 |
| `codex-agents-customizations.ts` | 100 | 100 |
| `copilot-customizations-engine.ts` | 97.99 | 82 |
| `copilot-customizations.ts` | 100 | 100 |
| `filesystem-adapter.ts` | 98.03 | 86.95 |
| `push-down-service-call.ts` | 100 | 86.66 |
| `reference-rewrites.ts` | 99.17 | 93.75 |

### Recommended

```bash
cd extensions/drm-copilot
npm run format && npm run lint && npm run typecheck
node run-jest.cjs --coverage --collectCoverageFrom="src/lib/**/*.ts"
```

## Backward Compatibility / Migration Notes

- The `tool/summary/artifacts` return shape of the three push-down methods is preserved exactly; callers are unaffected.
- No changes to `command-runtime.ts` or the `"python"` runtime branch; the Python code path for other commands remains functional.
- No changes to bundled Python scripts under `extensions/drm-copilot/resources/` or `scripts/dev_tools/**`; those are removed in F11.
- Existing tests that previously asserted a Python spawn for the three push-down tools are updated to assert the in-process contract; no surviving suite asserts a Python spawn for these tools.

## Risks and Mitigations

| Risk | Mitigation |
|---|---|
| Behavior divergence from Python implementation | Exact-string assertions in ported unit tests; 14 per-feature ACs (AC-F3-1..14) all confirmed PASS by independent audit; full 825-test suite passes. |
| `repo-automation-service.ts` at exactly 500 lines (limit) | File is compliant at the limit. Future additions to this file must extract logic into helpers or the support file. |
| CI has not been observed green on this branch head yet | Local proxy gates (format/lint/typecheck/test/coverage/file-size) all pass. CI confirmation occurs at the orchestrator S9 gate. No workflow files changed, so `modified-workflow-needs-green-run` does not fire. |
| Epic AC-E3/E4 (full Python removal) still open | By design; removal is deferred to F11. The remaining `runtimeKind:"python"` sites are out of F3 scope and are intentionally unchanged. |

## Review Guide

1. **Start with** `src/lib/push-down/push-down-service-call.ts` and `src/repo-automation-service.ts` (lines 249–271) — this is the integration seam connecting the service layer to the new TS modules.
2. **Review the shared engine** `src/lib/push-down/copilot-customizations-engine.ts` — the largest single file (448 lines) and the core of the copilot and codex/agents variants.
3. **Review claude-specific modules** in file-size order: `claude-pack-selection.ts` → `claude-filesystem-adapter.ts` → `claude-customizations.ts` → `claude-memory-scope.ts`.
4. **Review shared utilities**: `filesystem-adapter.ts`, `reference-rewrites.ts`.
5. **Review tests** in the same order as production files; `push-down.test-helpers.ts` provides the shared in-memory FS used across all push-down test suites.
6. **Modified test files** (`extension.integration.test.ts`, `extension.push-down-claude-customizations.test.ts`, `repo-automation-service.push-down-claude.test.ts`) contain the removed Python-spawn assertions — these diffs are mechanical and can be reviewed last.
7. Documentation files (`docs/features/active/.../`) are evidence artifacts and do not require line-by-line review.

## Follow-ups

- **F11** — remove the `"python"` runtime branch from `command-runtime.ts` and delete bundled Python resources; this completes AC-E3 and AC-E4 of epic #240.
- Add a package-level ESLint `no-restricted-syntax` rule to block future `child_process` use in push-down modules (tracked as an epic-level follow-up in the policy audit).
- Update `dependency-cruiser` config to enforce the `src/lib/push-down/` module boundary as the epic matures.

## GitHub Auto-close

None

---

Relates to #240
