### PR TITLE
release: bump root, extension, and mcp-server to 1.0.0

### DIFF
--- a/extensions/drm-copilot/package-lock.json
+++ b/extensions/drm-copilot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drm-copilot",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drm-copilot",
-      "version": "0.0.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/extensions/drm-copilot/package.json
+++ b/extensions/drm-copilot/package.json
@@ -2,7 +2,7 @@
   "name": "drm-copilot",
   "displayName": "drm-copilot",
   "description": "Extension-side bundled workflow execution utilities and MCP bridge.",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "publisher": "DanMoisan",
   "license": "MIT",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drm-copilot",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drm-copilot",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "DanMoisan",
   "displayName": "drm-copilot",
   "description": "VS Code extension to facilitate standardized development tools to repos.",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "engines": {
     "vscode": "^1.118.0"
   },

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danmoisan/drm-copilot-mcp",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danmoisan/drm-copilot-mcp",
-      "version": "0.0.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danmoisan/drm-copilot-mcp",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "Stdio MCP server exposing drm-copilot repo-automation tools.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

- Bumps the version field in all three package manifests from pre-1.0 levels to `1.0.0`: repo-root `package.json` (0.0.1 → 1.0.0), `extensions/drm-copilot/package.json` (0.0.6 → 1.0.0), and `packages/mcp-server/package.json` (0.0.6 → 1.0.0).
- Updates the corresponding `package-lock.json` files for each manifest to reflect the new version.
- Follows the established release flow defined in `scripts/dev-tools/Invoke-FullRelease.ps1`: clean-tree check, release branch, `npm version --no-git-tag-version`, commit, push, PR against main.
- Extends that flow to the repo-root manifest and uses an explicit `1.0.0` target rather than a patch increment.
- Does not publish to any registry and does not push a release tag; those steps are performed by CI after this PR merges, via `Invoke-ReleaseTagPush.ps1`.

## Why

The extension and MCP server packages had reached a stable, production-ready state at pre-release patch versions (0.0.6). The repo-root manifest was still at 0.0.1. This PR advances all three to a unified `1.0.0` to align public versioning with the product's release readiness and to ensure the npm publish and marketplace upload steps that follow will reflect the intended release version.

## What Changed

**Version manifests**

| File | Before | After |
|---|---|---|
| `package.json` (root) | 0.0.1 | 1.0.0 |
| `extensions/drm-copilot/package.json` | 0.0.6 | 1.0.0 |
| `packages/mcp-server/package.json` | 0.0.6 | 1.0.0 |

**Lockfiles**

- `package-lock.json` (root)
- `extensions/drm-copilot/package-lock.json`
- `packages/mcp-server/package-lock.json`

All lockfile changes are the mechanical `"version": "1.0.0"` field updates generated by `npm version --no-git-tag-version`. No dependency graph changes.

## Architecture / How It Fits Together

This PR is a pure version-bump commit. No source files, configuration files, or CI workflows are modified. The three workspaces (root, extension, MCP server) each maintain their own `package.json` and `package-lock.json`; this change updates only the `version` field in each. The post-merge release sequence is:

1. This PR merges to `main`.
2. `Invoke-ReleaseTagPush.ps1` pushes the `v1.0.0` git tag.
3. CI responds to the tag push, performs the marketplace upload and npm publish steps.

## Verification

**Completed**

- Not verified in this PR (no CI run recorded against this branch head in the context bundle).

**Recommended**

```bash
# Confirm version fields in all three manifests
node -e "console.log(require('./package.json').version)"
node -e "console.log(require('./extensions/drm-copilot/package.json').version)"
node -e "console.log(require('./packages/mcp-server/package.json').version)"
# Expected output: 1.0.0 (three times)

# Confirm lockfiles are consistent
npm install --package-lock-only --workspaces
git diff --exit-code package-lock.json extensions/drm-copilot/package-lock.json packages/mcp-server/package-lock.json
```

## Backward Compatibility / Migration Notes

- The version change is additive from a consumer standpoint; no API surfaces are altered.
- Callers that pin to `0.0.6` or `0.0.1` of these packages will need to update their version constraints to `^1.0.0` after publication.

## Risks and Mitigations

| Risk | Mitigation |
|---|---|
| Lockfile drift (lock does not match manifest after bump) | Recommended verification step above confirms lockfile consistency before merge. |
| Post-merge tag push targets wrong commit | `Invoke-ReleaseTagPush.ps1` reads the merge commit SHA from the main branch at run time; no manual SHA is required. |
| Accidental publish before tag push | This PR contains no publish step. CI only publishes in response to the tag event, not to a merge event. |

## Review Guide

This PR contains 6 files, all JSON. The diff is 9 insertions and 9 deletions, limited to `"version"` field changes. No logic review is required. Suggested order:

1. `package.json` (root) — confirm `"version": "1.0.0"`.
2. `extensions/drm-copilot/package.json` — confirm `"version": "1.0.0"`.
3. `packages/mcp-server/package.json` — confirm `"version": "1.0.0"`.
4. The three `package-lock.json` files — confirm only `"version"` fields changed; no dependency graph changes.

## Follow-ups

- After merge: run `Invoke-ReleaseTagPush.ps1` to push the `v1.0.0` tag and trigger the CI publish pipeline.
- Confirm marketplace upload and npm publish succeed in CI before communicating the release externally.

## GitHub Auto-close

- None
