### PR TITLE
docs: restore #310 feature-review audit trail

### DIFF
--- a/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/code-review.2026-07-05T02-34.md
+++ b/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/code-review.2026-07-05T02-34.md
@@ -1,0 +1,66 @@
+# Code Review — Issue #310 (release-flow-wait-for-ci)
+
+- Timestamp: 2026-07-05T02-34
+- Files reviewed: `scripts/dev-tools/Invoke-FullReleaseFlow.ps1` (modified), `tests/scripts/dev-tools/Invoke-FullReleaseFlow.Tests.ps1` (modified), `tests/scripts/dev-tools/Invoke-FullReleaseFlow.AdditionalFailurePaths.Tests.ps1` (modified), `tests/scripts/dev-tools/Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` (new)
+
+## Summary
+
+The change replaces a single `gh pr checks $prNumber --watch` call (which fails immediately during the window before GitHub registers workflow checks on a newly opened PR) with a two-phase bounded poll: `Wait-ForPullRequestChecks` waits for check registration, then waits for registration to leave the pending bucket, before `Invoke-FullReleaseFlowGuarded` proceeds to merge. The design follows the repository's existing wrapper-seam pattern (`Invoke-GhExe`) and adds a new `Invoke-Sleep` wrapper seam so tests can assert on retry/backoff behavior without a real wall-clock wait. Code quality is consistent with the surrounding file.
+
+## Design Principles (`.claude/rules/general-code-change.md`)
+
+- **Simplicity first**: The two-phase loop structure (registration loop, then completion loop) is the simplest correct design for the stated problem; no unnecessary abstraction layers were introduced.
+- **Reusability**: `Invoke-Sleep` is a small, generically reusable wrapper seam placed alongside the existing `Invoke-GitExe`/`Invoke-GhExe`/`Invoke-ChildPowerShellScript` seams, following the same pattern rather than inventing a new one.
+- **Extensibility**: All four new tunables (`RegistrationMaxAttempts`, `RegistrationIntervalSeconds`, `CompletionMaxAttempts`, `CompletionIntervalSeconds`) are optional keyword parameters with sensible defaults, consistent with the "prefer keyword-style parameters with defaults" guidance.
+- **Separation of concerns**: `Wait-ForPullRequestChecks` is a pure orchestration function over the `Invoke-GhExe`/`Invoke-Sleep` seams; it does not itself touch the network, matching the existing I/O-isolation pattern in this file.
+
+## Findings
+
+### 1. (Non-blocking) Comment-based help does not restate numeric defaults or worst-case total wait
+
+`Wait-ForPullRequestChecks`'s `.PARAMETER` blocks (lines 185–194) describe each parameter's role ("Maximum number of registration-phase poll attempts before timing out.") but do not restate the default value or the resulting worst-case wall-clock bound. With the shipped defaults (`RegistrationMaxAttempts=24`, `RegistrationIntervalSeconds=5`, `CompletionMaxAttempts=60`, `CompletionIntervalSeconds=10`), the function can block for up to 2 minutes waiting for check registration and up to an additional 10 minutes waiting for completion, entirely within a single VS Code task invocation. This is discoverable by reading the parameter defaults in the signature, but a maintainer skimming only the comment-based help (e.g., via `Get-Help Wait-ForPullRequestChecks -Full`) will not see the derived total.
+
+Suggestion: add one sentence to `.DESCRIPTION` or a `.NOTES` block stating the default worst-case bounds, e.g., "With default parameters, registration is bounded at ~2 minutes (24 × 5s) and completion at ~10 minutes (60 × 10s)."
+
+### 2. (Non-blocking) Untested edge case: zero required checks
+
+If a PR has no required status checks configured at all, `gh pr checks $prNumber --required --json bucket` would return exit code 0 with an empty JSON array `[]`. Tracing the code: `$buckets` becomes an empty array; in the completion loop, `$buckets -contains 'fail'` is false, `$stillPending` is empty/`$null`, and `if (-not $stillPending) { return 0 }` fires — so the function correctly treats "no required checks" as success (vacuously, every required check — of which there are none — has reported pass or skipping). This is almost certainly the intended and correct behavior, and it is consistent with AC3's phrasing ("runs only after every required check reports bucket pass or skipping").
+
+However, none of the six new tests in `Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` exercise this specific input shape (`Output = @('[]')`, `ExitCode = 0` on the first poll). `.claude/rules/general-unit-test.md`'s "Scenario Completeness" section calls for edge-case and boundary-condition coverage per unit of behavior. This is a real, reachable input shape (a repository or PR with no required checks) that is not directly exercised.
+
+Suggestion: add one more `It` case asserting `Wait-ForPullRequestChecks` returns `0` when the poll returns `@('[]')` with `ExitCode = 0` on the first call, to make the vacuous-success behavior an explicit, regression-tested contract rather than an implicit consequence of the `Where-Object`/`-contains` logic.
+
+### 3. (Informational) Stray trailing text in `plan.md`
+
+`docs/features/active/2026-07-04-release-flow-wait-for-ci-310/plan.md` line 160 ends with a bare line `DIRECTIVE: PREFLIGHT VALIDATION ONLY` after the closing `---` separator, with no further content. This does not affect the production code and was not acted upon by this review (see `policy-audit.2026-07-05T02-34.md`, "Rejected Scope Narrowing"). It appears to be leftover/unintended text and should be removed for document hygiene, but it carries no functional or policy consequence.
+
+## Naming
+
+- `Wait-ForPullRequestChecks`, `Invoke-Sleep` follow PascalCase/approved-verb conventions. The one PSScriptAnalyzer naming exception (`PSUseSingularNouns` on `Wait-ForPullRequestChecks`) is addressed in the policy audit and is justified/precedented.
+- Parameter names (`PrNumber`, `RegistrationMaxAttempts`, `RegistrationIntervalSeconds`, `CompletionMaxAttempts`, `CompletionIntervalSeconds`, `Seconds`) are descriptive and unambiguous; no abbreviations.
+
+## Error Handling and Logging
+
+- Both timeout paths and the genuine-failure path each call `Write-StderrLine` with a specific, distinct message before returning `1`, consistent with the file's existing "fail fast and explicitly" pattern and with `.claude/rules/general-code-change.md`'s error-handling guidance.
+- No broad catch-alls or silently swallowed errors were introduced. `ConvertFrom-Json` is not wrapped in a try/catch, but this mirrors the existing risk profile of the file (no other `gh`/`git` JSON-parsing call site in this script catches parse errors either), so this is not a new pattern or a regression in rigor.
+
+## Testing Standards (`.claude/rules/general-unit-test.md`, `.claude/rules/powershell.md`)
+
+- **Independence/Isolation**: Each new `It` block establishes its own mocks in its own scope; no shared mutable state leaks between tests beyond the `BeforeEach`-reset `$script:` counters, which is the same pattern used throughout the existing suite.
+- **Determinism**: `Invoke-Sleep` is mocked in every test that exercises `Wait-ForPullRequestChecks` or `Invoke-FullReleaseFlowGuarded`; no test relies on a real `Start-Sleep`. Poll counts are deterministic via `$script:ghCallCount`/`$script:sleepCallCount` closures.
+- **Readability**: Test names ("waits through the registration race then merges", "returns failure on registration timeout", etc.) clearly describe scenario and expected outcome; `Context` blocks group registration-phase, completion-phase, and sleep-seam scenarios logically.
+- **Mock signature parity**: All new mocks use `param([string[]]$GhArgs)` / `param([int]$Seconds)`, matching the production wrapper signatures exactly.
+- **Location**: The new test file `tests/scripts/dev-tools/Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` mirrors the production path (`scripts/dev-tools/Invoke-FullReleaseFlow.ps1`) under `tests/scripts/dev-tools/`, consistent with the required test-file layout, and follows the existing sibling-file split pattern (`AdditionalFailurePaths`) rather than growing a single file past the line limit.
+
+## Compatibility / Public API
+
+- `Wait-ForPullRequestChecks` is a new function; it does not break any existing public API. `Invoke-FullReleaseFlowGuarded`'s external contract (parameters, return codes 0/1/2) is unchanged.
+- Internal call-site change (replacing the `--watch` invocation) is not part of any published/public API; no external callers exist outside this script and its dedicated test suites.
+
+## Dependencies
+
+- No new third-party dependencies introduced; `Invoke-Sleep` wraps the built-in `Start-Sleep` cmdlet.
+
+## Conclusion
+
+No blocking code-quality findings. Two non-blocking suggestions (documentation completeness for default timeouts; one additional edge-case test for the zero-required-checks scenario) and one informational note (stray text in `plan.md`) are recorded for optional follow-up; none block merge.

--- a/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/feature-audit.2026-07-05T02-34.md
+++ b/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/feature-audit.2026-07-05T02-34.md
@@ -1,0 +1,62 @@
+# Feature Audit — Issue #310 (release-flow-wait-for-ci)
+
+- Timestamp: 2026-07-05T02-34
+- Work mode: `full-bug`
+- AC source resolution: Per `.claude/skills/acceptance-criteria-tracking/SKILL.md`, `full-bug` resolves to `spec.md` only. `spec.md`'s `## Acceptance Criteria` section (lines 109–117) is the unfilled generic bug-report template — every field under Context, Environment, Repro Steps, and Acceptance Criteria is still placeholder text (`One or two sentences on what is broken.`, `1. ...`, etc.). Per this delegation's explicit instruction, `plan.md`'s `## Acceptance Criteria` section (lines 14–23, `AC1`–`AC8`) is treated as the authoritative, feature-specific AC source in place of the unfilled template, and is the primary evaluation table below. The generic `spec.md` template checklist is evaluated secondarily for completeness.
+
+## Primary AC Evaluation — `plan.md` AC1–AC8
+
+| AC | Criterion | Verdict | Evidence |
+|---|---|---|---|
+| AC1 | Flow waits (bounded) for required checks to **register** before treating an empty/not-yet-reported set as failure | **PASS** | `Wait-ForPullRequestChecks` registration loop (`scripts/dev-tools/Invoke-FullReleaseFlow.ps1` lines 220–232); unit-tested in `Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` "waits through the registration race then merges" and "returns failure on registration timeout" |
+| AC2 | Flow waits (bounded) for registered checks to **complete** before evaluating pass/fail | **PASS** | Completion loop (lines 236–257); unit-tested in "waits through pending checks then completes" and "returns failure on completion timeout" |
+| AC3 | `gh pr merge ... --merge --delete-branch` runs only after every required check reports `pass`/`skipping` | **PASS** | Wiring at lines 364–369 gates the merge call on `$checksResult -eq 0`; "successful automated flow" test in `Invoke-FullReleaseFlow.Tests.ps1` asserts the exact gh-call sequence `pr view → pr checks ... --required --json bucket → pr merge` |
+| AC4 | Genuine check failure (`fail`/`cancel`) returns 1, no merge, no tag push | **PASS** | `Wait-ForPullRequestChecks` returns 1 immediately on `fail`/`cancel` without further polling (lines 238–241, confirmed by "returns failure immediately on a genuine check failure..." asserting `Invoke-GhExe` called exactly once); integration-level "stops before merge, pull, and tag push when checks fail" test in `Invoke-FullReleaseFlow.Tests.ps1` confirms no merge/checkout/pull/tag-push occurs |
+| AC5 | Registration timeout or completion timeout returns 1, no merge, no tag push | **PASS** | Unit-tested directly on `Wait-ForPullRequestChecks` (both timeout paths return 1 with a distinct stderr message); wiring (`if ($checksResult -ne 0) { return 1 }`) is exercised generically by the checks-fail integration test, which proves the same code path used for both a genuine failure and a timeout halts before merge |
+| AC6 | New/updated tests use the dot-source + `Mock` seam pattern; no real git/gh/network/sleep | **PASS** | Verified by inspection of all three touched test files: `Invoke-GhExe`, `Invoke-GitExe`, `Invoke-ChildPowerShellScript`, `Invoke-Sleep`, and `Write-StderrLine` are the only mocked seams; no `Start-Sleep` outside the production wrapper body; `Invoke-Sleep` mocked in every `BeforeEach` that reaches it |
+| AC7 | Full PowerShell toolchain (format → analyze → test-with-coverage) passes in a single clean pass, no line/branch coverage regression | **PASS**, with a documented tooling caveat | `evidence/qa-gates/format-final.2026-07-04T22-35.md`, `lint-final.2026-07-04T22-36.md`, `test-final.2026-07-04T22-40.md` all EXIT_CODE 0; `coverage-delta.2026-07-04T22-42.md` shows line coverage improved 93.75% → 94.26% (no regression). Branch coverage is not numerically emitted by this repository's Pester/JaCoCo exporter for any PowerShell file (pre-existing, repo-wide tooling limitation, also documented under issue #298); see `policy-audit.2026-07-05T02-34.md` for full detail |
+| AC8 | Production file and every touched test file remain <= 500 lines | **PASS** | `Invoke-FullReleaseFlow.ps1` 401 lines; `Invoke-FullReleaseFlow.Tests.ps1` 426 lines; `Invoke-FullReleaseFlow.AdditionalFailurePaths.Tests.ps1` 99 lines; `Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` 141 lines — all confirmed via direct `wc -l` |
+
+All eight AC1–AC8 items were already marked `[x]` in `plan.md` by the executor; this audit independently re-verified each against the code, tests, and evidence artifacts rather than relying on the pre-existing checkmarks, and confirms all eight hold.
+
+### Acceptance Criteria Status (plan.md AC1–AC8)
+- Source: `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/plan.md`
+- Total AC items: 8
+- Checked off (delivered): 8
+- Remaining (unchecked): 0
+- Items remaining: none
+
+## Secondary AC Evaluation — `spec.md` Generic Bug-Report Template
+
+| Criterion | Verdict | Note |
+|---|---|---|
+| Repro steps now produce the expected behavior in all documented environments | UNVERIFIED | `spec.md`'s Environment/Repro Steps sections were never filled in (still literal placeholder text); no documented environment exists to verify against. The underlying root cause (premature `gh pr checks --watch` failure during the check-registration race) is fixed and covered by dedicated tests, but this specific template field cannot be marked PASS against undefined repro/environment content. Left unchecked in `spec.md`. |
+| Regression test(s) added and passing (list file path and test name) | PASS | `tests/scripts/dev-tools/Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` (6 new `It` blocks); `tests/scripts/dev-tools/Invoke-FullReleaseFlow.Tests.ps1` and `Invoke-FullReleaseFlow.AdditionalFailurePaths.Tests.ps1` updated; 32/32 passing. Checked off in `spec.md`. |
+| Edge cases and invalid inputs are handled with correct errors or fallbacks | PARTIAL | Registration timeout, completion timeout, and genuine failure are all tested. One reachable edge case — a PR with zero required checks configured (`gh` returns `[]` with exit 0) — is handled correctly by the code (traced by inspection: vacuously returns 0) but is not exercised by a dedicated test. See `code-review.2026-07-05T02-34.md` finding 2. Left unchecked in `spec.md` pending that test. |
+| No unintended behavior changes outside the defined scope | PASS | Diff and test assertions confirm preflight/merge/checkout/pull/tag-push logic is untouched apart from the checks-wait replacement. Checked off in `spec.md`. |
+| Required logs/telemetry updated and validated (if applicable) | PASS | `Write-StderrLine` messages updated for the new registration-timeout, completion-timeout, and genuine-failure cases; asserted by mocked-and-captured message tests. Checked off in `spec.md`. |
+| Performance constraints met or explicitly waived with rationale | UNVERIFIED | `spec.md` defines no explicit numeric performance constraint to check against (template unfilled) and none was explicitly waived. The implemented defaults bound worst-case wait to ~2 minutes (registration) + ~10 minutes (completion), which is a reasonable design choice for a manual release-automation flow, but this was not stated as an explicit constraint anywhere in the AC source. Left unchecked in `spec.md`. |
+| Full toolchain pass completed (format → lint → type-check → test) | PASS | All three PoshQC stages green per baseline and final QA-gate evidence. Checked off in `spec.md`. |
+| Docs/config references updated to match the new behavior | PASS | Searched the repository (excluding this feature's own docs) for other references to the old `gh pr checks --watch` behavior or to `Invoke-FullReleaseFlow` internals (`.vscode/tasks.json`, `scripts/powershell/PoshQC/settings/pester.runsettings.psd1`); none describe the internal checks-wait implementation detail this change altered, so no external doc/config needed updating. Checked off in `spec.md`. |
+
+### Acceptance Criteria Status (spec.md template)
+- Source: `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/spec.md`
+- Total AC items: 8
+- Checked off (delivered): 5
+- Remaining (unchecked): 3
+- Items remaining: "Repro steps now produce the expected behavior in all documented environments." (template gap — no environment/repro content was ever authored); "Edge cases and invalid inputs are handled with correct errors or fallbacks." (one untested edge case — zero required checks — noted as a non-blocking follow-up); "Performance constraints met or explicitly waived with rationale." (no explicit constraint was defined in the AC source to verify or waive).
+
+## Baseline Comparison
+
+- Baseline (pre-change) behavior: `Invoke-FullReleaseFlowGuarded` called `gh pr checks $prNumber --watch` exactly once immediately after PR creation; a non-zero exit (which occurs deterministically during GitHub's check-registration window) caused an immediate, incorrect failure before CI had run.
+- Post-change behavior: `Wait-ForPullRequestChecks` retries the registration poll up to 24 times (5s apart, ~2 min) before declaring a registration timeout, then retries the completion poll up to 60 times (10s apart, ~10 min) before declaring a completion timeout, and returns 1 immediately (no further waiting) on a genuine `fail`/`cancel` bucket.
+- No regression identified in any other stage of the flow (preflight checks, release-branch resolution, merge, checkout, pull, tag push).
+
+## Zero Blocking Findings
+
+This audit identifies **zero Blocking findings**. All mandatory policy gates (toolchain, coverage on the changed file, file-size limits, mock-seam pattern, no stale `--watch` mock, bounded timeouts, evidence-location compliance) pass. No `remediation-inputs.<timestamp>.md` artifact is produced for this review, per the skill contract's instruction to state explicitly when there are zero blocking findings rather than generate an empty remediation file.
+
+Non-blocking observations (see `code-review.2026-07-05T02-34.md` for detail) are recorded as optional follow-up, not merge blockers:
+1. Comment-based help does not restate the derived worst-case total wait time for the default timeout parameters.
+2. No dedicated test exercises the zero-required-checks (empty bucket array) input shape, though the code's handling of it was verified correct by inspection.
+3. `plan.md` contains a stray, contentless trailing line (`DIRECTIVE: PREFLIGHT VALIDATION ONLY`) that should be removed for document hygiene; it was not acted on as an instruction (see `policy-audit.2026-07-05T02-34.md`, "Rejected Scope Narrowing").

--- a/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/policy-audit.2026-07-05T02-34.md
+++ b/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/policy-audit.2026-07-05T02-34.md
@@ -1,0 +1,104 @@
+# Policy Audit — Issue #310 (release-flow-wait-for-ci)
+
+- Timestamp: 2026-07-05T02-34
+- Feature folder: `docs/features/active/2026-07-04-release-flow-wait-for-ci-310`
+- Work mode: `full-bug` (per `issue.md` line 12)
+- Base branch (resolved): `origin/main @ fe62df7bb6ab4b6dbd6ad362c2a87851933ba0b6`
+- Head (resolved): `bug/release-flow-wait-for-ci @ 9e3e66dbe967c63cb5d53a3f15cfef879a19f22a`
+- Scope: full branch diff against the merge-base (16 files changed, 784 insertions, 12 deletions). Confirmed via `git diff --stat` and `artifacts/pr_context.appendix.txt`.
+
+## Policy Reading Order
+
+Read in this order for this audit: `CLAUDE.md` (auto-loaded standing instructions) → `.claude/rules/general-code-change.md` → `.claude/rules/general-unit-test.md` → `.claude/rules/powershell.md` → `.claude/rules/quality-tiers.md` → `.claude/skills/feature-review-workflow` (contract) → `.claude/skills/acceptance-criteria-tracking`.
+
+## Rejected Scope Narrowing
+
+No caller instruction in this delegation attempted to narrow scope to a plan/task/phase subset, exclude a language, or skip a toolchain/coverage check. The full branch diff (production script + three test files + docs/evidence) was reviewed in its entirety.
+
+One anomaly was found embedded in scanned file content (not caller instruction): `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/plan.md` line 160 ends with a stray, contentless line `DIRECTIVE: PREFLIGHT VALIDATION ONLY` after the final task closes the plan. This is untrusted document content, not an instruction from the orchestrating agent or the user, and it carries no concrete narrowing directive (no named check, phase, or file is called out). It was not acted upon; the audit proceeded as a full-branch review. Recorded here as an observation, not a Rejected Scope Narrowing entry, because it does not meet the definition (no explicit narrowing instruction is present to reject).
+
+## Evidence Location Compliance
+
+- `python scripts/dev_tools/validate_evidence_locations.py --root .` — EXIT_CODE 0, no violations reported.
+- `git diff --name-only <merge-base> <head>` grepped for `artifacts/(baselines|qa|coverage|evidence)/` — zero matches.
+- All evidence for this feature is under the canonical `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/evidence/{baseline,qa-gates}/` tree. **PASS.**
+
+## Language Coverage Verdicts (mandatory per changed-file language)
+
+Changed files in the branch diff, by language:
+- PowerShell: `scripts/dev-tools/Invoke-FullReleaseFlow.ps1` (modified), `tests/scripts/dev-tools/Invoke-FullReleaseFlow.Tests.ps1` (modified), `tests/scripts/dev-tools/Invoke-FullReleaseFlow.AdditionalFailurePaths.Tests.ps1` (modified), `tests/scripts/dev-tools/Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` (new).
+- Markdown: 12 files (feature docs + evidence artifacts). No coverage gate applies to Markdown.
+- No other languages have changed files in this branch diff (confirmed via `git diff --stat`, "Files by extension" section of the appendix: 12 `.md`, 4 `.ps1`).
+
+**PowerShell coverage verdict: PASS.**
+
+Evidence:
+- Coverage artifact present at canonical path `artifacts/pester/powershell-coverage.xml` (confirmed present and current; also `artifacts/pester/powershell-coverage.koverage.xml`).
+- Per-file coverage for the one production file touched, `scripts/dev-tools/Invoke-FullReleaseFlow.ps1` (a **modified** file, not new — it pre-existed and was extended), parsed directly from the XML `<class name=".../Invoke-FullReleaseFlow">` counters: `LINE missed="7" covered="115"` → 115/122 = **94.26%** line coverage. This matches the value recorded in `evidence/qa-gates/test-final.2026-07-04T22-40.md` and `evidence/qa-gates/coverage-delta.2026-07-04T22-42.md`.
+- Baseline (`evidence/baseline/test-baseline.2026-07-04T22-20.md`) recorded 93.75% (90/96) prior to the change. Post-change 94.26% (115/122) is an improvement, not a regression. Threshold (>= 85% line, modified-file tier) is met with margin.
+- New method-level detail confirms the newly added `Wait-ForPullRequestChecks` (26/26 lines, 100%) and the modified `Invoke-FullReleaseFlowGuarded` (78/78 lines, 100%) are fully covered. The only uncovered line touched by this change is the single-statement body of the new `Invoke-Sleep` wrapper (`Start-Sleep -Seconds $Seconds`), which is uncovered by the same wrapper-seam mocking convention already applied to the three pre-existing wrapper seams (`Invoke-GitExe`, `Invoke-GhExe`, `Invoke-ChildPowerShellScript`) — each of those is also uncovered at its real-call line in the same coverage report, so this is not a new pattern introduced by this change; it is consistent with `.claude/rules/powershell.md`'s "never mock the external executable directly, mock the wrapper" rule, which necessarily leaves the wrapper's one real-call line unexercised by unit tests.
+- **Branch coverage: not numerically emitted.** `grep -c 'type="BRANCH"'` against both `artifacts/pester/powershell-coverage.xml` and `artifacts/pester/powershell-coverage.koverage.xml` returns 0 — this repository's JaCoCo/CoverageGutters exporter for Pester does not emit a `BRANCH` counter type at all, for any file, in this or the baseline run. This is a pre-existing, repo-wide tooling limitation, not something introduced or newly discovered by this change; it is documented identically in `docs/features/active/2026-07-03-fix-convertto-commandresult-empty-array-298/evidence/qa-gates/test-final.2026-07-04T02-40.md`. Because the underlying data point does not exist in the tool's output for any PowerShell file in this repository, it cannot be evaluated as PASS or FAIL against the 75% branch threshold; it is recorded here as a **known, pre-existing tooling gap** rather than a coverage regression attributable to this change. This does not change the overall PowerShell coverage verdict to FAIL, because (a) the coverage artifact required by this skill's verification table is line coverage, which is present and passing, and (b) the absence is identical before and after this change (no regression).
+- **Repo-wide aggregate caveat:** the top-level `<report>` counters in `artifacts/pester/powershell-coverage.xml` (`LINE missed="1452" covered="115"`, ≈7.3%) are **not** a valid "repo-wide PowerShell coverage" figure. `scripts/powershell/PoshQC/settings/pester.runsettings.psd1`'s `CodeCoverage.Path` is a curated allowlist of files with dedicated Pester suites (not "every `.ps1` in the repo"), and the specific run that produced this XML was scoped to only the three touched test files (per `test-final.2026-07-04T22-40.md`'s `scan_folders`), so files in the allowlist whose own test files were not part of this scoped run correctly show 0% in this artifact — that is an artifact of test selection, not of undertested code. Applying the "repo-wide < 80% → FAIL" rule mechanically to this number would misclassify a scoped, feature-level test run as a repo-wide gap. The one file this feature touches is covered by its own dedicated, passing test suite at 94.26% line coverage, which is the correct signal for this change.
+
+## PowerShell Toolchain (format → analyze → test)
+
+- **Format**: `evidence/qa-gates/format-final.2026-07-04T22-35.md` — `mcp__drm-copilot__run_poshqc_format`, EXIT_CODE 0, zero residual diff on repeat run, across all four touched PowerShell files. **PASS.**
+- **Lint (PSScriptAnalyzer)**: `evidence/qa-gates/lint-final.2026-07-04T22-36.md` — `mcp__drm-copilot__run_poshqc_analyze`, EXIT_CODE 0, 0 findings across all four touched files. One deliberate suppression is recorded (see below). **PASS.**
+- **Type checking**: N/A for PowerShell per `.claude/rules/powershell.md`.
+- **Test (Pester v5.x with coverage)**: `evidence/qa-gates/test-final.2026-07-04T22-40.md` — EXIT_CODE 0, 32/32 tests passed (26 pre-existing + 6 new), 0 failed. **PASS.**
+- Toolchain restart discipline (`.claude/rules/general-code-change.md` "Mandatory Toolchain Loop"): baseline and final gates exist for format, lint, and test; `evidence/qa-gates/coverage-delta.2026-07-04T22-42.md` confirms the loop converged to a single clean pass with no residual changes. **PASS.**
+
+## `PSUseSingularNouns` Suppression on `Wait-ForPullRequestChecks`
+
+Finding: `Wait-ForPullRequestChecks` in `scripts/dev-tools/Invoke-FullReleaseFlow.ps1` line 200 carries:
+```
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Function name matches the gh CLI concept of a pull request''s set of required checks (plural); the plan contract for issue #310 binds this exact name.')]
+```
+
+Assessment: **Not blocking. Consistent with repo precedent.**
+- `.claude/hooks/enforce-pr-author-skill.ps1` line 117 carries an equivalent, structurally identical suppression: `[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'The plural noun names the byte-array return; the seam name is fixed by the receipt contract.')]` — i.e., a plural noun tied to a fixed external contract name is an established, accepted justification pattern in this codebase, not a novel exception.
+- The justification is substantive (the plural "Checks" reflects the gh CLI's own vocabulary for a PR's set of required checks, and the exact function name is bound by the atomic plan's function contract, `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/plan.md` lines 32–47), not a blanket or unexplained suppression.
+- Scope is narrow: it suppresses one rule on one function, not file-wide or rule-wide.
+- `.claude/rules/quality-tiers.md`'s tier-dependent gate for "Untyped escape hatches" (`any`/`dynamic`) does not apply to `PSUseSingularNouns` (a naming-convention rule, not an escape hatch), so no tier-based cap is violated.
+- Verdict: **PASS** — justified, narrowly scoped, and consistent with existing repo precedent for the same rule/justification pattern.
+
+## Stale `--watch` Mock Branch Check
+
+- `grep -rn "pr checks 291 --watch"` across `tests/scripts/dev-tools/Invoke-FullReleaseFlow.Tests.ps1` and `tests/scripts/dev-tools/Invoke-FullReleaseFlow.AdditionalFailurePaths.Tests.ps1` — **zero matches** in both files.
+- Broader `grep -n "--watch"` across both files — **zero matches**.
+- The third gh mock branch that previously used `'pr checks 291 --watch'` (at the former ~line 334 of `Invoke-FullReleaseFlow.Tests.ps1`, the "stops before checkout, pull, and tag push when merge fails" test) was confirmed updated to `'pr checks 291 --required --json bucket'` returning a passing bucket (line 335–337 of the current file).
+- **PASS** — no stale `--watch` mock branch remains in either file.
+
+## Bounded Timeouts (No Infinite Loop) and Default Documentation
+
+- **Boundedness — PASS.** Registration loop: `while ($poll.ExitCode -ne 0) { if ($registrationAttempt -ge $RegistrationMaxAttempts) { ...; return 1 } ... }` terminates after at most `RegistrationMaxAttempts` polls regardless of parameter value (including 0 or negative, which would terminate on the first check). Completion loop: `while ($true) { ... if ($completionAttempt -ge $CompletionMaxAttempts) { ...; return 1 } ... }` similarly terminates after at most `CompletionMaxAttempts` polls, and additionally short-circuits immediately (without consuming a completion attempt) on a genuine `fail`/`cancel` bucket. Both loops have a single, unconditional exit path bounded by an integer counter; no infinite loop is possible.
+- **Default documentation — PARTIAL.** The default values are visible in the function signature (`$RegistrationMaxAttempts = 24`, `$RegistrationIntervalSeconds = 5`, `$CompletionMaxAttempts = 60`, `$CompletionIntervalSeconds = 10`) and in the plan's function contract (`plan.md` lines 34–35), which is a form of documentation, but the comment-based help's `.PARAMETER` blocks describe each parameter's role without restating its numeric default or the resulting worst-case total wait (2 minutes for registration: 24×5s; 10 minutes for completion: 60×10s). This is a minor documentation gap, not a functional defect — flagged as a non-blocking code-review observation (see `code-review.2026-07-05T02-34.md`).
+
+## Non-Checks-Wait Behavior Preservation
+
+- `Invoke-FullReleaseFlowGuarded`'s preflight block (clean working tree, branch `main`, `fetch origin main`, local main == origin/main), full-release-script invocation, release-branch resolution, PR-number resolution, merge, checkout, pull, and tag-push invocation are byte-for-byte unchanged apart from the checks-wait replacement (verified by direct read of `scripts/dev-tools/Invoke-FullReleaseFlow.ps1` lines 260–395 against the diff, which shows only the `$checksResult = Wait-ForPullRequestChecks ...` block replacing the prior single `Invoke-GhExe -GhArgs @('pr','checks',$prNumber,'--watch')` call).
+- Regression tests in `Invoke-FullReleaseFlow.Tests.ps1` and `Invoke-FullReleaseFlow.AdditionalFailurePaths.Tests.ps1` continue to assert no-merge/no-checkout/no-pull/no-tag-push on every pre-existing failure path, and the "successful automated flow" test asserts the exact unchanged gh-call sequence (`pr view` → `pr checks ... --required --json bucket` → `pr merge`). **PASS.**
+
+## File Size Limit (500 lines)
+
+| File | Lines | Limit | Result |
+|---|---|---|---|
+| `scripts/dev-tools/Invoke-FullReleaseFlow.ps1` | 401 | 500 | PASS |
+| `tests/scripts/dev-tools/Invoke-FullReleaseFlow.Tests.ps1` | 426 | 500 | PASS |
+| `tests/scripts/dev-tools/Invoke-FullReleaseFlow.AdditionalFailurePaths.Tests.ps1` | 99 | 500 | PASS |
+| `tests/scripts/dev-tools/Invoke-FullReleaseFlow.ChecksWait.Tests.ps1` | 141 | 500 | PASS |
+
+Verified with `wc -l` against the working tree at the reviewed head SHA.
+
+## Design Seam / Mock Pattern Compliance (AC6)
+
+- New/updated tests mock only wrapper functions (`Invoke-GhExe`, `Invoke-GitExe`, `Invoke-ChildPowerShellScript`, `Invoke-Sleep`, `Write-StderrLine`); no direct mocking of `git`/`gh` executables, and no `Start-Sleep`/real wall-clock waits appear in any test file (`grep -n "Start-Sleep"` across the three test files returns no matches outside the production `Invoke-Sleep` wrapper body itself).
+- Mock signatures match production named parameters (`param([string[]]$GhArgs)`, `param([int]$Seconds)`, etc.). **PASS.**
+
+## Benchmark Baseline / CI Workflow Rules Applicability
+
+- `.claude/rules/benchmark-baselines.md` and `.claude/rules/ci-workflows.md`: no files under `scripts/benchmarks/**` or `.github/workflows/**` appear in this branch's diff. **Not applicable to this change; no rejection needed.**
+
+## Overall Policy Verdict
+
+**PASS.** No Blocking findings. All mandatory gates (format, lint, test, coverage-on-changed-file, file size, mock-seam pattern, no-stale-mock, bounded timeouts, evidence location) pass with evidence. Two non-blocking observations are carried forward to the code review (default-timeout documentation completeness; one untested edge case for a zero-required-checks response).

--- a/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/spec.md
+++ b/docs/features/active/2026-07-04-release-flow-wait-for-ci-310/spec.md
@@ -108,13 +108,13 @@ Seeded from issue:
 
 ## Acceptance Criteria
 - [ ] Repro steps now produce the expected behavior in all documented environments.
-- [ ] Regression test(s) added and passing (list file path and test name).
+- [x] Regression test(s) added and passing (list file path and test name).
 - [ ] Edge cases and invalid inputs are handled with correct errors or fallbacks.
-- [ ] No unintended behavior changes outside the defined scope.
-- [ ] Required logs/telemetry updated and validated (if applicable).
+- [x] No unintended behavior changes outside the defined scope.
+- [x] Required logs/telemetry updated and validated (if applicable).
 - [ ] Performance constraints met or explicitly waived with rationale.
-- [ ] Full toolchain pass completed (format → lint → type-check → test).
-- [ ] Docs/config references updated to match the new behavior.
+- [x] Full toolchain pass completed (format → lint → type-check → test).
+- [x] Docs/config references updated to match the new behavior.
 
 ## Risks & Mitigations
 - Technical or operational risks:


### PR DESCRIPTION
## Suggested title

docs: restore #310 feature-review audit trail (policy-audit, code-review, feature-audit, spec AC checkoffs)

## Summary

- Docs-only follow-up: restores the feature-review audit trail for issue #310 that was omitted from the already-merged fix in PR #311.
- Adds three previously-uncommitted review artifacts to `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/`: `policy-audit.2026-07-05T02-34.md`, `code-review.2026-07-05T02-34.md`, and `feature-audit.2026-07-05T02-34.md`.
- Updates `spec.md` to check off the acceptance-criteria items the review step verified as satisfied.
- No production code, script, or test file is touched by this branch.
- Single commit: `a1e57f7 docs(review): restore issue #310 feature-review audit trail`.

## Why

When the #310 fix (the `Invoke-FullReleaseFlow.ps1` CI-wait behavior) was merged via PR #311, the feature-review step ran and produced its audit artifacts and spec acceptance-criteria checkoffs after the pre-review commit, but those artifacts were left uncommitted and were not included in the PR #311 merge. This leaves the repository's audit trail for #310 incomplete relative to what the feature-review process actually verified. This PR closes that gap by committing the artifacts the review step produced, so the audit trail matches the review that was performed.

## What Changed

**Docs/audit trail:**
- `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/policy-audit.2026-07-05T02-34.md` (new, +104 lines)
- `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/code-review.2026-07-05T02-34.md` (new, +66 lines)
- `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/feature-audit.2026-07-05T02-34.md` (new, +62 lines)
- `docs/features/active/2026-07-04-release-flow-wait-for-ci-310/spec.md` (+5/-5): acceptance-criteria checkboxes updated to reflect the review outcome (regression tests added, no unintended behavior changes, telemetry/logging validated, full toolchain pass completed, docs/config references updated).

**Code:** None. No files under `scripts/`, `src/`, or `tests/` are modified by this branch.

## Architecture / How It Fits Together

This is a documentation-only change to the feature folder for `2026-07-04-release-flow-wait-for-ci-310`. It adds no new components, entry points, or control flow. The artifacts being added are the standard feature-review outputs (policy audit, code review, feature audit) that the review step already produced but that a prior commit boundary excluded from PR #311.

## Verification

**Completed:**
- Confirmed via the PR-context diff that the only changes in this branch are the three new audit-trail markdown files and the `spec.md` checkbox updates; no script, source, or test files are touched.
- The referenced feature-review evidence (format, lint, test, coverage-delta gates) for the underlying #310 fix was already captured and merged in PR #311; this branch does not re-run or duplicate those gates.

**Recommended:**
- Not verified in this PR: no additional toolchain run is required for a docs-only change, but reviewers may confirm `git diff --stat` shows only the four files listed above.

## Backward Compatibility / Migration Notes

None. No code, configuration, schema, or public API is changed.

## Risks and Mitigations

- **Risk:** None identified — the change is additive documentation with no runtime effect.
- **Mitigation:** Not applicable; rollback would simply be reverting the single commit, with no functional impact.

## Review Guide

- Review order: `spec.md` diff first (acceptance-criteria checkoffs), then the three new audit artifacts (`policy-audit`, `code-review`, `feature-audit`) for consistency with the checked-off criteria.
- No mechanical or noisy diffs; all four files are small and additive/targeted.

## Follow-ups

None identified in this PR's context.

## GitHub Auto-close

None. This PR does not close #310 — the issue was already resolved by #311. It is referenced here only as related context for the audit trail being restored.
