### PR TITLE
release: bump extension 1.0.7 and mcp-server 1.0.7

### DIFF
--- a/extensions/drm-copilot/package-lock.json
+++ b/extensions/drm-copilot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drm-copilot",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drm-copilot",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/extensions/drm-copilot/package.json
+++ b/extensions/drm-copilot/package.json
@@ -3,7 +3,7 @@
   "displayName": "drm-copilot",
   "description": "Repository automation, customization publishing, and MCP bridge for drm-copilot workflows.",
   "icon": "resources/icon.png",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publisher": "DanMoisan",
   "license": "MIT",
   "repository": {

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danmoisan/drm-copilot-mcp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danmoisan/drm-copilot-mcp",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danmoisan/drm-copilot-mcp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Stdio MCP server exposing drm-copilot repo-automation tools.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
Automated full release version-bump PR. Extension -> 1.0.7, mcp-server -> 1.0.7. Merge to main, then run the post-merge tag-push task to publish.