### PR TITLE
feat(extension): add Show Subagent Tree command (#320)

### DIFF
--- a/docs/features/active/subagent-tree-command/code-review.2026-07-05T23-16.md
+++ b/docs/features/active/subagent-tree-command/code-review.2026-07-05T23-16.md
@@ -1,0 +1,115 @@
+# Code Review: subagent-tree-command (drmCopilotExtension.showSubagentTree)
+
+---
+
+**Review Date:** 2026-07-05
+**Reviewer:** feature-review agent (Claude Sonnet 5)
+**Feature Folder:** `docs/features/active/subagent-tree-command/`
+**Feature Folder Selection Rule:** Only active feature folder whose scoping docs (`issue.md`) match the staged diff scope (`extensions/drm-copilot/src/lib/subagent-tree/**`, `extensions/drm-copilot/src/subagent-tree-command.ts`).
+**Base Branch:** `main` @ `6e73fe292fcac017b9c3c6d0b37e5e0e71dbfa10`
+**Head Branch:** staged working tree on `drm-copilot-wt-2026-07-05-18-24` (`git diff --cached main`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+This change adds a host-neutral subagent-call-tree builder (`extensions/drm-copilot/src/lib/subagent-tree/`) and a thin VS Code command wrapper (`extensions/drm-copilot/src/subagent-tree-command.ts`) that render the parent→child spawn structure of a Claude Code session's subagent transcripts. The pure module (parser, scanner, assembler, formatter) is cleanly separated from the one VS Code-touching file; the algorithm (exact `toolUseId` matching, verbatim `spawnDepth`, deterministic sibling ordering, orphan attachment) is a faithful, testable port of the specification in `issue.md`. All toolchain stages (format, lint, typecheck, targeted tests, manual architecture-boundary grep) were independently reproduced by this review and passed cleanly; per-file coverage figures were independently parsed from `coverage/lcov.info` and matched the executor's claims exactly.
+
+**What changed:**
+Seven new production files (`types.ts`, `transcript-parser.ts`, `transcript-scanner.ts`, `tree-assembler.ts`, `tree-formatter.ts`, `index.ts`, `subagent-tree-command.ts`), seven new test files, and three small modifications (`extension.ts` +2 lines to register the command, `package.json` +4 lines for the command contribution, `jest.config.cjs` +33 lines for six new per-file coverage thresholds plus a documented `types.ts` omission comment).
+
+**Top 3 risks:**
+1. The manual `grep`-based architecture-boundary check is a substitute for the repo's designated `dependency-cruiser` tool, which is not configured anywhere in this extension — a pre-existing, repository-wide gap, not introduced by this feature, but it means future refactors could reintroduce a `vscode` dependency into `lib/subagent-tree/` without an automated CI catch.
+2. `RealFileSystem.glob`'s directory walk order (`fs.readdirSync`, unsorted) is not itself deterministic across filesystems; the implementation correctly neutralizes this by sorting matched children by spawn-index (from file-line order) rather than by scan order, so this risk does not currently manifest as a defect, but it is a subtlety worth documenting for future maintainers.
+3. Coverage for `subagent-tree-command.ts` (92.44% lines / 85.71% branches) is the lowest of the new files; the uncovered lines/branches are host-wiring edge cases (e.g., the `onlyCandidate !== undefined` guard's false branch, which is unreachable given `candidates.length === 1`) rather than untested business logic — low risk, but worth a brief look if this file grows.
+
+**PR readiness recommendation:** **Go** — no Blocker or Major findings; all acceptance criteria independently verified; toolchain fully green.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `docs/features/active/subagent-tree-command/plan.2026-07-05T18-28.md` | Header field `**Status:** Draft` | The plan's `Status` field still reads `Draft` even though every task in the plan checklist is marked `[x]` complete and all evidence artifacts exist. | Update the `Status` field to `Complete` (or the repo's equivalent terminal status) to keep plan metadata consistent with its checklist state. | Stale status metadata can mislead a future reader (or orchestrator) into believing the plan is still in progress. | Read `plan.2026-07-05T18-28.md` line 7 (`- **Status:** Draft`) against the fully-checked task list in the same file. |
+| Info | `extensions/drm-copilot/src/lib/subagent-tree/transcript-scanner.ts` | `readSubagent` / `parseSubagentMeta` | Malformed meta files (bad filename pattern, invalid JSON, non-object, missing/mistyped field) are silently skipped with no observability signal (no count, no log) surfaced to the eventual command output. | Consider, as a low-priority follow-up, having `scanTranscripts` return a count or list of skipped paths so `subagent-tree-command.ts` could optionally note "N subagents skipped" in its output. Not required for this feature. | This is a deliberate, tested, documented tolerance decision (Design Decision item in the plan) appropriate for a best-effort discovery tool operating on external, unversioned transcript files; it is not a policy violation, but silent skips reduce debuggability if a user expects a subagent that never appears. | `transcript-scanner.ts` lines ~940-962 (`readSubagent` returns `undefined` on any malformed input); all five malformed-input paths are exercised by dedicated tests in `transcript-scanner.test.ts`. |
+| Info | `extensions/drm-copilot/src/lib/subagent-tree/tree-assembler.ts` | `findParentKey` | `findParentKey` performs a linear scan over all transcripts (root + every subagent) for every subagent, giving `O(n^2)` behavior in the number of subagents. | No action needed at current expected scale (a session's subagent count is bounded by practical session length); if sessions with hundreds of subagents become common, consider building a `toolUseId -> parentKey` index once instead of scanning per-subagent. | Purely a performance note; correctness is unaffected, and the current implementation is simple and easy to verify, consistent with the "simplicity first" design principle. | `tree-assembler.ts` lines ~1103-1113 (`findParentKey`), called once per element of `scanned.subagents` in `assembleTree`. |
+| Info | `extensions/drm-copilot/src/subagent-tree-command.ts` | `discoverRootSessionCandidates` / `RealFileSystem.glob` | Root-session discovery relies on `RealFileSystem.glob`'s directory walk, whose entry order depends on `fs.readdirSync` (not guaranteed sorted); the code correctly re-sorts candidates via `.sort((left, right) => left.localeCompare(right))` before presenting them, so this is already handled correctly. | None — noting only as confirmation that the non-deterministic glob order does not leak into user-visible ordering. | Documents why the design is correct as written; helps a future reviewer avoid re-flagging this as a risk. | `subagent-tree-command.ts` lines ~1401-1409 (`discoverRootSessionCandidates`). |
+
+No Blocker or Major findings.
+
+---
+
+## Implementation Audit
+
+### TypeScript implementation audit
+
+#### What changed well
+
+- Clean separation between pure logic (`types.ts`, `transcript-parser.ts`, `tree-assembler.ts`, `tree-formatter.ts`) and the single I/O-touching module (`transcript-scanner.ts`), with the VS Code host wiring isolated entirely in `subagent-tree-command.ts`. Independently verified zero `vscode` imports under `src/lib/subagent-tree/`.
+- Reuses the pre-existing `FileSystem` interface/`RealFileSystem` (`src/lib/file-system.ts`) instead of introducing a parallel I/O abstraction — a direct application of the repo's reusability principle.
+- The tree-assembly algorithm (`assembleTree`) is a faithful, readable port of the issue's five-step specification: verbatim `spawnDepth`, exact `toolUseId` matching via a `ROOT_KEY` sentinel map, deterministic spawn-index sibling ordering with `agentId` tie-break, and orphan attachment to the root ordered by `agentId`. The `ROOT_KEY` sentinel comment explains precisely why a string sentinel was chosen over a discriminated union.
+- `formatTree`'s model-sorting-before-render (`[...node.models].sort()`) guarantees deterministic multi-model output regardless of scan/assembly order, matching the issue's explicit requirement.
+
+#### Type safety and maintainability
+
+- No `any` anywhere in the new code (verified by grep); all external JSON parsing narrows through `unknown` plus an `isRecord` type guard before field access.
+- Public function signatures are precise: `buildSubagentTree(rootSessionPath: string, deps: { readonly fileSystem: FileSystem }): TreeNode` uses a readonly dependency-injection object, matching the repo's "prefer keyword-style parameters with defaults" and extensibility guidance.
+- Every file stays well under the 500-line limit (max 189 lines for `tree-assembler.ts`), keeping each module easy to review in full.
+- No suppressions of any kind (`eslint-disable`, `@ts-expect-error`, `@ts-ignore`, `@ts-nocheck`) were needed anywhere in the new code.
+
+#### Error handling and logging
+
+- `scanTranscripts` fails fast with an explicit, descriptive `Error` when `rootSessionPath` does not end in `.jsonl` — an invariant violation at the I/O boundary, exactly where fail-fast is appropriate.
+- Malformed subagent inputs (bad meta filename, invalid/non-object/incomplete JSON) are tolerated by returning `undefined` and filtering — a deliberate, tested design choice for a best-effort tree-discovery tool (see Findings Table Info item above for a minor observability suggestion, not a defect).
+- `registerSubagentTreeCommand`'s one catch-all sits at the correct architectural boundary (the VS Code command handler), matches the established pattern used elsewhere in the extension (`src/extension.ts`, `src/repo-automation-command-registration-admin.ts`), logs to the output channel, and surfaces to the user via `showErrorMessage` without silently swallowing the failure.
+
+---
+
+## Test Quality Audit
+
+Automated evidence was independently reproduced rather than trusted from the executor's narrative alone: this review re-ran `npx prettier --check`, `npm run lint`, `npm run typecheck`, and `npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts` directly, and independently parsed `extensions/drm-copilot/coverage/lcov.info` to confirm per-file line/branch figures match `evidence/qa-gates/final-coverage-per-file.md` exactly (see Policy Audit Section 5 for the full breakdown). No coverage or test-count discrepancy was found between the executor's claims and this review's independent measurements.
+
+### Reviewed test and QA artifacts
+
+- `extensions/drm-copilot/test/lib/subagent-tree/transcript-parser.test.ts` — verifies line-order preservation, multi-model collection, and tolerant skipping of blank/non-JSON/malformed lines. Clean, fast (part of the 0.446s / 25-test run), well isolated.
+- `extensions/drm-copilot/test/lib/subagent-tree/transcript-scanner.test.ts` — the most thorough suite (8 tests): positive multi-agent scan, empty-subagents, grandchild nesting, fail-fast on bad extension, and four distinct malformed-meta negative paths. No gaps identified relative to the module's actual branch surface (100%/100% coverage).
+- `extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts` — covers every scenario the issue explicitly required (positive, empty-subagents, multi-model, multi-depth/grandchild, orphan, sibling ordering).
+- `extensions/drm-copilot/test/lib/subagent-tree/tree-formatter.test.ts` — covers rendering format, multi-model sort-before-join, and single-line (empty-children) output.
+- `extensions/drm-copilot/test/lib/subagent-tree/index.test.ts` — one focused end-to-end composition test confirming the barrel wires the scanner and assembler together and that the result round-trips through `formatTree` without throwing.
+- `extensions/drm-copilot/test/subagent-tree-command.test.ts` — mocks `vscode`, `node:fs`, and `../src/command-runtime`, following the established `test/extension.collect-pr-context.test.ts` pattern; covers zero-candidate, single-candidate auto-select, and multi-candidate quick-pick paths.
+- `docs/features/active/subagent-tree-command/evidence/qa-gates/final-coverage-per-file.md` — independently re-verified against `coverage/lcov.info`; all seven figures matched exactly.
+
+### Quality assessment prompts
+
+- **Determinism:** No `setTimeout`, `Date.now`, `Math.random`, or real filesystem/network access anywhere in the new test or production code (grep-confirmed). All I/O is faked via the in-memory `FileSystem` or jest-mocked `node:fs`/`vscode`.
+- **Isolation:** Each `it()` builds its own fixture inline; `subagent-tree-command.test.ts` resets all mocks in `beforeEach`/`afterEach`.
+- **Speed:** 0.446 seconds for all 25 new tests — well within the "fast execution" expectation.
+- **Diagnostics:** Assertions use concrete `toEqual`/`toHaveLength`/`toThrow(/regex/)` expectations, giving actionable failure diffs; test names state the exact scenario and expected behavior.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | No credentials, tokens, or API keys in any new file; the module only reads local `.jsonl`/`.meta.json` transcript files already present on disk. |
+| No unsafe subprocess or command construction | ✅ PASS | No subprocess/shell invocation anywhere in this feature's code. |
+| Input validation at boundaries | ✅ PASS | `transcript-parser.ts` and `transcript-scanner.ts` validate every externally-sourced JSON value via `isRecord`/`typeof` narrowing before use; malformed input is tolerated (skipped) rather than propagating `undefined`/`any` into downstream logic. |
+| Error handling remains explicit | ✅ PASS | Fail-fast `Error` at the one true invariant boundary (`rootSessionPath` extension check); explicit catch-and-report at the one VS Code command boundary. |
+| Configuration / path handling is safe | ✅ PASS | Path derivation (`subagentsDir`, `transcriptPath`) uses simple string slicing/concatenation on paths already produced by the injected `FileSystem`/`RealFileSystem`, with no user-supplied path concatenation beyond the VS Code `showQuickPick` selection from a pre-discovered candidate list (no path traversal surface introduced). |
+
+---
+
+## Research Log
+
+No external research was required. All findings in this review are grounded in direct inspection of the staged diff, independently re-run toolchain commands, and the parsed `coverage/lcov.info` artifact.
+
+---
+
+## Verdict
+
+The implementation is a clean, well-tested, policy-compliant port of the specified subagent-tree algorithm. Separation of concerns between pure logic and I/O/host wiring is exemplary, typing is precise with zero suppressions, and every scenario the issue's acceptance criteria call out (positive, empty-subagents, multi-model, multi-depth nesting, orphan handling) has a dedicated, passing test. All toolchain stages were independently reproduced by this review and matched the executor's evidence exactly. The one Minor finding (a stale `Status: Draft` field in the plan document) and three Info-level observations (all confirming correct-as-written behavior or noting low-priority future-maintainability suggestions) do not block merge.
+
+**Ready for normal PR flow.**

--- a/docs/features/active/subagent-tree-command/evidence/baseline/baseline-format.md
+++ b/docs/features/active/subagent-tree-command/evidence/baseline/baseline-format.md
@@ -1,0 +1,7 @@
+# Baseline — Format Check
+
+Timestamp: 2026-07-05T22-40
+Command: `npx prettier --check "src/**/*.ts" "test/**/*.ts"` (run from `extensions/drm-copilot/`)
+EXIT_CODE: 0
+
+Output Summary: "All matched files use Prettier code style!" — no formatting violations found in the pre-existing extension source and test trees.

--- a/docs/features/active/subagent-tree-command/evidence/baseline/baseline-lint.md
+++ b/docs/features/active/subagent-tree-command/evidence/baseline/baseline-lint.md
@@ -1,0 +1,7 @@
+# Baseline — Lint Check
+
+Timestamp: 2026-07-05T22-44
+Command: `npm run lint` (run from `extensions/drm-copilot/`; wraps `eslint --no-error-on-unmatched-pattern src test`)
+EXIT_CODE: 0
+
+Output Summary: ESLint ran against `src` and `test` with zero errors and zero warnings reported (no diagnostic lines emitted). Note: `node_modules` was not present at session start; `npm install` was run once (460 packages, 0 vulnerabilities) before this baseline could execute.

--- a/docs/features/active/subagent-tree-command/evidence/baseline/baseline-test-coverage.md
+++ b/docs/features/active/subagent-tree-command/evidence/baseline/baseline-test-coverage.md
@@ -1,0 +1,11 @@
+# Baseline — Test Coverage
+
+Timestamp: 2026-07-05T22-47
+Command: `npm run test:coverage` (run from `extensions/drm-copilot/`; wraps `node run-jest.cjs --coverage --coverageReporters=lcov --coverageReporters=text-summary`)
+EXIT_CODE: 0
+
+Output Summary:
+- Test Suites: 124 passed, 124 total
+- Tests: 1481 passed, 1481 total
+- Aggregate coverage: Statements 96.75% (29912/30915), Branches 88.31% (3823/4329), Functions 87.42% (855/978), Lines 96.75% (29912/30915)
+- All per-file `coverageThreshold` entries in `jest.config.cjs` (pre-existing) passed.

--- a/docs/features/active/subagent-tree-command/evidence/baseline/baseline-typecheck.md
+++ b/docs/features/active/subagent-tree-command/evidence/baseline/baseline-typecheck.md
@@ -1,0 +1,7 @@
+# Baseline — Type Check
+
+Timestamp: 2026-07-05T22-45
+Command: `npm run typecheck` (run from `extensions/drm-copilot/`; wraps `tsc -p ./ --noEmit`)
+EXIT_CODE: 0
+
+Output Summary: `tsc --noEmit` completed with zero type errors reported.

--- a/docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,19 @@
+# Phase 0 — Policy Instructions Read
+
+Timestamp: 2026-07-05T22-39
+
+Policy Order:
+1. `.claude/rules/general-code-change.md`
+2. `.claude/rules/general-unit-test.md`
+3. `.claude/rules/typescript.md`
+4. `.claude/rules/typescript-suppressions.md`
+5. `.claude/rules/architecture-boundaries.md`
+6. `.claude/rules/quality-tiers.md`
+
+Files read (in order, in full, before touching code):
+- [x] `.claude/rules/general-code-change.md` — cross-language code change policy (simplicity, reusability, extensibility, separation of concerns, mandatory toolchain loop, 500-line file limit, error handling, naming, public APIs, dependencies, I/O boundaries).
+- [x] `.claude/rules/general-unit-test.md` — cross-language unit test policy (independence/isolation/fast/determinism/readability, 85% line / 75% branch coverage, no-exclusion policy, AAA structure, no temp files, test file location mirrors `src/`).
+- [x] `.claude/rules/typescript.md` — TypeScript standards, noting this plan's binding override: the `drm-copilot` extension uses Jest (not Vitest) with v8 coverage per its established convention.
+- [x] `.claude/rules/typescript-suppressions.md` — suppression authorization policy (pre-authorized single-line ESLint/`@ts-expect-error` patterns only; no file-level or `@ts-ignore`/`@ts-nocheck`).
+- [x] `.claude/rules/architecture-boundaries.md` — No-COM architecture assertions and layer boundary rules; `dependency-cruiser` is the TypeScript enforcement tool (not configured for this extension, so Phase 7 uses a manual `grep` per the plan).
+- [x] `.claude/rules/quality-tiers.md` — T1–T4 module rigor tiers; this module is T3/T4 dev tooling, so uniform coverage thresholds (85% line / 75% branch) apply and property-based/mutation testing are not required.

--- a/docs/features/active/subagent-tree-command/evidence/qa-gates/final-arch-boundary.md
+++ b/docs/features/active/subagent-tree-command/evidence/qa-gates/final-arch-boundary.md
@@ -1,0 +1,7 @@
+# Final QC — Architecture Boundary Check (Manual)
+
+Timestamp: 2026-07-05T23-13
+Command: `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/`
+EXIT_CODE: 1
+
+Output Summary: `grep` returned exit code 1 (no matches), confirming zero `vscode` imports/references anywhere under `src/lib/subagent-tree/`. No `dependency-cruiser` configuration exists for this extension, so this manual grep is the enforcement mechanism for this change, as noted in the plan. The host-bound file `src/subagent-tree-command.ts` (outside this directory) is the only file in the feature that imports `vscode`.

--- a/docs/features/active/subagent-tree-command/evidence/qa-gates/final-build.md
+++ b/docs/features/active/subagent-tree-command/evidence/qa-gates/final-build.md
@@ -1,0 +1,7 @@
+# Final QC — Build
+
+Timestamp: 2026-07-05T23-16
+Command: `npm run build` (run from `extensions/drm-copilot/`; wraps `tsc -p ./ --noEmit && npm run bundle:extension && npm run bundle:mcp-server`)
+EXIT_CODE: 0
+
+Output Summary: `tsc --noEmit` completed with zero errors, `bundle:extension` (`node esbuild-extension.cjs`) completed without error, and `bundle:mcp-server` (`node esbuild-mcp-server.cjs`) completed without error. All three build steps succeeded in sequence.

--- a/docs/features/active/subagent-tree-command/evidence/qa-gates/final-coverage-per-file.md
+++ b/docs/features/active/subagent-tree-command/evidence/qa-gates/final-coverage-per-file.md
@@ -1,0 +1,26 @@
+# Final QC — Per-File Coverage Breakdown (New Production Files)
+
+Timestamp: 2026-07-05T23-15
+Source: `coverage/lcov.info` from the `npm run test:coverage` run recorded in `final-test-coverage.md`.
+
+## Per-file results
+
+| File | Lines | Line % | Branches | Branch % | Threshold Gate |
+|---|---|---|---|---|---|
+| `src/lib/subagent-tree/types.ts` | 0/73 | 0.00% | 0/1 | 0.00% | Not gated — interface-only file, no executable behavior (see note below) |
+| `src/lib/subagent-tree/transcript-parser.ts` | 127/129 | 98.45% | 27/28 | 96.43% | PASS (>= 85% / >= 75%) |
+| `src/lib/subagent-tree/transcript-scanner.ts` | 155/155 | 100.00% | 26/26 | 100.00% | PASS (>= 85% / >= 75%) |
+| `src/lib/subagent-tree/tree-assembler.ts` | 179/189 | 94.71% | 17/19 | 89.47% | PASS (>= 85% / >= 75%) |
+| `src/lib/subagent-tree/tree-formatter.ts` | 33/33 | 100.00% | 3/3 | 100.00% | PASS (>= 85% / >= 75%) |
+| `src/lib/subagent-tree/index.ts` | 28/28 | 100.00% | 2/2 | 100.00% | PASS (>= 85% / >= 75%) |
+| `src/subagent-tree-command.ts` | 110/119 | 92.44% | 12/14 | 85.71% | PASS (>= 85% / >= 75%) |
+
+## `types.ts` note
+
+`types.ts` consists solely of `TreeNode`, `SubagentMeta`, `ScannedTranscript`, `ScannedSubagent`, and `ScannedSession` `interface` declarations — no functions, no statements, no runtime behavior. TypeScript interfaces compile away entirely; there are zero executable lines/branches for any test to exercise. This matches the documented exception in `.claude/rules/general-unit-test.md`: "Interface/type-only files with no executable behavior... may be omitted from coverage measurement... Such modules legitimately report 0% executable coverage." The file remains in `jest.config.cjs`'s `collectCoverageFrom` (not excluded from measurement, per `general-unit-test.md`'s Coverage Exclusion Policy); only its per-file `coverageThreshold` gate entry was omitted, since no test could ever raise it above 0%.
+
+## Baseline comparison
+
+- Baseline aggregate (from `baseline-test-coverage.md`): Statements 96.75%, Branches 88.31%, Functions 87.42%, Lines 96.75%.
+- Post-change aggregate (from `final-test-coverage.md`): Statements 96.53%, Branches 88.42%, Functions 87.5%, Lines 96.53%.
+- The small aggregate statement/line percentage decrease (96.75% -> 96.53%) is expected and consistent with adding the `types.ts` interface-only file (0 executable lines contributing to the denominator) to the measured file set; branch and function percentages both increased slightly. No pre-existing file's coverage regressed — the six executable new files (`transcript-parser.ts`, `transcript-scanner.ts`, `tree-assembler.ts`, `tree-formatter.ts`, `index.ts`, `subagent-tree-command.ts`) each individually exceed the 85% line / 75% branch gate.

--- a/docs/features/active/subagent-tree-command/evidence/qa-gates/final-format.md
+++ b/docs/features/active/subagent-tree-command/evidence/qa-gates/final-format.md
@@ -1,0 +1,7 @@
+# Final QC — Format Check
+
+Timestamp: 2026-07-05T23-10
+Command: `npm run format` (run from `extensions/drm-copilot/`; wraps `prettier --write "src/**/*.ts" "test/**/*.ts" "*.json" "*.cjs"`)
+EXIT_CODE: 0
+
+Output Summary: First run (after Phase 5/6 changes) auto-formatted 4 files (`src/lib/subagent-tree/transcript-scanner.ts`, `test/lib/subagent-tree/transcript-scanner.test.ts`, `test/lib/subagent-tree/tree-assembler.test.ts`, `test/subagent-tree-command.test.ts`); per the mandatory toolchain loop the loop restarted from format. A second run after those changes reported all files unchanged — zero formatting violations remain.

--- a/docs/features/active/subagent-tree-command/evidence/qa-gates/final-lint.md
+++ b/docs/features/active/subagent-tree-command/evidence/qa-gates/final-lint.md
@@ -1,0 +1,7 @@
+# Final QC — Lint Check
+
+Timestamp: 2026-07-05T23-11
+Command: `npm run lint` (run from `extensions/drm-copilot/`; wraps `eslint --no-error-on-unmatched-pattern src test`)
+EXIT_CODE: 0
+
+Output Summary: ESLint ran against `src` and `test` with zero errors and zero warnings reported.

--- a/docs/features/active/subagent-tree-command/evidence/qa-gates/final-test-coverage.md
+++ b/docs/features/active/subagent-tree-command/evidence/qa-gates/final-test-coverage.md
@@ -1,0 +1,13 @@
+# Final QC — Test Coverage
+
+Timestamp: 2026-07-05T23-14
+Command: `npm run test:coverage` (run from `extensions/drm-copilot/`; wraps `node run-jest.cjs --coverage --coverageReporters=lcov --coverageReporters=text-summary`)
+EXIT_CODE: 0
+
+Output Summary:
+- Test Suites: 130 passed, 130 total (baseline was 124; +6 new suites: `transcript-parser.test.ts`, `transcript-scanner.test.ts`, `tree-assembler.test.ts`, `tree-formatter.test.ts`, `index.test.ts`, `subagent-tree-command.test.ts`)
+- Tests: 1506 passed, 1506 total (baseline was 1481; +25 new tests)
+- Aggregate coverage: Statements 96.53% (30548/31645), Branches 88.42% (3911/4423), Functions 87.5% (875/1000), Lines 96.53% (30548/31645)
+- All per-file `coverageThreshold` entries in `jest.config.cjs` (pre-existing plus the six new entries added in Phase 6) passed. No threshold-violation messages were emitted.
+
+Note: the coverage run reached this clean state after one intermediate iteration. The first Phase-7 attempt reported two threshold failures: `./src/lib/subagent-tree/types.ts` (0% lines/branches — an interface-only file with no executable code) and `./src/lib/subagent-tree/transcript-scanner.ts` (branches 62.5% < 75%). `transcript-scanner.ts` was brought to 100%/100% by adding five additional test cases covering the invariant-violation throw, the non-matching-filename skip, and the three malformed-meta.json skip paths. The `types.ts` per-file `coverageThreshold` entry was removed (not the file's inclusion in `collectCoverageFrom`) per the documented exception in `.claude/rules/general-unit-test.md` for interface/type-only files with no executable behavior; see `final-coverage-per-file.md` for the measured 0% figures confirming this is a structural (not a testing-gap) result.

--- a/docs/features/active/subagent-tree-command/evidence/qa-gates/final-typecheck.md
+++ b/docs/features/active/subagent-tree-command/evidence/qa-gates/final-typecheck.md
@@ -1,0 +1,7 @@
+# Final QC — Type Check
+
+Timestamp: 2026-07-05T23-12
+Command: `npm run typecheck` (run from `extensions/drm-copilot/`; wraps `tsc -p ./ --noEmit`)
+EXIT_CODE: 0
+
+Output Summary: `tsc --noEmit` completed with zero type errors reported across `src/**/*.ts`, including the seven new subagent-tree files.

--- a/docs/features/active/subagent-tree-command/feature-audit.2026-07-05T23-16.md
+++ b/docs/features/active/subagent-tree-command/feature-audit.2026-07-05T23-16.md
@@ -1,0 +1,91 @@
+# Feature Audit: subagent-tree-command (drmCopilotExtension.showSubagentTree)
+
+**Audit Date:** 2026-07-05
+**Feature Folder:** `docs/features/active/subagent-tree-command/`
+**Base Branch:** `main`
+**Head Branch:** staged working tree on `drm-copilot-wt-2026-07-05-18-24`
+**Work Mode:** `minor-audit`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `6e73fe292fcac017b9c3c6d0b37e5e0e71dbfa10`)
+- **Head branch/commit:** staged working tree on `drm-copilot-wt-2026-07-05-18-24` (`git diff --cached main`); the branch tip commit equals the resolved base commit because all feature changes are currently staged, not yet committed.
+- **Merge base:** `6e73fe292fcac017b9c3c6d0b37e5e0e71dbfa10` (equals `main` HEAD)
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt` (full staged diff, read in full across three passes)
+  - Feature evidence: `docs/features/active/subagent-tree-command/evidence/{baseline,qa-gates}/**`
+  - Additional evidence: independently re-run toolchain commands (`npx prettier --check`, `npm run lint`, `npm run typecheck`, `npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts`) and a direct parse of `extensions/drm-copilot/coverage/lcov.info`.
+- **Feature folder used:** `docs/features/active/subagent-tree-command/` (only active feature folder whose scoping docs match the staged diff; not versioned — no `v1/`/`v2/` subfolders).
+- **Requirements source:** `issue.md` only (work mode `minor-audit`).
+- **Work mode resolution note:** `issue.md` carries the explicit persisted marker `- Work Mode: minor-audit` and an explicit `## Acceptance Criteria` section (AC1–AC5); per the work-mode routing rule, only that section is treated as the AC source. `spec.md`/`user-story.md` do not exist for this feature and are correctly not required.
+- **Scope note:** The change is fully staged (not committed); `git diff --cached main` was used as the audit scope per the task instructions, consistent with the Scope Invariant (full feature-vs-base diff, not a plan/task subset — this task did not attempt to narrow scope, so no `## Rejected Scope Narrowing` entry was required in the policy audit).
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/subagent-tree-command/issue.md` — only source (work mode `minor-audit`).
+
+### Acceptance criteria
+
+1. AC1: Command `drmCopilotExtension.showSubagentTree` ("drm-copilot: Show Subagent Tree") is registered in `extensions/drm-copilot/package.json` under `contributes.commands` and wired/activated in the extension; invoking it renders the tree for a selected/active session.
+2. AC2: Pure builder `buildSubagentTree` and renderer `formatTree` are implemented in a host-neutral module with no VS Code imports.
+3. AC3: Unit tests cover positive, empty-subagents, multi-model node, multi-depth nesting, and orphan/unmatched `toolUseId` handled gracefully.
+4. AC4: Full TypeScript toolchain passes for the extension: format → lint → type-check → arch tests → unit tests; coverage >= 85% line and >= 75% branch for the new production files; no production file excluded from coverage.
+5. AC5: Local feature-review (policy-audit, code-review, feature-audit) is clean of blocking findings.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | AC1: command registered, wired, activated, renders tree for selected/active session | PASS | `extensions/drm-copilot/package.json` `contributes.commands` array contains `{ "command": "drmCopilotExtension.showSubagentTree", "title": "drm-copilot: Show Subagent Tree" }`; `extensions/drm-copilot/src/extension.ts` imports `registerSubagentTreeCommand` and calls it in `activate`, pushing the returned disposable into `context.subscriptions`; `test/subagent-tree-command.test.ts` verifies auto-select (single candidate, no prompt) and multi-candidate quick-pick flows both render and write output. | `grep -n "showSubagentTree" extensions/drm-copilot/package.json extensions/drm-copilot/src/extension.ts`; `npx jest test/subagent-tree-command.test.ts` | Independently re-ran the targeted test file (3/3 tests pass) as part of this audit. |
+| 2 | AC2: pure `buildSubagentTree`/`formatTree` in a host-neutral module, no VS Code imports | PASS | `extensions/drm-copilot/src/lib/subagent-tree/index.ts` exports `buildSubagentTree`; `tree-formatter.ts` exports `formatTree`; both modules import only from `./transcript-scanner`, `./tree-assembler`, `./types`, and `../file-system` (never `vscode`). | `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/` | Command exit 1 (no matches) — independently reproduced by this audit, confirming zero VS Code imports anywhere under the module directory. |
+| 3 | AC3: unit tests cover positive, empty-subagents, multi-model node, multi-depth nesting, orphan/unmatched toolUseId | PASS | `test/lib/subagent-tree/tree-assembler.test.ts` contains one test per named scenario: positive (`"assembles a root with two direct subagent children..."`), empty-subagents (`"assembles an empty children array when there are no subagents"`), multi-model node (`"sorts a subagent node's multiple models ascending"`), multi-depth nesting (`"places a grandchild inside its direct parent's children, not the root's"`), and orphan/unmatched toolUseId (`"attaches an orphan (unmatched toolUseId) as a root child after matched children, without throwing"`). Equivalent scenario coverage additionally exists at the scan level in `transcript-scanner.test.ts` (positive multi-agent, empty-subagents, multi-depth nesting). | `npx jest test/lib/subagent-tree/tree-assembler.test.ts test/lib/subagent-tree/transcript-scanner.test.ts` | Independently re-ran; all tests pass. Every named scenario in the criterion text maps to a specific, identifiable test case — no scenario was found missing. |
+| 4 | AC4: full toolchain passes; coverage >= 85%/75% for new production files; no production file excluded from coverage | PASS | Format: `npx prettier --check` exit 0. Lint: `npm run lint` exit 0 (zero errors/warnings). Type-check: `npm run typecheck` exit 0. Architecture check: manual `grep -rn "vscode" .../lib/subagent-tree/` exit 1 (no matches) — the documented substitute for `dependency-cruiser`, which is not configured anywhere in this extension (a pre-existing, repo-wide gap, not introduced by this feature). Unit tests: 6/6 new suites, 25/25 tests pass. Coverage (independently parsed from `extensions/drm-copilot/coverage/lcov.info`): `transcript-parser.ts` 98.45%/96.43%, `transcript-scanner.ts` 100%/100%, `tree-assembler.ts` 94.71%/89.47%, `tree-formatter.ts` 100%/100%, `index.ts` 100%/100%, `subagent-tree-command.ts` 92.44%/85.71% — all 6 executable files exceed 85%/75%. `types.ts` (0/73 lines, interface-only, zero executable statements) remains present in `jest.config.cjs`'s `collectCoverageFrom` (`["src/**/*.ts", "!src/**/*.d.ts"]`) and is not excluded from coverage measurement; only its per-file `coverageThreshold` gate entry is omitted, per the explicit exception documented in `.claude/rules/general-unit-test.md` for interface/type-only files with no executable behavior. | `npx prettier --check "src/**/*.ts" "test/**/*.ts"`; `npm run lint`; `npm run typecheck`; `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/`; `npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts` | All commands independently re-run by this audit from `extensions/drm-copilot/`; results matched the executor's recorded evidence in `evidence/qa-gates/*.md` exactly, including the specific per-file coverage percentages. |
+| 5 | AC5: local feature-review (policy-audit, code-review, feature-audit) is clean of blocking findings | PASS | This feature-review cycle produced `policy-audit.2026-07-05T23-16.md` (Overall Status: FULLY COMPLIANT; two documented Gaps, both pre-existing and repo-wide, non-blocking) and `code-review.2026-07-05T23-16.md` (Findings Table: 1 Minor + 3 Info, zero Blocker/Major; PR readiness recommendation: Go). No blocking finding was raised in either artifact. | `python scripts/dev_tools/validate_orchestration_artifacts.py policy-audit docs/features/active/subagent-tree-command/policy-audit.2026-07-05T23-16.md`; `python scripts/dev_tools/validate_orchestration_artifacts.py code-review docs/features/active/subagent-tree-command/code-review.2026-07-05T23-16.md` | Both artifacts passed structural validation. This is the review that resolves AC5; no `remediation-inputs.<timestamp>.md` was produced because no blocking finding exists. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+**Criteria summary:**
+- **PASS:** 5 criteria
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. None.
+
+**Recommended follow-up verification steps:**
+
+1. Track the two pre-existing, repository-wide infrastructure gaps noted in the policy audit (missing `dependency-cruiser` configuration for `extensions/drm-copilot/`; missing `quality-tiers.yml` at repository root) as separate follow-up work items, since they are out of scope for this feature but relevant to future architecture-boundary and tier-classification automation.
+2. Optionally address the Minor code-review finding (stale `Status: Draft` field in `plan.2026-07-05T18-28.md`) before archiving the feature folder.
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules, AC1–AC4 were already checked `[x]` by the executor prior to this review (confirmed correct by independent re-verification above). AC5 was the one criterion whose evidence (this review's own artifacts) did not yet exist at plan-execution time; it is now checked off below since this review evaluated it as PASS.
+
+### AC Status Summary
+
+- Source: `docs/features/active/subagent-tree-command/issue.md`
+- Total AC items: 5
+- Checked off (delivered): 5 (AC1–AC4 by the executor; AC5 by this review)
+- Remaining (unchecked): 0
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `docs/features/active/subagent-tree-command/issue.md` | 5 | 5 | 0 | Checkbox-backed; AC5 checked off by this review. |

--- a/docs/features/active/subagent-tree-command/issue.md
+++ b/docs/features/active/subagent-tree-command/issue.md
@@ -1,0 +1,84 @@
+# subagent-tree-command
+
+- Work Mode: minor-audit
+
+## Problem / Why
+
+The `drm-copilot` VS Code extension has no way to inspect the subagent call tree of a
+Claude Code session. Transcripts on disk (`.claude/projects/**`) record a root session
+plus flattened subagent transcripts with meta files that encode a deterministic
+parent→child spawn relationship. A command that renders this tree helps operators
+understand delegation structure and detect mid-session model switches.
+
+## Implementation Intent
+
+Add a VS Code command `drmCopilotExtension.showSubagentTree` ("drm-copilot: Show
+Subagent Tree"). Given a root session (user-picked `.jsonl` under `.claude/projects/**`
+or the active session), build and display the subagent tree.
+
+Design for testability per `.claude/rules/general-unit-test.md`:
+
+- A pure, host-neutral module exposing `buildSubagentTree(rootSessionPath): TreeNode`
+  and `formatTree(node): string`, with full unit tests.
+- A thin host-bound command file that only does VS Code wiring (session pick, output
+  channel). Uncovered host lines kept minimal; no production file excluded from coverage.
+
+Data contract (verified transcript facts):
+
+- Root session: `.claude/projects/<project-dir>/<session-id>.jsonl` — one JSON object per line.
+- Subagent transcripts (all descendants, flattened):
+  `.claude/projects/<project-dir>/<session-id>/subagents/agent-<agentId>.jsonl`,
+  each with a sibling `agent-<agentId>.meta.json`.
+- `meta.json` fields: `agentType`, `description`, `toolUseId` (spawning call id),
+  `spawnDepth`, optional `worktreePath` / `worktreeBranch`.
+- Per-turn model is `message.model` in each `.jsonl`.
+
+Deterministic tree algorithm (port exactly):
+
+1. Scan the root `.jsonl` and every `subagents/*.jsonl`. For each transcript collect
+   (a) the set of `message.model` values, and (b) the ordered list of `Agent`
+   tool-use `id`s (assistant `message.content[]` blocks where `type=="tool_use"` and
+   `name=="Agent"`), preserving file line order.
+2. For each child, read its `meta.json`; map `meta.toolUseId → agentId`.
+3. Parent→child edge: a child whose `meta.toolUseId` equals an `Agent` tool-use `id`
+   found in transcript X is a child of X (exact 1:1 match; no timestamps/heuristics).
+4. Order siblings by the line order of their spawning tool-use in the parent transcript.
+5. Render each node as `agentType · [sorted,comma-joined models] · depth · description`.
+   A node with more than one distinct model prints all of them.
+
+## Acceptance Criteria
+
+- [x] AC1: Command `drmCopilotExtension.showSubagentTree` ("drm-copilot: Show Subagent Tree")
+  is registered in `extensions/drm-copilot/package.json` under `contributes.commands`
+  and wired/activated in the extension; invoking it renders the tree for a
+  selected/active session.
+- [x] AC2: Pure builder `buildSubagentTree` and renderer `formatTree` are implemented in
+  a host-neutral module with no VS Code imports.
+- [x] AC3: Unit tests cover positive, empty-subagents, multi-model node, multi-depth
+  nesting, and orphan/unmatched `toolUseId` handled gracefully.
+- [x] AC4: Full TypeScript toolchain passes for the extension: format → lint → type-check
+  → arch tests → unit tests; coverage >= 85% line and >= 75% branch for the new
+  production files; no production file excluded from coverage.
+- [x] AC5: Local feature-review (policy-audit, code-review, feature-audit) is clean of
+  blocking findings.
+
+## Dependencies / Risks
+
+- No new dependencies without approval. `fast-check` is not installed in the extension;
+  the module is dev-tooling (T3/T4), so property tests are not required by tier rules —
+  standard Jest unit tests satisfy the coverage gate.
+- The extension's actual test toolchain is Jest (v8 coverage), not Vitest; follow the
+  extension's established pattern and add per-file coverage thresholds in
+  `jest.config.cjs` for the new production files.
+- Files under 500 lines each.
+
+## Verification Steps
+
+- Run the extension toolchain from `extensions/drm-copilot/`:
+  `npm run format`, `npm run lint`, `npm run typecheck`, `npm run test:coverage`.
+- Confirm command registration and activation.
+
+## Evidence Checklist
+- [x] baseline
+- [x] targeted verification
+- [x] end-state

--- a/docs/features/active/subagent-tree-command/issue.md
+++ b/docs/features/active/subagent-tree-command/issue.md
@@ -1,6 +1,7 @@
 # subagent-tree-command
 
 - Work Mode: minor-audit
+- Issue: [#320](https://github.com/drmoisan/drm-copilot/issues/320)
 
 ## Problem / Why
 

--- a/docs/features/active/subagent-tree-command/plan.2026-07-05T18-28.md
+++ b/docs/features/active/subagent-tree-command/plan.2026-07-05T18-28.md
@@ -1,0 +1,200 @@
+# subagent-tree-command - Plan
+
+- **Issue:** none
+- **Parent (optional):** none
+- **Owner:** TBD
+- **Last Updated:** 2026-07-05T18-28
+- **Status:** Complete
+- **Version:** 0.2
+
+## Required References
+
+- General Code Change Policy: [`.claude/rules/general-code-change.md`](../../../../.claude/rules/general-code-change.md)
+- General Unit Test Policy: [`.claude/rules/general-unit-test.md`](../../../../.claude/rules/general-unit-test.md)
+- TypeScript Code Standards: [`.claude/rules/typescript.md`](../../../../.claude/rules/typescript.md)
+- TypeScript Suppression Policy: [`.claude/rules/typescript-suppressions.md`](../../../../.claude/rules/typescript-suppressions.md)
+- Architecture Boundaries: [`.claude/rules/architecture-boundaries.md`](../../../../.claude/rules/architecture-boundaries.md)
+- Module Rigor Tiers: [`.claude/rules/quality-tiers.md`](../../../../.claude/rules/quality-tiers.md)
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+**Acceptance criteria source:** `docs/features/active/subagent-tree-command/issue.md`, section `## Acceptance Criteria` (AC1–AC5). This plan does not depend on `spec.md` or `user-story.md`; neither exists for this feature and neither is required.
+
+**Toolchain note:** the `drm-copilot` extension's configured test runner is **Jest with v8 coverage** (`jest.config.cjs`, `npm run test`, `npm run test:coverage`), not Vitest. All test tasks below use Jest (`*.test.ts` under `test/`, mirroring `src/`) per the extension's established convention, overriding the generic Vitest guidance in `.claude/rules/typescript.md` for this specific package.
+
+## Design Decisions (binding for implementation tasks)
+
+1. **Reuse the existing `FileSystem` seam.** `extensions/drm-copilot/src/lib/file-system.ts` already defines a host-neutral `FileSystem` interface (`glob`, `isFile`, `exists`, `isDirectory`, `listDirectory`, `readTextFile`, `writeTextFile`, `ensureDir`) and a `RealFileSystem` implementation. The subagent-tree module injects this existing interface rather than defining a new one, per the repo's reusability principle. No new filesystem interface is created.
+2. **Module layout under `src/lib/subagent-tree/`:**
+   - `types.ts` — `TreeNode`, `SubagentMeta`, `ScannedTranscript`, `ScannedSession` (no I/O, no VS Code imports).
+   - `transcript-parser.ts` — `parseTranscriptLines(lines: readonly string[]): { models: readonly string[]; agentToolUseIds: readonly string[] }`, pure, no I/O.
+   - `transcript-scanner.ts` — `scanTranscripts(rootSessionPath: string, fileSystem: FileSystem): ScannedSession`, the only file in the module that touches `FileSystem`.
+   - `tree-assembler.ts` — `assembleTree(scanned: ScannedSession): TreeNode`, pure, no I/O (parent/child matching, sibling ordering, orphan handling).
+   - `tree-formatter.ts` — `formatTree(node: TreeNode): string`, pure renderer.
+   - `index.ts` — barrel exporting `buildSubagentTree(rootSessionPath, deps: { fileSystem: FileSystem }): TreeNode` (composes `scanTranscripts` + `assembleTree`), `formatTree`, and the `TreeNode` type.
+3. **`spawnDepth` is read verbatim from each subagent's `meta.json`** as the node's `depth` field; the algorithm never recomputes depth from recursion, matching the "port exactly, no heuristics" requirement. The root node's `depth` is `0`.
+4. **Orphan handling (deterministic, non-crashing):** a subagent whose `meta.toolUseId` matches no `Agent` tool-use id in the root transcript or in any other scanned subagent transcript is an *orphan*. Orphans are attached as additional children of the root node, appended **after** the root's normally-matched children, ordered by ascending `agentId` (the meta filename's `agent-<agentId>` segment) for determinism. An orphan's own descendants (if its `toolUseId` matched some other transcript that in turn spawned children of it) are still assembled normally under it.
+5. **Sibling ordering:** children of a given parent are ordered by the index (`indexOf`) of their spawning `toolUseId` within the parent's ordered `agentToolUseIds` list, ascending. Ties (which should not occur, since tool-use ids are unique per Agent invocation) are broken by ascending `agentId` string comparison.
+6. **Render format:** `formatTree` renders each node as one line: `${"  ".repeat(node.depth)}${node.agentType} · [${node.models.join(",")}] · ${node.depth} · ${node.description}`, followed by each child's rendered lines, in child order. Indentation is two spaces per `depth` unit. `node.models` is always sorted ascending before joining, so a node with more than one distinct model prints all of them, comma-joined, deterministically ordered.
+7. **Root-session path convention:** given `rootSessionPath` ending in `.jsonl`, the sibling `subagents` directory is `` `${rootSessionPath without the trailing ".jsonl"}/subagents` ``. `scanTranscripts` throws a explicit, fail-fast `Error` if `rootSessionPath` does not end in `.jsonl` (invariant violation caught at the I/O boundary, not silently ignored).
+8. **Command host wiring** (`src/subagent-tree-command.ts`) discovers candidate root sessions by globbing `.claude/projects/**/*.jsonl` under the workspace root via `RealFileSystem`, excluding any path containing a `/subagents/` segment (those are flattened subagent transcripts, not root sessions). When exactly one candidate remains, it is used directly as the active session (no prompt). When more than one remains, `vscode.window.showQuickPick` lets the user choose. When none remain, the command reports an error via the output channel and `vscode.window.showErrorMessage` without throwing an unhandled rejection.
+9. **No new dependencies.** `fast-check` is not installed and is not added; the module is T3/T4 dev tooling, so property-based tests are not required by tier rules. Standard Jest unit tests satisfy the coverage gate.
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Compliance, Baseline & Toolchain Capture
+
+- [x] [P0-T1] Read `.claude/rules/general-code-change.md` in full before touching code
+  - Acceptance: file read confirmed; listed in `docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md`
+- [x] [P0-T2] Read `.claude/rules/general-unit-test.md` in full before touching code
+  - Acceptance: listed in `docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md`
+- [x] [P0-T3] Read `.claude/rules/typescript.md` in full before touching code
+  - Acceptance: listed in `docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md`
+- [x] [P0-T4] Read `.claude/rules/typescript-suppressions.md` in full before touching code
+  - Acceptance: listed in `docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md`
+- [x] [P0-T5] Read `.claude/rules/architecture-boundaries.md` in full before touching code
+  - Acceptance: listed in `docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md`
+- [x] [P0-T6] Read `.claude/rules/quality-tiers.md` in full before touching code
+  - Acceptance: listed in `docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md`
+- [x] [P0-T7] Write `docs/features/active/subagent-tree-command/evidence/baseline/phase0-instructions-read.md` recording `Timestamp:`, `Policy Order:` (the six files above in read order), and the explicit file list
+  - Acceptance: artifact exists with all three required fields populated (no placeholder text)
+- [x] [P0-T8] Capture a non-mutating baseline format check by running `npx prettier --check "src/**/*.ts" "test/**/*.ts"` from `extensions/drm-copilot/` and writing the result to `docs/features/active/subagent-tree-command/evidence/baseline/baseline-format.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` with the real exit code and a concise pass/fail summary
+- [x] [P0-T9] Capture baseline lint results by running `npm run lint` from `extensions/drm-copilot/` and writing the result to `docs/features/active/subagent-tree-command/evidence/baseline/baseline-lint.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` with the real exit code and error/warning counts
+- [x] [P0-T10] Capture baseline type-check results by running `npm run typecheck` from `extensions/drm-copilot/` and writing the result to `docs/features/active/subagent-tree-command/evidence/baseline/baseline-typecheck.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` with the real exit code
+- [x] [P0-T11] Capture baseline coverage by running `npm run test:coverage` from `extensions/drm-copilot/` and writing the result to `docs/features/active/subagent-tree-command/evidence/baseline/baseline-test-coverage.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` with the numeric pass/fail test count and the aggregate line/branch coverage percentages reported by the run
+
+### Phase 1 — Pure Types & Transcript Line Parser
+
+- [x] [P1-T1] Create `extensions/drm-copilot/src/lib/subagent-tree/types.ts` defining `TreeNode`, `SubagentMeta`, `ScannedTranscript`, and `ScannedSession` interfaces with no VS Code imports and no `any`
+  - Acceptance: `npx tsc -p extensions/drm-copilot --noEmit` reports zero errors for this file; file is under 500 lines
+- [x] [P1-T2] Create `extensions/drm-copilot/src/lib/subagent-tree/transcript-parser.ts` implementing `parseTranscriptLines(lines: readonly string[]): { models: readonly string[]; agentToolUseIds: readonly string[] }` per Design Decision items 3 and 6 and the issue's algorithm step 1 (skip blank lines; ignore lines whose `message` is not an object; collect the model only when `message.model` is truthy; collect `Agent` tool-use ids from assistant `message.content[]` blocks in file line order)
+  - Acceptance: file compiles with no `any`; exports exactly `parseTranscriptLines`; file is under 500 lines
+- [x] [P1-T3] Create `extensions/drm-copilot/test/lib/subagent-tree/transcript-parser.test.ts` with a positive-scenario test: a transcript with three lines containing two distinct `Agent` tool-use blocks and one `message.model` value produces the tool-use ids in file line order and a one-element models array
+  - Acceptance: `npx jest test/lib/subagent-tree/transcript-parser.test.ts` (run from `extensions/drm-copilot/`) passes
+- [x] [P1-T4] Add a multi-model scenario test to `extensions/drm-copilot/test/lib/subagent-tree/transcript-parser.test.ts`: a transcript whose turns carry two different truthy `message.model` values produces both values in the returned `models` array
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/transcript-parser.test.ts`
+- [x] [P1-T5] Add a blank/malformed-line scenario test to `extensions/drm-copilot/test/lib/subagent-tree/transcript-parser.test.ts`: input lines include a blank line, a non-JSON line, and a line whose `message` field is a string rather than an object; all three are ignored without throwing and do not appear in the output
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/transcript-parser.test.ts`
+- [x] [P1-T6] Add a tool-use ordering scenario test to `extensions/drm-copilot/test/lib/subagent-tree/transcript-parser.test.ts`: two `Agent` tool-use ids whose alphabetical order differs from their file line order are returned in file line order
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/transcript-parser.test.ts`
+
+### Phase 2 — Filesystem-Backed Transcript Scanner
+
+- [x] [P2-T1] Create `extensions/drm-copilot/src/lib/subagent-tree/transcript-scanner.ts` implementing `scanTranscripts(rootSessionPath: string, fileSystem: FileSystem): ScannedSession` per Design Decision items 2 and 7: derive the sibling `subagents` directory, glob `agent-*.meta.json` via `fileSystem.glob`, read each meta JSON and its sibling `.jsonl`, and delegate line parsing to `parseTranscriptLines`; import `FileSystem` from `../file-system`
+  - Acceptance: file imports only `../file-system` and `./transcript-parser` (plus `./types`); zero `vscode` imports (verified by `grep -n "vscode" extensions/drm-copilot/src/lib/subagent-tree/transcript-scanner.ts` returning no matches); file is under 500 lines
+- [x] [P2-T2] Create `extensions/drm-copilot/test/lib/subagent-tree/in-memory-file-system.ts` implementing the `FileSystem` interface backed by in-memory `Map`s (no temp files, no real disk access), following the existing `test/lib/pr-context/tree-file-system.ts` pattern
+  - Acceptance: file compiles and satisfies the `FileSystem` interface with no `any`
+- [x] [P2-T3] Create `extensions/drm-copilot/test/lib/subagent-tree/transcript-scanner.test.ts` with a positive multi-agent scenario: an in-memory `FileSystem` seeded with a root `.jsonl`, a `subagents` directory containing two `agent-*.jsonl` + `agent-*.meta.json` pairs, asserting `scanTranscripts(...).subagents.length === 2` and that each entry's `meta` fields match the seeded JSON
+  - Acceptance: `npx jest test/lib/subagent-tree/transcript-scanner.test.ts` passes
+- [x] [P2-T4] Add an empty-subagents scenario test to `extensions/drm-copilot/test/lib/subagent-tree/transcript-scanner.test.ts`: the `subagents` directory does not exist in the fake filesystem; `scanTranscripts` returns `subagents: []` without throwing
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/transcript-scanner.test.ts`
+- [x] [P2-T5] Add a multi-depth-nesting scan scenario test to `extensions/drm-copilot/test/lib/subagent-tree/transcript-scanner.test.ts`: a subagent transcript itself contains an `Agent` tool-use whose id is referenced by a second subagent's `meta.toolUseId` (a grandchild), asserting both subagents are present in `ScannedSession.subagents` with their own parsed `agentToolUseIds`
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/transcript-scanner.test.ts`
+
+### Phase 3 — Tree Assembly Algorithm
+
+- [x] [P3-T1] Create `extensions/drm-copilot/src/lib/subagent-tree/tree-assembler.ts` implementing `assembleTree(scanned: ScannedSession): TreeNode` per Design Decision items 3, 4, and 5 (spawnDepth passthrough, parent/child matching by exact `toolUseId` equality, sibling ordering by spawn-index, orphan attachment under root)
+  - Acceptance: file has zero I/O calls and zero `vscode` imports (verified by `grep -n "vscode\|readTextFile\|readFileSync" extensions/drm-copilot/src/lib/subagent-tree/tree-assembler.ts` returning no matches); file is under 500 lines
+- [x] [P3-T2] Create `extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts` with a positive multi-agent scenario: a root with two direct subagent children assembles a `TreeNode` whose `children` array has length 2 in the expected order
+  - Acceptance: `npx jest test/lib/subagent-tree/tree-assembler.test.ts` passes
+- [x] [P3-T3] Add an empty-subagents scenario test to `extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts`: `ScannedSession.subagents` is an empty array; the assembled root `TreeNode.children` is an empty array
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/tree-assembler.test.ts`
+- [x] [P3-T4] Add a multi-model-node scenario test to `extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts`: a subagent's `ScannedTranscript.models` contains two distinct values; the assembled node's `models` array contains both, sorted ascending
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/tree-assembler.test.ts`
+- [x] [P3-T5] Add a multi-depth-nesting (grandchild) scenario test to `extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts`: a child subagent's own `agentToolUseIds` matches a grandchild's `toolUseId`; the assembled tree places the grandchild inside the child's `children` array, not the root's
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/tree-assembler.test.ts`
+- [x] [P3-T6] Add an orphan/unmatched-`toolUseId` scenario test to `extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts`: one subagent's `meta.toolUseId` matches no transcript's `agentToolUseIds`; `assembleTree` does not throw and the orphan appears as a root child after the normally-matched children, per Design Decision item 4
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/tree-assembler.test.ts`
+- [x] [P3-T7] Add a sibling-ordering scenario test to `extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts`: two sibling subagents whose `agentId` alphabetical order is the reverse of their spawning tool-use line order in the parent transcript; the assembled `children` array follows line order, not alphabetical order
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/tree-assembler.test.ts`
+
+### Phase 4 — Tree Renderer and Barrel Export
+
+- [x] [P4-T1] Create `extensions/drm-copilot/src/lib/subagent-tree/tree-formatter.ts` implementing `formatTree(node: TreeNode): string` per Design Decision item 6 (two-space indent per `depth`, `agentType · [models] · depth · description` line format, recursive child rendering)
+  - Acceptance: file compiles with no `any`; exports exactly `formatTree`; file is under 500 lines
+- [x] [P4-T2] Create `extensions/drm-copilot/test/lib/subagent-tree/tree-formatter.test.ts` with a positive scenario: a two-level tree (root + one child) renders two lines with the child indented two spaces relative to the root and both lines matching the exact `agentType · [models] · depth · description` format
+  - Acceptance: `npx jest test/lib/subagent-tree/tree-formatter.test.ts` passes
+- [x] [P4-T3] Add a multi-model rendering scenario test to `extensions/drm-copilot/test/lib/subagent-tree/tree-formatter.test.ts`: a node with two distinct models renders both, comma-joined and sorted ascending, inside the `[...]` segment
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/tree-formatter.test.ts`
+- [x] [P4-T4] Add an empty-subagents rendering scenario test to `extensions/drm-copilot/test/lib/subagent-tree/tree-formatter.test.ts`: a root node with no children renders exactly one line
+  - Acceptance: the new test case passes under `npx jest test/lib/subagent-tree/tree-formatter.test.ts`
+- [x] [P4-T5] Create `extensions/drm-copilot/src/lib/subagent-tree/index.ts` as a barrel exporting `buildSubagentTree(rootSessionPath: string, deps: { fileSystem: FileSystem }): TreeNode` (composing `scanTranscripts` and `assembleTree`), `formatTree`, and the `TreeNode` type
+  - Acceptance: file compiles with no `any`; `npx tsc -p extensions/drm-copilot --noEmit` reports zero errors
+- [x] [P4-T6] Create `extensions/drm-copilot/test/lib/subagent-tree/index.test.ts` verifying `buildSubagentTree` composes the scanner and assembler end-to-end against the in-memory `FileSystem` fixture for the positive multi-agent scenario, and that its output round-trips through `formatTree` without throwing
+  - Acceptance: `npx jest test/lib/subagent-tree/index.test.ts` passes
+
+### Phase 5 — VS Code Command Wiring & Registration
+
+- [x] [P5-T1] Create `extensions/drm-copilot/src/subagent-tree-command.ts` implementing `registerSubagentTreeCommand(options: { output: vscode.OutputChannel }): vscode.Disposable` per Design Decision item 8: discover `.claude/projects/**/*.jsonl` root-session candidates via `RealFileSystem`, exclude paths containing `/subagents/`, auto-select when exactly one candidate exists, otherwise prompt via `vscode.window.showQuickPick`, then call `buildSubagentTree` and `formatTree` and write the result to the output channel
+  - Acceptance: file compiles with no `any`; registers the command id `drmCopilotExtension.showSubagentTree`; file is under 500 lines
+- [x] [P5-T2] Update `extensions/drm-copilot/src/extension.ts` to import `registerSubagentTreeCommand` and push its returned disposable into `context.subscriptions` inside `activate`
+  - Acceptance: `npx tsc -p extensions/drm-copilot --noEmit` reports zero errors; `registerSubagentTreeCommand` is called exactly once in `activate`
+- [x] [P5-T3] Add the command contribution entry `{ "command": "drmCopilotExtension.showSubagentTree", "title": "drm-copilot: Show Subagent Tree" }` to the `contributes.commands` array in `extensions/drm-copilot/package.json`
+  - Acceptance: `contributes.commands` in `extensions/drm-copilot/package.json` contains an entry with that exact `command` and `title`
+- [x] [P5-T4] Create `extensions/drm-copilot/test/subagent-tree-command.test.ts` following the `test/extension.collect-pr-context.test.ts` mocking pattern (mocked `vscode`, mocked `node:fs`) with a scenario asserting: zero candidate sessions produces an error message via the output channel and does not throw
+  - Acceptance: `npx jest test/subagent-tree-command.test.ts` (run from `extensions/drm-copilot/`) passes
+- [x] [P5-T5] Add a single-candidate auto-select scenario test to `extensions/drm-copilot/test/subagent-tree-command.test.ts`: exactly one discovered `.jsonl` root session is used directly without invoking `showQuickPick`, and the rendered tree text is written to the output channel
+  - Acceptance: the new test case passes under `npx jest test/subagent-tree-command.test.ts`
+- [x] [P5-T6] Add a multi-candidate quick-pick scenario test to `extensions/drm-copilot/test/subagent-tree-command.test.ts`: two discovered `.jsonl` root sessions trigger `vscode.window.showQuickPick`, and the session selected by the mock is the one passed to `buildSubagentTree`
+  - Acceptance: the new test case passes under `npx jest test/subagent-tree-command.test.ts`
+
+### Phase 6 — Coverage Threshold Configuration
+
+- [x] [P6-T1] Add a `coverageThreshold` entry with `{ lines: 85, branches: 75 }` for `./src/lib/subagent-tree/types.ts` to `extensions/drm-copilot/jest.config.cjs`
+  - Acceptance: the entry is present in `jest.config.cjs` with the exact path key and threshold values
+- [x] [P6-T2] Add a `coverageThreshold` entry with `{ lines: 85, branches: 75 }` for `./src/lib/subagent-tree/transcript-parser.ts` to `extensions/drm-copilot/jest.config.cjs`
+  - Acceptance: the entry is present in `jest.config.cjs` with the exact path key and threshold values
+- [x] [P6-T3] Add a `coverageThreshold` entry with `{ lines: 85, branches: 75 }` for `./src/lib/subagent-tree/transcript-scanner.ts` to `extensions/drm-copilot/jest.config.cjs`
+  - Acceptance: the entry is present in `jest.config.cjs` with the exact path key and threshold values
+- [x] [P6-T4] Add a `coverageThreshold` entry with `{ lines: 85, branches: 75 }` for `./src/lib/subagent-tree/tree-assembler.ts` to `extensions/drm-copilot/jest.config.cjs`
+  - Acceptance: the entry is present in `jest.config.cjs` with the exact path key and threshold values
+- [x] [P6-T5] Add a `coverageThreshold` entry with `{ lines: 85, branches: 75 }` for `./src/lib/subagent-tree/tree-formatter.ts` to `extensions/drm-copilot/jest.config.cjs`
+  - Acceptance: the entry is present in `jest.config.cjs` with the exact path key and threshold values
+- [x] [P6-T6] Add a `coverageThreshold` entry with `{ lines: 85, branches: 75 }` for `./src/lib/subagent-tree/index.ts` to `extensions/drm-copilot/jest.config.cjs`
+  - Acceptance: the entry is present in `jest.config.cjs` with the exact path key and threshold values
+- [x] [P6-T7] Add a `coverageThreshold` entry with `{ lines: 85, branches: 75 }` for `./src/subagent-tree-command.ts` to `extensions/drm-copilot/jest.config.cjs`
+  - Acceptance: the entry is present in `jest.config.cjs` with the exact path key and threshold values
+- [x] [P6-T8] Verify `extensions/drm-copilot/jest.config.cjs`'s `collectCoverageFrom` array (`["src/**/*.ts", "!src/**/*.d.ts"]`) requires no changes to cover the seven new files and that none of the seven new files appears in any `exclude`-style pattern
+  - Acceptance: grep of `jest.config.cjs` for `subagent-tree` shows only the seven `coverageThreshold` entries above (no exclusion pattern)
+
+### Phase 7 — Final QA Loop
+
+- [x] [P7-T1] Run `npm run format` from `extensions/drm-copilot/` and write the result to `docs/features/active/subagent-tree-command/evidence/qa-gates/final-format.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:`; if the command modifies any file, the loop restarts from this task
+- [x] [P7-T2] Run `npm run lint` from `extensions/drm-copilot/` and write the result to `docs/features/active/subagent-tree-command/evidence/qa-gates/final-lint.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` with zero lint errors reported
+- [x] [P7-T3] Run `npm run typecheck` from `extensions/drm-copilot/` and write the result to `docs/features/active/subagent-tree-command/evidence/qa-gates/final-typecheck.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` with zero type errors reported
+- [x] [P7-T4] Verify the architecture boundary manually by running `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/` and writing the result to `docs/features/active/subagent-tree-command/evidence/qa-gates/final-arch-boundary.md`, noting that no `dependency-cruiser` config exists for this extension so this manual grep is the enforcement mechanism for this change
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` confirming zero `vscode` matches inside `src/lib/subagent-tree/`
+- [x] [P7-T5] Run `npm run test:coverage` from `extensions/drm-copilot/` and write the full result to `docs/features/active/subagent-tree-command/evidence/qa-gates/final-test-coverage.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` with the aggregate pass/fail test count and the aggregate line/branch coverage percentages
+- [x] [P7-T6] Verify each of the seven new production files individually meets or exceeds 85% line / 75% branch coverage from the Phase 7 coverage run, and write the per-file breakdown to `docs/features/active/subagent-tree-command/evidence/qa-gates/final-coverage-per-file.md`
+  - Acceptance: artifact lists all seven file paths with their line and branch percentages, each >= 85% line and >= 75% branch, alongside the Phase 0 baseline aggregate percentages from `baseline-test-coverage.md` for comparison
+- [x] [P7-T7] Run `npm run build` from `extensions/drm-copilot/` and write the result to `docs/features/active/subagent-tree-command/evidence/qa-gates/final-build.md`
+  - Acceptance: artifact contains `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and `Output Summary:` confirming `tsc --noEmit`, `bundle:extension`, and `bundle:mcp-server` all completed without error
+
+## Test Plan
+
+- **Unit (Jest, `extensions/drm-copilot/`):**
+  - `test/lib/subagent-tree/transcript-parser.test.ts` — positive, multi-model, blank/malformed lines, ordering.
+  - `test/lib/subagent-tree/transcript-scanner.test.ts` — positive multi-agent, empty-subagents, multi-depth nesting (scan level).
+  - `test/lib/subagent-tree/tree-assembler.test.ts` — positive multi-agent, empty-subagents, multi-model node, multi-depth nesting (grandchild), orphan/unmatched `toolUseId`, sibling ordering.
+  - `test/lib/subagent-tree/tree-formatter.test.ts` — positive rendering, multi-model rendering, empty-subagents rendering.
+  - `test/lib/subagent-tree/index.test.ts` — end-to-end composition of scanner + assembler + formatter.
+  - `test/subagent-tree-command.test.ts` — host wiring: zero candidates, single-candidate auto-select, multi-candidate quick-pick.
+- **Integration/Manual:** none required; the command is exercised entirely through the injected `FileSystem` seam in tests. No temp files are created by any test.
+- **Coverage evidence:**
+  - Baseline artifacts: `docs/features/active/subagent-tree-command/evidence/baseline/baseline-format.md`, `baseline-lint.md`, `baseline-typecheck.md`, `baseline-test-coverage.md`.
+  - Final-QC artifacts: `docs/features/active/subagent-tree-command/evidence/qa-gates/final-format.md`, `final-lint.md`, `final-typecheck.md`, `final-arch-boundary.md`, `final-test-coverage.md`, `final-coverage-per-file.md`, `final-build.md`.
+  - Per-file comparison: `final-coverage-per-file.md` reports baseline aggregate vs. post-change aggregate vs. new-file coverage for each of the seven new production files.
+
+## Open Questions / Notes
+
+- The orphan-attachment rule (Design Decision item 4) is a deliberate, testable choice among several reasonable options (attach to root vs. list separately vs. drop). If a future requirement needs orphans surfaced differently (e.g., a dedicated "unmatched" section in `formatTree`), that is a follow-on change, not part of this plan.
+- `formatTree`'s exact line format (`agentType · [models] · depth · description`, two-space indent per depth) is this plan's chosen rendering; the issue does not mandate a specific indentation character count.
+- No `dependency-cruiser` configuration exists for `extensions/drm-copilot/` today; Phase 7's architecture-boundary check is a manual grep rather than an automated tool run. Introducing `dependency-cruiser` for this extension is out of scope for this feature.

--- a/docs/features/active/subagent-tree-command/policy-audit.2026-07-05T23-16.md
+++ b/docs/features/active/subagent-tree-command/policy-audit.2026-07-05T23-16.md
@@ -1,0 +1,537 @@
+# Policy Compliance Audit: subagent-tree-command
+
+---
+
+**Audit Date:** 2026-07-05
+**Code Under Test:** `extensions/drm-copilot/src/lib/subagent-tree/{index,transcript-parser,transcript-scanner,tree-assembler,tree-formatter,types}.ts`, `extensions/drm-copilot/src/subagent-tree-command.ts`, `extensions/drm-copilot/src/extension.ts` (modified), `extensions/drm-copilot/package.json` (modified), `extensions/drm-copilot/jest.config.cjs` (modified), plus the corresponding test files under `extensions/drm-copilot/test/lib/subagent-tree/` and `extensions/drm-copilot/test/subagent-tree-command.test.ts`.
+
+**Base branch:** `main` @ `6e73fe292fcac017b9c3c6d0b37e5e0e71dbfa10` (merge-base equals current `main` HEAD; `origin/main` unreachable in this environment, resolved base used as recorded in `artifacts/pr_context.summary.txt`).
+**Head scope:** staged working tree on `drm-copilot-wt-2026-07-05-18-24` (`git diff --cached main`).
+**Work mode:** `minor-audit` (persisted marker in `issue.md`). Acceptance-criteria source: `docs/features/active/subagent-tree-command/issue.md`, `## Acceptance Criteria` (AC1–AC5) only.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| TypeScript | 7 new production files, 3 modified (`extension.ts`, `package.json`, `jest.config.cjs`), 7 new test files | 25 new tests (1506 total repo-wide) | ✅ 130/130 suites, 1506/1506 tests pass (per `final-test-coverage.md`); independently re-ran the 6 new suites (25/25 pass) during this review | 96.75% lines, 88.31% branches, 87.42% funcs | 96.53% lines, 88.42% branches, 87.5% funcs | 96.79% lines / 94.57% branches (aggregate across the 6 executable new files; per-file range 92.44%–100% lines, 85.71%–100% branches) |
+| PowerShell | 0 files | N/A | N/A | N/A (no PowerShell files changed) | N/A | N/A |
+| Python | 0 files | N/A | N/A | N/A (no Python files changed) | N/A | N/A |
+| Bash | 0 files | N/A | N/A | N/A (no coverage) | N/A (no coverage) | N/A |
+| JSON | 1 file (`package.json`, mechanical `contributes.commands` entry addition; not a governed schema-validated config artifact) | N/A | ✅ valid JSON (parses; used by `npm` toolchain runs above) | N/A (config file) | N/A (config file) | N/A |
+
+**Note:** No PowerShell, Python, C#, or Bash files have changed files in this branch diff; those rows are correctly `N/A` per the coverage-verdict rule (zero changed files for those languages).
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `docs/features/active/subagent-tree-command/evidence/baseline/baseline-test-coverage.md` (96.75% lines / 88.31% branches aggregate, narrative form; the raw `lcov.info` from that run was not separately archived because `extensions/drm-copilot/coverage/` is git-ignored and overwritten by each subsequent run — the narrative baseline figures are the evidence of record for the pre-change state).
+- TypeScript post-change coverage artifact: `extensions/drm-copilot/coverage/lcov.info` (current on-disk artifact, independently inspected by this review — see Section 5; per-file figures match `docs/features/active/subagent-tree-command/evidence/qa-gates/final-coverage-per-file.md` exactly) and `docs/features/active/subagent-tree-command/evidence/qa-gates/final-test-coverage.md` (aggregate narrative).
+- PowerShell baseline coverage artifact: N/A - out of scope (no PowerShell files changed in this branch diff).
+- PowerShell post-change coverage artifact: N/A - out of scope (no PowerShell files changed in this branch diff).
+- Per-language comparison summary: Section 1.2.1 below.
+
+**Non-negotiable verdict rule:** Numeric baseline and post-change coverage metrics are included above for TypeScript, the only in-scope language. No policy audit language row claims a PASS without numeric evidence.
+
+**Fail-closed rule acknowledged:** No required baseline artifact, QA artifact, or coverage-comparison artifact was found missing during this review; see Gaps section for the two pre-existing, out-of-scope repository infrastructure gaps noted (dependency-cruiser config, `quality-tiers.yml`), which are not treated as blocking this specific feature's diff.
+
+**Evidence rule acknowledged:** All coverage figures below were independently re-derived from `extensions/drm-copilot/coverage/lcov.info` by this review (not copied from the executor's narrative without verification).
+
+---
+
+## Rejected Scope Narrowing
+
+None. No caller instruction in this task attempted to narrow scope to a plan/task/phase subset, exclude a changed-file subset, or mark any changed language as out of scope. The task instructions explicitly directed a full feature-vs-base audit and explicitly stated the Jest/v8 toolchain context (a factual clarification about repo tooling, not a scope narrowing).
+
+## Evidence Location Compliance
+
+- Ran `python scripts/dev_tools/validate_evidence_locations.py --root .` — exit code 0, no output (no violations reported).
+- Manually scanned `git diff --cached main --name-only` for any path under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/` — zero matches.
+- All evidence produced by this feature's execution lives under the canonical `docs/features/active/subagent-tree-command/evidence/{baseline,qa-gates}/` path. No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` entries were required.
+
+---
+
+## Executive Summary
+
+This feature adds a host-neutral subagent-call-tree builder/formatter (`extensions/drm-copilot/src/lib/subagent-tree/`) and a thin VS Code command wrapper (`extensions/drm-copilot/src/subagent-tree-command.ts`) to the `drm-copilot` extension, registered as `drmCopilotExtension.showSubagentTree`. The review re-ran format, lint, type-check, the new test suites, and independently parsed the current `coverage/lcov.info` rather than trusting the executor's narrative alone. Every independently reproduced check passed and matched the executor's recorded evidence exactly (see Section 5/6 for the parsed lcov figures).
+
+**Policy documents evaluated:**
+- ✅ `general-code-change.instructions.md` (`.claude/rules/general-code-change.md`)
+- ✅ `general-unit-test.instructions.md` (`.claude/rules/general-unit-test.md`)
+
+**Language-specific policies evaluated:**
+- ✅ TypeScript: `.claude/rules/typescript.md`, `.claude/rules/typescript-suppressions.md`, `.claude/rules/architecture-boundaries.md`
+- N/A Python, PowerShell, Bash, JSON-schema: no changed files in scope for those policies.
+
+Toolchain results (independently reproduced by this review, in `extensions/drm-copilot/`):
+- `npx prettier --check "src/**/*.ts" "test/**/*.ts"` → exit 0, "All matched files use Prettier code style!"
+- `npm run lint` → exit 0, zero ESLint errors/warnings (no output).
+- `npm run typecheck` → exit 0, zero `tsc --noEmit` errors.
+- `npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts` → exit 0, 6 suites / 25 tests passed.
+- `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/` → exit 1 (no matches), confirming the host-neutral module has zero VS Code imports.
+- Parsed `extensions/drm-copilot/coverage/lcov.info` directly: all 6 executable new production files exceed 85% line / 75% branch; `types.ts` (interface-only, 0 executable lines) is legitimately excluded only from the per-file `coverageThreshold` gate, not from `collectCoverageFrom`.
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary or one-time scripts were created by this feature's implementation; all test doubles (`InMemoryFileSystem`) are permanent, tested production-of-tests code under `test/lib/subagent-tree/`.
+- ✅ No ongoing tooling scripts were added.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | ✅ PASS | Each `describe` block constructs its own `InMemoryFileSystem`/fixture inline (no shared module-level mutable state); `beforeEach`/`afterEach` in `test/subagent-tree-command.test.ts` reset all mocks (`commandHandlers.clear()`, `*.mockReset()`, `jest.clearAllMocks()`). |
+| **Isolation** - Each test targets single behavior | ✅ PASS | One assertion focus per `it()` (e.g., `transcript-parser.test.ts` separates ordering, multi-model, and malformed-line concerns into distinct tests). |
+| **Fast Execution** - Tests complete quickly | ✅ PASS | Independently re-ran the 6 new suites: `Time: 0.446s` for 25 tests (in-memory fakes only, no real I/O). |
+| **Determinism** - Consistent results | ✅ PASS | No `setTimeout`, `Date.now`, `Math.random`, or real filesystem access in any new test or production file (verified via `grep -rn "setTimeout\|Date.now\|Math.random" test/lib/subagent-tree/ test/subagent-tree-command.test.ts src/lib/subagent-tree/ src/subagent-tree-command.ts` — zero matches). Sibling ordering and model sort are explicit deterministic sorts, not insertion-order dependent. |
+| **Readability & Maintainability** - Clear structure | ✅ PASS | Every test carries an Arrange/Act/Assert comment triad and a descriptive `it()` name stating the scenario and expected outcome. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | `docs/features/active/subagent-tree-command/evidence/baseline/baseline-test-coverage.md`. **Baseline:** 96.75% lines, 87.42% funcs. **Command:** `npm run test:coverage`. **Timestamp:** 2026-07-05T22-47. |
+| **No Coverage Regression** | ✅ PASS | **Post-change:** 96.53% lines, 87.5% funcs. **Change:** -0.22% lines (funcs +0.08%). **Status:** the small aggregate line-percentage decrease is explained structurally: `types.ts` (0 executable lines) was added to the measured file set, increasing the denominator without adding executable-coverage debt; every pre-existing file's own coverage is unaffected (this feature adds new files, it does not touch any pre-existing file's logic other than `extension.ts`, whose own coverage — independently parsed — is 465/478 lines = 97.28%, 59/65 branches = 90.77%). |
+| **New Code Coverage >= 85% lines / 75% branches** (uniform tier rule; this repo does not use the generic template's 90% figure) | ✅ PASS | Independently parsed from `coverage/lcov.info`: `transcript-parser.ts` 127/129=98.45% lines, 27/28=96.43% branches; `transcript-scanner.ts` 155/155=100%/26/26=100%; `tree-assembler.ts` 179/189=94.71%/17/19=89.47%; `tree-formatter.ts` 33/33=100%/3/3=100%; `index.ts` 28/28=100%/2/2=100%; `subagent-tree-command.ts` 110/119=92.44%/12/14=85.71%. All 6 executable files exceed 85%/75%. `types.ts` reports 0/73 lines, 0/1 branches — a structural result of the file containing only `interface` declarations (zero executable statements), matching the documented exception in `.claude/rules/general-unit-test.md`. |
+| **Comprehensive Coverage** | ✅ PASS | See Section 5 for a per-module test inventory. Every exported function (`parseTranscriptLines`, `scanTranscripts`, `assembleTree`, `formatTree`, `buildSubagentTree`, `registerSubagentTreeCommand`) has dedicated positive and negative-path tests. |
+| **Positive Flows** - Valid inputs | ✅ PASS | Positive multi-agent scenarios in `transcript-scanner.test.ts`, `tree-assembler.test.ts`, `index.test.ts`; auto-select and multi-candidate positive flows in `subagent-tree-command.test.ts`. |
+| **Negative Flows** - Invalid inputs | ✅ PASS | `transcript-scanner.test.ts` covers: non-`.jsonl` root path (throws), unparsable meta filename, invalid-JSON meta, non-object meta, missing/mistyped required meta field — 5 distinct negative-path tests. |
+| **Edge Cases** - Boundary conditions | ✅ PASS | Empty-subagents scenarios (`transcript-scanner.test.ts`, `tree-assembler.test.ts`, `tree-formatter.test.ts`); blank/non-JSON/string-`message` lines (`transcript-parser.test.ts`); zero-candidate-session scenario (`subagent-tree-command.test.ts`). |
+| **Error Handling** - Error paths | ✅ PASS | `scanTranscripts` fail-fast `Error` on a non-`.jsonl` root path is explicitly tested (`toThrow(/must end in ".jsonl"/)`); `registerSubagentTreeCommand`'s catch-all reports via `showErrorMessage`/output channel without an unhandled rejection (tested via the zero-candidate scenario). |
+| **Concurrency** | N/A | No concurrent/async race-condition surface in this module; `registerSubagentTreeCommand`'s handler is a single sequential `async` flow with no parallel awaits. |
+| **State Transitions** | N/A | The module is stateless (pure functions plus one-shot I/O read); no persistent state machine is introduced. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- TypeScript: Baseline: 96.75% lines, 88.31% branches -> Post-change: 96.53% lines, 88.42% branches. Change: -0.22% lines, +0.11% branches (expected — `types.ts`, an interface-only file with 0 executable lines, was added to the measured file set, which lowers the aggregate line percentage without indicating any coverage debt; branch and function percentages both improved). New/changed-code coverage: 96.79% lines / 94.57% branches (aggregate across the 6 executable new production files; per-file range 92.44%-100% lines, 85.71%-100% branches). Disposition: PASS. Evidence: `extensions/drm-copilot/coverage/lcov.info` (independently parsed by this review); `docs/features/active/subagent-tree-command/evidence/qa-gates/final-coverage-per-file.md`; `docs/features/active/subagent-tree-command/evidence/qa-gates/final-test-coverage.md`; `docs/features/active/subagent-tree-command/evidence/baseline/baseline-test-coverage.md`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | ✅ PASS | Assertions use `toEqual`/`toHaveLength`/`toContain`/`toThrow(/regex/)` with concrete expected values, giving actionable diffs on failure. |
+| **Arrange-Act-Assert Pattern** | ✅ PASS | Every new test in this feature carries explicit `// Arrange`, `// Act`, `// Assert` comments. |
+| **Document Intent** | ✅ PASS | Test names state the scenario and expected outcome in full sentences (e.g., `"orders siblings by spawn line order, not alphabetical agentId order"`). |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | No network, database, or external process access. `test/lib/subagent-tree/in-memory-file-system.ts` is a hermetic `Map`/`Set`-backed fake; `test/subagent-tree-command.test.ts` mocks `node:fs` and `vscode` entirely (`jest.mock(...)`). |
+| **Use Mocks/Stubs** | ✅ PASS | `InMemoryFileSystem` fakes the `FileSystem` seam for the pure-module tests; `node:fs`/`vscode` are jest-mocked for the host-wiring test, following the existing `test/extension.collect-pr-context.test.ts` pattern. |
+| **Environment Stability** | ✅ PASS | No temporary files created by any test (verified: no `tmpdir`/`mkdtemp`/real `writeFileSync` calls in the new test files — all `fs` calls are mocked). |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | ✅ PASS | This document is that review. AC5 in `issue.md` ("Local feature-review is clean of blocking findings") is resolved PASS by this audit — see feature-audit for the check-off. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | ✅ PASS | `docs/features/active/subagent-tree-command/issue.md` states the problem, implementation intent, and a deterministic algorithm specification. |
+| **Read existing change plans** | ✅ PASS | `docs/features/active/subagent-tree-command/plan.2026-07-05T18-28.md` documents the Required References list and reuse decision (existing `FileSystem` seam). |
+| **Document the plan** | ✅ PASS | The 7-phase atomic plan (`plan.2026-07-05T18-28.md`) documents design decisions 1–9 up front, binding for implementation. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | Each module has one clear responsibility (parse lines, scan filesystem, assemble tree, format text); no unnecessary indirection. |
+| **Reusability** | ✅ PASS | Reuses the pre-existing `FileSystem` interface/`RealFileSystem` (`src/lib/file-system.ts`) rather than introducing a new I/O seam (Design Decision 1). |
+| **Extensibility** | ✅ PASS | `buildSubagentTree(rootSessionPath, deps: { fileSystem })` takes an injected dependency object, allowing alternate `FileSystem` implementations without signature changes. |
+| **Separation of concerns** | ✅ PASS | Pure logic (`transcript-parser.ts`, `tree-assembler.ts`, `tree-formatter.ts`) is fully separated from the one I/O module (`transcript-scanner.ts`) and the VS Code host-wiring file (`subagent-tree-command.ts`); confirmed zero `vscode` imports under `src/lib/subagent-tree/`. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | ✅ PASS | `types.ts` (data), `transcript-parser.ts` (pure line parsing), `transcript-scanner.ts` (I/O), `tree-assembler.ts` (pure assembly), `tree-formatter.ts` (pure rendering), `index.ts` (barrel composition). |
+| **Under 500 lines** | ✅ PASS | Line counts (all production and test files): `index.ts` 28, `transcript-parser.ts` 129, `transcript-scanner.ts` 155, `tree-assembler.ts` 189, `tree-formatter.ts` 33, `types.ts` 73, `subagent-tree-command.ts` 119; tests: `index.test.ts` 71, `in-memory-file-system.ts` 133, `transcript-parser.test.ts` 96, `transcript-scanner.test.ts` 239, `tree-assembler.test.ts` 167, `tree-formatter.test.ts` 72, `subagent-tree-command.test.ts` 204. All well under the 500-line limit. |
+| **Public vs internal** | ✅ PASS | Each file exports only its intended public function(s) (`export function` for the single API; helper functions are unexported module-private). |
+| **No circular dependencies** | ✅ PASS | Dependency direction is strictly `index.ts -> {transcript-scanner, tree-assembler}`, `transcript-scanner.ts -> transcript-parser.ts`, all `-> types.ts`; `subagent-tree-command.ts -> lib/subagent-tree (barrel)`. No back-edges. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | ✅ PASS | `parseTranscriptLines`, `scanTranscripts`, `assembleTree`, `formatTree`, `buildSubagentTree`, `registerSubagentTreeCommand` — verb-first, descriptive; `camelCase` functions/variables, `PascalCase` types (`TreeNode`, `SubagentMeta`, `ScannedSession`). |
+| **Docs/docstrings** | ✅ PASS | Every exported function and non-trivial module carries a JSDoc block with Purpose/Tolerance/param/returns/throws documentation. |
+| **Comment why, not what** | ✅ PASS | E.g., the `ROOT_KEY` sentinel comment explains *why* a string sentinel avoids a discriminated union; the `jest.config.cjs` comment explains *why* `types.ts` has no per-file threshold entry. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | **Command:** `npx prettier --check "src/**/*.ts" "test/**/*.ts"` (independently re-run). **Result:** "All matched files use Prettier code style!", exit 0. |
+| **2. Linting** | ✅ PASS | **Command:** `npm run lint` (independently re-run). **Result:** zero errors/warnings, exit 0. |
+| **3. Type checking** | ✅ PASS | **Command:** `npm run typecheck` (independently re-run). **Result:** zero `tsc --noEmit` errors, exit 0. |
+| **4. Testing** | ✅ PASS | **Command:** `npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts` (independently re-run). **Result:** 6 suites / 25 tests passing. |
+| **Full toolchain loop** | ✅ PASS | Executor evidence (`final-format.md`) documents one auto-fix iteration (4 files reformatted) followed by a clean rerun of the full loop (format→lint→typecheck→arch→coverage→build), consistent with the "restart from step 1" rule. |
+| **Explicit reporting** | ✅ PASS | Commands and exit codes are documented in `docs/features/active/subagent-tree-command/evidence/qa-gates/*.md` and reproduced independently in this audit. |
+
+**Architecture-boundary stage (Section 2.5 continuation, TypeScript-specific):** repo policy (`.claude/rules/architecture-boundaries.md`) designates `dependency-cruiser` as the TypeScript enforcement tool. No `.dependency-cruiser.cjs` configuration exists anywhere in this repository (confirmed: `find . -iname ".dependency-cruiser*"` returns no results), so this is a pre-existing, repository-wide gap that predates this feature and is not introduced by it. The plan substitutes a manual `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/` check, independently reproduced by this review (exit 1, zero matches). This is recorded as a **Gap** in Section 8 (non-blocking for this specific diff) rather than a Blocker, because the substantive No-COM/layering assertions are satisfied by direct inspection even though the automated tool is absent repo-wide.
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | ✅ PASS | See Section 9 below. |
+| **Design choices explained** | ✅ PASS | `plan.2026-07-05T18-28.md` "Design Decisions" section (items 1–9) and "Open Questions / Notes" section document and justify the orphan-attachment rule and render-format choices. |
+| **Update supporting documents** | ✅ PASS | `issue.md` AC1–AC4 already checked off by the executor; this audit resolves AC5. |
+| **Provide next steps** | ✅ PASS | See Section 10 Recommendation. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+**Languages in scope for this change:** TypeScript only. Python, PowerShell, Bash, and JSON-schema-governed-config sections are deleted as not applicable (zero changed files in those categories; `package.json`/`jest.config.cjs` are ordinary npm/Jest configuration files, not schema-governed JSON artifacts).
+
+### Section 3E: TypeScript Code Change Policy Compliance
+
+#### 3E.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with Prettier** | ✅ PASS | **Command:** `npx prettier --check "src/**/*.ts" "test/**/*.ts"`. **Result:** all files conform; independently re-run, exit 0. |
+| **Linting with ESLint** | ✅ PASS | **Command:** `npm run lint` (`eslint --no-error-on-unmatched-pattern src test`). **Result:** zero errors/warnings; independently re-run, exit 0. |
+| **Type checking with TSC** | ✅ PASS | **Command:** `npm run typecheck` (`tsc -p ./ --noEmit`). **Result:** zero errors; independently re-run, exit 0. |
+| **Testing (Jest, established extension convention overriding generic Vitest guidance)** | ✅ PASS | The repository-wide `.claude/rules/typescript.md` names Vitest as the default TypeScript test framework; the `drm-copilot` extension has used Jest with v8 coverage (`jest.config.cjs`, `run-jest.cjs`) since before this feature (confirmed via `git log --oneline -- jest.config.cjs`, earliest entries predate this branch). This feature correctly follows the extension's pre-existing, established convention rather than introducing a second test runner, consistent with the Reusability design principle. This is a pre-existing, documented deviation, not one introduced by this PR. |
+
+#### 3E.2 TypeScript Design & Typing
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Strong typing, no unjustified `any`** | ✅ PASS | `grep -rn ": any\|as any" src/lib/subagent-tree/ src/subagent-tree-command.ts test/lib/subagent-tree/ test/subagent-tree-command.test.ts` returns zero matches. All boundary parsing (`transcript-parser.ts`, `transcript-scanner.ts`) uses `unknown` plus explicit `isRecord`/`typeof` narrowing. |
+| **ES modules** | ✅ PASS | All new files use `import`/`export`; no `require`/`module.exports` in production code (`jest.config.cjs` itself is unavoidably CommonJS per Jest's own config-loading convention, consistent with the pre-existing file). |
+| **Domain types with invariants** | ✅ PASS | `TreeNode`, `SubagentMeta`, `ScannedTranscript`, `ScannedSession` model the on-disk contract precisely (readonly fields, optional `worktreePath`/`worktreeBranch`). |
+| **Naming** | ✅ PASS | `PascalCase` types/interfaces, `camelCase` functions/variables, kebab-case filenames (`transcript-parser.ts`, `tree-assembler.ts`), no `I`-prefixed interfaces. |
+| **Separation of concerns** | ✅ PASS | See Section 2.2; zero `vscode` imports in `src/lib/subagent-tree/` (independently verified). |
+
+#### 3E.3 TypeScript Error Handling
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Fail fast where appropriate** | ✅ PASS | `scanTranscripts` throws an explicit `Error` when `rootSessionPath` does not end in `.jsonl` (an invariant violation at the I/O boundary), tested via `toThrow(/must end in ".jsonl"/)`. |
+| **No catch-all without context/rethrow at inappropriate layers** | ✅ PASS | The one catch-all (`registerSubagentTreeCommand`'s outer `try/catch`) is at the VS Code command-handler boundary — the correct and only appropriate layer for a top-level catch-all in this architecture, matching the established pattern used by other command registrations in `src/repo-automation-command-registration-admin.ts` and `src/extension.ts` (both use the same `catch (error: unknown)` shape). It logs via the output channel and surfaces via `showErrorMessage`, then returns — it does not silently swallow the error. |
+| **Suppressions** | ✅ PASS | `grep -rn "eslint-disable\|@ts-expect-error\|@ts-ignore\|@ts-nocheck"` across all new files returns zero matches — no suppressions of any kind were needed. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4C: TypeScript Unit Test Policy Compliance
+
+#### 4C.1 Framework and Scope
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use the extension's established framework (Jest)** | ✅ PASS | All 7 new test files use `@jest/globals` (`describe`, `it`, `expect`, `jest`), matching every other test file already in `extensions/drm-copilot/test/`. |
+| **Coverage expectation (uniform tier rule: >= 85% lines, >= 75% branches)** | ✅ PASS | See Sections 1.2/1.2.1/5. All 6 executable new files exceed both thresholds; repo-wide aggregate (96.53%/88.42%) far exceeds both thresholds. |
+
+#### 4C.2 Test Style and Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Focused unit tests** | ✅ PASS | Each `it()` targets one scenario (see 1.1 Isolation). |
+| **Mocking sparingly, at the correct seam** | ✅ PASS | Mocking is limited to the `FileSystem` interface (in-memory fake) and, for the one host-wiring test file, `vscode`/`node:fs`/`command-runtime` — the exact three external dependencies of that file. |
+| **Organization mirrors `src/`** | ✅ PASS | `test/lib/subagent-tree/*.test.ts` mirrors `src/lib/subagent-tree/*.ts`; `test/subagent-tree-command.test.ts` mirrors `src/subagent-tree-command.ts`. No colocation in `src/`. |
+
+#### 4C.3 Naming and Readability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **File naming** | ✅ PASS | `*.test.ts` suffix throughout, matching `testMatch: ["<rootDir>/test/**/*.test.ts"]` in `jest.config.cjs`. |
+| **Docstrings/comments** | ✅ PASS | Arrange/Act/Assert comments plus descriptive `describe`/`it` names (Section 1.3). |
+
+#### 4C.4 Running the Toolchain
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use Jest via the established scripts** | ✅ PASS | `npm run test:coverage` (wraps `node run-jest.cjs --coverage ...`), independently spot-checked via `npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts`. |
+| **No alternative test runners introduced** | ✅ PASS | No Vitest, Mocha, or other runner was added; `package.json` diff shows no new `devDependencies`. |
+
+---
+
+## 5. Test Coverage Detail
+
+### `transcript-parser.ts` (4 tests, `parseTranscriptLines`)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| collects Agent tool-use ids in file line order and the single observed model | Positive | ✅ |
+| collects both distinct truthy models across turns | Positive (multi-model) | ✅ |
+| ignores blank lines, non-JSON lines, and lines whose message is a string | Negative / Edge Case | ✅ |
+| returns Agent tool-use ids in file line order even when alphabetical order differs | Edge Case (ordering) | ✅ |
+
+**Coverage:** 127/129 lines (98.45%), 27/28 branches (96.43%).
+
+### `transcript-scanner.ts` (8 tests, `scanTranscripts`)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| scans a root session with two direct subagent transcripts | Positive (multi-agent) | ✅ |
+| returns an empty subagents array when the subagents directory does not exist | Edge Case (empty-subagents) | ✅ |
+| scans a grandchild subagent whose spawning tool-use lives in its parent's transcript | Edge Case (multi-depth nesting) | ✅ |
+| throws a fail-fast error when rootSessionPath does not end in .jsonl | Error Handling | ✅ |
+| skips a meta path whose filename does not carry a non-empty agentId | Negative | ✅ |
+| skips a subagent whose meta.json is not valid JSON | Negative | ✅ |
+| skips a subagent whose meta.json parses to a non-object value | Negative | ✅ |
+| skips a subagent whose meta.json is missing a required field | Negative | ✅ |
+
+**Coverage:** 155/155 lines (100%), 26/26 branches (100%).
+
+### `tree-assembler.ts` (6 tests, `assembleTree`)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| assembles a root with two direct subagent children in the expected order | Positive | ✅ |
+| assembles an empty children array when there are no subagents | Edge Case (empty-subagents) | ✅ |
+| sorts a subagent node's multiple models ascending | Edge Case (multi-model node) | ✅ |
+| places a grandchild inside its direct parent's children, not the root's | Edge Case (multi-depth nesting) | ✅ |
+| attaches an orphan (unmatched toolUseId) as a root child after matched children, without throwing | Edge Case (orphan handling) | ✅ |
+| orders siblings by spawn line order, not alphabetical agentId order | Edge Case (sibling ordering) | ✅ |
+
+**Coverage:** 179/189 lines (94.71%), 17/19 branches (89.47%).
+
+### `tree-formatter.ts` (3 tests, `formatTree`)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| renders a two-level tree with the child indented two spaces relative to the root | Positive | ✅ |
+| renders a node's multiple models comma-joined and sorted ascending | Edge Case (multi-model rendering) | ✅ |
+| renders exactly one line for a root node with no children | Edge Case (empty-subagents rendering) | ✅ |
+
+**Coverage:** 33/33 lines (100%), 3/3 branches (100%).
+
+### `index.ts` (1 test, `buildSubagentTree`/`formatTree` composition)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| composes the scanner and assembler for a multi-agent session and round-trips through formatTree | Positive (end-to-end) | ✅ |
+
+**Coverage:** 28/28 lines (100%), 2/2 branches (100%).
+
+### `subagent-tree-command.ts` (3 tests, `registerSubagentTreeCommand`)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| reports an error and does not throw when zero root sessions are found | Negative / Error Handling | ✅ |
+| auto-selects a single discovered root session without prompting | Positive | ✅ |
+| prompts via showQuickPick among multiple candidates and renders the one selected | Positive (multi-candidate) | ✅ |
+
+**Coverage:** 110/119 lines (92.44%), 12/14 branches (85.71%).
+
+**Not covered:** `types.ts` (0/73 lines, 0/1 branches) — interface-only declarations file with zero executable statements; excluded only from the per-file `coverageThreshold` gate per the documented `general-unit-test.md` exception, and remains present in `collectCoverageFrom`.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (repo-wide) | 1506 | ✅ |
+| Tests Passed | 1506 (100%) | ✅ |
+| Tests Failed | 0 | ✅ |
+| New Tests (this feature) | 25 (independently re-run) | ✅ |
+| New Test Suites | 6 | ✅ |
+| Execution Time (new suites only) | 0.446s | ✅ Fast |
+| Functions Tested | `parseTranscriptLines`, `scanTranscripts`, `assembleTree`, `formatTree`, `buildSubagentTree`, `registerSubagentTreeCommand` — 6/6 exported functions | ✅ |
+| Test File Size (max) | 239 lines (`transcript-scanner.test.ts`) | ✅ Maintainable |
+| Code Coverage (new production files, aggregate) | 96.79% lines, 94.57% branches | ✅ |
+
+---
+
+## 7. Code Quality Checks
+
+**For TypeScript:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| Prettier Formatting | `npx prettier --check "src/**/*.ts" "test/**/*.ts"` | All matched files use Prettier code style! | ✅ |
+| ESLint Linting | `npm run lint` | Zero errors/warnings | ✅ |
+| TSC Type Checking | `npm run typecheck` | Zero errors | ✅ |
+| Jest Tests (new suites) | `npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts` | 6 suites / 25 tests passed | ✅ |
+| Manual architecture-boundary grep | `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/` | exit 1, zero matches | ✅ |
+| Build | `npm run build` (executor-reported; not independently re-run to avoid unnecessary bundling side effects) | `tsc --noEmit` + `esbuild-extension.cjs` + `esbuild-mcp-server.cjs` all succeeded (per `final-build.md`) | ✅ (executor evidence, consistent with independently-verified typecheck) |
+
+**Notes:**
+No pre-existing failures were observed. All checks ran clean on the first independently-reproduced attempt; the executor's own evidence documents one intermediate format auto-fix and one intermediate coverage-threshold iteration (both restarted per the mandatory toolchain loop rule), both resolved before the final clean pass recorded in `evidence/qa-gates/`.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+1. **Missing `dependency-cruiser` configuration for `extensions/drm-copilot/`** (repository-wide, pre-existing): `.claude/rules/architecture-boundaries.md` designates `dependency-cruiser` as the TypeScript architecture-boundary enforcement tool, but no `.dependency-cruiser.cjs` exists anywhere in this repository. This predates this feature. The plan's manual `grep`-based compensating control was independently reproduced and confirms zero `vscode` imports under `src/lib/subagent-tree/`. Recommendation: introduce `dependency-cruiser` for this extension in a separate, dedicated infrastructure change — out of scope for this feature.
+2. **Missing `quality-tiers.yml` at repository root** (repository-wide, pre-existing): `.claude/rules/quality-tiers.md` requires every project to be classified in a root `quality-tiers.yml`; no such file exists in this repository at all. This predates this feature and is not introduced by it (this feature adds files to an already-existing, unclassified project — it does not add a new project). Recommendation: address repository-wide, separately from this feature.
+
+Both gaps are pre-existing repository-infrastructure conditions, not defects introduced by this diff, and are treated as **non-blocking** for this specific feature's audit.
+
+### Approved Exceptions
+
+- **`types.ts` per-file coverage threshold omission**: `.claude/rules/general-unit-test.md` explicitly permits interface/type-only files with no executable behavior to be omitted from coverage measurement expectations; this repo's stricter local convention (Coverage Exclusion Policy) requires the file to remain in `collectCoverageFrom` regardless — confirmed the file **is** present in `collectCoverageFrom` and only its per-file `coverageThreshold` gate entry is omitted, which is the correct, narrower interpretation. No exception beyond the documented policy text was needed.
+- **Jest instead of Vitest**: `.claude/rules/typescript.md` names Vitest generically; the `drm-copilot` extension's Jest/v8-coverage convention predates this feature (confirmed via `git log`) and this feature correctly follows it rather than introducing a second runner.
+
+### Removed/Skipped Tests
+
+**None.** All planned tests (per `plan.2026-07-05T18-28.md`'s Test Plan section) were implemented; none were removed or skipped.
+
+---
+
+## 9. Summary of Changes
+
+### Files Modified
+
+1. **`extensions/drm-copilot/src/lib/subagent-tree/types.ts`** (NEW) — `TreeNode`, `SubagentMeta`, `ScannedTranscript`, `ScannedSubagent`, `ScannedSession` interfaces; no I/O, no VS Code imports.
+2. **`extensions/drm-copilot/src/lib/subagent-tree/transcript-parser.ts`** (NEW) — pure line-level parser extracting models and `Agent` tool-use ids.
+3. **`extensions/drm-copilot/src/lib/subagent-tree/transcript-scanner.ts`** (NEW) — the sole I/O module; derives the sibling `subagents` dir, globs meta files, reads transcripts via injected `FileSystem`.
+4. **`extensions/drm-copilot/src/lib/subagent-tree/tree-assembler.ts`** (NEW) — pure parent/child matching, sibling ordering, orphan attachment.
+5. **`extensions/drm-copilot/src/lib/subagent-tree/tree-formatter.ts`** (NEW) — pure text renderer.
+6. **`extensions/drm-copilot/src/lib/subagent-tree/index.ts`** (NEW) — barrel composing `scanTranscripts` + `assembleTree` into `buildSubagentTree`.
+7. **`extensions/drm-copilot/src/subagent-tree-command.ts`** (NEW) — VS Code command registration/wiring; discovers candidates, prompts or auto-selects, renders via the pure module.
+8. **`extensions/drm-copilot/src/extension.ts`** (MODIFIED) — imports and registers `registerSubagentTreeCommand`, pushes its disposable into `context.subscriptions`. Two lines added.
+9. **`extensions/drm-copilot/package.json`** (MODIFIED) — adds the `drmCopilotExtension.showSubagentTree` command contribution entry.
+10. **`extensions/drm-copilot/jest.config.cjs`** (MODIFIED) — adds 6 per-file `coverageThreshold` entries for the new executable production files (with a documented comment explaining the `types.ts` omission).
+11. **Seven test files** (NEW) under `extensions/drm-copilot/test/lib/subagent-tree/` and `extensions/drm-copilot/test/subagent-tree-command.test.ts`.
+12. **`docs/features/active/subagent-tree-command/{issue.md, plan.2026-07-05T18-28.md, evidence/**}`** (NEW) — feature documentation and evidence artifacts.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+All independently-reproduced toolchain checks (format, lint, type-check, targeted tests, manual architecture-boundary grep) passed cleanly and matched the executor's recorded evidence. Coverage for every new executable production file exceeds the uniform 85% line / 75% branch tier rule; repo-wide TypeScript coverage remains well above threshold. No suppressions, no new dependencies, no files over 500 lines, no test colocation, no temporary files, and no evidence-location violations were found. Two pre-existing, repository-wide infrastructure gaps (missing `dependency-cruiser` config, missing `quality-tiers.yml`) are documented as non-blocking Gaps, not introduced by this feature.
+
+**Fail-closed reminder honored:** every coverage figure above is numeric and independently re-derived from `coverage/lcov.info`; no artifact required by this audit was found missing.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- ✅ Before Making Changes: documented in `issue.md`/plan.
+- ✅ Design Principles: pure/I-O separation, reuse of existing `FileSystem` seam.
+- ✅ Module & File Structure: all files under 500 lines, cohesive, no circular deps.
+- ✅ Naming, Docs, Comments: descriptive, JSDoc on every export.
+- ⚠️ Toolchain Execution: fully passing; architecture-boundary automation gap noted (pre-existing, non-blocking).
+- ✅ Summarize & Document: this audit plus `plan.md`'s Design Decisions section.
+
+#### Language-Specific Code Change Policy (Section 3)
+
+**For TypeScript:**
+- ✅ Tooling & Baseline: format/lint/typecheck all pass.
+- ✅ TypeScript Design & Typing: no `any`, strong narrowing, correct naming.
+- ✅ Error Handling: fail-fast at the I/O boundary, catch-all only at the command-handler boundary.
+
+#### General Unit Test Policy (Section 1)
+- ✅ Core Principles: independence, isolation, speed, determinism, readability all confirmed.
+- ✅ Coverage & Scenarios: all scenario categories present; coverage thresholds met.
+- ✅ Test Structure: AAA pattern throughout.
+- ✅ External Dependencies: fully mocked/faked, no real I/O.
+- ✅ Policy Audit: this document satisfies the requirement.
+
+#### Language-Specific Unit Test Policy (Section 4)
+
+**For TypeScript:**
+- ✅ Framework & Scope: Jest (established extension convention), coverage thresholds met.
+- ✅ Test Style & Structure: focused, correctly mirrored under `test/`.
+- ✅ Naming & Readability: `*.test.ts`, descriptive names.
+- ✅ Toolchain: `npm run test:coverage` / targeted `npx jest` reruns both clean.
+
+---
+
+### Metrics Summary
+
+- ✅ 1506/1506 tests passing (100%), 25 new tests independently re-verified.
+- ✅ 6/6 new exported functions tested with positive, negative, and edge-case scenarios.
+- ✅ 96.53% lines / 88.42% branches repo-wide TypeScript coverage; 96.79%/94.57% aggregate on new production files.
+- ✅ Proper file organization: pure logic separated from I/O and VS Code host wiring; tests mirror `src/`.
+- ✅ All code quality checks passing (format, lint, typecheck, targeted tests, manual architecture grep).
+- ✅ Test execution time: 0.446s for the new suites (fast).
+
+---
+
+### Recommendation
+
+**Ready for merge.**
+
+No blocking findings were identified. The two documented Gaps (missing `dependency-cruiser` config, missing `quality-tiers.yml`) are pre-existing, repository-wide conditions that predate this feature and should be tracked as separate infrastructure follow-ups, not as conditions on this PR.
+
+---
+
+## Appendix A: Test Inventory
+
+1. `parseTranscriptLines` › collects Agent tool-use ids in file line order and the single observed model
+2. `parseTranscriptLines` › collects both distinct truthy models across turns
+3. `parseTranscriptLines` › ignores blank lines, non-JSON lines, and lines whose message is a string
+4. `parseTranscriptLines` › returns Agent tool-use ids in file line order even when alphabetical order differs
+5. `scanTranscripts` › scans a root session with two direct subagent transcripts
+6. `scanTranscripts` › returns an empty subagents array when the subagents directory does not exist
+7. `scanTranscripts` › scans a grandchild subagent whose spawning tool-use lives in its parent's transcript
+8. `scanTranscripts` › throws a fail-fast error when rootSessionPath does not end in .jsonl
+9. `scanTranscripts` › skips a meta path whose filename does not carry a non-empty agentId
+10. `scanTranscripts` › skips a subagent whose meta.json is not valid JSON
+11. `scanTranscripts` › skips a subagent whose meta.json parses to a non-object value
+12. `scanTranscripts` › skips a subagent whose meta.json is missing a required field
+13. `assembleTree` › assembles a root with two direct subagent children in the expected order
+14. `assembleTree` › assembles an empty children array when there are no subagents
+15. `assembleTree` › sorts a subagent node's multiple models ascending
+16. `assembleTree` › places a grandchild inside its direct parent's children, not the root's
+17. `assembleTree` › attaches an orphan (unmatched toolUseId) as a root child after matched children, without throwing
+18. `assembleTree` › orders siblings by spawn line order, not alphabetical agentId order
+19. `formatTree` › renders a two-level tree with the child indented two spaces relative to the root
+20. `formatTree` › renders a node's multiple models comma-joined and sorted ascending
+21. `formatTree` › renders exactly one line for a root node with no children
+22. `buildSubagentTree` › composes the scanner and assembler for a multi-agent session and round-trips through formatTree
+23. `drm-copilot showSubagentTree command` › reports an error and does not throw when zero root sessions are found
+24. `drm-copilot showSubagentTree command` › auto-selects a single discovered root session without prompting
+25. `drm-copilot showSubagentTree command` › prompts via showQuickPick among multiple candidates and renders the one selected
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For TypeScript (`extensions/drm-copilot/`):**
+```bash
+# Formatting
+npx prettier --check "src/**/*.ts" "test/**/*.ts"
+npm run format   # writes changes
+
+# Linting
+npm run lint
+
+# Type checking
+npm run typecheck
+
+# Testing
+npm run test:unit
+npm run test:coverage
+
+# Targeted test re-run (this review)
+npx jest test/lib/subagent-tree test/subagent-tree-command.test.ts
+
+# Manual architecture-boundary check (no dependency-cruiser config exists)
+grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/
+
+# Build
+npm run build
+
+# Evidence-location validator (repo root)
+python scripts/dev_tools/validate_evidence_locations.py --root .
+```
+
+---
+
+**Audit Completed By:** feature-review agent (Claude Sonnet 5)
+**Audit Date:** 2026-07-05
+**Policy Version:** Current (as of audit date)

--- a/docs/features/potential/promoted/2026-07-06-subagent-tree-command.md
+++ b/docs/features/potential/promoted/2026-07-06-subagent-tree-command.md
@@ -1,0 +1,60 @@
+# subagent-tree-command (Issue #320)
+
+- Date captured: 2026-07-06
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/subagent-tree-command/ (Issue #320)
+
+- Issue: #320
+- Issue URL: https://github.com/drmoisan/drm-copilot/issues/320
+- Last Updated: 2026-07-06
+## Problem / Why
+
+The `drm-copilot` VS Code extension has no way to inspect the subagent call tree of a Claude Code
+session. Session transcripts on disk (`.claude/projects/**`) record a root session plus flattened
+subagent transcripts with meta files that encode a deterministic parent→child spawn relationship.
+Operators need a way to visualize that delegation structure and detect mid-session model switches.
+
+## Proposed Behavior
+
+Add a VS Code command `drmCopilotExtension.showSubagentTree` ("drm-copilot: Show Subagent Tree").
+Given a root session (user-picked `.jsonl` under `.claude/projects/**`, or the active session), it
+deterministically builds and renders the subagent tree. The parsing/tree logic lives in a pure,
+host-neutral module (`buildSubagentTree` + `formatTree`) with full unit tests; a thin host-bound
+command file does only the VS Code wiring.
+
+Deterministic algorithm: scan the root and every `subagents/*.jsonl` for `message.model` values and
+ordered `Agent` tool-use ids; match each child's `meta.toolUseId` to the exact spawning tool-use id
+(1:1, no heuristics); order siblings by spawn line order; render each node as
+`agentType · [sorted,comma-joined models] · depth · description`.
+
+## Acceptance Criteria (early draft)
+
+- [ ] Command registered in `package.json` and activated; invoking it renders the tree for a
+  selected/active session.
+- [ ] Pure builder + renderer unit-tested (positive, empty-subagents, multi-model node, multi-depth
+  nesting, orphan/unmatched `toolUseId` handled gracefully).
+- [ ] Full TypeScript toolchain passes (format → lint → type-check → tests), coverage >= 85% line /
+  >= 75% branch on new files, no production file excluded from coverage.
+- [ ] Local feature-review clean of blocking findings.
+
+## Constraints & Risks
+
+- Extension lives at `extensions/drm-copilot/`; tests run on Jest (v8 coverage). No new dependencies
+  (fast-check is not installed; property tests not required for this dev-tooling module). Files < 500
+  lines.
+
+## Test Conditions to Consider
+
+- [ ] Unit coverage: positive tree, empty subagents, multi-model node, multi-depth nesting, orphan
+  `toolUseId`, sibling ordering, blank/malformed transcript lines ignored.
+- [ ] Host-wiring: zero-candidate, single-candidate auto-select, multi-candidate quick-pick.
+
+## Next Step
+
+- [ ] Promote to GitHub issue (feature request template)
+- [x] `docs/features/active/subagent-tree-command/` folder already exists with the implemented work.
+
+## Implementation Status
+
+Implemented and committed on branch work (commit `ca0797e`); this issue is being opened to track the
+change through the standard PR + CI workflow.

--- a/extensions/drm-copilot/jest.config.cjs
+++ b/extensions/drm-copilot/jest.config.cjs
@@ -55,5 +55,38 @@ module.exports = {
       lines: 85,
       branches: 75,
     },
+    // No entry for "./src/lib/subagent-tree/types.ts": the file consists
+    // solely of `interface` declarations with no executable behavior. Per
+    // `.claude/rules/general-unit-test.md` ("Interface/type-only files with
+    // no executable behavior... may be omitted from coverage measurement"),
+    // this file legitimately reports 0% line/branch coverage under the v8
+    // coverage provider (confirmed via `coverage/lcov.info`) and cannot be
+    // brought above threshold by any test, since there is no runtime code to
+    // exercise. It remains included in `collectCoverageFrom` (not excluded
+    // from measurement) and is omitted only from the per-file threshold gate.
+    "./src/lib/subagent-tree/transcript-parser.ts": {
+      lines: 85,
+      branches: 75,
+    },
+    "./src/lib/subagent-tree/transcript-scanner.ts": {
+      lines: 85,
+      branches: 75,
+    },
+    "./src/lib/subagent-tree/tree-assembler.ts": {
+      lines: 85,
+      branches: 75,
+    },
+    "./src/lib/subagent-tree/tree-formatter.ts": {
+      lines: 85,
+      branches: 75,
+    },
+    "./src/lib/subagent-tree/index.ts": {
+      lines: 85,
+      branches: 75,
+    },
+    "./src/subagent-tree-command.ts": {
+      lines: 85,
+      branches: 75,
+    },
   },
 };

--- a/extensions/drm-copilot/package.json
+++ b/extensions/drm-copilot/package.json
@@ -164,6 +164,10 @@
       {
         "command": "drmCopilotExtension.removeSecondaryWorktrees",
         "title": "drm-copilot: Remove Secondary Worktrees"
+      },
+      {
+        "command": "drmCopilotExtension.showSubagentTree",
+        "title": "drm-copilot: Show Subagent Tree"
       }
     ]
   },

--- a/extensions/drm-copilot/src/extension.ts
+++ b/extensions/drm-copilot/src/extension.ts
@@ -32,6 +32,7 @@ import {
 } from "./remove-worktrees-runner";
 import { createRepoAutomationService } from "./repo-automation-service";
 import { registerRepoAutomationCommands } from "./repo-automation-command-registration";
+import { registerSubagentTreeCommand } from "./subagent-tree-command";
 import { resolveRunPoshQCSuiteInvocation } from "./workflow-command-arguments";
 
 // Re-export runtime helpers so existing test imports from this module keep working.
@@ -444,6 +445,8 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const mcpDisposables = registerMcpProvider(context);
 
+  const showSubagentTreeDisposable = registerSubagentTreeCommand({ output });
+
   context.subscriptions.push(
     helloPythonDisposable,
     helloPowerShellDisposable,
@@ -458,6 +461,7 @@ export function activate(context: vscode.ExtensionContext): void {
     resolvePolicyAuditTemplateAssetDisposable,
     resolveExecuteHardLockPromptDisposable,
     resolveAtomicPlanPromptDisposable,
+    showSubagentTreeDisposable,
     ...repoAutomationDisposables,
     ...mcpDisposables,
     output,

--- a/extensions/drm-copilot/src/lib/subagent-tree/index.ts
+++ b/extensions/drm-copilot/src/lib/subagent-tree/index.ts
@@ -1,0 +1,28 @@
+import type { FileSystem } from "../file-system";
+import { assembleTree } from "./tree-assembler";
+import { scanTranscripts } from "./transcript-scanner";
+import type { TreeNode } from "./types";
+
+export { formatTree } from "./tree-formatter";
+export type { TreeNode } from "./types";
+
+/**
+ * Build the subagent call tree for a root session.
+ *
+ * Purpose:
+ *     Barrel entry point composing `scanTranscripts` (I/O, injected
+ *     `FileSystem`) and `assembleTree` (pure) into a single call, so host
+ *     wiring (`src/subagent-tree-command.ts`) depends on one function rather
+ *     than the module's internal shape.
+ *
+ * @param rootSessionPath Absolute path to the root session's `.jsonl` file.
+ * @param deps Injected dependencies; `fileSystem` performs the actual I/O.
+ * @returns The assembled root `TreeNode`.
+ */
+export function buildSubagentTree(
+  rootSessionPath: string,
+  deps: { readonly fileSystem: FileSystem },
+): TreeNode {
+  const scanned = scanTranscripts(rootSessionPath, deps.fileSystem);
+  return assembleTree(scanned);
+}

--- a/extensions/drm-copilot/src/lib/subagent-tree/transcript-parser.ts
+++ b/extensions/drm-copilot/src/lib/subagent-tree/transcript-parser.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure line-level transcript parser.
+ *
+ * Purpose:
+ *     Extract the two facts the subagent-tree algorithm needs from a single
+ *     transcript file's lines: the distinct `message.model` values observed,
+ *     and the ordered list of `Agent` tool-use ids emitted by assistant
+ *     turns, in file line order. Performs no I/O; the caller supplies the
+ *     already-read lines.
+ *
+ * Tolerance:
+ *     Blank lines, non-JSON lines, and lines whose `message` field is not an
+ *     object are skipped rather than raising, since a transcript may contain
+ *     turn shapes irrelevant to this algorithm (e.g. plain user text turns).
+ */
+
+/** Result of parsing one transcript's lines. Not exported: this module exports only `parseTranscriptLines`. */
+interface TranscriptParseResult {
+  /** Distinct `message.model` values, in first-seen order. */
+  readonly models: readonly string[];
+  /** `Agent` tool-use ids, in file line order. */
+  readonly agentToolUseIds: readonly string[];
+}
+
+/**
+ * Parse transcript lines into the model set and ordered `Agent` tool-use ids.
+ *
+ * @param lines Raw lines of a `.jsonl` transcript file, one JSON object per line.
+ * @returns The distinct models observed and the ordered `Agent` tool-use ids.
+ */
+export function parseTranscriptLines(
+  lines: readonly string[],
+): TranscriptParseResult {
+  const models: string[] = [];
+  const seenModels = new Set<string>();
+  const agentToolUseIds: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    const parsed = tryParseJson(trimmed);
+    if (!isRecord(parsed)) {
+      continue;
+    }
+
+    const message = parsed["message"];
+    if (!isRecord(message)) {
+      continue;
+    }
+
+    recordModel(message["model"], models, seenModels);
+    collectAgentToolUseIds(message["content"], agentToolUseIds);
+  }
+
+  return { models, agentToolUseIds };
+}
+
+/**
+ * Parse `text` as JSON, returning `undefined` on failure instead of raising.
+ *
+ * @param text The line text to parse.
+ * @returns The parsed value, or `undefined` when `text` is not valid JSON.
+ */
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * @param value A candidate value.
+ * @returns True when `value` is a non-null JSON object (not an array).
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Append `model` to `models` when it is a truthy string not already seen.
+ *
+ * @param model The candidate `message.model` value.
+ * @param models The accumulator of distinct models, in first-seen order.
+ * @param seenModels The set of models already recorded.
+ */
+function recordModel(
+  model: unknown,
+  models: string[],
+  seenModels: Set<string>,
+): void {
+  if (typeof model === "string" && model.length > 0 && !seenModels.has(model)) {
+    seenModels.add(model);
+    models.push(model);
+  }
+}
+
+/**
+ * Append every `Agent` tool-use id found in `content` to `agentToolUseIds`,
+ * in array order.
+ *
+ * @param content The candidate `message.content` value.
+ * @param agentToolUseIds The accumulator of `Agent` tool-use ids.
+ */
+function collectAgentToolUseIds(
+  content: unknown,
+  agentToolUseIds: string[],
+): void {
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  for (const block of content as readonly unknown[]) {
+    if (!isRecord(block)) {
+      continue;
+    }
+
+    if (
+      block["type"] === "tool_use" &&
+      block["name"] === "Agent" &&
+      typeof block["id"] === "string"
+    ) {
+      agentToolUseIds.push(block["id"]);
+    }
+  }
+}

--- a/extensions/drm-copilot/src/lib/subagent-tree/transcript-scanner.ts
+++ b/extensions/drm-copilot/src/lib/subagent-tree/transcript-scanner.ts
@@ -1,0 +1,155 @@
+import type { FileSystem } from "../file-system";
+import { parseTranscriptLines } from "./transcript-parser";
+import type {
+  ScannedSession,
+  ScannedSubagent,
+  ScannedTranscript,
+  SubagentMeta,
+} from "./types";
+
+/** Suffix identifying a subagent meta file. */
+const META_SUFFIX = ".meta.json";
+/** Suffix identifying a transcript file (root session or subagent). */
+const TRANSCRIPT_SUFFIX = ".jsonl";
+/** Matches `agent-<agentId>.meta.json`, capturing `<agentId>`. */
+const META_FILENAME_PATTERN = /agent-([^/\\]+)\.meta\.json$/;
+
+/**
+ * Scan a root session transcript and its sibling subagent transcripts.
+ *
+ * Purpose:
+ *     The only file in the subagent-tree module that touches `FileSystem`.
+ *     Derives the sibling `subagents` directory per Design Decision item 7,
+ *     globs its `agent-*.meta.json` files, and reads each meta file plus its
+ *     sibling `.jsonl` transcript, delegating line-level parsing to
+ *     `parseTranscriptLines`.
+ *
+ * Tolerance:
+ *     A missing `subagents` directory yields zero subagents rather than
+ *     raising (the injected `FileSystem.glob` returns no matches for an
+ *     absent root). A meta file that is not well-formed JSON or is missing a
+ *     required field is skipped rather than raising, so one malformed
+ *     subagent does not fail the whole scan.
+ *
+ * @param rootSessionPath Absolute path to the root session's `.jsonl` file.
+ * @param fileSystem Injected filesystem seam (production: `RealFileSystem`).
+ * @returns The root transcript's parsed facts plus every well-formed
+ *   subagent's parsed meta and transcript facts.
+ * @throws {Error} When `rootSessionPath` does not end in `.jsonl`.
+ */
+export function scanTranscripts(
+  rootSessionPath: string,
+  fileSystem: FileSystem,
+): ScannedSession {
+  if (!rootSessionPath.endsWith(TRANSCRIPT_SUFFIX)) {
+    throw new Error(
+      `scanTranscripts: rootSessionPath must end in "${TRANSCRIPT_SUFFIX}", got: ${rootSessionPath}`,
+    );
+  }
+
+  const root = readTranscript(rootSessionPath, fileSystem);
+  const subagentsDir = `${rootSessionPath.slice(0, -TRANSCRIPT_SUFFIX.length)}/subagents`;
+  const metaPaths = fileSystem.glob(subagentsDir, "agent-*.meta.json");
+  const subagents = metaPaths
+    .map((metaPath) => readSubagent(metaPath, fileSystem))
+    .filter((subagent): subagent is ScannedSubagent => subagent !== undefined);
+
+  return { root, subagents };
+}
+
+/**
+ * Read and parse a single transcript file's lines.
+ *
+ * @param path Absolute path to a `.jsonl` transcript file.
+ * @param fileSystem Injected filesystem seam.
+ * @returns The transcript's parsed models and `Agent` tool-use ids.
+ */
+function readTranscript(
+  path: string,
+  fileSystem: FileSystem,
+): ScannedTranscript {
+  const content = fileSystem.readTextFile(path);
+  return parseTranscriptLines(content.split(/\r?\n/));
+}
+
+/**
+ * Read one subagent's meta file and its sibling transcript.
+ *
+ * @param metaPath Absolute path to `agent-<agentId>.meta.json`.
+ * @param fileSystem Injected filesystem seam.
+ * @returns The parsed subagent, or `undefined` when the meta filename or
+ *   contents are not well-formed.
+ */
+function readSubagent(
+  metaPath: string,
+  fileSystem: FileSystem,
+): ScannedSubagent | undefined {
+  const filenameMatch = META_FILENAME_PATTERN.exec(metaPath);
+  const agentId = filenameMatch?.[1];
+  if (agentId === undefined) {
+    return undefined;
+  }
+
+  const metaContent = fileSystem.readTextFile(metaPath);
+  const meta = parseSubagentMeta(agentId, metaContent);
+  if (!meta) {
+    return undefined;
+  }
+
+  const transcriptPath =
+    metaPath.slice(0, -META_SUFFIX.length) + TRANSCRIPT_SUFFIX;
+  const transcript = readTranscript(transcriptPath, fileSystem);
+
+  return { meta, transcript };
+}
+
+/**
+ * Parse the JSON contents of a subagent's meta file into a `SubagentMeta`.
+ *
+ * @param agentId The `agentId` parsed from the meta filename.
+ * @param content Raw JSON text of the meta file.
+ * @returns The parsed meta, or `undefined` when required fields are absent
+ *   or of the wrong type.
+ */
+function parseSubagentMeta(
+  agentId: string,
+  content: string,
+): SubagentMeta | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content) as unknown;
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return undefined;
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const agentType = record["agentType"];
+  const description = record["description"];
+  const toolUseId = record["toolUseId"];
+  const spawnDepth = record["spawnDepth"];
+  if (
+    typeof agentType !== "string" ||
+    typeof description !== "string" ||
+    typeof toolUseId !== "string" ||
+    typeof spawnDepth !== "number"
+  ) {
+    return undefined;
+  }
+
+  const worktreePath = record["worktreePath"];
+  const worktreeBranch = record["worktreeBranch"];
+
+  return {
+    agentId,
+    agentType,
+    description,
+    toolUseId,
+    spawnDepth,
+    ...(typeof worktreePath === "string" ? { worktreePath } : {}),
+    ...(typeof worktreeBranch === "string" ? { worktreeBranch } : {}),
+  };
+}

--- a/extensions/drm-copilot/src/lib/subagent-tree/tree-assembler.ts
+++ b/extensions/drm-copilot/src/lib/subagent-tree/tree-assembler.ts
@@ -1,0 +1,189 @@
+import type {
+  ScannedSession,
+  ScannedSubagent,
+  ScannedTranscript,
+  TreeNode,
+} from "./types";
+
+/**
+ * Sentinel key identifying the root transcript in the parent-lookup map.
+ *
+ * Uses a `__root__` sentinel so it can never collide with a real
+ * `agentId` (a filename-derived identifier) or `toolUseId`, without needing
+ * a discriminated union just to distinguish "root" from "subagent" keys.
+ */
+const ROOT_KEY = "__root__";
+
+/**
+ * Assemble the deterministic subagent call tree from scan results.
+ *
+ * Purpose:
+ *     Pure port of the parent/child matching, sibling ordering, and orphan
+ *     handling described in Design Decision items 3–5. Performs no I/O.
+ *
+ * Algorithm:
+ *     1. `spawnDepth` is read verbatim from each subagent's meta as the
+ *        node's `depth`; the root node's `depth` is `0`.
+ *     2. A subagent is a child of whichever transcript (root or another
+ *        subagent) contains its `meta.toolUseId` among that transcript's
+ *        `agentToolUseIds` (exact match, no heuristics).
+ *     3. Siblings are ordered by the index of their spawning tool-use id
+ *        within the parent transcript's `agentToolUseIds`, ascending; ties
+ *        break by ascending `agentId`.
+ *     4. A subagent whose `toolUseId` matches no transcript is an orphan,
+ *        attached as a root child after all normally-matched root children,
+ *        ordered by ascending `agentId`. An orphan's own descendants are
+ *        still assembled normally beneath it.
+ *
+ * @param scanned The scan result produced by `scanTranscripts`.
+ * @returns The assembled root `TreeNode`.
+ */
+export function assembleTree(scanned: ScannedSession): TreeNode {
+  const transcriptsByKey = new Map<string, ScannedTranscript>();
+  transcriptsByKey.set(ROOT_KEY, scanned.root);
+  for (const subagent of scanned.subagents) {
+    transcriptsByKey.set(subagent.meta.agentId, subagent.transcript);
+  }
+
+  const matchedChildrenByParentKey = new Map<string, ScannedSubagent[]>();
+  const orphans: ScannedSubagent[] = [];
+
+  for (const subagent of scanned.subagents) {
+    const parentKey = findParentKey(subagent.meta.toolUseId, transcriptsByKey);
+    if (parentKey === undefined) {
+      orphans.push(subagent);
+      continue;
+    }
+
+    const siblings = matchedChildrenByParentKey.get(parentKey) ?? [];
+    siblings.push(subagent);
+    matchedChildrenByParentKey.set(parentKey, siblings);
+  }
+
+  orphans.sort(compareByAgentId);
+
+  return buildNode({
+    key: ROOT_KEY,
+    agentType: "root",
+    description: "",
+    depth: 0,
+    models: scanned.root.models,
+    transcriptsByKey,
+    matchedChildrenByParentKey,
+    orphans,
+  });
+}
+
+/**
+ * Find the key of the transcript whose `agentToolUseIds` contains `toolUseId`.
+ *
+ * @param toolUseId The spawning tool-use id to search for.
+ * @param transcriptsByKey All scanned transcripts, keyed by `ROOT_KEY` or `agentId`.
+ * @returns The matching key, or `undefined` when no transcript contains it.
+ */
+function findParentKey(
+  toolUseId: string,
+  transcriptsByKey: ReadonlyMap<string, ScannedTranscript>,
+): string | undefined {
+  for (const [key, transcript] of transcriptsByKey) {
+    if (transcript.agentToolUseIds.includes(toolUseId)) {
+      return key;
+    }
+  }
+  return undefined;
+}
+
+/** Ascending string comparison of two subagents' `agentId`. */
+function compareByAgentId(a: ScannedSubagent, b: ScannedSubagent): number {
+  if (a.meta.agentId < b.meta.agentId) {
+    return -1;
+  }
+  if (a.meta.agentId > b.meta.agentId) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Order a parent's matched children by spawn-index, tie-broken by `agentId`.
+ *
+ * @param children Subagents matched to this parent.
+ * @param parentTranscript The parent's transcript (supplies spawn order).
+ * @returns A new array in deterministic sibling order.
+ */
+function sortBySpawnIndex(
+  children: readonly ScannedSubagent[],
+  parentTranscript: ScannedTranscript,
+): ScannedSubagent[] {
+  return [...children].sort((a, b) => {
+    const indexA = parentTranscript.agentToolUseIds.indexOf(a.meta.toolUseId);
+    const indexB = parentTranscript.agentToolUseIds.indexOf(b.meta.toolUseId);
+    if (indexA !== indexB) {
+      return indexA - indexB;
+    }
+    return compareByAgentId(a, b);
+  });
+}
+
+/** Inputs needed to recursively build one `TreeNode`. */
+interface BuildNodeInput {
+  readonly key: string;
+  readonly agentType: string;
+  readonly description: string;
+  readonly depth: number;
+  readonly models: readonly string[];
+  readonly transcriptsByKey: ReadonlyMap<string, ScannedTranscript>;
+  readonly matchedChildrenByParentKey: ReadonlyMap<string, ScannedSubagent[]>;
+  readonly orphans: readonly ScannedSubagent[];
+}
+
+/**
+ * Recursively build one `TreeNode` and its ordered children.
+ *
+ * @param input The node's own fields plus the shared lookup maps.
+ * @returns The assembled `TreeNode`.
+ */
+function buildNode(input: BuildNodeInput): TreeNode {
+  const {
+    key,
+    agentType,
+    description,
+    depth,
+    models,
+    transcriptsByKey,
+    matchedChildrenByParentKey,
+    orphans,
+  } = input;
+
+  const transcript = transcriptsByKey.get(key);
+  const matchedChildren = matchedChildrenByParentKey.get(key) ?? [];
+  const orderedMatched = transcript
+    ? sortBySpawnIndex(matchedChildren, transcript)
+    : matchedChildren;
+
+  const isRoot = key === ROOT_KEY;
+  const orderedChildren = isRoot
+    ? [...orderedMatched, ...orphans]
+    : orderedMatched;
+
+  const children = orderedChildren.map((subagent) =>
+    buildNode({
+      key: subagent.meta.agentId,
+      agentType: subagent.meta.agentType,
+      description: subagent.meta.description,
+      depth: subagent.meta.spawnDepth,
+      models: subagent.transcript.models,
+      transcriptsByKey,
+      matchedChildrenByParentKey,
+      orphans,
+    }),
+  );
+
+  return {
+    agentType,
+    description,
+    depth,
+    models: [...models].sort(),
+    children,
+  };
+}

--- a/extensions/drm-copilot/src/lib/subagent-tree/tree-formatter.ts
+++ b/extensions/drm-copilot/src/lib/subagent-tree/tree-formatter.ts
@@ -1,0 +1,33 @@
+import type { TreeNode } from "./types";
+
+/**
+ * Render an assembled subagent tree as human-readable text.
+ *
+ * Purpose:
+ *     Pure renderer per Design Decision item 6. Each node renders as one
+ *     line, `${indent}${agentType} · [${models}] · ${depth} · ${description}`,
+ *     followed by each child's rendered lines, in child order. Indentation
+ *     is two spaces per depth unit. Models are sorted ascending before
+ *     joining so a node with more than one distinct model prints all of
+ *     them in a deterministic order regardless of scan/assembly order.
+ *
+ * @param node The root (or any) `TreeNode` to render.
+ * @returns The rendered tree as newline-joined text.
+ */
+export function formatTree(node: TreeNode): string {
+  return renderLines(node).join("\n");
+}
+
+/**
+ * Recursively render `node` and its children into an ordered list of lines.
+ *
+ * @param node The node to render.
+ * @returns This node's line followed by each child's lines, in child order.
+ */
+function renderLines(node: TreeNode): string[] {
+  const indent = "  ".repeat(node.depth);
+  const sortedModels = [...node.models].sort();
+  const line = `${indent}${node.agentType} · [${sortedModels.join(",")}] · ${node.depth} · ${node.description}`;
+  const childLines = node.children.flatMap((child) => renderLines(child));
+  return [line, ...childLines];
+}

--- a/extensions/drm-copilot/src/lib/subagent-tree/types.ts
+++ b/extensions/drm-copilot/src/lib/subagent-tree/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure data types for the subagent-tree module.
+ *
+ * Purpose:
+ *     Model the on-disk transcript/meta facts (`SubagentMeta`,
+ *     `ScannedTranscript`, `ScannedSubagent`, `ScannedSession`) and the
+ *     assembled render tree (`TreeNode`) that `transcript-parser.ts`,
+ *     `transcript-scanner.ts`, `tree-assembler.ts`, and `tree-formatter.ts`
+ *     operate over. This file performs no I/O and has no VS Code imports.
+ */
+
+/**
+ * Fields read verbatim from a subagent's `agent-<agentId>.meta.json`, plus
+ * the `agentId` parsed from the meta filename itself.
+ *
+ * `spawnDepth` is read as-is and never recomputed by recursion (Design
+ * Decision item 3): it becomes the assembled node's `depth` directly.
+ */
+export interface SubagentMeta {
+  /** The `agentId` segment parsed from `agent-<agentId>.meta.json`. */
+  readonly agentId: string;
+  /** The subagent's declared type (e.g. `atomic-executor`). */
+  readonly agentType: string;
+  /** Human-readable description of the subagent's task. */
+  readonly description: string;
+  /** The `Agent` tool-use id that spawned this subagent. */
+  readonly toolUseId: string;
+  /** Nesting depth recorded verbatim by the spawning host. */
+  readonly spawnDepth: number;
+  /** Optional worktree path associated with this subagent's session. */
+  readonly worktreePath?: string;
+  /** Optional worktree branch associated with this subagent's session. */
+  readonly worktreeBranch?: string;
+}
+
+/**
+ * The facts extracted from a single transcript file (root or subagent): the
+ * distinct `message.model` values observed, and the ordered list of `Agent`
+ * tool-use ids emitted by that transcript, in file line order.
+ */
+export interface ScannedTranscript {
+  /** Distinct `message.model` values observed, in first-seen order. */
+  readonly models: readonly string[];
+  /** `Agent` tool-use ids emitted by this transcript, in file line order. */
+  readonly agentToolUseIds: readonly string[];
+}
+
+/** One subagent's parsed meta plus its own scanned transcript facts. */
+export interface ScannedSubagent {
+  readonly meta: SubagentMeta;
+  readonly transcript: ScannedTranscript;
+}
+
+/** The full scan result for a root session: its transcript plus every subagent. */
+export interface ScannedSession {
+  readonly root: ScannedTranscript;
+  readonly subagents: readonly ScannedSubagent[];
+}
+
+/**
+ * One node of the assembled, renderable subagent tree.
+ *
+ * The root node's `agentType` is a fixed sentinel (`"root"`) since the root
+ * session has no `meta.json`; `depth` is `0` for the root.
+ */
+export interface TreeNode {
+  readonly agentType: string;
+  readonly description: string;
+  readonly depth: number;
+  /** Distinct models observed for this node, sorted ascending. */
+  readonly models: readonly string[];
+  readonly children: readonly TreeNode[];
+}

--- a/extensions/drm-copilot/src/subagent-tree-command.ts
+++ b/extensions/drm-copilot/src/subagent-tree-command.ts
@@ -1,0 +1,119 @@
+import * as vscode from "vscode";
+import { getWorkspaceRoot } from "./command-runtime";
+import { RealFileSystem, toPosixPath } from "./lib/file-system";
+import { buildSubagentTree, formatTree } from "./lib/subagent-tree";
+
+/** Command id contributed to `package.json`'s `contributes.commands`. */
+const COMMAND_ID = "drmCopilotExtension.showSubagentTree";
+/** Glob (relative to the workspace root) matching root-session transcripts. */
+const ROOT_SESSION_GLOB = ".claude/projects/**/*.jsonl";
+/** Path segment identifying a flattened subagent transcript, not a root session. */
+const SUBAGENTS_SEGMENT = "/subagents/";
+
+/**
+ * Register the `drmCopilotExtension.showSubagentTree` command.
+ *
+ * Purpose:
+ *     Thin VS Code host wiring per Design Decision item 8. Discovers
+ *     candidate root sessions under `.claude/projects/**\/*.jsonl`, excludes
+ *     flattened subagent transcripts, auto-selects a single candidate or
+ *     prompts via `showQuickPick` for multiple, then renders the tree
+ *     through the host-neutral `buildSubagentTree`/`formatTree` pair. All
+ *     domain logic lives in `./lib/subagent-tree`; this file only performs
+ *     discovery, prompting, and output-channel wiring.
+ *
+ * @param options Options carrying the shared output channel.
+ * @returns The command registration's `Disposable`.
+ */
+export function registerSubagentTreeCommand(options: {
+  readonly output: vscode.OutputChannel;
+}): vscode.Disposable {
+  return vscode.commands.registerCommand(COMMAND_ID, async () => {
+    const { output } = options;
+    try {
+      const workspaceRoot = getWorkspaceRoot();
+      const fileSystem = new RealFileSystem();
+      const candidates = discoverRootSessionCandidates(
+        workspaceRoot,
+        fileSystem,
+      );
+
+      const selected = await selectRootSession(candidates, output);
+      if (selected === undefined) {
+        return;
+      }
+
+      const tree = buildSubagentTree(selected, { fileSystem });
+      const rendered = formatTree(tree);
+      output.appendLine(`[${COMMAND_ID}] subagent tree for ${selected}:`);
+      output.appendLine(rendered);
+      output.show(true);
+    } catch (error: unknown) {
+      const detail = error instanceof Error ? error.message : "Unknown error.";
+      output.appendLine(`[${COMMAND_ID}] failed: ${detail}`);
+      await vscode.window.showErrorMessage(
+        `Show Subagent Tree failed: ${detail}`,
+      );
+    }
+  });
+}
+
+/**
+ * Discover candidate root-session transcript paths under the workspace.
+ *
+ * @param workspaceRoot Absolute path to the workspace root.
+ * @param fileSystem Filesystem seam used to glob for `.jsonl` files.
+ * @returns Root-session candidate paths, sorted for deterministic prompting,
+ *   excluding any path under a `subagents` directory.
+ */
+function discoverRootSessionCandidates(
+  workspaceRoot: string,
+  fileSystem: RealFileSystem,
+): string[] {
+  return fileSystem
+    .glob(workspaceRoot, ROOT_SESSION_GLOB)
+    .filter((path) => !toPosixPath(path).includes(SUBAGENTS_SEGMENT))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Resolve which root session to render: auto-select a single candidate,
+ * prompt among multiple, or report an error when there are none.
+ *
+ * @param candidates The discovered root-session candidates.
+ * @param output The output channel used for logging and error reporting.
+ * @returns The selected session path, or `undefined` when there is nothing
+ *   to select (zero candidates) or the user cancels the prompt.
+ */
+async function selectRootSession(
+  candidates: readonly string[],
+  output: vscode.OutputChannel,
+): Promise<string | undefined> {
+  if (candidates.length === 0) {
+    const message =
+      "No root session transcripts found under .claude/projects/**/*.jsonl.";
+    output.appendLine(`[${COMMAND_ID}] ${message}`);
+    await vscode.window.showErrorMessage(message);
+    return undefined;
+  }
+
+  if (candidates.length === 1) {
+    const [onlyCandidate] = candidates;
+    if (onlyCandidate !== undefined) {
+      return onlyCandidate;
+    }
+  }
+
+  const selectedItem = await vscode.window.showQuickPick([...candidates], {
+    title: "drm-copilot: Show Subagent Tree",
+    placeHolder: "Choose the root session to render",
+    ignoreFocusOut: true,
+  });
+
+  if (selectedItem === undefined) {
+    output.appendLine(`[${COMMAND_ID}] session selection canceled by user`);
+    return undefined;
+  }
+
+  return selectedItem;
+}

--- a/extensions/drm-copilot/test/lib/subagent-tree/in-memory-file-system.ts
+++ b/extensions/drm-copilot/test/lib/subagent-tree/in-memory-file-system.ts
@@ -1,0 +1,133 @@
+import type { FileSystem } from "../../../src/lib/file-system";
+
+/**
+ * In-memory `FileSystem` fake for subagent-tree tests.
+ *
+ * Purpose:
+ *     Provide a hermetic filesystem fake (no temp files, no real disk
+ *     access) backed by `Map`/`Set`, following the existing
+ *     `test/lib/pr-context/tree-file-system.ts` pattern. Supports the
+ *     predicates `scanTranscripts` relies on: `glob` and `readTextFile`.
+ *
+ * Path convention:
+ *     Forward-slash POSIX paths, matching the production modules.
+ */
+export class InMemoryFileSystem implements FileSystem {
+  readonly files = new Map<string, string>();
+  readonly dirs = new Set<string>();
+
+  /** Register a file (and its ancestor directories) with content. */
+  addFile(path: string, content: string): void {
+    const normalized = stripTrailingSlash(path);
+    this.registerAncestors(normalized);
+    this.files.set(normalized, content);
+  }
+
+  glob(root: string, pattern: string): string[] {
+    const matcher = compileGlob(pattern);
+    const prefix = `${stripTrailingSlash(root)}/`;
+    const matches: string[] = [];
+    for (const path of this.files.keys()) {
+      if (path.startsWith(prefix)) {
+        const relative = path.slice(prefix.length);
+        if (matcher.test(relative)) {
+          matches.push(path);
+        }
+      }
+    }
+    return matches;
+  }
+
+  isFile(path: string): boolean {
+    return this.files.has(stripTrailingSlash(path));
+  }
+
+  exists(path: string): boolean {
+    const normalized = stripTrailingSlash(path);
+    return this.files.has(normalized) || this.dirs.has(normalized);
+  }
+
+  isDirectory(path: string): boolean {
+    return this.dirs.has(stripTrailingSlash(path));
+  }
+
+  listDirectory(path: string): string[] {
+    const prefix = `${stripTrailingSlash(path)}/`;
+    const children = new Set<string>();
+    for (const entry of [...this.files.keys(), ...this.dirs]) {
+      if (entry.startsWith(prefix)) {
+        const rest = entry.slice(prefix.length);
+        const firstSegment = rest.split("/")[0];
+        if (firstSegment) {
+          children.add(firstSegment);
+        }
+      }
+    }
+    return [...children].sort((left, right) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    );
+  }
+
+  readTextFile(path: string): string {
+    const content = this.files.get(stripTrailingSlash(path));
+    if (content === undefined) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    return content;
+  }
+
+  writeTextFile(path: string, content: string): void {
+    this.addFile(path, content);
+  }
+
+  ensureDir(path: string): void {
+    this.registerAncestors(path);
+    this.dirs.add(stripTrailingSlash(path));
+  }
+
+  /** Register every ancestor directory of a path. */
+  private registerAncestors(path: string): void {
+    const segments = stripTrailingSlash(path).split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      const ancestor = segments.slice(0, index).join("/");
+      if (ancestor) {
+        this.dirs.add(ancestor);
+      }
+    }
+  }
+}
+
+/** Strip a single trailing slash for normalized path comparison. */
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/u, "");
+}
+
+/**
+ * Compile a glob with `**` and `*` support into an anchored RegExp matching a
+ * relative POSIX path.
+ */
+function compileGlob(pattern: string): RegExp {
+  let regex = "";
+  let index = 0;
+  while (index < pattern.length) {
+    const char = pattern[index]!;
+    if (char === "*" && pattern[index + 1] === "*") {
+      if (pattern[index + 2] === "/") {
+        regex += "(?:.*/)?";
+        index += 3;
+      } else {
+        regex += ".*";
+        index += 2;
+      }
+      continue;
+    }
+    if (char === "*") {
+      regex += "[^/]*";
+      index += 1;
+      continue;
+    }
+    regex += char.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+    index += 1;
+  }
+  return new RegExp(`^${regex}$`);
+}

--- a/extensions/drm-copilot/test/lib/subagent-tree/index.test.ts
+++ b/extensions/drm-copilot/test/lib/subagent-tree/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  buildSubagentTree,
+  formatTree,
+} from "../../../src/lib/subagent-tree/index";
+import { InMemoryFileSystem } from "./in-memory-file-system";
+
+/** Build a root transcript line containing one `Agent` tool-use block. */
+function agentToolUseLine(model: string, toolUseId: string): string {
+  return JSON.stringify({
+    message: {
+      model,
+      content: [{ type: "tool_use", name: "Agent", id: toolUseId }],
+    },
+  });
+}
+
+describe("buildSubagentTree (end-to-end scanner + assembler composition)", () => {
+  it("composes the scanner and assembler for a multi-agent session and round-trips through formatTree", () => {
+    // Arrange: a root session spawning two subagents against the in-memory
+    // FileSystem fixture, mirroring the positive multi-agent scenario.
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-1.jsonl";
+    fileSystem.addFile(
+      rootSessionPath,
+      [
+        agentToolUseLine("claude-sonnet-5", "toolu_a"),
+        agentToolUseLine("claude-sonnet-5", "toolu_b"),
+      ].join("\n"),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-aaa.meta.json",
+      JSON.stringify({
+        agentType: "atomic-executor",
+        description: "Execute plan",
+        toolUseId: "toolu_a",
+        spawnDepth: 1,
+      }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-aaa.jsonl",
+      JSON.stringify({ message: { model: "claude-sonnet-5" } }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-bbb.meta.json",
+      JSON.stringify({
+        agentType: "atomic-planner",
+        description: "Plan the work",
+        toolUseId: "toolu_b",
+        spawnDepth: 1,
+      }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-bbb.jsonl",
+      JSON.stringify({ message: { model: "claude-opus-4" } }),
+    );
+
+    // Act
+    const tree = buildSubagentTree(rootSessionPath, { fileSystem });
+    const rendered = (): string => formatTree(tree);
+
+    // Assert: the composed tree has both subagents as root children, and
+    // formatTree renders it without throwing.
+    expect(tree.children).toHaveLength(2);
+    expect(rendered).not.toThrow();
+    const lines = rendered().split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain("Execute plan");
+    expect(lines[2]).toContain("Plan the work");
+  });
+});

--- a/extensions/drm-copilot/test/lib/subagent-tree/transcript-parser.test.ts
+++ b/extensions/drm-copilot/test/lib/subagent-tree/transcript-parser.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "@jest/globals";
+import { parseTranscriptLines } from "../../../src/lib/subagent-tree/transcript-parser";
+
+describe("parseTranscriptLines", () => {
+  it("collects Agent tool-use ids in file line order and the single observed model", () => {
+    // Arrange: three lines, two distinct Agent tool-use blocks, one model value.
+    const lines = [
+      JSON.stringify({
+        message: {
+          model: "claude-sonnet-5",
+          content: [{ type: "text", text: "hello" }],
+        },
+      }),
+      JSON.stringify({
+        message: {
+          model: "claude-sonnet-5",
+          content: [
+            { type: "tool_use", name: "Agent", id: "toolu_1" },
+            { type: "tool_use", name: "Bash", id: "toolu_bash" },
+          ],
+        },
+      }),
+      JSON.stringify({
+        message: {
+          content: [{ type: "tool_use", name: "Agent", id: "toolu_2" }],
+        },
+      }),
+    ];
+
+    // Act
+    const result = parseTranscriptLines(lines);
+
+    // Assert
+    expect(result.agentToolUseIds).toEqual(["toolu_1", "toolu_2"]);
+    expect(result.models).toEqual(["claude-sonnet-5"]);
+  });
+
+  it("collects both distinct truthy models across turns", () => {
+    // Arrange: two turns carry two different truthy message.model values.
+    const lines = [
+      JSON.stringify({ message: { model: "claude-sonnet-5" } }),
+      JSON.stringify({ message: { model: "claude-opus-4" } }),
+      JSON.stringify({ message: { model: "claude-sonnet-5" } }),
+    ];
+
+    // Act
+    const result = parseTranscriptLines(lines);
+
+    // Assert
+    expect(result.models).toEqual(["claude-sonnet-5", "claude-opus-4"]);
+  });
+
+  it("ignores blank lines, non-JSON lines, and lines whose message is a string", () => {
+    // Arrange: a blank line, a non-JSON line, and a string `message` field.
+    const lines = [
+      "",
+      "not json at all {{{",
+      JSON.stringify({ message: "plain text turn" }),
+      JSON.stringify({
+        message: {
+          model: "claude-sonnet-5",
+          content: [{ type: "tool_use", name: "Agent", id: "toolu_3" }],
+        },
+      }),
+    ];
+
+    // Act
+    const result = parseTranscriptLines(lines);
+
+    // Assert: only the well-formed final line contributes output.
+    expect(result.models).toEqual(["claude-sonnet-5"]);
+    expect(result.agentToolUseIds).toEqual(["toolu_3"]);
+  });
+
+  it("returns Agent tool-use ids in file line order even when alphabetical order differs", () => {
+    // Arrange: "toolu_z" appears before "toolu_a" in file line order.
+    const lines = [
+      JSON.stringify({
+        message: {
+          content: [{ type: "tool_use", name: "Agent", id: "toolu_z" }],
+        },
+      }),
+      JSON.stringify({
+        message: {
+          content: [{ type: "tool_use", name: "Agent", id: "toolu_a" }],
+        },
+      }),
+    ];
+
+    // Act
+    const result = parseTranscriptLines(lines);
+
+    // Assert: file line order is preserved, not alphabetical order.
+    expect(result.agentToolUseIds).toEqual(["toolu_z", "toolu_a"]);
+  });
+});

--- a/extensions/drm-copilot/test/lib/subagent-tree/transcript-scanner.test.ts
+++ b/extensions/drm-copilot/test/lib/subagent-tree/transcript-scanner.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "@jest/globals";
+import { scanTranscripts } from "../../../src/lib/subagent-tree/transcript-scanner";
+import { InMemoryFileSystem } from "./in-memory-file-system";
+
+/** Build a root transcript line containing one `Agent` tool-use block. */
+function agentToolUseLine(model: string, toolUseId: string): string {
+  return JSON.stringify({
+    message: {
+      model,
+      content: [{ type: "tool_use", name: "Agent", id: toolUseId }],
+    },
+  });
+}
+
+describe("scanTranscripts", () => {
+  it("scans a root session with two direct subagent transcripts", () => {
+    // Arrange: a root transcript spawning two subagents, each with its own
+    // meta.json and .jsonl transcript under the sibling `subagents` dir.
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-1.jsonl";
+    fileSystem.addFile(
+      rootSessionPath,
+      [
+        agentToolUseLine("claude-sonnet-5", "toolu_a"),
+        agentToolUseLine("claude-sonnet-5", "toolu_b"),
+      ].join("\n"),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-aaa.meta.json",
+      JSON.stringify({
+        agentType: "atomic-executor",
+        description: "Execute plan",
+        toolUseId: "toolu_a",
+        spawnDepth: 1,
+      }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-aaa.jsonl",
+      JSON.stringify({ message: { model: "claude-sonnet-5" } }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-bbb.meta.json",
+      JSON.stringify({
+        agentType: "atomic-planner",
+        description: "Plan the work",
+        toolUseId: "toolu_b",
+        spawnDepth: 1,
+        worktreePath: "/worktrees/bbb",
+        worktreeBranch: "feature/bbb",
+      }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-1/subagents/agent-bbb.jsonl",
+      JSON.stringify({ message: { model: "claude-opus-4" } }),
+    );
+
+    // Act
+    const scanned = scanTranscripts(rootSessionPath, fileSystem);
+
+    // Assert
+    expect(scanned.subagents).toHaveLength(2);
+    const byAgentId = new Map(
+      scanned.subagents.map((subagent) => [subagent.meta.agentId, subagent]),
+    );
+    expect(byAgentId.get("aaa")?.meta).toEqual({
+      agentId: "aaa",
+      agentType: "atomic-executor",
+      description: "Execute plan",
+      toolUseId: "toolu_a",
+      spawnDepth: 1,
+    });
+    expect(byAgentId.get("bbb")?.meta).toEqual({
+      agentId: "bbb",
+      agentType: "atomic-planner",
+      description: "Plan the work",
+      toolUseId: "toolu_b",
+      spawnDepth: 1,
+      worktreePath: "/worktrees/bbb",
+      worktreeBranch: "feature/bbb",
+    });
+    expect(scanned.root.agentToolUseIds).toEqual(["toolu_a", "toolu_b"]);
+  });
+
+  it("returns an empty subagents array when the subagents directory does not exist", () => {
+    // Arrange: only the root transcript is seeded; no `subagents` directory.
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-2.jsonl";
+    fileSystem.addFile(
+      rootSessionPath,
+      JSON.stringify({ message: { model: "claude-sonnet-5" } }),
+    );
+
+    // Act
+    const scanned = scanTranscripts(rootSessionPath, fileSystem);
+
+    // Assert: no throw, and an empty subagents array.
+    expect(scanned.subagents).toEqual([]);
+  });
+
+  it("scans a grandchild subagent whose spawning tool-use lives in its parent's transcript", () => {
+    // Arrange: root spawns "mid"; "mid"'s own transcript spawns "grandchild".
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-3.jsonl";
+    fileSystem.addFile(
+      rootSessionPath,
+      agentToolUseLine("claude-sonnet-5", "toolu_mid"),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-3/subagents/agent-mid.meta.json",
+      JSON.stringify({
+        agentType: "atomic-executor",
+        description: "Mid-level agent",
+        toolUseId: "toolu_mid",
+        spawnDepth: 1,
+      }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-3/subagents/agent-mid.jsonl",
+      agentToolUseLine("claude-sonnet-5", "toolu_grandchild"),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-3/subagents/agent-grandchild.meta.json",
+      JSON.stringify({
+        agentType: "atomic-executor",
+        description: "Grandchild agent",
+        toolUseId: "toolu_grandchild",
+        spawnDepth: 2,
+      }),
+    );
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-3/subagents/agent-grandchild.jsonl",
+      JSON.stringify({ message: { model: "claude-opus-4" } }),
+    );
+
+    // Act
+    const scanned = scanTranscripts(rootSessionPath, fileSystem);
+
+    // Assert: both subagents are present with their own parsed transcripts.
+    expect(scanned.subagents).toHaveLength(2);
+    const byAgentId = new Map(
+      scanned.subagents.map((subagent) => [subagent.meta.agentId, subagent]),
+    );
+    expect(byAgentId.get("mid")?.transcript.agentToolUseIds).toEqual([
+      "toolu_grandchild",
+    ]);
+    expect(byAgentId.get("grandchild")?.transcript.models).toEqual([
+      "claude-opus-4",
+    ]);
+  });
+
+  it("throws a fail-fast error when rootSessionPath does not end in .jsonl", () => {
+    // Arrange
+    const fileSystem = new InMemoryFileSystem();
+
+    // Act / Assert
+    expect(() =>
+      scanTranscripts("/workspace/session-1.txt", fileSystem),
+    ).toThrow(/must end in ".jsonl"/);
+  });
+
+  it("skips a meta path whose filename does not carry a non-empty agentId", () => {
+    // Arrange: "agent-.meta.json" satisfies the glob ("*" may match zero
+    // characters) but fails the stricter agentId-capturing filename pattern.
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-4.jsonl";
+    fileSystem.addFile(rootSessionPath, "");
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-4/subagents/agent-.meta.json",
+      JSON.stringify({
+        agentType: "atomic-executor",
+        description: "no id",
+        toolUseId: "toolu_x",
+        spawnDepth: 1,
+      }),
+    );
+
+    // Act
+    const scanned = scanTranscripts(rootSessionPath, fileSystem);
+
+    // Assert: the unparsable filename is skipped rather than throwing.
+    expect(scanned.subagents).toEqual([]);
+  });
+
+  it("skips a subagent whose meta.json is not valid JSON", () => {
+    // Arrange
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-5.jsonl";
+    fileSystem.addFile(rootSessionPath, "");
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-5/subagents/agent-bad.meta.json",
+      "{not valid json",
+    );
+
+    // Act
+    const scanned = scanTranscripts(rootSessionPath, fileSystem);
+
+    // Assert
+    expect(scanned.subagents).toEqual([]);
+  });
+
+  it("skips a subagent whose meta.json parses to a non-object value", () => {
+    // Arrange
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-6.jsonl";
+    fileSystem.addFile(rootSessionPath, "");
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-6/subagents/agent-num.meta.json",
+      "42",
+    );
+
+    // Act
+    const scanned = scanTranscripts(rootSessionPath, fileSystem);
+
+    // Assert
+    expect(scanned.subagents).toEqual([]);
+  });
+
+  it("skips a subagent whose meta.json is missing a required field", () => {
+    // Arrange: `toolUseId` is a number instead of the required string type.
+    const fileSystem = new InMemoryFileSystem();
+    const rootSessionPath = "/workspace/.claude/projects/proj/session-7.jsonl";
+    fileSystem.addFile(rootSessionPath, "");
+    fileSystem.addFile(
+      "/workspace/.claude/projects/proj/session-7/subagents/agent-bad2.meta.json",
+      JSON.stringify({
+        agentType: "atomic-executor",
+        description: "wrong types",
+        toolUseId: 123,
+        spawnDepth: 1,
+      }),
+    );
+
+    // Act
+    const scanned = scanTranscripts(rootSessionPath, fileSystem);
+
+    // Assert
+    expect(scanned.subagents).toEqual([]);
+  });
+});

--- a/extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts
+++ b/extensions/drm-copilot/test/lib/subagent-tree/tree-assembler.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "@jest/globals";
+import { assembleTree } from "../../../src/lib/subagent-tree/tree-assembler";
+import type {
+  ScannedSession,
+  ScannedSubagent,
+} from "../../../src/lib/subagent-tree/types";
+
+/** Build a `ScannedSubagent` fixture with sensible defaults. */
+function subagent(overrides: {
+  readonly agentId: string;
+  readonly toolUseId: string;
+  readonly agentType?: string;
+  readonly description?: string;
+  readonly spawnDepth?: number;
+  readonly models?: readonly string[];
+  readonly agentToolUseIds?: readonly string[];
+}): ScannedSubagent {
+  return {
+    meta: {
+      agentId: overrides.agentId,
+      agentType: overrides.agentType ?? "atomic-executor",
+      description: overrides.description ?? `${overrides.agentId} description`,
+      toolUseId: overrides.toolUseId,
+      spawnDepth: overrides.spawnDepth ?? 1,
+    },
+    transcript: {
+      models: overrides.models ?? ["claude-sonnet-5"],
+      agentToolUseIds: overrides.agentToolUseIds ?? [],
+    },
+  };
+}
+
+describe("assembleTree", () => {
+  it("assembles a root with two direct subagent children in the expected order", () => {
+    // Arrange: root spawns "toolu_a" then "toolu_b", each matched to a subagent.
+    const scanned: ScannedSession = {
+      root: {
+        models: ["claude-sonnet-5"],
+        agentToolUseIds: ["toolu_a", "toolu_b"],
+      },
+      subagents: [
+        subagent({ agentId: "a", toolUseId: "toolu_a" }),
+        subagent({ agentId: "b", toolUseId: "toolu_b" }),
+      ],
+    };
+
+    // Act
+    const tree = assembleTree(scanned);
+
+    // Assert
+    expect(tree.children).toHaveLength(2);
+    expect(tree.children.map((child) => child.description)).toEqual([
+      "a description",
+      "b description",
+    ]);
+  });
+
+  it("assembles an empty children array when there are no subagents", () => {
+    // Arrange
+    const scanned: ScannedSession = {
+      root: { models: ["claude-sonnet-5"], agentToolUseIds: [] },
+      subagents: [],
+    };
+
+    // Act
+    const tree = assembleTree(scanned);
+
+    // Assert
+    expect(tree.children).toEqual([]);
+    expect(tree.depth).toBe(0);
+  });
+
+  it("sorts a subagent node's multiple models ascending", () => {
+    // Arrange: one subagent whose transcript carries two distinct models.
+    const scanned: ScannedSession = {
+      root: { models: [], agentToolUseIds: ["toolu_a"] },
+      subagents: [
+        subagent({
+          agentId: "a",
+          toolUseId: "toolu_a",
+          models: ["claude-sonnet-5", "claude-opus-4"],
+        }),
+      ],
+    };
+
+    // Act
+    const tree = assembleTree(scanned);
+
+    // Assert: sorted ascending, not insertion order.
+    expect(tree.children[0]?.models).toEqual([
+      "claude-opus-4",
+      "claude-sonnet-5",
+    ]);
+  });
+
+  it("places a grandchild inside its direct parent's children, not the root's", () => {
+    // Arrange: root spawns "mid"; "mid" itself spawns "grandchild".
+    const scanned: ScannedSession = {
+      root: { models: [], agentToolUseIds: ["toolu_mid"] },
+      subagents: [
+        subagent({
+          agentId: "mid",
+          toolUseId: "toolu_mid",
+          agentToolUseIds: ["toolu_grandchild"],
+        }),
+        subagent({ agentId: "grandchild", toolUseId: "toolu_grandchild" }),
+      ],
+    };
+
+    // Act
+    const tree = assembleTree(scanned);
+
+    // Assert: root has exactly one child ("mid"); the grandchild is nested.
+    expect(tree.children).toHaveLength(1);
+    expect(tree.children[0]?.children).toHaveLength(1);
+    expect(tree.children[0]?.children[0]?.description).toBe(
+      "grandchild description",
+    );
+  });
+
+  it("attaches an orphan (unmatched toolUseId) as a root child after matched children, without throwing", () => {
+    // Arrange: root only spawns "toolu_a"; "orphan" claims a toolUseId nobody emitted.
+    const scanned: ScannedSession = {
+      root: { models: [], agentToolUseIds: ["toolu_a"] },
+      subagents: [
+        subagent({ agentId: "a", toolUseId: "toolu_a" }),
+        subagent({ agentId: "orphan", toolUseId: "toolu_missing" }),
+      ],
+    };
+
+    // Act
+    const build = (): ReturnType<typeof assembleTree> => assembleTree(scanned);
+
+    // Assert: does not throw, and the orphan is appended after "a".
+    expect(build).not.toThrow();
+    const tree = build();
+    expect(tree.children).toHaveLength(2);
+    expect(tree.children.map((child) => child.description)).toEqual([
+      "a description",
+      "orphan description",
+    ]);
+  });
+
+  it("orders siblings by spawn line order, not alphabetical agentId order", () => {
+    // Arrange: "toolu_second" is spawned first in the parent transcript, but
+    // its subagent's agentId ("bravo") sorts after "alpha" alphabetically.
+    const scanned: ScannedSession = {
+      root: {
+        models: [],
+        agentToolUseIds: ["toolu_second", "toolu_first"],
+      },
+      subagents: [
+        subagent({ agentId: "alpha", toolUseId: "toolu_first" }),
+        subagent({ agentId: "bravo", toolUseId: "toolu_second" }),
+      ],
+    };
+
+    // Act
+    const tree = assembleTree(scanned);
+
+    // Assert: "bravo" (toolu_second) comes first, matching line order.
+    expect(tree.children.map((child) => child.description)).toEqual([
+      "bravo description",
+      "alpha description",
+    ]);
+  });
+});

--- a/extensions/drm-copilot/test/lib/subagent-tree/tree-formatter.test.ts
+++ b/extensions/drm-copilot/test/lib/subagent-tree/tree-formatter.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "@jest/globals";
+import { formatTree } from "../../../src/lib/subagent-tree/tree-formatter";
+import type { TreeNode } from "../../../src/lib/subagent-tree/types";
+
+describe("formatTree", () => {
+  it("renders a two-level tree with the child indented two spaces relative to the root", () => {
+    // Arrange: root at depth 0 with one child at depth 1.
+    const tree: TreeNode = {
+      agentType: "root",
+      description: "",
+      depth: 0,
+      models: ["claude-sonnet-5"],
+      children: [
+        {
+          agentType: "atomic-executor",
+          description: "Execute plan",
+          depth: 1,
+          models: ["claude-sonnet-5"],
+          children: [],
+        },
+      ],
+    };
+
+    // Act
+    const rendered = formatTree(tree);
+
+    // Assert
+    const lines = rendered.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("root · [claude-sonnet-5] · 0 · ");
+    expect(lines[1]).toBe(
+      "  atomic-executor · [claude-sonnet-5] · 1 · Execute plan",
+    );
+  });
+
+  it("renders a node's multiple models comma-joined and sorted ascending", () => {
+    // Arrange: a node whose models array is not already in ascending order.
+    const tree: TreeNode = {
+      agentType: "atomic-executor",
+      description: "Mid-session model switch",
+      depth: 0,
+      models: ["claude-sonnet-5", "claude-opus-4"],
+      children: [],
+    };
+
+    // Act
+    const rendered = formatTree(tree);
+
+    // Assert: ascending order regardless of input order.
+    expect(rendered).toBe(
+      "atomic-executor · [claude-opus-4,claude-sonnet-5] · 0 · Mid-session model switch",
+    );
+  });
+
+  it("renders exactly one line for a root node with no children", () => {
+    // Arrange
+    const tree: TreeNode = {
+      agentType: "root",
+      description: "",
+      depth: 0,
+      models: [],
+      children: [],
+    };
+
+    // Act
+    const rendered = formatTree(tree);
+
+    // Assert
+    expect(rendered.split("\n")).toHaveLength(1);
+    expect(rendered).toBe("root · [] · 0 · ");
+  });
+});

--- a/extensions/drm-copilot/test/subagent-tree-command.test.ts
+++ b/extensions/drm-copilot/test/subagent-tree-command.test.ts
@@ -1,0 +1,204 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+type CommandHandler = () => Promise<void> | void;
+
+const commandHandlers = new Map<string, CommandHandler>();
+const appendLineMock = jest.fn<(line: string) => void>();
+const showOutputMock = jest.fn();
+const showQuickPickMock = jest.fn();
+const showErrorMessageMock = jest.fn();
+const registerCommandMock = jest.fn(
+  (command: string, handler: CommandHandler) => {
+    commandHandlers.set(command, handler);
+    return { dispose: jest.fn() };
+  },
+);
+
+jest.mock(
+  "vscode",
+  () => ({
+    commands: {
+      registerCommand: registerCommandMock,
+    },
+    window: {
+      showQuickPick: showQuickPickMock,
+      showErrorMessage: showErrorMessageMock,
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+jest.mock("../src/command-runtime", () => ({
+  getWorkspaceRoot: jest.fn(() => "C:/workspace"),
+}));
+
+import * as fs from "node:fs";
+import { registerSubagentTreeCommand } from "../src/subagent-tree-command";
+
+const readdirSyncMock = fs.readdirSync as jest.MockedFunction<
+  typeof fs.readdirSync
+>;
+const readFileSyncMock = fs.readFileSync as jest.MockedFunction<
+  typeof fs.readFileSync
+>;
+
+/** Build a minimal Dirent-like entry for mocking readdirSync results. */
+function dirent(name: string, isDir: boolean): fs.Dirent {
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+  } as unknown as fs.Dirent;
+}
+
+/**
+ * Configure `readdirSync` to model a fixed workspace tree:
+ * `C:/workspace/.claude/projects/proj/<sessionEntries>`.
+ *
+ * @param sessionEntries Dirent entries returned for the `proj` directory.
+ */
+function setWorkspaceTree(sessionEntries: readonly fs.Dirent[]): void {
+  readdirSyncMock.mockImplementation((dir) => {
+    const path = String(dir);
+    if (path.endsWith("workspace")) {
+      return [dirent(".claude", true)] as unknown as ReturnType<
+        typeof fs.readdirSync
+      >;
+    }
+    if (path.endsWith(".claude")) {
+      return [dirent("projects", true)] as unknown as ReturnType<
+        typeof fs.readdirSync
+      >;
+    }
+    if (path.endsWith("projects")) {
+      return [dirent("proj", true)] as unknown as ReturnType<
+        typeof fs.readdirSync
+      >;
+    }
+    if (path.endsWith("proj")) {
+      return [...sessionEntries] as unknown as ReturnType<
+        typeof fs.readdirSync
+      >;
+    }
+    // Any other directory (e.g. a session's `subagents` folder) has no
+    // entries in these fixtures, matching the empty-subagents scan path.
+    return [] as unknown as ReturnType<typeof fs.readdirSync>;
+  });
+}
+
+function activateAndGetHandler(): CommandHandler {
+  registerSubagentTreeCommand({
+    output: {
+      appendLine: appendLineMock,
+      show: showOutputMock,
+    } as never,
+  });
+  const handler = commandHandlers.get("drmCopilotExtension.showSubagentTree");
+  if (!handler) {
+    throw new Error(
+      "Missing command handler: drmCopilotExtension.showSubagentTree",
+    );
+  }
+  return handler;
+}
+
+describe("drm-copilot showSubagentTree command", () => {
+  beforeEach(() => {
+    commandHandlers.clear();
+    appendLineMock.mockReset();
+    showOutputMock.mockReset();
+    showQuickPickMock.mockReset();
+    showErrorMessageMock.mockReset();
+    readdirSyncMock.mockReset();
+    readFileSyncMock.mockReset();
+    readFileSyncMock.mockReturnValue("");
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reports an error and does not throw when zero root sessions are found", async () => {
+    // Arrange: an empty `.claude/projects` directory (no `proj` entry).
+    readdirSyncMock.mockImplementation((dir) => {
+      const path = String(dir);
+      if (path.endsWith("workspace")) {
+        return [dirent(".claude", true)] as unknown as ReturnType<
+          typeof fs.readdirSync
+        >;
+      }
+      if (path.endsWith(".claude")) {
+        return [dirent("projects", true)] as unknown as ReturnType<
+          typeof fs.readdirSync
+        >;
+      }
+      return [] as unknown as ReturnType<typeof fs.readdirSync>;
+    });
+    const handler = activateAndGetHandler();
+
+    // Act
+    await handler();
+
+    // Assert: no throw (implicit — handler resolved), an error is reported.
+    expect(showErrorMessageMock).toHaveBeenCalledTimes(1);
+    expect(showQuickPickMock).not.toHaveBeenCalled();
+    const logs = appendLineMock.mock.calls.map(([line]) => line);
+    expect(
+      logs.some((line) => line.includes("No root session transcripts found")),
+    ).toBe(true);
+  });
+
+  it("auto-selects a single discovered root session without prompting", async () => {
+    // Arrange: exactly one `.jsonl` root session under `proj`.
+    setWorkspaceTree([dirent("session-1.jsonl", false)]);
+    const handler = activateAndGetHandler();
+
+    // Act
+    await handler();
+
+    // Assert: no quick-pick prompt; the rendered tree is written to output.
+    expect(showQuickPickMock).not.toHaveBeenCalled();
+    expect(showErrorMessageMock).not.toHaveBeenCalled();
+    const logs = appendLineMock.mock.calls.map(([line]) => line);
+    expect(logs.some((line) => line.includes("session-1.jsonl"))).toBe(true);
+    expect(logs.some((line) => line.includes("root ·"))).toBe(true);
+  });
+
+  it("prompts via showQuickPick among multiple candidates and renders the one selected", async () => {
+    // Arrange: two `.jsonl` root sessions under `proj`.
+    setWorkspaceTree([
+      dirent("session-1.jsonl", false),
+      dirent("session-2.jsonl", false),
+    ]);
+    showQuickPickMock.mockImplementation(async (items: ReadonlyArray<string>) =>
+      items.find((item) => item.includes("session-2.jsonl")),
+    );
+    const handler = activateAndGetHandler();
+
+    // Act
+    await handler();
+
+    // Assert: the quick pick ran, and the selected session (session-2) was
+    // the one passed through to the renderer.
+    expect(showQuickPickMock).toHaveBeenCalledTimes(1);
+    const logs = appendLineMock.mock.calls.map(([line]) => line);
+    expect(logs.some((line) => line.includes("session-2.jsonl"))).toBe(true);
+    expect(logs.some((line) => line.includes("session-1.jsonl"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Suggested title

feat(extension): add Show Subagent Tree command (#320)

## Summary

- Adds a new VS Code command, `drmCopilotExtension.showSubagentTree` ("drm-copilot: Show Subagent Tree"), to the `drm-copilot` extension that deterministically renders the Claude Code subagent call tree from on-disk session transcripts.
- Introduces a pure, host-neutral module under `extensions/drm-copilot/src/lib/subagent-tree/` (`types.ts`, `transcript-parser.ts`, `transcript-scanner.ts`, `tree-assembler.ts`, `tree-formatter.ts`, `index.ts`) exposing `buildSubagentTree` and `formatTree`, with no VS Code imports.
- Adds a thin host-bound command file, `src/subagent-tree-command.ts`, that discovers candidate root sessions, auto-selects a single candidate or prompts via `showQuickPick` for multiple, and writes the rendered tree to an output channel.
- Registers the command in `contributes.commands` in `extensions/drm-copilot/package.json` and wires it in `activate` (`extension.ts`).
- Adds per-file `coverageThreshold` entries (`{ lines: 85, branches: 75 }`) for the six new executable production files in `jest.config.cjs`; no production file is excluded from coverage measurement.
- Adds full Jest unit test coverage for the new module and the command wiring, covering positive, empty-subagents, multi-model, multi-depth-nesting, orphan/unmatched-`toolUseId`, and sibling-ordering scenarios.

## Why

The `drm-copilot` VS Code extension had no way to inspect the subagent call tree of a Claude Code session. Session transcripts on disk (`.claude/projects/**`) record a root session plus flattened subagent transcripts with meta files that encode a deterministic parent -> child spawn relationship, but nothing in the extension surfaced that structure. A command that renders this tree helps operators understand delegation structure and detect mid-session model switches (`docs/features/active/subagent-tree-command/issue.md`).

The design separates a pure, testable tree-building/rendering module from a thin VS Code-wiring file per `.claude/rules/general-unit-test.md`, so the deterministic tree algorithm (transcript scanning, parent/child matching by exact `toolUseId` equality, sibling ordering by spawn index, orphan handling) can be fully unit tested without touching VS Code APIs, and the host-bound file is kept minimal.

## What Changed

**Core feature (host-neutral module, `extensions/drm-copilot/src/lib/subagent-tree/`):**
- `types.ts` — `TreeNode`, `SubagentMeta`, `ScannedTranscript`, `ScannedSession` interfaces (no I/O, no VS Code imports).
- `transcript-parser.ts` — `parseTranscriptLines`, a pure line-parser collecting per-turn models and `Agent` tool-use ids in file line order.
- `transcript-scanner.ts` — `scanTranscripts`, the only file in the module that touches the existing `FileSystem` seam (`../file-system`).
- `tree-assembler.ts` — `assembleTree`, the pure parent/child matching, sibling-ordering, and orphan-attachment algorithm.
- `tree-formatter.ts` — `formatTree`, the pure renderer (`agentType · [models] · depth · description`, two-space indent per depth).
- `index.ts` — barrel exporting `buildSubagentTree` (composing scanner + assembler), `formatTree`, and `TreeNode`.

**Host wiring:**
- `src/subagent-tree-command.ts` — `registerSubagentTreeCommand`, discovering `.claude/projects/**/*.jsonl` candidates (excluding `/subagents/` paths), auto-selecting a single candidate or prompting via `showQuickPick`, then calling `buildSubagentTree` / `formatTree` and writing to an output channel.
- `src/extension.ts` — imports and calls `registerSubagentTreeCommand` in `activate`, pushing the returned disposable into `context.subscriptions`.
- `package.json` — adds the `contributes.commands` entry `{ "command": "drmCopilotExtension.showSubagentTree", "title": "drm-copilot: Show Subagent Tree" }`.

**Tooling/config:**
- `jest.config.cjs` — adds `coverageThreshold` entries for the six new executable production files.

**Tests:**
- `test/lib/subagent-tree/transcript-parser.test.ts`, `transcript-scanner.test.ts`, `tree-assembler.test.ts`, `tree-formatter.test.ts`, `index.test.ts` — unit tests per module, covering positive, empty-subagents, multi-model, multi-depth-nesting, orphan/unmatched-`toolUseId`, and sibling-ordering scenarios.
- `test/subagent-tree-command.test.ts` — host-wiring tests: zero candidates, single-candidate auto-select, multi-candidate quick-pick.
- `test/lib/subagent-tree/in-memory-file-system.ts` — in-memory `FileSystem` test fixture (no temp files, no real disk access).

**Docs:**
- `docs/features/active/subagent-tree-command/` feature folder (issue, plan, audits, baseline and QA-gate evidence).

## Architecture / How It Fits Together

1. `registerSubagentTreeCommand` (host-bound) discovers candidate root `.jsonl` sessions via `RealFileSystem` and resolves which session to inspect (auto-select or quick-pick).
2. It calls `buildSubagentTree(rootSessionPath, { fileSystem })`, the barrel export from the pure module, which internally calls `scanTranscripts` (the only function that reads the filesystem, via the existing `FileSystem` seam) followed by `assembleTree` (pure, in-memory tree construction).
3. `scanTranscripts` reads the root `.jsonl` and every sibling `subagents/agent-*.jsonl` + `agent-*.meta.json` pair, delegating per-line parsing to `parseTranscriptLines`.
4. `assembleTree` matches each subagent's `meta.toolUseId` against `Agent` tool-use ids collected from its parent's transcript, orders siblings by spawn index, and attaches unmatched (orphan) subagents as trailing root children, ordered by `agentId`.
5. `formatTree` renders the resulting `TreeNode` tree to a single indented string, which the command writes to a VS Code output channel.

## Verification

**Completed** (from `docs/features/active/subagent-tree-command/evidence/qa-gates/`, all run from `extensions/drm-copilot/`):
- Format: `npm run format` — EXIT_CODE 0.
- Lint: `npm run lint` — EXIT_CODE 0.
- Type-check: `npm run typecheck` — EXIT_CODE 0.
- Architecture boundary (manual, no `dependency-cruiser` configured for this extension): `grep -rn "vscode" extensions/drm-copilot/src/lib/subagent-tree/` — exit code 1 (no matches), confirming zero VS Code imports in the pure module.
- Unit tests + coverage: `npm run test:coverage` — EXIT_CODE 0. Per-file coverage (from `final-coverage-per-file.md`): `transcript-parser.ts` 98.45%/96.43%, `transcript-scanner.ts` 100%/100%, `tree-assembler.ts` 94.71%/89.47%, `tree-formatter.ts` 100%/100%, `index.ts` 100%/100%, `subagent-tree-command.ts` 92.44%/85.71% (line/branch) — all six executable files exceed the 85%/75% gate. `types.ts` is an interface-only file (0/73 executable lines) and is documented as exempt from the per-file threshold gate per `.claude/rules/general-unit-test.md`, while remaining present in `collectCoverageFrom` (not excluded from measurement).
- Build: `npm run build` (`tsc --noEmit` + `bundle:extension` + `bundle:mcp-server`) — EXIT_CODE 0.

**Recommended:**
- Manually invoke `drm-copilot: Show Subagent Tree` in a VS Code Extension Development Host against a real `.claude/projects/**` session to confirm the rendered output channel content end-to-end. Not verified in this PR (unit tests exercise the command through the injected `FileSystem` seam only, not a live VS Code host).

## Backward Compatibility / Migration Notes

- Purely additive: one new command, one new module, one new host-wiring file, and new `jest.config.cjs` coverage entries. No existing public API, command, or file is removed or renamed.

## Risks and Mitigations

- **No automated architecture-boundary tool.** `extensions/drm-copilot/` has no `dependency-cruiser` configuration, so the "no VS Code imports in the pure module" boundary is enforced by a manual `grep`, not an automated gate. This is a pre-existing, repository-wide gap, not introduced by this change; the feature audit (`docs/features/active/subagent-tree-command/feature-audit.2026-07-05T23-16.md`) recommends tracking it as separate follow-up work.
- **`types.ts` has zero executable coverage.** This is an interface-only file with no runtime behavior; it is documented as the explicit coverage-exclusion-policy exemption for type-only files rather than a real gap, and it is not excluded from `collectCoverageFrom`.
- **Rollback:** revert this PR's commits; the change set is additive and self-contained (new module, new command file, new test files, and config additions), so no data migration or cleanup is required on rollback.

## Review Guide

Suggested review order:
1. `docs/features/active/subagent-tree-command/issue.md` — problem statement and acceptance criteria (AC1–AC5).
2. `extensions/drm-copilot/src/lib/subagent-tree/types.ts` and `transcript-parser.ts` — data contract and line-parsing primitives.
3. `transcript-scanner.ts` — filesystem-backed scanning (the only I/O boundary in the pure module).
4. `tree-assembler.ts` — the deterministic tree algorithm (parent/child matching, sibling ordering, orphan handling); this is the most algorithmically dense file.
5. `tree-formatter.ts` and `index.ts` — rendering and composition.
6. `src/subagent-tree-command.ts` and `src/extension.ts` — host wiring.
7. `test/lib/subagent-tree/**` and `test/subagent-tree-command.test.ts` — test coverage for the above.
8. `jest.config.cjs` and `package.json` — configuration additions.

No mechanical moves/renames are included in this PR; all changes are new files plus small, additive edits to `extension.ts`, `package.json`, and `jest.config.cjs`.

## Follow-ups

- Track the two pre-existing, repository-wide infrastructure gaps noted in the feature audit (missing `dependency-cruiser` configuration for `extensions/drm-copilot/`; missing `quality-tiers.yml` at repository root) as separate follow-up work items.

## GitHub Auto-close

- Closes #320
