### PR TITLE
Add workspace PowerShell terminal profile that activates the venv

### DIFF
--- a/.vscode/settings_required.json
+++ b/.vscode/settings_required.json
@@ -37,5 +37,16 @@
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
     "python.testing.pytestArgs": ["tests"],
-    "python.testing.autoTestDiscoverOnSaveEnabled": false
+    "python.testing.autoTestDiscoverOnSaveEnabled": false,
+    "terminal.integrated.profiles.windows": {
+        "PowerShell 7 (drm-copilot)": {
+            "source": "PowerShell",
+            "args": [
+                "-NoExit",
+                "-Command",
+                ". '${workspaceFolder}/scripts/dev-tools/activate.ps1'"
+            ]
+        }
+    },
+    "terminal.integrated.defaultProfile.windows": "PowerShell 7 (drm-copilot)"
 }


### PR DESCRIPTION
# Add workspace PowerShell terminal profile that activates the venv

## Summary
- Add a workspace-scoped VS Code terminal profile `PowerShell 7 (drm-copilot)` that dot-sources `scripts/dev-tools/activate.ps1` on terminal launch.
- Set this profile as the default Windows integrated-terminal profile.
- Use `source: "PowerShell"` rather than a hardcoded executable path so the profile resolves PowerShell across machines.
- Scope is a single configuration file: `.vscode/settings_required.json` (12 insertions, 1 deletion).

## Why
New integrated terminals did not automatically activate the in-project Poetry venv or install the repo-relative prompt. `scripts/dev-tools/activate.ps1` must be dot-sourced to persist its venv activation and `global:prompt` redefinition in the caller's session. Wiring this into a default terminal profile makes activation automatic for every new PowerShell terminal.

## What Changed
Tooling/configuration:
- `.vscode/settings_required.json`
  - Added `terminal.integrated.profiles.windows` with a `PowerShell 7 (drm-copilot)` entry using `source: "PowerShell"` and `args` `["-NoExit", "-Command", ". '${workspaceFolder}/scripts/dev-tools/activate.ps1'"]`.
  - Added `terminal.integrated.defaultProfile.windows` set to `PowerShell 7 (drm-copilot)`.

## Architecture / How It Fits Together
- VS Code launches the configured default profile for new Windows integrated terminals.
- The profile starts PowerShell (resolved via the `PowerShell` source generator), then runs `-Command ". '${workspaceFolder}/scripts/dev-tools/activate.ps1'"`.
- The leading `.` dot-sources the script so its side effects (venv activation, `global:prompt` install) persist in the session; `-NoExit` keeps the terminal open after activation.
- `${workspaceFolder}` is expanded by VS Code, keeping the path portable across clones.

## Verification
Completed:
- Not verified in this PR. CI status at HEAD is `in_progress`.

Recommended:
- Open a new integrated terminal and confirm it launches with the `PowerShell 7 (drm-copilot)` profile, activates the in-project `.venv`, and renders the repo-relative prompt.
- Confirm behavior when `.venv` is absent: the script throws activation guidance while the terminal remains open due to `-NoExit`.

## Backward Compatibility / Migration Notes
- Changes the default Windows integrated-terminal profile. Contributors who relied on the prior default PowerShell profile will now get the activating profile.
- Affects PowerShell terminals only; Bash/Git Bash terminals are unaffected.
- The PowerShell extension's Integrated Console does not use `terminal.integrated.profiles` and is not changed by this PR.

## Risks and Mitigations
- Risk: Activation fails when `.venv` does not exist. Mitigation: the script emits corrective guidance to run `poetry install`; `-NoExit` keeps the terminal usable.
- Risk: Non-Windows contributors are unaffected and may expect a default profile. Mitigation: only `terminal.integrated.*.windows` keys are set; other platforms retain their existing defaults.
- Rollback: revert the two added keys in `.vscode/settings_required.json`.

## Review Guide
- Single configuration file; review `.vscode/settings_required.json` for correct JSON structure, the `source`/`args` profile shape, and the default-profile assignment.

## Follow-ups
- Consider whether a parallel non-Windows profile is needed for contributors on other platforms.

## GitHub Auto-close
- None
